### PR TITLE
replace exprt::copy_to_operands by add_to_operands

### DIFF
--- a/src/vcegar/discover_predicates.cpp
+++ b/src/vcegar/discover_predicates.cpp
@@ -185,8 +185,8 @@ void gen_lhs_eq_rhs_preds(const std::set<exprt> &lhs_assignment,
        exprt new_definition_expr(*it2);
        
        exprt new_predicate("=", typet("bool"));
-       new_predicate.copy_to_operands(new_variable_expr);
-       new_predicate.copy_to_operands(new_definition_expr);
+       new_predicate.add_to_operands(new_variable_expr);
+       new_predicate.add_to_operands(new_definition_expr);
        predicates.insert(new_predicate);
        
     }

--- a/src/vcegar/simulator.cpp
+++ b/src/vcegar/simulator.cpp
@@ -103,19 +103,17 @@ bool simulatort::check_spurious_using_bmc
 
      std::list<exprt> properties;
 
-     
-     if (!cmdline.isset("claim"))
-       {
-	 exprt new_property("AG");
-	 new_property.copy_to_operands(spec_property);
-	 properties.push_back(new_property); 
-       }
+     if(!cmdline.isset("claim"))
+     {
+       exprt new_property("AG");
+       new_property.add_to_operands(spec_property);
+       properties.push_back(new_property);
+     }
      else
