### PR TITLE
Verilog: output source location when an include file is not found

### DIFF
--- a/regression/verilog/include/not_found1.v
+++ b/regression/verilog/include/not_found1.v
@@ -1,0 +1,1 @@
+`include "file_that_does_not_exist.v"

--- a/regression/verilog/include/test.desc
+++ b/regression/verilog/include/test.desc
@@ -1,0 +1,7 @@
+CORE
+not_found1.v
+
+^file not_found1\.v line 1: include file .file_that_does_not_exist\.v. not found$
+^EXIT=1$
+^SIGNAL=0$
+--

--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -14,6 +14,28 @@ Author: Daniel Kroening, kroening@kroening.com
 
 /*******************************************************************\
 
+Function: verilog_preprocessort::filet::make_source_location
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+source_locationt verilog_preprocessort::filet::make_source_location() const
+{
+  source_locationt result;
+
+  result.set_file(filename);
+  result.set_line(line);
+
+  return result;
+}
+
+/*******************************************************************\
+
 Function: verilog_preprocessort::getline
 
   Inputs:
@@ -178,7 +200,9 @@ Function: verilog_preprocessort::include
 
 \*******************************************************************/
 
-void verilog_preprocessort::include(const std::string &filename)
+void verilog_preprocessort::include(
+  const std::string &filename,
+  const source_locationt &source_location)
 {
   {
     filet tmp_file;
@@ -209,6 +233,7 @@ void verilog_preprocessort::include(const std::string &filename)
     file.close=false;
   }
 
+  error().source_location = source_location;
   error() << "include file `" << filename << "' not found" << eom;
   throw 0;
 }
@@ -504,6 +529,9 @@ void verilog_preprocessort::directive()
   }
   else if(text=="include")
   {
+    // remember the source location
+    auto source_location = files.back().make_source_location();
+
     files.back().getline(line);
 
     const char *tptr=line.c_str();
@@ -534,7 +562,7 @@ void verilog_preprocessort::directive()
       tptr++;
     }
 
-    include(filename);
+    include(filename, source_location);
   }
   else if(text=="resetall")
   {

--- a/src/verilog/verilog_preprocessor.h
+++ b/src/verilog/verilog_preprocessor.h
@@ -32,7 +32,7 @@ protected:
   
   virtual void directive();
   virtual void replace_macros(std::string &s);
-  virtual void include(const std::string &filename);
+  virtual void include(const std::string &filename, const source_locationt &);
 
   static std::string build_path(
     const std::string &path,
@@ -89,6 +89,8 @@ protected:
     void print_line(std::ostream &out, unsigned level)
     { out << "`line " << line << " \"" 
           <<filename << "\" " << level << std::endl; }
+
+    source_locationt make_source_location() const;
   };
 
   std::list<filet> files;  


### PR DESCRIPTION
This outputs the source location of the include directive when the file that is to be included is not found.