### PR TITLE
Verilog: SystemVerilog 2012 generate for without begin ... end

### DIFF
--- a/regression/verilog/generate/generate-for1.desc
+++ b/regression/verilog/generate/generate-for1.desc
@@ -1,0 +1,6 @@
+CORE
+generate-for1.v
+--module main --bound 1
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/verilog/generate/generate-for1.v
+++ b/regression/verilog/generate/generate-for1.v
@@ -1,0 +1,14 @@
+module main;
+
+  wire [15:0] some_wire;
+
+  generate
+    genvar i;
+    for (i = 0; i <= 15; i = i + 1)
+      assign some_wire[i] = (i%2) == 0;
+  endgenerate
+
+  // should pass
+  always assert property1: some_wire == 'b0101_0101_0101_0101;
+
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1125,17 +1125,22 @@ genvar_case_item:
 	;
 
 generate_loop_statement:
+	  // The following is a generalisation of the Verilog 2001
+	  // grammar, which requires begin ... end, and does not allow
+	  // the generate_item. Found in the SystemVerilog IEEE 1800-2012
+	  // grammar.
 	  TOK_FOR '(' genvar_assignment ';'
 	              constant_expression ';'
                       genvar_assignment ')'
-          generate_block
-          	{ init($$, ID_generate_for);
-          	  stack_expr($$).reserve_operands(4);
-          	  mto($$, $3);
-          	  mto($$, $5);
-          	  mto($$, $7);
-          	  mto($$, $9);
-          	}
+          // generate_block
+          generate_item
+		{ init($$, ID_generate_for);
+		  stack_expr($$).reserve_operands(4);
+		  mto($$, $3);
+		  mto($$, $5);
+		  mto($$, $7);
+		  mto($$, $9);
+		}
         ;
 
 generate_block_identifier: TOK_CHARSTR;


### PR DESCRIPTION
This adjusts the Verilog grammar to allow a generate-for module item without `begin` ...  `end`.