### PR TITLE
use symbol_table_baset where possible

### DIFF
--- a/src/ebmc/cegar/bmc_cegar.h
+++ b/src/ebmc/cegar/bmc_cegar.h
@@ -17,22 +17,22 @@ class bmc_cegart:public messaget
 {
 public:
   bmc_cegart(
-    symbol_tablet &_symbol_table,
+    symbol_table_baset &_symbol_table,
     const irep_idt &_main_module,
     message_handlert &_message_handler,
-    const std::list<exprt> &_properties):
-    messaget(_message_handler),
-    symbol_table(_symbol_table),
-    ns(_symbol_table),
-    main_module(_main_module),
-    properties(_properties)
+    const std::list<exprt> &_properties)
+    : messaget(_message_handler),
+      symbol_table(_symbol_table),
+      ns(_symbol_table),
+      main_module(_main_module),
+      properties(_properties)
   {
   }
 
   void bmc_cegar();
   
 protected:
-  symbol_tablet &symbol_table;
+  symbol_table_baset &symbol_table;
   const namespacet ns;
   const irep_idt &main_module;
   const std::list<exprt> &properties;

--- a/src/ebmc/ebmc_base.h
+++ b/src/ebmc/ebmc_base.h
@@ -11,18 +11,19 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <fstream>
 
-#include <util/cmdline.h>
-#include <util/mathematical_expr.h>
-#include <util/message.h>
-#include <util/std_expr.h>
-#include <util/ui_message.h>
-
 #include <langapi/language_file.h>
 #include <solvers/prop/prop_conv_solver.h>
 #include <solvers/sat/cnf.h>
 #include <trans-netlist/bmc_map.h>
 #include <trans-netlist/netlist.h>
 #include <trans-netlist/trans_trace.h>
