### PR TITLE
replace exprt::move_to_operands by add_to_operands(std::move(...))

### DIFF
--- a/src/smvlang/parser.y
+++ b/src/smvlang/parser.y
@@ -25,7 +25,7 @@ extern char *yytext;
 
 /*------------------------------------------------------------------------*/
 
-#define mto(x, y) stack_expr(x).move_to_operands(stack_expr(y))
+#define mto(x, y) stack_expr(x).add_to_operands(std::move(stack_expr(y)))
 
   /*******************************************************************\
 

--- a/src/smvlang/smv_typecheck.cpp
+++ b/src/smvlang/smv_typecheck.cpp
@@ -1091,8 +1091,8 @@ void smv_typecheckt::convert(exprt &expr, expr_modet expr_mode)
       exprt &condition=it->op0();
       exprt &value=it->op1();
 
-      expr.move_to_operands(condition);
-      expr.move_to_operands(value);
+      expr.add_to_operands(std::move(condition));
+      expr.add_to_operands(std::move(value));
     }
 
     expr.id(ID_cond);

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -24,7 +24,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 //#define YYDEBUG 1
 
-#define mto(x, y) stack_expr(x).move_to_operands(stack_expr(y))
+#define mto(x, y) stack_expr(x).add_to_operands(std::move(stack_expr(y)))
 #define mts(x, y) stack_expr(x).move_to_sub((irept &)stack_expr(y))
 #define swapop(x, y) stack_expr(x).operands().swap(stack_expr(y).operands())
 #define addswap(x, y, z) stack_expr(x).add(y).swap(stack_expr(z))
@@ -139,7 +139,7 @@ static void extractbit(YYSTYPE &expr, YYSTYPE &identifier, YYSTYPE &part)
 {
   init(expr, ID_extractbit);
   mto(expr, identifier);
-  stack_expr(expr).move_to_operands(stack_expr(part).op0());
+  stack_expr(expr).add_to_operands(std::move(stack_expr(part).op0()));
 }
 
 /*******************************************************************\
@@ -161,8 +161,8 @@ static void extractbits(YYSTYPE &expr, YYSTYPE &identifier, YYSTYPE &range)
   
   if(stack_expr(range).id()==ID_part_select)
   {
-    stack_expr(expr).move_to_operands(stack_expr(range).op0(),
-                                 stack_expr(range).op1());
+    stack_expr(expr).add_to_operands(std::move(stack_expr(range).op0()),
+                                 std::move(stack_expr(range).op1()));
   }
   else if(stack_expr(range).id()==ID_indexed_part_select_plus)
   {
@@ -942,7 +942,7 @@ port_declaration_brace:
 	| port_declaration_brace ',' port_identifier
 		{ $$=$1;
 		  exprt decl(ID_decl);
-		  decl.move_to_operands(stack_expr($3));
+		  decl.add_to_operands(std::move(stack_expr($3)));
 		  // grab the type and class from previous!
 		  const irept &prev=stack_expr($$).get_sub().back();
                   decl.set(ID_type, prev.find(ID_type));
@@ -2117,13 +2117,13 @@ conditional_statement:
 case_statement:
 	  TOK_CASE '(' expression ')' case_item_brace TOK_ENDCASE
 		{ init($$, ID_case);  mto($$, $3);
-                  Forall_operands(it, stack_expr($5)) stack_expr($$).move_to_operands(*it); }
+                  Forall_operands(it, stack_expr($5)) stack_expr($$).add_to_operands(std::move(*it)); }
 	| TOK_CASEX '(' expression ')' case_item_brace TOK_ENDCASE
 		{ init($$, ID_casex); mto($$, $3);
-                  Forall_operands(it, stack_expr($5)) stack_expr($$).move_to_operands(*it); }
+                  Forall_operands(it, stack_expr($5)) stack_expr($$).add_to_operands(std::move(*it)); }
 	| TOK_CASEZ '(' expression ')' case_item_brace TOK_ENDCASE
 		{ init($$, ID_casez); mto($$, $3);
-                  Forall_operands(it, stack_expr($5)) stack_expr($$).move_to_operands(*it); }
+                  Forall_operands(it, stack_expr($5)) stack_expr($$).add_to_operands(std::move(*it)); }
 	;
 
 case_item_brace:

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -434,7 +434,7 @@ void verilog_synthesist::assignment_rec(
     new_rhs.reserve_operands(3);
     new_rhs.add_to_operands(lhs_array);
     new_rhs.add_to_operands(lhs_index);
-    new_rhs.move_to_operands(rhs);
+    new_rhs.add_to_operands(std::move(rhs));
 
     // do the array
     synth_expr(new_rhs.op0(), symbol_statet::FINAL);
@@ -507,15 +507,15 @@ void verilog_synthesist::assignment_rec(
       exprt rhs_extractbit(ID_extractbit, bool_typet());
       rhs_extractbit.reserve_operands(2);
       rhs_extractbit.add_to_operands(rhs);
-      rhs_extractbit.move_to_operands(offset);
+      rhs_extractbit.add_to_operands(std::move(offset));
 
       exprt count=from_integer(i, integer_typet());
 
       exprt new_rhs(ID_with, lhs_bv.type());
       new_rhs.reserve_operands(3);
       new_rhs.add_to_operands(synth_lhs_bv);
-      new_rhs.move_to_operands(count);
-      new_rhs.move_to_operands(rhs_extractbit);
+      new_rhs.add_to_operands(std::move(count));
+      new_rhs.add_to_operands(std::move(rhs_extractbit));
 
       // do the value
       assignment_rec(lhs_bv, new_rhs, new_value); // recursive call
@@ -530,8 +530,8 @@ void verilog_synthesist::assignment_rec(
         assert(last_value.id()==ID_with);
         assert(last_value.operands().size()>=3);
 
-        last_value.move_to_operands(new_value.op1());
-        last_value.move_to_operands(new_value.op2());
+        last_value.add_to_operands(std::move(new_value.op1()));
+        last_value.add_to_operands(std::move(new_value.op2()));
       }
     }
 
@@ -554,8 +554,8 @@ void verilog_synthesist::assignment_rec(
     tmp.swap(new_value.op0());
 
     tmp.reserve_operands(tmp.operands().size()+2);
-    tmp.move_to_operands(new_value.op1());
-    tmp.move_to_operands(new_value.op2());
+    tmp.add_to_operands(std::move(new_value.op1()));
+    tmp.add_to_operands(std::move(new_value.op2()));
 
     new_value.swap(tmp);
   }
@@ -951,7 +951,7 @@ void verilog_synthesist::instantiate_port(
   if(equality.op0().type()!=equality.op1().type())
     equality.op0() = typecast_exprt{equality.op0(), equality.op1().type()};
 
-  trans.invar().move_to_operands(equality);
+  trans.invar().add_to_operands(std::move(equality));
 }
 
 /*******************************************************************\
@@ -1082,7 +1082,7 @@ void verilog_synthesist::synth_module_instance_builtin(
       constraint.set(ID_module, module);
     
       assert(trans.operands().size()==3);
-      trans.invar().move_to_operands(constraint);
+      trans.invar().add_to_operands(std::move(constraint));
     }
     else if(module==ID_nmos ||
             module==ID_pmos ||
@@ -1097,7 +1097,7 @@ void verilog_synthesist::synth_module_instance_builtin(
       constraint.set(ID_module, module);
     
       assert(trans.operands().size()==3);
-      trans.invar().move_to_operands(constraint);
+      trans.invar().add_to_operands(std::move(constraint));
     }
     else if(module==ID_and ||
             module==ID_nand ||
@@ -1112,7 +1112,7 @@ void verilog_synthesist::synth_module_instance_builtin(
       {
         equal_exprt constraint{instance.operands()[0],
                                instance.operands().back()};
-        trans.invar().move_to_operands(constraint);
+        trans.invar().add_to_operands(std::move(constraint));
       }
       else
       {
@@ -1136,12 +1136,12 @@ void verilog_synthesist::synth_module_instance_builtin(
 
           equal_exprt constraint(instance.op0(), op);
           assert(trans.operands().size()==3);
-          trans.invar().move_to_operands(constraint);
+          trans.invar().add_to_operands(std::move(constraint));
         }
       }
-      
+
       /*assert(instance.operands().size()!=3);      
-      op.move_to_operands(instance.op1(), instance.op2());
+      op.add_to_operands(std::move(instance.op1()), std::move(instance.op2()));
       
       if(instance.type().id()!=ID_bool)
         op.id("bit"+op.id_string());
@@ -1149,7 +1149,7 @@ void verilog_synthesist::synth_module_instance_builtin(
       equal_exprt constraint(instance.op0(), op);
     
       assert(trans.operands().size()!=3);
-      trans.invar().move_to_operands(constraint);
+      trans.invar().add_to_operands(std::move(constraint));
       */
     }
     else if(module==ID_buf)
