### PR TITLE
fix for bison invocations for frontends

### DIFF
--- a/src/smvlang/Makefile
+++ b/src/smvlang/Makefile
@@ -1,5 +1,5 @@
 SRC = smv_language.cpp smv_parser.cpp smv_typecheck.cpp expr2smv.cpp \
-      y.tab.cpp lex.yy.cpp smv_parse_tree.cpp
+      smv_y.tab.cpp lex.yy.cpp smv_parse_tree.cpp
 
 include $(CPROVER_DIR)/config.inc
 include $(CPROVER_DIR)/common
@@ -7,7 +7,7 @@ include $(CPROVER_DIR)/common
 INCLUDES= -I $(CPROVER_DIR) -I ..
 CXXFLAGS += -D'LOCAL_IREP_IDS=<hw_cbmc_irep_ids.h>'
 
-CLEANFILES = smvlang$(LIBEXT) y.tab.h y.tab.cpp lex.yy.cpp y.tab.cpp.output y.output
+CLEANFILES = smvlang$(LIBEXT) smv_y.tab.h smv_y.tab.cpp lex.yy.cpp smv_y.output
 
 all: smvlang$(LIBEXT)
 
@@ -18,6 +18,8 @@ smvlang$(LIBEXT): $(OBJ)
 
 smv_y.tab.cpp: parser.y
 	$(YACC) $(YFLAGS) $$flags -pyysmv --defines=smv_y.tab.h -d parser.y -o $@
+
+smv_y.tab.h: smv_y.tab.cpp
 
 lex.yy.cpp: scanner.l
 	$(LEX) -Pyysmv -olex.yy.cpp scanner.l

--- a/src/verilog/Makefile
+++ b/src/verilog/Makefile
@@ -26,6 +26,8 @@ verilog$(LIBEXT): $(OBJ)
 verilog_y.tab.cpp: parser.y
 	$(YACC) $(YFLAGS) $$flags -pyyverilog --defines=verilog_y.tab.h -d parser.y -o $@
 
+verilog_y.tab.h: verilog_y.tab.cpp
+
 verilog_lex.yy.cpp: scanner.l
 	$(LEX) -Pyyverilog -o$@ scanner.l
 

--- a/src/vhdl/Makefile
+++ b/src/vhdl/Makefile
@@ -8,7 +8,7 @@ include $(CPROVER_DIR)/common
 INCLUDES= -I $(CPROVER_DIR) -I ..
 CXXFLAGS += -D'LOCAL_IREP_IDS=<hw_cbmc_irep_ids.h>'
 
-CLEANFILES = vhdl$(LIBEXT) vhdl_y.tab.cpp vhdl_y.tab.h vhdl_lex.yy.cpp y.output
+CLEANFILES = vhdl$(LIBEXT) vhdl_y.tab.cpp vhdl_y.tab.h vhdl_lex.yy.cpp vhdl_y.output
 
 all: vhdl$(LIBEXT)
 
@@ -18,11 +18,9 @@ vhdl$(LIBEXT): $(OBJ)
 	$(LINKLIB)
 
 vhdl_y.tab.cpp: parser.y
-	$(YACC) $(YFLAGS) $$flags -pyyvhdl -d parser.y -o $@
+	$(YACC) $(YFLAGS) $$flags -pyyvhdl --defines=vhdl_y.tab.h -d parser.y -o $@
 
 vhdl_y.tab.h: vhdl_y.tab.cpp
-	if [ -e vhdl_y.tab.hpp ] ; then mv vhdl_y.tab.hpp $@ ; else \
-        mv vhdl_y.tab.cpp.h $@ ; fi
 
 vhdl_lex.yy.cpp: scanner.l
 	$(LEX) -i -Pyyvhdl -o$@ scanner.l


### PR DESCRIPTION
1) This tells bison the desired name of the generated header file, as opposed to trying to rename it.
    
2) The names of CLEANFILES and dependencies are fixed.
    
Fixes issue #37.
