### PR TITLE
strengthen expression class typing

### DIFF
--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -412,10 +412,8 @@ void bdd_enginet::check_property(propertyt &property)
   if(property.expr.id()==ID_AG ||
      property.expr.id()==ID_sva_always)
   {
-    assert(property.expr.operands().size()==1);
-
     // recursive call
-    const exprt &sub_expr=property.expr.op0();
+    const exprt &sub_expr = to_unary_expr(property.expr).op();
     BDD p=property2BDD(sub_expr);
 
     // Start with !p, and go backwards until saturation or we hit an
@@ -535,8 +533,8 @@ bdd_enginet::BDD bdd_enginet::property2BDD(const exprt &expr)
   else if(expr.id()==ID_implies ||
           expr.id()==ID_sva_overlapped_implication)
   {
-    assert(expr.operands().size()==2);
-    return (!property2BDD(expr.op0())) | property2BDD(expr.op1());
+    return (!property2BDD(to_binary_expr(expr).lhs())) |
+           property2BDD(to_binary_expr(expr).rhs());
   }
   else if(expr.id()==ID_and)
   {
@@ -554,18 +552,14 @@ bdd_enginet::BDD bdd_enginet::property2BDD(const exprt &expr)
   }
   else if(expr.id()==ID_sva_non_overlapped_implication)
   {
-    assert(expr.operands().size()==2);
-    
     // use sva_nexttime for this
-    unary_predicate_exprt tmp(ID_sva_nexttime, expr.op1());
-    return (!property2BDD(expr.op0())) | property2BDD(tmp);
+    unary_predicate_exprt tmp(ID_sva_nexttime, to_binary_expr(expr).rhs());
+    return (!property2BDD(to_binary_expr(expr).lhs())) | property2BDD(tmp);
   }
   else if(expr.id()==ID_sva_nexttime)
   {
-    assert(expr.operands().size()==1);
-
     // recursive call
-    const exprt &sub_expr=expr.op0();
+    const exprt &sub_expr = to_unary_expr(expr).op();
     BDD p=property2BDD(sub_expr);
 
     // make 'p' be expressed in terms of 'next' variables
@@ -587,10 +581,8 @@ bdd_enginet::BDD bdd_enginet::property2BDD(const exprt &expr)
   }
   else if(expr.id()==ID_sva_eventually)
   {
-    assert(expr.operands().size()==1);
-
     // recursive call
-    const exprt &sub_expr=expr.op0();
+    const exprt &sub_expr = to_unary_expr(expr).op();
     BDD p=property2BDD(sub_expr);
     BDD states=p;
     
@@ -626,10 +618,8 @@ bdd_enginet::BDD bdd_enginet::property2BDD(const exprt &expr)
   else if(expr.id()==ID_AG ||
           expr.id()==ID_sva_always)
   {
-    assert(expr.operands().size()==1);
-
     // recursive call
-    const exprt &sub_expr=expr.op0();
+    const exprt &sub_expr = to_unary_expr(expr).op();
     BDD p=property2BDD(sub_expr);
     BDD states=p;
     

--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -165,10 +165,8 @@ int k_inductiont::induction_step()
       error() << "unsupported property - only SVA always or AG implemented" << eom;
       return 1;
     }
-    
-    assert(property.operands().size()==1);
 
-    const exprt &p=property.op0();
+    const exprt &p = to_unary_expr(property).op();
 
     // assumption: time frames 0,...,k-1
     for(unsigned c=0; c<no_timeframes-1; c++)

--- a/src/ebmc/negate_property.cpp
+++ b/src/ebmc/negate_property.cpp
@@ -84,7 +84,7 @@ exprt negate_property(const exprt &expr)
   {
     // rewrite using 'next'
     assert(expr.operands().size()==2);
-    unary_predicate_exprt next(ID_sva_nexttime, expr.op1());
+    unary_predicate_exprt next(ID_sva_nexttime, to_binary_expr(expr).rhs());
     binary_exprt result=to_binary_expr(expr);
     result.op1()=negate_property(next);
     return std::move(result);

--- a/src/hw-cbmc/next_timeframe.cpp
+++ b/src/hw-cbmc/next_timeframe.cpp
@@ -74,10 +74,11 @@ void add_next_timeframe(
     
     if(top_level_inputs.find(name)!=top_level_inputs.end()) continue;
 
-    const exprt member_expr1 = member_exprt(struct_symbol_expr, name, type);
-    const exprt member_expr2=member_exprt(index_expr, name, type);
+    const auto member_expr1 = member_exprt(struct_symbol_expr, name, type);
+    const auto member_expr2 = member_exprt(index_expr, name, type);
 
-    CHECK_RETURN(member_expr1.op0().type() == member_expr2.op0().type());
+    CHECK_RETURN(
+      member_expr1.compound().type() == member_expr2.compound().type());
     const code_assignt member_assignment(member_expr1, member_expr2);
     block.add(member_assignment);
   }

--- a/src/ic3/r1ead_input.cc
+++ b/src/ic3/r1ead_input.cc
@@ -36,11 +36,9 @@ void ic3_enginet::find_prop_lit()
   bool found = find_prop(Prop);
 
   assert(found);
-  assert(Prop.expr.id()==ID_sva_always);    
+  assert(Prop.expr.id() == ID_sva_always);
 
-  assert(Prop.expr.operands().size()==1);
-
-  exprt Oper = Prop.expr.op0();
+  exprt Oper = to_unary_expr(Prop.expr).op();
 
   found = banned_expr(Oper);
   if (found) {

--- a/src/smvlang/expr2smv.cpp
+++ b/src/smvlang/expr2smv.cpp
@@ -21,9 +21,14 @@ public:
 
   bool convert_binary(const exprt &src, std::string &dest, const std::string &symbol, unsigned precedence);
 
-  bool convert_unary(const exprt &src, std::string &dest, const std::string &symbol, unsigned precedence);
+  bool convert_unary(
+    const unary_exprt &,
+    std::string &dest,
+    const std::string &symbol,
+    unsigned precedence);
 
-  bool convert_index(const exprt &src, std::string &dest, unsigned precedence);
+  bool
+  convert_index(const index_exprt &, std::string &dest, unsigned precedence);
 
   bool convert(const exprt &src, std::string &dest, unsigned &precedence);
 
@@ -218,17 +223,16 @@ Function: expr2smvt::convert_unary
 \*******************************************************************/
 
 bool expr2smvt::convert_unary(
-  const exprt &src, std::string &dest,
+  const unary_exprt &src,
+  std::string &dest,
   const std::string &symbol,
   unsigned precedence)
 {
-  if(src.operands().size()!=1)
-    return convert_norep(src, dest, precedence);
-    
   std::string op;
   unsigned p;
 
-  if(convert(src.op0(), op, p)) return true;
+  if(convert(src.op(), op, p))
+    return true;
 
   dest+=symbol;
   if(precedence>p) dest+='(';
@@ -251,13 +255,10 @@ Function: expr2smvt::convert_index
 \*******************************************************************/
 
 bool expr2smvt::convert_index(
-  const exprt &src,
+  const index_exprt &src,
   std::string &dest,
   unsigned precedence)
 {
-  if(src.operands().size()!=2)
-    return convert_norep(src, dest, precedence);
-
   std::string op;
   unsigned p;
 
@@ -423,12 +424,13 @@ bool expr2smvt::convert(
   {
     if(src.operands().size()!=1)
       return convert_norep(src, dest, precedence);
-    else     
-      return convert_unary(src, dest, "-", precedence=17);
+    else
+      return convert_unary(
+        to_unary_minus_expr(src), dest, "-", precedence = 17);
   }
 
   else if(src.id()==ID_index)
-    return convert_index(src, dest, precedence=20);
+    return convert_index(to_index_expr(src), dest, precedence = 20);
 
   else if(src.id()==ID_mult || src.id()==ID_div)
     return convert_binary(src, dest, src.id_string(), precedence=16);
@@ -444,7 +446,7 @@ bool expr2smvt::convert(
     return convert_binary(src, dest, "!=", precedence=11);
 
   else if(src.id()==ID_not)
-    return convert_unary(src, dest, "!", precedence=6);
+    return convert_unary(to_not_expr(src), dest, "!", precedence = 6);
 
   else if(src.id()==ID_and)
     return convert_binary(src, dest, "&", precedence=5);
@@ -460,7 +462,8 @@ bool expr2smvt::convert(
 
   else if(src.id()==ID_AG || src.id()==ID_EG ||
           src.id()==ID_AX || src.id()==ID_EX)
-    return convert_unary(src, dest, src.id_string()+" ", precedence=7);
+    return convert_unary(
+      to_unary_expr(src), dest, src.id_string() + " ", precedence = 7);
 
   else if(src.id()==ID_symbol)
     return convert_symbol(src, dest, precedence);

--- a/src/smvlang/parser.y
+++ b/src/smvlang/parser.y
@@ -3,6 +3,7 @@
 #include "smv_typecheck.h"
 
 #include <util/mathematical_types.h>
+#include <util/std_expr.h>
 #include <util/std_types.h>
 
 #define YYSTYPE unsigned
@@ -372,10 +373,8 @@ assignment : assignment_head '(' assignment_var ')' BECOMES_Token formula ';'
 
              if(stack_expr($1).id()=="next")
              {
-               exprt &op=stack_expr($$).op0();
-               exprt tmp("smv_next");
-               tmp.operands().resize(1);
-               tmp.op0().swap(op);
+               exprt &op=to_binary_expr(stack_expr($$)).op0();
+               unary_exprt tmp("smv_next", std::move(op));
                tmp.swap(op);
                PARSER.module->add_trans(stack_expr($$));
              }

--- a/src/smvlang/smv_typecheck.cpp
+++ b/src/smvlang/smv_typecheck.cpp
@@ -711,9 +711,8 @@ void smv_typecheckt::typecheck(
 
     expr.type()=bool_typet();
 
-    exprt &op0=expr.op0(),
-          &op1=expr.op1();
-          
+    exprt &op0 = to_binary_expr(expr).op0(), &op1 = to_binary_expr(expr).op1();
+
     typet op_type=type_union(op0.type(), op1.type());
     
     typecheck(op0, op_type, mode);
@@ -753,9 +752,9 @@ void smv_typecheckt::typecheck(
         // find proper type for precise arithmetic
         smv_ranget new_range;
 
-        smv_ranget smv_range0=convert_type(expr.op0().type());
-        smv_ranget smv_range1=convert_type(expr.op1().type());
-        
+        smv_ranget smv_range0 = convert_type(to_binary_expr(expr).op0().type());
+        smv_ranget smv_range1 = convert_type(to_binary_expr(expr).op1().type());
+
         if(expr.id()==ID_plus)
           new_range=smv_range0+smv_range1;
         else if(expr.id()==ID_minus)
@@ -929,8 +928,8 @@ void smv_typecheckt::typecheck(
     }
 
     expr.type()=bool_typet();
-    
-    typecheck(expr.op0(), expr.type(), mode);
+
+    typecheck(to_unary_expr(expr).op(), expr.type(), mode);
   }
   else if(expr.id()==ID_typecast)
   {
@@ -1013,7 +1012,7 @@ void smv_typecheckt::convert(exprt &expr, expr_modet expr_mode)
     assert(expr.operands().size()==1);
 
     exprt tmp;
-    tmp.swap(expr.op0());
+    tmp.swap(to_unary_expr(expr).op());
     expr.swap(tmp);
 
     convert(expr, NEXT);
@@ -1088,8 +1087,8 @@ void smv_typecheckt::convert(exprt &expr, expr_modet expr_mode)
         throw "case expected to have two operands";
       }
 
-      exprt &condition=it->op0();
-      exprt &value=it->op1();
+      exprt &condition = to_binary_expr(*it).op0();
+      exprt &value = to_binary_expr(*it).op1();
 
       expr.add_to_operands(std::move(condition));
       expr.add_to_operands(std::move(value));
@@ -1250,8 +1249,8 @@ void smv_typecheckt::collect_define(const exprt &expr)
   if(expr.id()!=ID_equal || expr.operands().size()!=2)
     throw "collect_define expects equality";
 
-  const exprt &op0=expr.op0();
-  const exprt &op1=expr.op1();
+  const exprt &op0 = to_equal_expr(expr).op0();
+  const exprt &op1 = to_equal_expr(expr).op1();
 
   if(op0.id()!=ID_symbol)
     throw "collect_define expects symbol on left hand side";

--- a/src/trans-netlist/instantiate_netlist.cpp
+++ b/src/trans-netlist/instantiate_netlist.cpp
@@ -200,18 +200,19 @@ literalt instantiate_bmc_mapt::convert_bool(const exprt &expr)
   {
     // same as regular implication
     if(expr.operands().size()==2)
-      return prop.limplies(convert_bool(expr.op0()),
-                           convert_bool(expr.op1()));
+      return prop.limplies(
+        convert_bool(to_binary_expr(expr).op0()),
+        convert_bool(to_binary_expr(expr).op1()));
   }
   else if(expr.id()==ID_sva_non_overlapped_implication)
   {
     // right-hand side is shifted by one tick
     if(expr.operands().size()==2)
     {
-      literalt lhs=convert_bool(expr.op0());
+      literalt lhs = convert_bool(to_binary_expr(expr).lhs());
       unsigned old_current=current;
       unsigned old_next=next;
-      literalt rhs=convert_bool(expr.op1());
+      literalt rhs = convert_bool(to_binary_expr(expr).rhs());
       // restore      
       current=old_current;
       next=old_next;
@@ -242,8 +243,10 @@ literalt instantiate_bmc_mapt::convert_bool(const exprt &expr)
         if(
           to_integer_non_constant(expr.op0(), from) ||
           to_integer_non_constant(expr.op1(), to))
+        {
           throw "failed to convert sva_cycle_delay offsets";
-          
+        }
+
         // this is an 'or'
         bvt disjuncts;
         
@@ -293,8 +296,9 @@ literalt instantiate_bmc_mapt::convert_bool(const exprt &expr)
   else if(expr.id()==ID_sva_sequence_concatenation)
   {
     if(expr.operands().size()==2)
-      return prop.land(convert_bool(expr.op0()),
-                       convert_bool(expr.op1()));
+      return prop.land(
+        convert_bool(to_binary_expr(expr).op0()),
+        convert_bool(to_binary_expr(expr).op1()));
   }
 
   return SUB::convert_bool(expr);
@@ -535,8 +539,9 @@ literalt instantiate_var_mapt::convert_bool(const exprt &expr)
   {
     // same as regular implication
     if(expr.operands().size()==2)
-      return prop.limplies(convert_bool(expr.op0()),
-                           convert_bool(expr.op1()));
+      return prop.limplies(
+        convert_bool(to_binary_expr(expr).op0()),
+        convert_bool(to_binary_expr(expr).op1()));
   }
 
   return SUB::convert_bool(expr);

--- a/src/trans-netlist/trans_trace.cpp
+++ b/src/trans-netlist/trans_trace.cpp
@@ -359,9 +359,8 @@ static std::string as_vcd_binary(
     return result;
   }
   else if(expr.id()==ID_union)
-  { 
-    assert(expr.operands().size()==1);
-    return as_vcd_binary(expr.op0(), ns);
+  {
+    return as_vcd_binary(to_union_expr(expr).op(), ns);
   }
 
   // build "xxx"

--- a/src/trans-netlist/unwind_netlist.cpp
+++ b/src/trans-netlist/unwind_netlist.cpp
@@ -179,11 +179,9 @@ void unwind_property(
   if(property_expr.id()!=ID_AG &&
      property_expr.id()!=ID_sva_always)
     throw "unsupported property - only SVA always implemented";
-  
-  assert(property_expr.operands().size()==1);
 
-  const exprt &p=property_expr.op0();
-  
+  const exprt &p = to_unary_expr(property_expr).op();
+
   for(unsigned c=0; c<map.get_no_timeframes(); c++)
   {
     literalt l=instantiate_convert(solver, map, p, c, c+1, ns, message_handler);

--- a/src/trans-word-level/instantiate_word_level.cpp
+++ b/src/trans-word-level/instantiate_word_level.cpp
@@ -129,8 +129,8 @@ void wl_instantiatet::instantiate_rec(exprt &expr)
     if(expr.operands().size()==2)
     {
       expr.id(ID_implies);
-      instantiate_rec(expr.op0());
-      
+      instantiate_rec(to_binary_expr(expr).op0());
+
       save_currentt save_current(current);
       
       current++;
@@ -138,9 +138,9 @@ void wl_instantiatet::instantiate_rec(exprt &expr)
       // Do we exceed the bound? Make it 'true',
       // works on NNF only
       if(current>=no_timeframes)
-        expr.op1()=true_exprt();
+        to_binary_expr(expr).op1() = true_exprt();
       else
-        instantiate_rec(expr.op1());
+        instantiate_rec(to_binary_expr(expr).op1());
     }
   }
   else if(expr.id()==ID_sva_cycle_delay) // ##[1:2] something
@@ -169,7 +169,6 @@ void wl_instantiatet::instantiate_rec(exprt &expr)
       else
       {
         mp_integer from, to;
-
         if(to_integer_non_constant(expr.op0(), from))
           throw "failed to convert sva_cycle_delay offsets";
           
@@ -221,7 +220,7 @@ void wl_instantiatet::instantiate_rec(exprt &expr)
 
     for(; current<no_timeframes; current++)
     {
-      conjuncts.push_back(expr.op0());
+      conjuncts.push_back(to_unary_expr(expr).op());
       instantiate_rec(conjuncts.back());
     }
     
@@ -239,7 +238,7 @@ void wl_instantiatet::instantiate_rec(exprt &expr)
     
     if(current<no_timeframes)
     {
-      expr=expr.op0();
+      expr = to_unary_expr(expr).op();
       instantiate_rec(expr);
     }
     else
@@ -265,7 +264,7 @@ void wl_instantiatet::instantiate_rec(exprt &expr)
       save_currentt save_current(current);
       for(; current<no_timeframes; current++)
       {
-        disjuncts.push_back(expr.op0());
+        disjuncts.push_back(to_unary_expr(expr).op());
         instantiate_rec(disjuncts.back());
       }
       expr=disjunction(disjuncts);
@@ -286,10 +285,10 @@ void wl_instantiatet::instantiate_rec(exprt &expr)
     save_currentt save_current(current);
     
     // we expand: p U q <=> q || (p && X(p U q))
-    exprt tmp_q=expr.op1();
+    exprt tmp_q = to_binary_expr(expr).op1();
     instantiate_rec(tmp_q);
-    
-    exprt expansion=expr.op0();
+
+    exprt expansion = to_binary_expr(expr).op0();
     instantiate_rec(expansion);
     
     current++;
@@ -311,7 +310,7 @@ void wl_instantiatet::instantiate_rec(exprt &expr)
     assert(expr.operands().size()==2);
     
     // we rewrite using 'next'
-    exprt tmp=expr;
+    binary_exprt tmp = to_binary_expr(expr);
     if(expr.id()==ID_sva_until_with)
       tmp.id(ID_sva_until);
     else

--- a/src/trans-word-level/property.cpp
+++ b/src/trans-word-level/property.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cstdlib>
 
 #include <util/namespace.h>
+#include <util/std_expr.h>
 
 #include "instantiate_word_level.h"
 #include "property.h"
@@ -44,10 +45,8 @@ void property(const exprt &property_expr, bvt &prop_bv,
     exit(1);
   }
 
-  assert(property_expr.operands().size()==1);
+  const exprt &p = to_unary_expr(property_expr).op();
 
-  const exprt &p=property_expr.op0();
-  
   for(unsigned c=0; c<no_timeframes; c++)
   {
     exprt tmp=

--- a/src/trans-word-level/word_level_trans.cpp
+++ b/src/trans-word-level/word_level_trans.cpp
@@ -56,8 +56,8 @@ void word_level_transt::read_trans_rec(const exprt &expr)
   }
   else if(expr.id()==ID_equal)
   {
-    assert(expr.operands().size()==2);
-    equality(expr.op0(), expr.op1());
+    auto &equal_expr = to_equal_expr(expr);
+    equality(equal_expr.lhs(), equal_expr.rhs());
   }
   else
     throw "word_level_transt: unexpected proposition "

--- a/src/verilog/expr2verilog_class.h
+++ b/src/verilog/expr2verilog_class.h
@@ -9,7 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_VERILOG_EXPR2VERILOG_H
 #define CPROVER_VERILOG_EXPR2VERILOG_H
 
-#include <util/expr.h>
+#include <util/std_expr.h>
 
 class expr2verilogt
 {
@@ -25,34 +25,26 @@ public:
     unsigned precedence);
 
   virtual std::string convert_binary(
-    const exprt &src,
+    const multi_ary_exprt &,
     const std::string &symbol,
     unsigned precedence);
 
   virtual std::string convert_unary(
-    const exprt &src,
+    const unary_exprt &,
     const std::string &symbol,
     unsigned precedence);
 
-  virtual std::string convert_if(
-    const exprt &src,
-    unsigned precedence);
+  virtual std::string convert_if(const if_exprt &, unsigned precedence);
 
-  virtual std::string convert_index(
-    const index_exprt &src,
-    unsigned precedence);
+  virtual std::string convert_index(const index_exprt &, unsigned precedence);
 
-  virtual std::string convert_extractbit(
-    const extractbit_exprt &src,
-    unsigned precedence);
+  virtual std::string
+  convert_extractbit(const extractbit_exprt &, unsigned precedence);
 
-  virtual std::string convert_member(
-    const exprt &src,
-    unsigned precedence);
+  virtual std::string convert_member(const member_exprt &, unsigned precedence);
 
-  virtual std::string convert_extractbits(
-    const extractbits_exprt &src,
-    unsigned precedence);
+  virtual std::string
+  convert_extractbits(const extractbits_exprt &, unsigned precedence);
 
   virtual std::string convert(
     const exprt &src,
@@ -72,17 +64,14 @@ public:
     const exprt &src,
     unsigned &precedence);
 
-  virtual std::string convert_constant(
-    const constant_exprt &src,
-    unsigned &precedence);
+  virtual std::string
+  convert_constant(const constant_exprt &, unsigned &precedence);
 
-  virtual std::string convert_typecast(
-    const typecast_exprt &src,
-    unsigned &precedence);
+  virtual std::string
+  convert_typecast(const typecast_exprt &, unsigned &precedence);
 
-  virtual std::string convert_concatenation(
-    const concatenation_exprt &src,
-    unsigned precedence);
+  virtual std::string
+  convert_concatenation(const concatenation_exprt &, unsigned precedence);
 
   virtual std::string convert_function(
     const std::string &name,
@@ -92,27 +81,22 @@ public:
     const std::string &name,
     const exprt &src);
 
-  virtual std::string convert_replication(
-    const replication_exprt &src,
-    unsigned precedence);
+  virtual std::string
+  convert_replication(const replication_exprt &, unsigned precedence);
 
   virtual std::string convert_norep(
     const exprt &src,
     unsigned &precedence);
 
-  virtual std::string convert_with(
-    const exprt &src,
-    unsigned precedence);
+  virtual std::string convert_with(const with_exprt &, unsigned precedence);
 
-  virtual std::string convert_sva_cycle_delay(
-    const exprt &src,
-    unsigned precedence);
+  virtual std::string
+  convert_sva_cycle_delay(const exprt &, unsigned precedence);
 
-  virtual std::string convert_sva_sequence_concatenation(
-    const exprt &src,
-    unsigned precedence);
+  virtual std::string
+  convert_sva_sequence_concatenation(const binary_exprt &, unsigned precedence);
 
-  virtual std::string convert_function_call(const exprt &src);
+  virtual std::string convert_function_call(const class function_call_exprt &);
 };
 
 #endif

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -96,14 +96,14 @@ private:
   void convert_nullary_expr(exprt &);
   void convert_unary_expr  (unary_exprt &);
   void convert_binary_expr (binary_exprt &);
-  void convert_trinary_expr(exprt &);
+  void convert_trinary_expr(ternary_exprt &);
   void convert_expr_function_call(class function_call_exprt &);
   void convert_system_function(const irep_idt &identifier,
                                class function_call_exprt &);
   void convert_constraint_select_one(exprt &);
-  void convert_extractbit_expr(exprt &);
-  void convert_replication_expr(exprt &);
-  void convert_shl_expr(exprt &);
+  void convert_extractbit_expr(extractbit_exprt &);
+  void convert_replication_expr(replication_exprt &);
+  void convert_shl_expr(shl_exprt &);
   void typecast(exprt &, const typet &type);
   void tc_binary_expr(exprt &);
   void tc_binary_expr(const exprt &expr, exprt &op0, exprt &op1);

--- a/src/vhdl/vhdl_typecheck.cpp
+++ b/src/vhdl/vhdl_typecheck.cpp
@@ -124,13 +124,12 @@ void vhdl_typecheckt::typecheck_expr(exprt &expr)
     for(auto & op : expr.operands())
       typecheck_expr(op);
 
-    expr.type()=expr.op0().type();
+    expr.type() = to_binary_expr(expr).op0().type();
   }
   else if(expr.id()==ID_not)
   {
-    assert(expr.operands().size()==1);
-    typecheck_expr(expr.op0());
-    expr.type()=expr.op0().type();
+    typecheck_expr(to_not_expr(expr).op());
+    expr.type() = to_not_expr(expr).op().type();
   }
   else if(expr.id()==ID_symbol)
   {
@@ -173,10 +172,10 @@ void vhdl_typecheckt::typecheck_expr(exprt &expr)
           expr.id()==ID_lt || expr.id()==ID_gt)
   {
     assert(expr.operands().size()==2);
-    
-    typecheck_expr(expr.op0());
-    typecheck_expr(expr.op1());
-  
+
+    typecheck_expr(to_binary_expr(expr).lhs());
+    typecheck_expr(to_binary_expr(expr).rhs());
+
     // result is always boolean
     expr.type()=bool_typet();
   }


### PR DESCRIPTION
Objects with specific expression class types are casted up to that type. This avoids direct, unguarded accesses to `exprt::op0`, `op1`, etc.