@@ -1162,7 +1162,7 @@ void verilog_synthesist::synth_module_instance_builtin(
                                instance.operands().back()};
 
         assert(trans.operands().size()==3);
-        trans.invar().move_to_operands(constraint);
+        trans.invar().add_to_operands(std::move(constraint));
       }
     }
     else if(module==ID_not)
@@ -1180,7 +1180,7 @@ void verilog_synthesist::synth_module_instance_builtin(
         equal_exprt constraint{op, instance.operands().back()};
 
         assert(trans.operands().size()==3);
-        trans.invar().move_to_operands(constraint);
+        trans.invar().add_to_operands(std::move(constraint));
       }
     }
     else if(module=="tranif0" ||
@@ -1196,7 +1196,7 @@ void verilog_synthesist::synth_module_instance_builtin(
       constraint.set(ID_module, module);
     
       assert(trans.operands().size()==3);
-      trans.invar().move_to_operands(constraint);
+      trans.invar().add_to_operands(std::move(constraint));
     }
     else if(module=="tran"  ||
             module=="rtran")
@@ -1209,7 +1209,7 @@ void verilog_synthesist::synth_module_instance_builtin(
       constraint.set(ID_module, module);
     
       assert(trans.operands().size()==3);
-      trans.invar().move_to_operands(constraint);
+      trans.invar().add_to_operands(std::move(constraint));
     }
     else
     {
@@ -1317,7 +1317,7 @@ void verilog_synthesist::expand_module_instance(
     replace_symbols(replace_map, tmp);
 
     for(unsigned i=0; i<3; i++)
-      trans.operands()[i].move_to_operands(tmp.operands()[i]);
+      trans.operands()[i].add_to_operands(std::move(tmp.operands()[i]));
   }
 
   instantiate_ports(instance, op, symbol, replace_map, trans);
@@ -1985,7 +1985,7 @@ void verilog_synthesist::synth_case(
 
     if_statement.op1()=e.op1();
 
-    last_if->move_to_operands(if_statement);
+    last_if->add_to_operands(std::move(if_statement));
     last_if=&last_if->operands().back();
   }
 
@@ -2681,7 +2681,7 @@ void verilog_synthesist::synth_assignments(
 
   equal_exprt equality_expr{symbol_expr(symbol, curr_or_next), new_value};
 
-  constraints.move_to_operands(equality_expr);
+  constraints.add_to_operands(std::move(equality_expr));
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -437,7 +437,7 @@ void verilog_typecheck_exprt::convert_system_function(
     {
       exprt tmp(ID_typecast, argument.type());
       tmp.type().id(ID_signedbv);
-      tmp.move_to_operands(argument);
+      tmp.add_to_operands(std::move(argument));
       tmp.add_source_location()=expr.source_location();
       expr.swap(tmp);
     }
@@ -1298,7 +1298,7 @@ void verilog_typecheck_exprt::typecast(
 
       exprt tmp(ID_extractbit, bool_typet());
       exprt no_expr=from_integer(0, integer_typet());
-      tmp.move_to_operands(expr, no_expr);
+      tmp.add_to_operands(std::move(expr), std::move(no_expr));
       expr.swap(tmp);
       return;
     }

--- a/src/vhdl/parser.y
+++ b/src/vhdl/parser.y
@@ -18,7 +18,9 @@
 #define stack(x) (PARSER.stack[x.stack_index])
 #define stack_type(x) (static_cast<typet &>(static_cast<irept &>(PARSER.stack[x.stack_index])))
 
-#define mto(x, y) stack(x).move_to_operands(stack(y))
+#define mto(x, y) stack(x).add_to_operands(std::move(stack(y)))
+#define mto2(dest, s1, s2) stack(dest).add_to_operands(std::move(stack(s1)), std::move(stack(s2)))
+#define mto3(dest, s1, s2, s3) stack(dest).add_to_operands(std::move(stack(s1)), std::move(stack(s2)), std::move(stack(s3)))
 #define mts(x, y) stack(x).move_to_sub(stack(y))
 
 int yyvhdllex();
@@ -848,7 +850,7 @@ process_item:
          init($$, ID_code);
          $1.set_location(stack($$));
          stack($$).set(ID_statement, ID_ifthenelse);
-         stack($$).move_to_operands(stack($2), stack($4), stack($5));
+         mto3($$, $2, $4, $5);
        }
        | TOK_FOR signal TOK_IN expr TOK_TO expr TOK_LOOP process_body TOK_END TOK_LOOP ';'
        {
@@ -926,7 +928,7 @@ elsepart:
        {
          init($$, ID_code);
          stack($$).set(ID_statement, ID_ifthenelse);
-         stack($$).move_to_operands(stack($2), stack($4), stack($5));
+         mto3($$, $2, $4, $5);
        }
        | TOK_ELSE process_body
        {
@@ -983,12 +985,12 @@ sigvalue:
        | expr delay_opt TOK_WHEN expr ';'
        {
          init($$, ID_when);
-         stack($$).move_to_operands(stack($1), stack($4));
+         mto2($$, $1, $4);
        }
        | expr delay_opt TOK_WHEN expr TOK_ELSE sigvalue
        {
          init($$, ID_when);
-         stack($$).move_to_operands(stack($1), stack($4), stack($6));
+         mto3($$, $1, $4, $6);
        }
        ;
 
@@ -1045,7 +1047,7 @@ signal:
        | name '(' expr updown expr ')'
        {
          init($$, ID_extractbits);
-         stack($$).move_to_operands(stack($1), stack($3), stack($5));
+         mto3($$, $1, $3, $5);
        }
        | name '(' name '\'' TOK_RANGE ')'
        {
@@ -1125,7 +1127,7 @@ expr:
        { // Vector chaining
          init($$, ID_concatenation);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | '-' expr %prec UMINUS
        {
@@ -1143,67 +1145,67 @@ expr:
        {
          init($$, ID_plus);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr '-' expr
        {
          init($$, ID_minus);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr TOK_SLL expr
        {
          init($$, ID_shl);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr TOK_SRL expr
        {
          init($$, ID_lshr);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr TOK_SLA expr
        {
          init($$, ID_shl);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr TOK_SRA expr
        {
          init($$, ID_ashr);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr TOK_ROL expr
        {
          init($$, ID_rol);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr TOK_ROR expr
        {
          init($$, ID_ror);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr '*' expr
        {
          init($$, ID_mult);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr '/' expr
        {
          init($$, ID_div);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr TOK_MOD expr
        {
          init($$, ID_mod);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | TOK_NOT expr
        {
@@ -1215,37 +1217,37 @@ expr:
        {
          init($$, ID_and);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr TOK_NAND expr
        {
          init($$, ID_nand);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr TOK_OR expr
        {
          init($$, ID_or);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr TOK_NOR expr
        {
          init($$, ID_nor);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr TOK_XOR expr
        {
          init($$, ID_xor);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr TOK_XNOR expr
        {
          init($$, ID_xnor);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | name '(' expr_list ')'
        {
@@ -1262,37 +1264,37 @@ expr:
        {
          init($$, ID_equal);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr '>' expr
        {
          init($$, ID_gt);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr TOK_GE expr
        {
          init($$, ID_ge);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr '<' expr
        {
          init($$, ID_lt);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr TOK_LE expr
        {
          init($$, ID_le);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        | expr TOK_NE expr
        {
          init($$, ID_notequal);
          $2.set_location(stack($$));
-         stack($$).move_to_operands(stack($1), stack($3));
+         mto2($$, $1, $3);
        }
        ;
 


### PR DESCRIPTION
This replaces usage of the deprecated `exprt::move_to_operands` by `add_to_operands(std::move(...))`.