### PR TITLE
avoid typet::subtype()

### DIFF
--- a/src/ebmc/output_verilog.cpp
+++ b/src/ebmc/output_verilog.cpp
@@ -534,7 +534,7 @@ std::string output_verilog_baset::type_string_base(const typet &type)
   }
   else if(type.id()==ID_array)
   {
-    return type_string_base(type.subtype());
+    return type_string_base(to_array_type(type).subtype());
   }
   else
   {
@@ -563,10 +563,11 @@ std::string output_verilog_baset::type_string_array(const typet &type)
 {
   if(type.id()==ID_array)
   {
+    auto &array_type = to_array_type(type);
     mp_integer size;
-    to_integer_non_constant(to_array_type(type).size(), size);
-    return type_string_array(type.subtype())+
-           " [0:"+integer2string(size)+']';
+    to_integer_non_constant(array_type.size(), size);
+    return type_string_array(array_type.subtype()) +
+           " [0:" + integer2string(size) + ']';
   }
 
   return "";

--- a/src/hw-cbmc/gen_interface.cpp
+++ b/src/hw-cbmc/gen_interface.cpp
@@ -153,13 +153,13 @@ std::string gen_interfacet::type_to_string(const typet& type)
   }
   else if(type.id()==ID_array)
   {
-    const exprt &size_expr=
-      to_array_type(type).size();
- 
+    auto &array_type = to_array_type(type);
+    const exprt &size_expr = array_type.size();
+
     mp_integer size = 0;
     to_integer_non_constant(size_expr, size);
 
-    std::string stype_str = type_to_string(type.subtype());
+    std::string stype_str = type_to_string(array_type.subtype());
     std::string array_str = "[" + integer2string(size)+"]" ;
     std::string key_str = stype_str + array_str;
 

--- a/src/hw-cbmc/map_vars.cpp
+++ b/src/hw-cbmc/map_vars.cpp
@@ -298,7 +298,7 @@ bool map_varst::check_types_rec(
       return array_types_eq(to_array_type(type1), to_array_type(type2), error_msg);
 
     // bool-array is mapped to bit-vector
-    if(type1.subtype().id()!=ID_bool)
+    if(to_array_type(type1).subtype().id() != ID_bool)
     {
       error_msg = "type `" + from_type(ns, "", type1) +
                   "' does not match type `" + from_type(ns, "", type2) +
@@ -718,7 +718,9 @@ void map_varst::map_vars(const irep_idt &top_module)
     exprt timeframe_expr=from_integer(0, index_type());
 
     index_exprt expr(
-      symbol_expr, timeframe_expr, ns.follow(symbol_expr.type()).subtype());
+      symbol_expr,
+      timeframe_expr,
+      to_array_type(ns.follow(symbol_expr.type())).subtype());
 
     top_level_inputs.clear();
 

--- a/src/smvlang/expr2smv.cpp
+++ b/src/smvlang/expr2smv.cpp
@@ -547,7 +547,8 @@ bool type2smv(const typet &type, std::string &code)
   else if(type.id()==ID_array)
   {
     std::string tmp;
-    if(type2smv(type.subtype(), tmp)) return true;
+    if(type2smv(to_array_type(type).subtype(), tmp))
+      return true;
     code="array ";
     code+="..";
     code+=" of ";

--- a/src/trans-netlist/trans_trace.cpp
+++ b/src/trans-netlist/trans_trace.cpp
@@ -266,10 +266,11 @@ static mp_integer vcd_width(
     return string2integer(type.get_string(ID_width));
   else if(type.id()==ID_array)
   {
-    mp_integer sub=vcd_width(type.subtype(), ns);
-  
+    auto &array_type = to_array_type(type);
+    mp_integer sub = vcd_width(array_type.subtype(), ns);
+
     // get size
-    const exprt &size=to_array_type(type).size();
+    const exprt &size = array_type.size();
 
     // constant?
     mp_integer i;
@@ -511,7 +512,8 @@ static std::string vcd_suffix(
   else if(type.id()==ID_array)
   {
     // get size
-    const exprt &size=to_array_type(type).size();
+    auto &array_type = to_array_type(type);
+    const exprt &size = array_type.size();
 
     // constant?
     mp_integer i;
@@ -523,8 +525,9 @@ static std::string vcd_suffix(
     left_bound=0;
     right_bound=left_bound+i-1;
 
-    return"["+integer2string(left_bound)+":"+integer2string(right_bound)+"]"+
-          vcd_suffix(type.subtype(), ns);
+    return "[" + integer2string(left_bound) + ":" +
+           integer2string(right_bound) + "]" +
+           vcd_suffix(array_type.subtype(), ns);
   }
   else if(type.id()==ID_bool)
     return "";

--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -1111,13 +1111,14 @@ std::string expr2verilogt::convert(const typet &type)
   }
   else if(type.id()==ID_array)
   {
+    auto &array_type = to_array_type(type);
     std::string dest="array [";
-    
-    dest+=convert(to_array_type(type).size());
+
+    dest += convert(array_type.size());
 
     dest+="] of ";
-    dest+=convert(type.subtype());
-    
+    dest += convert(array_type.subtype());
+
     return dest;
   }
   else if(type.id()==ID_genvar)

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -55,10 +55,12 @@ array_typet verilog_typecheckt::array_type(
     error().source_location=range.find_source_location();
     error() << "array size must be positive" << eom;
   }
-  
-  const typet src_subtype=
-    static_cast<const typet &>(src).subtype();
-  
+
+  const typet src_subtype =
+    static_cast<const typet &>(src).has_subtype()
+      ? static_cast<const type_with_subtypet &>(src).subtype()
+      : typet(ID_nil);
+
   typet array_subtype;
   
   // may need to go recursive

--- a/src/verilog/verilog_typecheck_base.cpp
+++ b/src/verilog/verilog_typecheck_base.cpp
@@ -185,7 +185,7 @@ std::size_t verilog_typecheck_baset::get_width(const typet &type)
 
   if(type.id()==ID_array)
   {
-    mp_integer subtype_width=get_width(type.subtype());
+    mp_integer subtype_width = get_width(to_array_type(type).subtype());
     return (array_size(type) * subtype_width).to_ulong();
   }
   

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1622,7 +1622,7 @@ void verilog_typecheck_exprt::convert_extractbit_expr(exprt &expr)
         expr.op1() = typecast_exprt{expr.op1(), _index_type};
     }
 
-    expr.type()=op0.type().subtype();
+    expr.type() = to_array_type(op0.type()).subtype();
     expr.id(ID_index);
   }
   else

--- a/src/verilog/verilog_typecheck_type.cpp
+++ b/src/verilog/verilog_typecheck_type.cpp
@@ -44,9 +44,11 @@ typet verilog_typecheck_exprt::convert_type(const irept &src)
     mp_integer offset=little_endian?lsb:msb;
     
     // let's look at the subtype
-    const irept &subtype=
-      static_cast<const typet &>(src).subtype();
-    
+    const auto subtype =
+      static_cast<const typet &>(src).has_subtype()
+        ? static_cast<const type_with_subtypet &>(src).subtype()
+        : typet(ID_nil);
+
     if(subtype.is_nil() ||
        subtype.id()==ID_signed ||
        subtype.id()==ID_unsigned)

--- a/src/vhdl/expr2vhdl.cpp
+++ b/src/vhdl/expr2vhdl.cpp
@@ -795,13 +795,14 @@ std::string expr2vhdlt::convert(const typet &type)
   }
   else if(type.id()==ID_array)
   {
+    auto &array_type = to_array_type(type);
     std::string dest="array [";
-    
-    dest+=convert(to_array_type(type).size());
+
+    dest += convert(array_type.size());
 
     dest+="] of ";
-    dest+=convert(type.subtype());
-    
+    dest += convert(array_type.subtype());
+
     return dest;
   }
   else if(type.id()==ID_genvar)


### PR DESCRIPTION
This avoids direct use of `typet::subtypet()` by casting to the appropriate derived type, which is usually `array_typet`.