### PR TITLE
ebmc: add command-line option --preprocess

### DIFF
--- a/regression/verilog/preprocessor/unknown_directive.desc
+++ b/regression/verilog/preprocessor/unknown_directive.desc
@@ -1,8 +1,8 @@
 CORE
 unknown_directive.v
-
+--preprocess
 ^file unknown_directive\.v line 1: unknown preprocessor directive "something"$
-^PARSING ERROR$
+^PREPROCESSING FAILED$
 ^EXIT=1$
 ^SIGNAL=0$
 --

--- a/src/ebmc/ebmc_base.h
+++ b/src/ebmc/ebmc_base.h
@@ -41,6 +41,8 @@ protected:
   const symbolt *main_symbol;
   optionalt<transt> trans_expr; // transition system expression
 
+  int preprocess();
+
   bool get_main();
   bool get_bound();
 

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -291,6 +291,7 @@ void ebmc_parse_optionst::help()
     " {y--z3}                        \t use Z3 as solver\n"
     "\n"
     "Debugging options:\n"
+    " {y--preprocess}                \t output the preprocessed source file\n"
     " {y--show-parse}                \t show parse trees\n"
     " {y--show-varmap}               \t show variable map\n"
     " {y--show-netlist}              \t show netlist\n"

--- a/src/ebmc/ebmc_parse_options.h
+++ b/src/ebmc/ebmc_parse_options.h
@@ -21,25 +21,30 @@ public:
   virtual void help();
 
   ebmc_parse_optionst(int argc, const char **argv)
-      : parse_options_baset(
-            "(diameter)(ediameter)"
-            "(diatest)(statebits):(bound):(max-bound):"
-            "(show-parse)(show-varmap)(show-symbol-table)(show-netlist)"
-            "(show-ldg)(show-modules)(show-trans)(show-bdds)"
-            "(show-properties)(property):p:(trace)"
-            "(dimacs)(module):(top):"
-            "(po)(cegar)(k-induction)(2pi)(bound2):"
-            "(outfile):(xml-ui)(verbosity):(gui)"
-            "(reset):"
-            "(version)(verilog-rtl)(verilog-netlist)"
-            "(compute-interpolant)(interpolation)(interpolation-vmcai)"
-            "(ic3)(property):(constr)(h)(new-mode)(aiger)"
-            "(interpolation-word)(interpolator):(bdd)"
-            "(smt1)(smt2)(boolector)(z3)(cvc4)(yices)(mathsat)(prover)(lifter)"
-            "(aig)(stop-induction)(stop-minimize)(start):(coverage)(naive)"
-            "(compute-ct)(dot-netlist)(smv-netlist)(vcd):I:",
-            argc, argv, std::string("EBMC ") + EBMC_VERSION),
-        ui_message_handler(cmdline, "EBMC " EBMC_VERSION) {}
+    : parse_options_baset(
+        "(diameter)(ediameter)"
+        "(diatest)(statebits):(bound):(max-bound):"
+        "(show-parse)(show-varmap)(show-symbol-table)(show-netlist)"
+        "(show-ldg)(show-modules)(show-trans)(show-bdds)"
+        "(show-properties)(property):p:(trace)"
+        "(dimacs)(module):(top):"
+        "(po)(cegar)(k-induction)(2pi)(bound2):"
+        "(outfile):(xml-ui)(verbosity):(gui)"
+        "(reset):"
+        "(version)(verilog-rtl)(verilog-netlist)"
+        "(compute-interpolant)(interpolation)(interpolation-vmcai)"
+        "(ic3)(property):(constr)(h)(new-mode)(aiger)"
+        "(interpolation-word)(interpolator):(bdd)"
+        "(smt1)(smt2)(boolector)(z3)(cvc4)(yices)(mathsat)(prover)(lifter)"
+        "(aig)(stop-induction)(stop-minimize)(start):(coverage)(naive)"
+        "(compute-ct)(dot-netlist)(smv-netlist)(vcd):"
+        "I:(preprocess)",
+        argc,
+        argv,
+        std::string("EBMC ") + EBMC_VERSION),
+      ui_message_handler(cmdline, "EBMC " EBMC_VERSION)
+  {
+  }
 
   virtual ~ebmc_parse_optionst() { }
   


### PR DESCRIPTION
This adds a command line option --preprocess to obtain the output of the preprocessor when applied to the given file.