### PR TITLE
remove copies of integer_typet and natural_typet

### DIFF
--- a/src/util/ebmc_util.h
+++ b/src/util/ebmc_util.h
@@ -14,16 +14,6 @@
 
 #include <solvers/sat/cnf.h>
 
-class integer_typet : public typet {
-public:
-  integer_typet() : typet(ID_integer) {}
-};
-
-class natural_typet : public typet {
-public:
-  natural_typet() : typet(ID_natural) {}
-};
-
 template <typename F>
 void for_all_module_symbols(const symbol_tablet &symbol_table,
                             const irep_idt &module_name, F &&f) {

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <cstring>
 
 #include <util/ebmc_util.h>
+#include <util/mathematical_types.h>
 #include <util/std_expr.h>
 #include <util/c_types.h>
 

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <set>
 
 #include <util/ebmc_util.h>
+#include <util/mathematical_types.h>
 #include <util/std_types.h>
 
 #include "verilog_typecheck.h"

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/ebmc_util.h>
 #include <util/expr_util.h>
 #include <util/identifier.h>
+#include <util/mathematical_types.h>
 #include <util/simplify_expr.h>
 #include <util/std_expr.h>
 

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/ebmc_util.h>
 #include <util/expr_util.h>
+#include <util/mathematical_types.h>
 #include <util/replace_symbol.h>
 #include <util/simplify_expr.h>
 #include <util/std_expr.h>

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/ebmc_util.h>
 #include <util/expr_util.h>
+#include <util/mathematical_types.h>
 #include <util/namespace.h>
 #include <util/prefix.h>
 #include <util/simplify_expr.h>

--- a/src/verilog/verilog_typecheck_type.cpp
+++ b/src/verilog/verilog_typecheck_type.cpp
@@ -7,6 +7,7 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 #include <util/ebmc_util.h>
+#include <util/mathematical_types.h>
 
 #include "verilog_typecheck_expr.h"
 


### PR DESCRIPTION
This removes the copies of `integer_typet` and `natural_typet` introduced in f374bd54197a19d117f1258e32c4242109449831, and replaces them by including the appropriate header file.