### PR TITLE
Verilog preprocessor: add proper constructor for filet

### DIFF
--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -204,15 +204,8 @@ void verilog_preprocessort::include(
   const std::string &filename,
   const source_locationt &source_location)
 {
-  {
-    filet tmp_file;
-    files.push_back(tmp_file);
-  }
-
+  files.emplace_back(true, nullptr, filename);
   filet &file=files.back();
-
-  file.filename=filename;
-  file.close=true;
 
   file.in=new std::ifstream(filename.c_str());
   if(*file.in) return;
@@ -252,12 +245,7 @@ Function: verilog_preprocessort::preprocessor
 
 void verilog_preprocessort::preprocessor()
 {
-  {
-    filet file;
-    file.in=&in;
-    file.filename=filename;
-    files.push_back(file);
-  }
+  files.emplace_back(false, &in, filename);
 
   while(!files.empty())
   {

--- a/src/verilog/verilog_preprocessor.h
+++ b/src/verilog/verilog_preprocessor.h
@@ -70,8 +70,17 @@ protected:
     std::istream *in;
     std::string filename;
     unsigned line, last_line;
-    
-    filet() { close=false; line=1; last_line=0; column=1; }
+
+    filet(bool _close, std::istream *_in, std::string _filename)
+      : close(_close),
+        in(_in),
+        filename(std::move(_filename)),
+        line(1),
+        last_line(0),
+        column(1)
+    {
+    }
+
     ~filet() { if(close) delete in; }
     
     bool get(char &ch);


### PR DESCRIPTION
This adds a complete constructor for `verilog_preprocessort::filet`.