### PR TITLE
Add regression tests from EBMC manual

### DIFF
--- a/regression/ebmc/example1/example1.sv
+++ b/regression/ebmc/example1/example1.sv
@@ -1,0 +1,16 @@
+module my_add(input a, input b, output [1:0] y);
+
+  assign y[0]=a^b;
+  assign y[1]=a&b;
+
+endmodule
+
+module main(input a, input b);
+
+  wire [1:0] result;
+
+  my_add adder(a, b, result);
+
+  assert property (a+b==result);
+
+endmodule

--- a/regression/ebmc/example1/test.desc
+++ b/regression/ebmc/example1/test.desc
@@ -1,0 +1,7 @@
+CORE
+example1.sv
+--bound 10
+SUCCESS$
+^EXIT=0$
+^SIGNAL=0$
+

--- a/regression/ebmc/example3/example3.sv
+++ b/regression/ebmc/example3/example3.sv
@@ -1,0 +1,17 @@
+module counter(
+  output [7:0] out,
+  input enable, input clk);
+
+  reg [7:0] state;
+  assign out = state;
+
+  initial state = 0;
+
+  always @(posedge clk)
+    if(enable)
+      state = state + 1;
+
+  assert property (enable && state[0] |-> ##1 !state[0]);
+  assert property (state!=3);
+
+endmodule

--- a/regression/ebmc/example3/test.desc
+++ b/regression/ebmc/example3/test.desc
@@ -1,0 +1,8 @@
+CORE
+example3.sv
+--bound 10
+SUCCESS$
+FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+

--- a/regression/ebmc/example4_reset/example4.sv
+++ b/regression/ebmc/example4_reset/example4.sv
@@ -1,0 +1,17 @@
+module counter(
+  output [7:0] out,
+  input reset, input clk);
+
+  reg [7:0] state;
+  assign out = state;
+
+  always @(posedge clk)
+    if(reset)
+      state = 0;
+    else
+      state = state + 1;
+
+  assert property (reset |-> ##1 state==0);
+  assert property (reset |-> ##2 state==1);
+
+endmodule

--- a/regression/ebmc/example4_reset/test.desc
+++ b/regression/ebmc/example4_reset/test.desc
@@ -1,0 +1,8 @@
+CORE
+example4.sv
+--bound 10 --reset "reset==1"
+SUCCESS$
+SUCCESS$
+^EXIT=0$
+^SIGNAL=0$
+

--- a/regression/ebmc/example4_trace/example4.sv
+++ b/regression/ebmc/example4_trace/example4.sv
@@ -1,0 +1,17 @@
+module counter(
+  output [7:0] out,
+  input reset, input clk);
+
+  reg [7:0] state;
+  assign out = state;
+
+  always @(posedge clk)
+    if(reset)
+      state = 0;
+    else
+      state = state + 1;
+
+  assert property (reset |-> ##1 state==0);
+  assert property (reset |-> ##2 state==1);
+
+endmodule

--- a/regression/ebmc/example4_trace/test.desc
+++ b/regression/ebmc/example4_trace/test.desc
@@ -1,0 +1,8 @@
+CORE
+example4.sv
+--bound 10 
+SUCCESS$
+FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+

--- a/regression/ebmc/example5/example5.sv
+++ b/regression/ebmc/example5/example5.sv
@@ -1,0 +1,13 @@
+module top(input clk);
+
+  reg [31:0] x, y;
+
+  initial x=0;
+  initial y=0;
+
+  always @(posedge clk) x<=x+1;
+  always @(posedge clk) y<=y+2;
+
+  p1: assert property (x==0 |-> ##[1:$] y==18);
+
+endmodule

--- a/regression/ebmc/example5/test.desc
+++ b/regression/ebmc/example5/test.desc
@@ -1,0 +1,7 @@
+CORE
+example5.sv
+--bound 10
+SUCCESS$
+^EXIT=0$
+^SIGNAL=0$
+

--- a/regression/ebmc/ring_buffer_bdd/ring_buffer.sv
+++ b/regression/ebmc/ring_buffer_bdd/ring_buffer.sv
@@ -1,0 +1,28 @@
+module ring_buffer(input clk, input read, input write);
+
+  reg [4:0] count=0;
+  reg [3:0] readptr=0, writeptr=0;
+
+  always @(posedge clk) begin
+    if(read) begin
+      readptr++;
+      count--;
+    end
+
+    if(write) begin
+      writeptr++;
+      count++;
+    end
+
+  end
+
+  wire full=count==15;
+  wire empty=count==0;
+
+  assume property (empty |-> !read);
+  assume property (full |-> !write);
+
+  assert property (((writeptr-readptr)&'b1111)==count);
+
+endmodule
+

--- a/regression/ebmc/ring_buffer_bdd/test.desc
+++ b/regression/ebmc/ring_buffer_bdd/test.desc
@@ -1,0 +1,7 @@
+CORE
+ring_buffer.sv
+--bdd
+SUCCESS$
+^EXIT=0$
+^SIGNAL=0$
+

--- a/regression/ebmc/ring_buffer_induction/ring_buffer.sv
+++ b/regression/ebmc/ring_buffer_induction/ring_buffer.sv
@@ -1,0 +1,28 @@
+module ring_buffer(input clk, input read, input write);
+
+  reg [4:0] count=0;
+  reg [3:0] readptr=0, writeptr=0;
+
+  always @(posedge clk) begin
+    if(read) begin
+      readptr++;
+      count--;
+    end
+
+    if(write) begin
+      writeptr++;
+      count++;
+    end
+
+  end
+
+  wire full=count==15;
+  wire empty=count==0;
+
+  assume property (empty |-> !read);
+  assume property (full |-> !write);
+
+  assert property (((writeptr-readptr)&'b1111)==count);
+
+endmodule
+

--- a/regression/ebmc/ring_buffer_induction/test.desc
+++ b/regression/ebmc/ring_buffer_induction/test.desc
@@ -1,0 +1,7 @@
+CORE
+ring_buffer.sv
+--k-induction
+SUCCESS$
+^EXIT=0$
+^SIGNAL=0$
+


### PR DESCRIPTION
For example 4 there is one with reset logic and one without, for ring_buffer,
one with BDD based verification and one with k-induction.