### PR TITLE
complete Makefile with aiger folder as dependency for ebmc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS = ebmc hw-cbmc trans-word-level trans-netlist verilog vhdl smvlang ic3
+SUBDIRS = ebmc hw-cbmc trans-word-level trans-netlist verilog vhdl smvlang ic3 aiger
 
 all: hw-cbmc ebmc
 
@@ -10,7 +10,7 @@ $(SUBDIRS):
 
 # Dependencies
 
-ebmc: trans-word-level trans-netlist verilog vhdl smvlang ic3
+ebmc: trans-word-level trans-netlist verilog vhdl smvlang ic3 aiger
 
 hw-cbmc: trans-word-level trans-netlist verilog vhdl smvlang
 

--- a/src/ic3/Makefile
+++ b/src/ic3/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS = -std=c++0x  -Wno-literal-suffix -Wno-write-strings -D __STDC_LIMIT_MACROS -D __STDC_FORMAT_MACROS -O3 $(INC_DIR)
+CXXFLAGS = -Wno-literal-suffix -Wno-write-strings -D __STDC_LIMIT_MACROS -D __STDC_FORMAT_MACROS -O3 $(INC_DIR)
 CXFLAGS = $(INC_DIR)
 CFLAGS =   -O3  $(INC_DIR) 
 CXX = g++
@@ -16,9 +16,9 @@ vpath %.hh build_prob
 
 include ../config.inc
 
-MINISAT_INC = -Iminisat
+MINISAT_INC = minisat
 
-INC_DIR = -I. -Ibuild_prob -Iseq_circ $(MINISAT_INC) -I$(CBMC)/src -I../ -I../ebmc -I../trans-netlist
+INC_DIR = -I. -Ibuild_prob -Iseq_circ -I$(MINISAT_INC) -I$(CBMC)/src -I../ -I../ebmc -I../trans-netlist
 
 OBJ_DIR = .
 


### PR DESCRIPTION
This completes the dependency list for EBMC which now also includes the `aiger` subdir. It also removes the `std=c++0x` flag from the EBMC Makefile as the included `config.inc` of CBMC defines `c++11`.