### PR TITLE
vhdl module depends on cprover.dir

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -15,6 +15,8 @@ $(patsubst %, %.dir, $(DIRS)):
 
 # Dependencies
 
+vhdl.dir: cprover.dir
+
 ebmc.dir: trans-word-level.dir trans-netlist.dir verilog.dir vhdl.dir \
       smvlang.dir ic3.dir aiger.dir cprover.dir
 


### PR DESCRIPTION
The vhdl module uses the file converter from ansi-c, and hence has a dependency on cprover.dir.