### PR TITLE
change the name of the branch we do CI on to 'main'

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -1,9 +1,9 @@
 name: Build and Test HW-CBMC
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   # This job takes approximately 15 minutes


### PR DESCRIPTION
This changes the name of the branch we do CI on to the new default branch.