### PR TITLE
Verilog: add test for module not found

### DIFF
--- a/regression/verilog/modules/module_not_found1.desc
+++ b/regression/verilog/modules/module_not_found1.desc
@@ -1,0 +1,7 @@
+CORE
+module_not_found1.v
+--bound 1 --top main
+^found no file that provides module Verilog::some_module_that_does_not_exist$
+^EXIT=2$
+^SIGNAL=0$
+--

--- a/regression/verilog/modules/module_not_found1.v
+++ b/regression/verilog/modules/module_not_found1.v
@@ -1,0 +1,5 @@
+module main;
+
+  some_module_that_does_not_exist instance();
+
+endmodule


### PR DESCRIPTION
This adds a test for the common scenario that a module that is instantiated is not found.