### PR TITLE
Verilog preprocessor: line count sync

### DIFF
--- a/regression/verilog/preprocessor/ifdef1.desc
+++ b/regression/verilog/preprocessor/ifdef1.desc
@@ -1,0 +1,7 @@
+CORE
+ifdef1.v
+
+^file ifdef1\.v line 4: syntax error before 'syntax'$
+^EXIT=1$
+^SIGNAL=0$
+--

--- a/regression/verilog/preprocessor/ifdef1.v
+++ b/regression/verilog/preprocessor/ifdef1.v
@@ -1,0 +1,4 @@
+`ifdef SOMETHING_NOT_DEFINED
+line
+`endif
+syntax error on line 4

--- a/regression/verilog/preprocessor/ifdef2.desc
+++ b/regression/verilog/preprocessor/ifdef2.desc
@@ -1,0 +1,7 @@
+CORE
+ifdef2.v
+
+^file ifdef2\.v line 4: syntax error before 'syntax'$
+^EXIT=1$
+^SIGNAL=0$
+--

--- a/regression/verilog/preprocessor/ifdef2.v
+++ b/regression/verilog/preprocessor/ifdef2.v
@@ -1,0 +1,5 @@
+`ifdef SOMETHING_NOT_DEFINED
+line
+`else
+syntax error on line 4
+`endif

--- a/regression/verilog/preprocessor/multi-line-define1.desc
+++ b/regression/verilog/preprocessor/multi-line-define1.desc
@@ -1,13 +1,7 @@
 CORE
 multi-line-define1.v
 --preprocess
-// Enable multi-line checking
-activate-multi-line-match
-`line 1 "multi-line-define1.v" 0
-
-A 
-B 
-C
+^A B C$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/preprocessor/multi-line-define2.desc
+++ b/regression/verilog/preprocessor/multi-line-define2.desc
@@ -1,0 +1,7 @@
+CORE
+multi-line-define2.v
+
+^file multi-line-define2\.v line 4: syntax error before 'syntax'$
+^EXIT=1$
+^SIGNAL=0$
+--

--- a/regression/verilog/preprocessor/multi-line-define2.v
+++ b/regression/verilog/preprocessor/multi-line-define2.v
@@ -1,0 +1,4 @@
+`define some_macro foo \
+bar \
+baz
+syntax error on line 4

--- a/regression/verilog/preprocessor/multi-line-define3.desc
+++ b/regression/verilog/preprocessor/multi-line-define3.desc
@@ -1,0 +1,7 @@
+CORE
+multi-line-define3.v
+
+^file multi-line-define3\.v line 4: syntax error before 'syntax'$
+^EXIT=1$
+^SIGNAL=0$
+--

--- a/regression/verilog/preprocessor/multi-line-define3.v
+++ b/regression/verilog/preprocessor/multi-line-define3.v
@@ -1,0 +1,4 @@
+`define foo A \
+B \
+C
+syntax error on line 4

--- a/src/verilog/verilog_preprocessor.h
+++ b/src/verilog/verilog_preprocessor.h
@@ -87,15 +87,19 @@ protected:
     void get_token_from_stream() override;
   };
 
+  // To synchronize the parser's line number
+  std::size_t parser_line_no = 0;
+  void emit_line_directive(unsigned level);
+
   // for include and for `define
   class contextt
   {
   protected:
     bool deallocate_in;
     std::istream *in;
-    std::string filename;
 
   public:
+    std::string filename;
     verilog_preprocessor_token_sourcet *tokenizer;
 
     // for `define with parameters
@@ -122,12 +126,6 @@ protected:
       delete tokenizer;
       if(deallocate_in)
         delete in;
-    }
-
-    void print_line_directive(std::ostream &out, unsigned level) const
-    {
-      out << "`line " << tokenizer->line_no() << " \"" << filename << "\" "
-          << level << '\n';
     }
 
     source_locationt make_source_location() const;


### PR DESCRIPTION
This keeps the line-count in the Verilog parser in sync by emitting newlines when multi-line `define` directives are read.