### PR TITLE
Verilog: convert_const_expression now returns a value

### DIFF
--- a/src/verilog/verilog_generate.cpp
+++ b/src/verilog/verilog_generate.cpp
@@ -114,9 +114,9 @@ void verilog_typecheckt::elaborate_generate_if(
     error() << "generate_if expects two or three operands" << eom;
     throw 0;
   }
-  
-  mp_integer condition;
-  convert_const_expression(to_multi_ary_expr(statement).op0(), condition);
+
+  mp_integer condition =
+    convert_const_expression(to_multi_ary_expr(statement).op0());
 
   if(condition==0)
   {
@@ -168,10 +168,8 @@ void verilog_typecheckt::elaborate_generate_assign(
     error() << "expected genvar on left hand side of assignment" << eom;
     throw 0;
   }
-  
-  mp_integer rhs;
 
-  convert_const_expression(to_binary_expr(statement).rhs(), rhs);
+  mp_integer rhs = convert_const_expression(to_binary_expr(statement).rhs());
 
   if(rhs<0)
   {
@@ -210,8 +208,8 @@ void verilog_typecheckt::elaborate_generate_for(
 
   while(true)
   {
-    mp_integer condition;
-    convert_const_expression(to_multi_ary_expr(statement).op1(), condition);
+    mp_integer condition =
+      convert_const_expression(to_multi_ary_expr(statement).op1());
 
     if(condition==0) break;
     

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -539,14 +539,13 @@ void verilog_typecheckt::convert_inst(verilog_instt &inst)
     // these must be constants
     if(it->id()==ID_named_parameter_assignment)
     {
-      mp_integer v_int;
-      convert_const_expression(static_cast<exprt &>(it->add(ID_value)), v_int);
+      mp_integer v_int =
+        convert_const_expression(static_cast<exprt &>(it->add(ID_value)));
       it->add(ID_value)=from_integer(v_int, integer_typet());
     }
     else
     {
-      mp_integer v_int;
-      convert_const_expression(*it, v_int);
+      mp_integer v_int = convert_const_expression(*it);
       *it=from_integer(v_int, integer_typet());
     }
   }

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -40,7 +40,7 @@ public:
   { }
 
   virtual void convert_expr(exprt &expr);
-  virtual void convert_const_expression(const exprt &expr, mp_integer &value);
+  virtual mp_integer convert_const_expression(const exprt &);
 
 protected:
   irep_idt module_identifier;


### PR DESCRIPTION
This changes `convert_const_expression` to return a value, instead of using a reference parameter.

This also removes one instance of `to_integer_non_constant`.