+
+#include <util/cmdline.h>
+#include <util/mathematical_expr.h>
+#include <util/message.h>
+#include <util/std_expr.h>
+#include <util/symbol_table.h>
+#include <util/ui_message.h>
 
 class ebmc_baset : public messaget {
 public:

--- a/src/hw-cbmc/gen_interface.cpp
+++ b/src/hw-cbmc/gen_interface.cpp
@@ -18,15 +18,18 @@ Author: Daniel Kroening, kroening@kroening.com
 class gen_interfacet
 {
 public:
-  gen_interfacet(const symbol_tablet &_symbol_table,
-                 std::ostream &_out,
-                 std::ostream &_err):
-    symbol_table(_symbol_table), out(_out), err(_err) { }
+  gen_interfacet(
+    const symbol_table_baset &_symbol_table,
+    std::ostream &_out,
+    std::ostream &_err)
+    : symbol_table(_symbol_table), out(_out), err(_err)
+  {
+  }
 
   void gen_interface(const symbolt &top_module, bool have_bound);
 
 protected:
-  const symbol_tablet &symbol_table;
+  const symbol_table_baset &symbol_table;
   std::ostream &out, &err;
 
   std::set<irep_idt> modules_done;
@@ -57,7 +60,7 @@ Function: gen_interfacet::lookup
 
 const symbolt &gen_interfacet::lookup(const irep_idt &identifier)
 {
-  symbol_tablet::symbolst::const_iterator it=
+  symbol_table_baset::symbolst::const_iterator it =
     symbol_table.symbols.find(identifier);
 
   if(it==symbol_table.symbols.end())
@@ -342,7 +345,7 @@ Function: gen_interfacet::gen_interface
 \*******************************************************************/
 
 void gen_interface(
-  const symbol_tablet &symbol_table,
+  const symbol_table_baset &symbol_table,
   const symbolt &top_module,
   bool have_bound,
   std::ostream &out,

--- a/src/hw-cbmc/gen_interface.h
+++ b/src/hw-cbmc/gen_interface.h
@@ -11,10 +11,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <ostream>
 
-#include <util/symbol_table.h>
+#include <util/symbol_table_base.h>
 
 void gen_interface(
-  const symbol_tablet &symbol_table,
+  const symbol_table_baset &,
   const symbolt &top_module,
   bool have_bound,
   std::ostream &out,

--- a/src/hw-cbmc/map_vars.cpp
+++ b/src/hw-cbmc/map_vars.cpp
@@ -62,17 +62,21 @@ void instantiate_symbol(exprt &expr, unsigned timeframe)
 class map_varst:public messaget
 {
 public:
-  map_varst(symbol_tablet &_symbol_table, std::list<exprt> &_constraints,
-            message_handlert &_message, unsigned _no_timeframes):
-    messaget(_message),
-    symbol_table(_symbol_table), constraints(_constraints),
-    no_timeframes(_no_timeframes)
+  map_varst(
+    symbol_table_baset &_symbol_table,
+    std::list<exprt> &_constraints,
+    message_handlert &_message,
+    unsigned _no_timeframes)
+    : messaget(_message),
+      symbol_table(_symbol_table),
+      constraints(_constraints),
+      no_timeframes(_no_timeframes)
   { }
 
   void map_vars(const irep_idt &top_module);
   
 protected:
-  symbol_tablet &symbol_table;
+  symbol_table_baset &symbol_table;
   std::list<exprt> &constraints;
   unsigned no_timeframes;
   std::set<irep_idt> top_level_inputs;
@@ -533,9 +537,9 @@ void map_varst::map_var_rec(
     bool module_instance=ns.follow(c_it->type()).id()==ID_struct;
     
     irep_idt full_name=id2string(prefix)+"."+id2string(base_name);
-    
-    const symbol_tablet::symbolst::const_iterator
-      sub_symbol_it=symbol_table.symbols.find(full_name);
+
+    const symbol_table_baset::symbolst::const_iterator sub_symbol_it =
+      symbol_table.symbols.find(full_name);
 
     if(sub_symbol_it==symbol_table.symbols.end())
     {
@@ -750,9 +754,13 @@ Function: map_vars
 
 \*******************************************************************/
 
-void map_vars(symbol_tablet &symbol_table, const irep_idt &module,
-              std::list<exprt> &constraints, message_handlert &message,
-              unsigned no_timeframes) {
+void map_vars(
+  symbol_table_baset &symbol_table,
+  const irep_idt &module,
+  std::list<exprt> &constraints,
+  message_handlert &message,
+  unsigned no_timeframes)
+{
   map_varst map_vars(symbol_table, constraints, message, no_timeframes);
   map_vars.map_vars(module);
 }

--- a/src/hw-cbmc/map_vars.h
+++ b/src/hw-cbmc/map_vars.h
@@ -9,11 +9,14 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_CBMC_MAP_VARS_H
 #define CPROVER_CBMC_MAP_VARS_H
 
-#include <util/symbol_table.h>
 #include <util/message.h>
+#include <util/symbol_table_base.h>
 
-void map_vars(symbol_tablet &symbol_table, const irep_idt &module,
-              std::list<exprt> &constraints, message_handlert &message,
-              unsigned no_timeframes);
+void map_vars(
+  symbol_table_baset &,
+  const irep_idt &module,
+  std::list<exprt> &constraints,
+  message_handlert &message,
+  unsigned no_timeframes);
 
 #endif

--- a/src/smvlang/smv_language.cpp
+++ b/src/smvlang/smv_language.cpp
@@ -11,6 +11,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "smv_parser.h"
 #include "expr2smv.h"
 
+#include <util/symbol_table.h>
+
 /*******************************************************************\
 
 Function: smv_languaget::parse

--- a/src/smvlang/smv_typecheck.cpp
+++ b/src/smvlang/smv_typecheck.cpp
@@ -24,15 +24,15 @@ class smv_typecheckt:public typecheckt
 public:
   smv_typecheckt(
     smv_parse_treet &_smv_parse_tree,
-    symbol_tablet &_symbol_table,
+    symbol_table_baset &_symbol_table,
     const std::string &_module,
     bool _do_spec,
-    message_handlert &_message_handler):
-    typecheckt(_message_handler),
-    smv_parse_tree(_smv_parse_tree),
-    symbol_table(_symbol_table),
-    module(_module),
-    do_spec(_do_spec)
+    message_handlert &_message_handler)
+    : typecheckt(_message_handler),
+      smv_parse_tree(_smv_parse_tree),
+      symbol_table(_symbol_table),
+      module(_module),
+      do_spec(_do_spec)
   {
     nondet_count=0;
   }
@@ -63,7 +63,7 @@ public:
 
 protected:
   smv_parse_treet &smv_parse_tree;
-  symbol_tablet &symbol_table;
+  symbol_table_baset &symbol_table;
   const std::string &module;
   bool do_spec;
 
@@ -270,7 +270,7 @@ void smv_typecheckt::instantiate(
   const exprt::operandst &operands,
   const source_locationt &location)
 {
-  symbol_tablet::symbolst::const_iterator s_it=
+  symbol_table_baset::symbolst::const_iterator s_it =
     symbol_table.symbols.find(identifier);
 
   if(s_it==symbol_table.symbols.end())
@@ -324,7 +324,7 @@ void smv_typecheckt::instantiate(
       v_it!=symbol_table.symbol_module_map.upper_bound(identifier);
       v_it++)
   {
-    symbol_tablet::symbolst::const_iterator s_it2=
+    symbol_table_baset::symbolst::const_iterator s_it2 =
       symbol_table.symbols.find(v_it->second);
 
     if(s_it2==symbol_table.symbols.end())
@@ -1497,7 +1497,7 @@ Function: smv_typecheck
 
 bool smv_typecheck(
   smv_parse_treet &smv_parse_tree,
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   const std::string &module,
   message_handlert &message_handler,
   bool do_spec)

--- a/src/smvlang/smv_typecheck.h
+++ b/src/smvlang/smv_typecheck.h
@@ -9,17 +9,17 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_SMV_TYPECHECK_H
 #define CPROVER_SMV_TYPECHECK_H
 
-#include <util/symbol_table.h>
 #include <util/message.h>
+#include <util/symbol_table_base.h>
 
 #include "smv_parse_tree.h"
 
 bool smv_typecheck(
   smv_parse_treet &smv_parse_tree,
-  symbol_tablet &symbol_table,
+  symbol_table_baset &,
   const std::string &module,
   message_handlert &message_handler,
-  bool do_spec=true);
+  bool do_spec = true);
 
 std::string smv_module_symbol(const std::string &module);
 

--- a/src/trans-netlist/trans_to_netlist.cpp
+++ b/src/trans-netlist/trans_to_netlist.cpp
@@ -30,20 +30,20 @@ class convert_trans_to_netlistt:public messaget
 {
 public:
   convert_trans_to_netlistt(
-    symbol_tablet &_symbol_table,
+    symbol_table_baset &_symbol_table,
     netlistt &_dest,
-    message_handlert &_message_handler):
-    messaget(_message_handler),
-    symbol_table(_symbol_table),
-    ns(_symbol_table),
-    dest(_dest)
+    message_handlert &_message_handler)
+    : messaget(_message_handler),
+      symbol_table(_symbol_table),
+      ns(_symbol_table),
+      dest(_dest)
   {
   }
 
   void operator()(const irep_idt &module);
   
 protected:
-  symbol_tablet &symbol_table;
+  symbol_table_baset &symbol_table;
   const namespacet ns;
   netlistt &dest;
   
@@ -718,7 +718,7 @@ Function: convert_trans_to_netlist
 \*******************************************************************/
 
 void convert_trans_to_netlist(
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   const irep_idt &module,
   netlistt &dest,
   message_handlert &message_handler)

--- a/src/trans-netlist/trans_to_netlist.h
+++ b/src/trans-netlist/trans_to_netlist.h
@@ -9,15 +9,15 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_TRANS_NETLIST_TRANS_H
 #define CPROVER_TRANS_NETLIST_TRANS_H
 
-#include <util/namespace.h>
-#include <util/message.h>
-#include <util/symbol_table.h>
 #include <util/expr.h>
+#include <util/message.h>
+#include <util/namespace.h>
+#include <util/symbol_table_base.h>
 
 void convert_trans_to_netlist(
-  symbol_tablet &symbol_table,
+  symbol_table_baset &,
   const irep_idt &module,
   class netlistt &dest,
-  message_handlert &message_handler);
+  message_handlert &);
 
 #endif

--- a/src/trans-netlist/trans_trace.h
+++ b/src/trans-netlist/trans_trace.h
@@ -9,9 +9,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_TRANS_TRACE_H
 #define CPROVER_TRANS_TRACE_H
 
-#include <util/ui_message.h>
-#include <util/threeval.h>
+#include <util/expr.h>
 #include <util/namespace.h>
+#include <util/threeval.h>
+#include <util/ui_message.h>
 
 class trans_tracet
 {

--- a/src/trans-netlist/var_map.h
+++ b/src/trans-netlist/var_map.h
@@ -9,16 +9,16 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_TRANS_VAR_MAP_H
 #define CPROVER_TRANS_VAR_MAP_H
 
+#include "bv_varid.h"
+
+#include <solvers/prop/prop.h>
+
+#include <util/type.h>
+
 #include <map>
 #include <set>
 #include <vector>
 #include <string>
-
-#include <util/symbol_table.h>
-
-#include <solvers/prop/prop.h>
-
-#include "bv_varid.h"
 
 class var_mapt
 {

--- a/src/trans-word-level/show_modules.cpp
+++ b/src/trans-word-level/show_modules.cpp
@@ -27,7 +27,7 @@ Function: show_modules
 \*******************************************************************/
 
 void show_modules(
-  const symbol_tablet &symbol_table,
+  const symbol_table_baset &symbol_table,
   ui_message_handlert::uit ui)
 {
   unsigned count=0;

--- a/src/trans-word-level/show_modules.h
+++ b/src/trans-word-level/show_modules.h
@@ -9,11 +9,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_TRANS_SHOW_MODULES_H
 #define CPROVER_TRANS_SHOW_MODULES_H
 
+#include <util/symbol_table_base.h>
 #include <util/ui_message.h>
-#include <util/symbol_table.h>
 
-void show_modules(
-  const symbol_tablet &symbol_table,
-  ui_message_handlert::uit ui);
+void show_modules(const symbol_table_baset &, ui_message_handlert::uit ui);
 
 #endif

--- a/src/vcegar/network_info.h
+++ b/src/vcegar/network_info.h
@@ -14,8 +14,8 @@ Date: July 2004
 #define CPROVER_NETWORK_INFO_H
 
 #include <util/message.h>
-#include <util/symbol_table.h>
 #include <util/namespace.h>
+#include <util/symbol_table_base.h>
 
 #include <trans-netlist/var_map.h>
 #include <verilog/expr2verilog.h>
@@ -33,7 +33,7 @@ class network_infot
   next_state_function_cachet next_state_function_cache;
  
   const var_mapt &var_map;
-  const symbol_tablet &symbol_table;
+  const symbol_table_baset &symbol_table;
 
   void create_network (const exprt& general_constrains,
 		       std::vector<std::set<irep_idt> > &vector_symbolsets,
@@ -87,15 +87,14 @@ class network_infot
  
 
  public:
-  
-  network_infot(const exprt& constraints, 
-		const exprt& trans, 
-		const var_mapt& _var_map,
-		const symbol_tablet& _symbol_table):
-    var_map(_var_map),
-    symbol_table (_symbol_table)
-    { 
-      create (constraints, trans, var_map);
+   network_infot(
+     const exprt &constraints,
+     const exprt &trans,
+     const var_mapt &_var_map,
+     const symbol_table_baset &_symbol_table)
+     : var_map(_var_map), symbol_table(_symbol_table)
+   {
+     create(constraints, trans, var_map);
     }
   
   ~network_infot() { }

--- a/src/vcegar/refiner.h
+++ b/src/vcegar/refiner.h
@@ -15,9 +15,9 @@ Purpose: Calculate predicates for predicate abstraction.
 
 #include <cassert>
 
-#include <util/message.h>
-#include <util/symbol_table.h>
 #include <util/cmdline.h>
+#include <util/message.h>
+#include <util/symbol_table_base.h>
 
 #include "concrete_trans.h"
 #include "predicates.h"
@@ -72,51 +72,52 @@ class refinert:public messaget
 
 
   // Calculates the initial set of predicates for the given program
-  void init_preds(predicatest &predicates, 
-		  const concrete_transt &concrete_trans, 
-		  const symbol_tablet &symbol_table); // symbol_table is for DEBUG
+  void init_preds(
+    predicatest &,
+    const concrete_transt &,
+    const symbol_table_baset &); // symbol_table is for DEBUG
 
   // Calculates the initial set of predicates for the given program
   void init_preds(predicatest &predicates, 
                   const std::vector<exprt> &initial_predicates);
 
-
- void spurious_ce(predicatest &predicates,
-		  const concrete_transt &concrete_trans,
-		  const abstract_counterexamplet &spurious_counterexample,
-		  const symbol_tablet &symbol_table,
-		  const exprt property,
-		  const network_infot &network,
-		  std::vector<std::set<unsigned> > &imp_preds_per_state,
-		  weakest_precondition_constrainst &weakest_precondition_constrains,
-		  bool generate_extra_preds); 
-
- void generate_predicates
-   (predicatest &predicates, 
+  void spurious_ce(
+    predicatest &predicates,
+    const concrete_transt &concrete_trans,
     const abstract_counterexamplet &spurious_counterexample,
-    const symbol_tablet &symbol_table, 
+    const symbol_table_baset &,
+    const exprt property,
     const network_infot &network,
-    std::vector<std::set<unsigned> > &imp_preds_per_state,
+    std::vector<std::set<unsigned>> &imp_preds_per_state,
     weakest_precondition_constrainst &weakest_precondition_constrains,
     bool generate_extra_preds);
 
- void compute_wp_seed_predicate
-   (predicatest &predicates, 
+  void generate_predicates(
+    predicatest &predicates,
     const abstract_counterexamplet &spurious_counterexample,
-    const symbol_tablet &symbol_table, 
+    const symbol_table_baset &,
     const network_infot &network,
-    weakest_precondition_constrainst &weakest_precondition_constrains, //constraints relating a predicate and its wp
-    unsigned pred_num, //we will take wp of this
-    int len, //no. of steps for which to take the weakest pre-condition
-    std::vector<std::set<unsigned> > &imp_preds_per_state,
-    bool generate_extra_preds
-    );
+    std::vector<std::set<unsigned>> &imp_preds_per_state,
+    weakest_precondition_constrainst &weakest_precondition_constrains,
+    bool generate_extra_preds);
 
- void relate_pred_and_wp
-   (const abstract_statet &abstract_state,
+  void compute_wp_seed_predicate(
+    predicatest &predicates,
+    const abstract_counterexamplet &spurious_counterexample,
+    const symbol_table_baset &,
+    const network_infot &network,
+    weakest_precondition_constrainst &
+      weakest_precondition_constrains, //constraints relating a predicate and its wp
+    unsigned pred_num,                 //we will take wp of this
+    int len, //no. of steps for which to take the weakest pre-condition
+    std::vector<std::set<unsigned>> &imp_preds_per_state,
+    bool generate_extra_preds);
+
+  void relate_pred_and_wp(
+    const abstract_statet &abstract_state,
     const std::set<unsigned> preds_used_to_simplify,
     weakest_precondition_constrainst &weakest_precondition_constrains,
-    unsigned pred_num, 
+    unsigned pred_num,
     unsigned wp_pred_num);   
  };
 

--- a/src/vcegar/vcegar_util.h
+++ b/src/vcegar/vcegar_util.h
@@ -13,9 +13,9 @@ Date: June 2003
 
 #include <sstream>
 
-#include <util/message.h>
-#include <util/symbol_table.h>
 #include <util/expr.h>
+#include <util/message.h>
+#include <util/symbol_table_base.h>
 
 #include <verilog/expr2verilog.h>
 #include <trans-netlist/var_map.h>

--- a/src/verilog/verilog_language.cpp
+++ b/src/verilog/verilog_language.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <sstream>
 
 #include <util/suffix.h>
+#include <util/symbol_table.h>
 
 #include "verilog_language.h"
 #include "verilog_typecheck.h"

--- a/src/verilog/verilog_symbol_table.h
+++ b/src/verilog/verilog_symbol_table.h
@@ -9,7 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_VERILOG_CONTEXT_H
 #define CPROVER_VERILOG_CONTEXT_H
 
-#include <util/symbol_table.h>
+#include <util/symbol_table_base.h>
 
 /*******************************************************************\
 
@@ -26,12 +26,13 @@ Author: Daniel Kroening, kroening@kroening.com
 class verilog_symbol_tablet
 {
 public:
-  verilog_symbol_tablet(symbol_tablet &_symbol_table):symbol_table(_symbol_table)
+  verilog_symbol_tablet(symbol_table_baset &_symbol_table)
+    : symbol_table(_symbol_table)
   {
   }
 
 protected:
-  symbol_tablet &symbol_table;
+  symbol_table_baset &symbol_table;
   symbolt &symbol_table_lookup(const irep_idt &identifier);
 };
 

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -828,7 +828,7 @@ const symbolt &verilog_synthesist::assignment_symbol(const exprt &lhs)
 
       const irep_idt &identifier=e->get(ID_identifier);
 
-      symbol_tablet::symbolst::const_iterator it=
+      symbol_table_baset::symbolst::const_iterator it =
         symbol_table.symbols.find(identifier);
 
       if(it==symbol_table.symbols.end())
@@ -3015,7 +3015,7 @@ Function: verilog_synthesis
 \*******************************************************************/
 
 bool verilog_synthesis(
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   const irep_idt &module,
   message_handlert &message_handler,
   const optionst &options)

--- a/src/verilog/verilog_synthesis.h
+++ b/src/verilog/verilog_synthesis.h
@@ -9,14 +9,14 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_VERILOG_SYNTHESIS_H
 #define CPROVER_VERILOG_SYNTHESIS_H
 
-#include <util/symbol_table.h>
 #include <util/message.h>
 #include <util/options.h>
+#include <util/symbol_table_base.h>
 
 bool verilog_synthesis(
-  symbol_tablet &symbol_table,
+  symbol_table_baset &,
   const irep_idt &module,
-  message_handlert &message_handler,
-  const optionst &options);
+  message_handlert &,
+  const optionst &);
 
 #endif

--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -40,17 +40,17 @@ class verilog_synthesist:
 {
 public:
   verilog_synthesist(
-    symbol_tablet &_symbol_table,
+    symbol_table_baset &_symbol_table,
     const irep_idt &_module,
     const optionst &_options,
-    message_handlert &_message_handler):
-    verilog_typecheck_baset(ns, _message_handler),
-    verilog_symbol_tablet(_symbol_table),
-    ns(_symbol_table),
-    options(_options),
-    value_map(NULL),
-    module(_module),
-    temporary_counter(0)
+    message_handlert &_message_handler)
+    : verilog_typecheck_baset(ns, _message_handler),
+      verilog_symbol_tablet(_symbol_table),
+      ns(_symbol_table),
+      options(_options),
+      value_map(NULL),
+      module(_module),
+      temporary_counter(0)
   {
   }
 

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1637,7 +1637,7 @@ Function: verilog_typecheck
 
 bool verilog_typecheck(
   const verilog_parse_treet &parse_tree,
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   const std::string &module,
   message_handlert &message_handler)
 {
@@ -1670,7 +1670,7 @@ Function: verilog_typecheck
 \*******************************************************************/
 
 bool verilog_typecheck(
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   const verilog_modulet &verilog_module,
   message_handlert &message_handler)
 {

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -9,10 +9,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_VERILOG_TYPECHECK_H
 #define CPROVER_VERILOG_TYPECHECK_H
 
-#include <util/symbol_table.h>
-#include <util/typecheck.h>
 #include <util/mp_arith.h>
 #include <util/replace_expr.h>
+#include <util/symbol_table_base.h>
+#include <util/typecheck.h>
 
 #include "verilog_typecheck_expr.h"
 #include "verilog_parse_tree.h"
@@ -20,17 +20,17 @@ Author: Daniel Kroening, kroening@kroening.com
 
 bool verilog_typecheck(
   const verilog_parse_treet &parse_tree,
-  symbol_tablet &symbol_table,
+  symbol_table_baset &,
   const std::string &module,
   message_handlert &message_handler);
 
 bool verilog_typecheck(
-  symbol_tablet &symbol_table,
+  symbol_table_baset &,
   const verilog_modulet &verilog_module,
   message_handlert &message_handler);
 
 bool verilog_typecheck(
-  symbol_tablet &symbol_table,
+  symbol_table_baset &,
   const std::string &module_identifier,
   const exprt::operandst &parameters,
   message_handlert &message_handler);
@@ -54,13 +54,13 @@ class verilog_typecheckt:
 public:
   verilog_typecheckt(
     symbolt &_module_symbol,
-    symbol_tablet &_symbol_table,
-    message_handlert &_message_handler):
-    verilog_typecheck_exprt(ns, _message_handler),
-    verilog_symbol_tablet(_symbol_table),
-    ns(_symbol_table),
-    module_symbol(_module_symbol),
-    assertion_counter(0)
+    symbol_table_baset &_symbol_table,
+    message_handlert &_message_handler)
+    : verilog_typecheck_exprt(ns, _message_handler),
+      verilog_symbol_tablet(_symbol_table),
+      ns(_symbol_table),
+      module_symbol(_module_symbol),
+      assertion_counter(0)
   {}
 
   void typecheck() override;

--- a/src/verilog/verilog_typecheck_base.h
+++ b/src/verilog/verilog_typecheck_base.h
@@ -10,7 +10,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_VERILOG_TYPECHEK_BASE_H
 
 #include <util/namespace.h>
-#include <util/symbol_table.h>
 #include <util/typecheck.h>
 #include <util/mp_arith.h>
 

--- a/src/vhdl/vhdl2expr.h
+++ b/src/vhdl/vhdl2expr.h
@@ -1,8 +1,8 @@
-#include <symbol_table.h>
+#include <symbol_table_base.h>
 
-bool vhdl2expr(const string &code, exprt &expr,
-               const symbol_tablet &symbol_table,
-               const sequentt &sequent,
-               std::string &msg);
-
-
+bool vhdl2expr(
+  const string &code,
+  exprt &expr,
+  const symbol_table_baset &,
+  const sequentt &,
+  std::string &msg);

--- a/src/vhdl/vhdl_language.cpp
+++ b/src/vhdl/vhdl_language.cpp
@@ -7,6 +7,7 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 #include <util/suffix.h>
+#include <util/symbol_table.h>
 
 #include "vhdl_language.h"
 #include "vhdl_typecheck.h"

--- a/src/vhdl/vhdl_libraries.h
+++ b/src/vhdl/vhdl_libraries.h
@@ -6,8 +6,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-#include <util/symbol_table.h>
 #include <util/message.h>
+#include <util/symbol_table.h>
 
 void load_vhdl_library(
   const irep_idt &name,

--- a/src/vhdl/vhdl_std_packages.cpp
+++ b/src/vhdl/vhdl_std_packages.cpp
@@ -8,9 +8,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "vhdl_std_packages.h"
 
-bool vhdl_std_packages(
-  symbol_tablet &,
-  message_handlert &)
+bool vhdl_std_packages(symbol_table_baset &, message_handlert &)
 {
   return false;
 }

--- a/src/vhdl/vhdl_std_packages.h
+++ b/src/vhdl/vhdl_std_packages.h
@@ -9,12 +9,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_VHDL_STD_PACKAGES_H
 #define CPROVER_VHDL_STD_PACKAGES_H
 
-#include <util/symbol_table.h>
 #include <util/message.h>
+#include <util/symbol_table_base.h>
 
-bool vhdl_std_packages(
-  symbol_tablet &,
-  message_handlert &);
+bool vhdl_std_packages(symbol_table_baset &, message_handlert &);
 
 #endif
 

--- a/src/vhdl/vhdl_synthesis.cpp
+++ b/src/vhdl/vhdl_synthesis.cpp
@@ -182,7 +182,7 @@ Function: vhdl_synthesis
 \*******************************************************************/
 
 bool vhdl_synthesis(
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   const irep_idt &module,
   message_handlert &message_handler)
 {

--- a/src/vhdl/vhdl_synthesis.h
+++ b/src/vhdl/vhdl_synthesis.h
@@ -9,11 +9,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_VHDL_SYNTHESIS_H
 #define CPROVER_VHDL_SYNTHESIS_H
 
-#include <util/symbol_table.h>
 #include <util/message.h>
+#include <util/symbol_table_base.h>
 
 bool vhdl_synthesis(
-  symbol_tablet &,
+  symbol_table_baset &,
   const irep_idt &module,
   message_handlert &);
 

--- a/src/vhdl/vhdl_synthesis_class.h
+++ b/src/vhdl/vhdl_synthesis_class.h
@@ -9,27 +9,25 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_VHDL_SYNTHESIS_CLASS_H
 #define CPROVER_VHDL_SYNTHESIS_CLASS_H
 
-#include <util/symbol_table.h>
-#include <util/std_code.h>
 #include <util/message.h>
+#include <util/std_code.h>
+#include <util/symbol_table_base.h>
 
 class vhdl_synthesist:public messaget
 {
 public:
   vhdl_synthesist(
-    symbol_tablet &_symbol_table,
+    symbol_table_baset &_symbol_table,
     const irep_idt &_module,
-    message_handlert &_message_handler):
-    messaget(_message_handler),
-    symbol_table(_symbol_table),
-    module(_module)
+    message_handlert &_message_handler)
+    : messaget(_message_handler), symbol_table(_symbol_table), module(_module)
   {
   }
   
   bool operator()();
 
 protected:
-  symbol_tablet &symbol_table;
+  symbol_table_baset &symbol_table;
   const irep_idt &module;
   const symbolt *module_symbol;
 

--- a/src/vhdl/vhdl_typecheck.cpp
+++ b/src/vhdl/vhdl_typecheck.cpp
@@ -143,9 +143,9 @@ void vhdl_typecheckt::typecheck_expr(exprt &expr)
       id2string(module_symbol->name)+"."+
       id2string(to_lower_identifier);
 
-    symbol_tablet::symbolst::const_iterator s_it=
+    symbol_table_baset::symbolst::const_iterator s_it =
       symbol_table.symbols.find(full_identifier);
-    
+
     if(s_it==symbol_table.symbols.end())
     {
       error() << "symbol `" << identifier << "' not found"
@@ -478,7 +478,7 @@ Function: vhdl_typecheck
 
 bool vhdl_typecheck(
   const vhdl_parse_treet &parse_tree,
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   const std::string &module,
   message_handlert &message_handler)
 {

--- a/src/vhdl/vhdl_typecheck.h
+++ b/src/vhdl/vhdl_typecheck.h
@@ -9,14 +9,14 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_VHDL_TYPECHECK_H
 #define CPROVER_VHDL_TYPECHECK_H
 
-#include <util/symbol_table.h>
 #include <util/message.h>
+#include <util/symbol_table_base.h>
 
 #include "vhdl_parse_tree.h"
 
 bool vhdl_typecheck(
   const vhdl_parse_treet &,
-  symbol_tablet &,
+  symbol_table_baset &,
   const std::string &module,
   message_handlert &);
 

--- a/src/vhdl/vhdl_typecheck_class.h
+++ b/src/vhdl/vhdl_typecheck_class.h
@@ -30,13 +30,13 @@ public:
   vhdl_typecheckt(
     const vhdl_parse_treet &_parse_tree,
     const irep_idt &_module_name,
-    symbol_tablet &_symbol_table,
-    message_handlert &_message_handler):
-    messaget(_message_handler),
-    ns(_symbol_table),
-    parse_tree(_parse_tree),
-    module_name(_module_name),
-    symbol_table(_symbol_table)
+    symbol_table_baset &_symbol_table,
+    message_handlert &_message_handler)
+    : messaget(_message_handler),
+      ns(_symbol_table),
+      parse_tree(_parse_tree),
+      module_name(_module_name),
+      symbol_table(_symbol_table)
   {
   }
 
@@ -47,8 +47,8 @@ protected:
   const vhdl_parse_treet &parse_tree;
   const irep_idt &module_name;
   symbolt *module_symbol;
-  symbol_tablet &symbol_table;
-  
+  symbol_table_baset &symbol_table;
+
   void typecheck_architecture(
     const vhdl_parse_treet::itemt &);
   


### PR DESCRIPTION
This switches use of `symbol_tablet` to the more general `symbol_table_baset`, unless `symbol_tablet` is required by the implemented API.