### PR TITLE
fix compilation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Compiling
 =========
 
 - initialize and update the CBMC submodule: `$> git submodule init; git submodule update`
-- build EBMC: `$> cd src; make` (this also build CBMC internally)
-- optionally: `$> export PATH=/full/path/hw-cbmc/src/ebmc:${PATH}` to get EBMC on the path
+- download minisat: `$> make -C lib/cbmc minisat2-download`
+- build EBMC: `$> make -C src` (this also builds the CBMC submodule)
+- optional: `$> export PATH=/full/path/hw-cbmc/src/ebmc:${PATH}` to get EBMC on the path
 
 Usage
 =====


### PR DESCRIPTION
The compilation instructions in README.md have ommitted the necessity to download minisat prior to starting the build.