### PR TITLE
Verilog preprocessor: implement multi-line defines

### DIFF
--- a/regression/verilog/preprocessor/multi-line-define1.desc
+++ b/regression/verilog/preprocessor/multi-line-define1.desc
@@ -1,0 +1,14 @@
+CORE
+multi-line-define1.v
+--preprocess
+// Enable multi-line checking
+activate-multi-line-match
+`line 1 "multi-line-define1.v" 0
+
+A 
+B 
+C
+^EXIT=0$
+^SIGNAL=0$
+--
+^PREPROCESSING FAILED$

--- a/regression/verilog/preprocessor/multi-line-define1.v
+++ b/regression/verilog/preprocessor/multi-line-define1.v
@@ -1,0 +1,4 @@
+`define foo A \
+B \
+C
+`foo

--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -362,13 +362,23 @@ void verilog_preprocessort::directive()
     // skip whitespace
     tokenizer().skip_ws();
 
-    // Read any tokens until end of line.
+    // Read any tokens until end of line,
+    // but note that \n can be escaped with a backslash.
     // Note that any defines in this sequence
     // are not expanded at this point.
     while(!tokenizer().eof() && tokenizer().peek() != '\n')
     {
       auto token = tokenizer().next_token();
-      define.tokens.push_back(std::move(token));
+      if(token == '\\' && tokenizer().peek() == '\n')
+      {
+        // Eat the newline, which is escaped.
+        // Not clear whether the newline is meant to show
+        // in the expansion.
+        auto nl = tokenizer().next_token();
+        define.tokens.push_back(std::move(nl));
+      }
+      else
+        define.tokens.push_back(std::move(token));
     }
 
 #ifdef DEBUG


### PR DESCRIPTION
This implements multi-line macros in the Verilog preprocessor.