-       {
-	 exprt new_property(spec_property);
-	 properties.push_back(new_property); 
-       }
-
+     {
+       exprt new_property(spec_property);
+       properties.push_back(new_property);
+     }
 
      property(properties, 
 	      prop_bv, 

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -167,13 +167,13 @@ static void extractbits(YYSTYPE &expr, YYSTYPE &identifier, YYSTYPE &range)
   else if(stack_expr(range).id()==ID_indexed_part_select_plus)
   {
     exprt offset=minus_exprt(stack_expr(range).op1(), from_integer(1, integer_typet{}));
-    stack_expr(expr).copy_to_operands(stack_expr(range).op0(),
+    stack_expr(expr).add_to_operands(stack_expr(range).op0(),
                                  plus_exprt(stack_expr(range).op0(), offset));
   }
   else if(stack_expr(range).id()==ID_indexed_part_select_minus)
   {
     exprt offset=minus_exprt(from_integer(1, integer_typet{}), stack_expr(range).op1());
-    stack_expr(expr).copy_to_operands(stack_expr(range).op0(),
+    stack_expr(expr).add_to_operands(stack_expr(range).op0(),
                                  plus_exprt(stack_expr(range).op0(), offset));
   }
   else
@@ -744,7 +744,7 @@ packed_dimension:
 		{ init($$, ID_array);
 		  stack_type($$).subtype().make_nil();
 		  exprt &range=static_cast<exprt &>(stack_type($$).add(ID_range));
-		  range.copy_to_operands(stack_expr($2), stack_expr($4)); }
+		  range.add_to_operands(stack_expr($2), stack_expr($4)); }
 	| unsized_dimension
 	;
 
@@ -753,7 +753,7 @@ unpacked_dimension:
 		{ init($$, ID_array);
 		  stack_type($$).subtype().make_nil();
 		  exprt &range=static_cast<exprt &>(stack_type($$).add(ID_range));
-		  range.copy_to_operands(stack_expr($2), stack_expr($4)); }
+		  range.add_to_operands(stack_expr($2), stack_expr($4)); }
 	| '[' expression ']'
 	{
 	  $$=$2;
@@ -2378,7 +2378,7 @@ cycle_delay_range:
         | "##" '[' number TOK_COLON number ']'
                 { init($$, ID_sva_cycle_delay); mto($$, $3); mto($$, $5); }
         | "##" '[' number TOK_COLON '$' ']'
-                { init($$, ID_sva_cycle_delay); mto($$, $3); stack_expr($$).copy_to_operands(exprt(ID_infinity)); }
+                { init($$, ID_sva_cycle_delay); mto($$, $3); stack_expr($$).add_to_operands(exprt(ID_infinity)); }
         ;
 
 unary_operator:

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -852,12 +852,11 @@ public:
   {
     operands().resize(2);
   }
-  
-  inline verilog_assignt(
-    const irep_idt &_id,
-    const exprt &_lhs, const exprt &_rhs):verilog_statementt(_id)
+
+  inline verilog_assignt(const irep_idt &_id, exprt _lhs, exprt _rhs)
+    : verilog_statementt(_id)
   {
-    copy_to_operands(_lhs, _rhs);
+    add_to_operands(std::move(_lhs), std::move(_rhs));
   }
   
   inline const exprt &lhs() const

--- a/src/verilog/verilog_generate.cpp
+++ b/src/verilog/verilog_generate.cpp
@@ -62,7 +62,7 @@ void verilog_typecheckt::elaborate_generate_item(
   {
     // no need for elaboration
     exprt tmp("set_genvars");
-    tmp.copy_to_operands(statement);
+    tmp.add_to_operands(statement);
     irept &variables=tmp.add("variables");
     
     for(const auto & it : genvars)

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -283,7 +283,7 @@ void verilog_synthesist::assignment(
       if(it->type().id()==ID_bool)
       {
         exprt bit_extract(ID_extractbit, it->type());
-        bit_extract.copy_to_operands(rhs, offset_constant);
+        bit_extract.add_to_operands(rhs, offset_constant);
         offset++;
 
         assignment(*it, bit_extract, blocking);
@@ -432,8 +432,8 @@ void verilog_synthesist::assignment_rec(
     exprt new_rhs(ID_with, lhs_array.type());
 
     new_rhs.reserve_operands(3);
-    new_rhs.copy_to_operands(lhs_array);
-    new_rhs.copy_to_operands(lhs_index);
+    new_rhs.add_to_operands(lhs_array);
+    new_rhs.add_to_operands(lhs_index);
     new_rhs.move_to_operands(rhs);
 
     // do the array
@@ -505,14 +505,14 @@ void verilog_synthesist::assignment_rec(
 
       exprt rhs_extractbit(ID_extractbit, bool_typet());
       rhs_extractbit.reserve_operands(2);
-      rhs_extractbit.copy_to_operands(rhs);
+      rhs_extractbit.add_to_operands(rhs);
       rhs_extractbit.move_to_operands(offset);
 
       exprt count=from_integer(i, integer_typet());
 
       exprt new_rhs(ID_with, lhs_bv.type());
       new_rhs.reserve_operands(3);
-      new_rhs.copy_to_operands(synth_lhs_bv);
+      new_rhs.add_to_operands(synth_lhs_bv);
       new_rhs.move_to_operands(count);
       new_rhs.move_to_operands(rhs_extractbit);
 
@@ -1120,11 +1120,15 @@ void verilog_synthesist::synth_module_instance_builtin(
           exprt op(module, instance.type());
 
           if(i==1)
-            op.copy_to_operands(instance.operands()[i],
-                                instance.operands()[i+1]);
+          {
+            op.add_to_operands(
+              instance.operands()[i], instance.operands()[i + 1]);
+          }
           else
-            op.copy_to_operands(instance.operands()[0],
-                                instance.operands()[i+1]);
+          {
+            op.add_to_operands(
+              instance.operands()[0], instance.operands()[i + 1]);
+          }
 
           if(instance.type().id()!=ID_bool)
             op.id("bit"+op.id_string());
@@ -1167,8 +1171,8 @@ void verilog_synthesist::synth_module_instance_builtin(
       for(unsigned i=0; i<instance.operands().size()-1; i++)
       {
         exprt op(ID_not, instance.type());
-        op.copy_to_operands(instance.operands()[i]);
-      
+        op.add_to_operands(instance.operands()[i]);
+
         if(instance.type().id()!=ID_bool)
           op.id("bit"+op.id_string());
 
@@ -1452,7 +1456,7 @@ void verilog_synthesist::synth_decl(const verilog_declt &statement) {
         // much like a continuous assignment
         verilog_continuous_assignt assign;
         assign.add_source_location()=it->source_location();
-        assign.copy_to_operands(*it);
+        assign.add_to_operands(*it);
         synth_continuous_assign(assign);
       }
     }
@@ -1573,7 +1577,7 @@ void verilog_synthesist::synth_force_rec(
       if(it->type().id()==ID_bool)
       {
         exprt bit_extract(ID_extractbit, it->type());
-        bit_extract.copy_to_operands(rhs, offset_constant);
+        bit_extract.add_to_operands(rhs, offset_constant);
         offset++;
 
         synth_force_rec(*it, bit_extract);
@@ -1587,8 +1591,8 @@ void verilog_synthesist::synth_force_rec(
                                         natural_typet{}};
 
         exprt bit_extract(ID_extractbits, it->type());
-        bit_extract.copy_to_operands(rhs, offset_constant, offset_constant2);
-        
+        bit_extract.add_to_operands(rhs, offset_constant, offset_constant2);
+
         synth_force_rec(*it, bit_extract);
         
         offset+=width;
@@ -2948,7 +2952,7 @@ void verilog_synthesist::convert_module_items(symbolt &symbol)
   synth_assignments(trans);
   
   for(const auto & it : invars)
-    trans.invar().copy_to_operands(it);
+    trans.invar().add_to_operands(it);
 
   trans.invar()=conjunction(trans.invar().operands());
   trans.init()=conjunction(trans.init().operands());

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1262,7 +1262,7 @@ void verilog_typecheck_exprt::typecast(
       unsignedbv_typet tmp_type(1);
       exprt tmp(ID_extractbit, bool_typet());
       exprt no_expr=from_integer(0, integer_typet());
-      tmp.copy_to_operands(typecast_exprt(expr, tmp_type), no_expr);
+      tmp.add_to_operands(typecast_exprt(expr, tmp_type), no_expr);
       expr.swap(tmp);
       return;
     }


### PR DESCRIPTION
This replaces usage of the deprecated `exprt::copy_to_operands` by `add_to_operands`.