### PR TITLE
fix exmp8 and exmp9 test case

### DIFF
--- a/regression/ebmc/ic3/exmp8/test.desc
+++ b/regression/ebmc/ic3/exmp8/test.desc
@@ -1,7 +1,7 @@
 CORE
 bobmiterbm1multi.sv
 --ic3 --prop 1079
-^property FAILED 
+^property FAILED
 ^verification is ok
 --
 ^verification failed

--- a/regression/ebmc/ic3/exmp9/test.desc
+++ b/regression/ebmc/ic3/exmp9/test.desc
@@ -1,7 +1,7 @@
 CORE
 sm98a7multi.sv
 --ic3 --prop 1 --constr
-^property FAILED 
+^property FAILED
 ^verification is ok
 --
 ^verification failed


### PR DESCRIPTION
The two test cases inadvertently tried to match on an additional space which
made them fail.