### PR TITLE
introduce verilog_module_exprt

### DIFF
--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -90,6 +90,37 @@ extern inline verilog_statementt &to_verilog_statement(exprt &expr)
   return static_cast<verilog_statementt &>(expr);
 }
 
+class verilog_module_exprt : public exprt
+{
+public:
+  inline explicit verilog_module_exprt() : exprt(ID_verilog_module)
+  {
+  }
+
+  using module_itemst = std::vector<class verilog_module_itemt>;
+
+  const module_itemst &module_items() const
+  {
+    return (const module_itemst &)(operands());
+  }
+
+  module_itemst &module_items()
+  {
+    return (module_itemst &)(operands());
+  }
+};
+
+extern inline const verilog_module_exprt &
+to_verilog_module_expr(const exprt &expr)
+{
+  return static_cast<const verilog_module_exprt &>(expr);
+}
+
+extern inline verilog_module_exprt &to_verilog_module_expr(exprt &expr)
+{
+  return static_cast<verilog_module_exprt &>(expr);
+}
+
 class verilog_module_itemt:public exprt
 {
 public:

--- a/src/verilog/verilog_generate.cpp
+++ b/src/verilog/verilog_generate.cpp
@@ -8,6 +8,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "verilog_typecheck.h"
 
+#include "verilog_expr.h"
+
 /*******************************************************************\
 
 Function: verilog_typecheckt::elaborate_generate_block
@@ -22,7 +24,7 @@ Function: verilog_typecheckt::elaborate_generate_block
 
 void verilog_typecheckt::elaborate_generate_block(
   const exprt &statement,
-  exprt::operandst &dest)
+  module_itemst &dest)
 {
   forall_operands(it, statement)
     elaborate_generate_item(*it, dest);
@@ -42,7 +44,7 @@ Function: verilog_typecheckt::elaborate_generate_item
 
 void verilog_typecheckt::elaborate_generate_item(
   const exprt &statement,
-  exprt::operandst &dest)
+  module_itemst &dest)
 {
   if(statement.id()==ID_generate_block)
     elaborate_generate_block(statement, dest);
@@ -61,15 +63,14 @@ void verilog_typecheckt::elaborate_generate_item(
   else
   {
     // no need for elaboration
-    exprt tmp("set_genvars");
+    verilog_module_itemt tmp("set_genvars");
     tmp.add_to_operands(statement);
     irept &variables=tmp.add("variables");
     
     for(const auto & it : genvars)
       variables.set(it.first, integer2string(it.second));
 
-    dest.push_back(exprt());
-    dest.back().swap(tmp);
+    dest.push_back(std::move(tmp));
   }
 }
 
@@ -87,7 +88,7 @@ Function: verilog_typecheckt::elaborate_generate_case
 
 void verilog_typecheckt::elaborate_generate_case(
   const exprt &statement,
-  exprt::operandst &dest)
+  module_itemst &dest)
 {
 }
 
@@ -105,7 +106,7 @@ Function: verilog_typecheckt::elaborate_generate_if
 
 void verilog_typecheckt::elaborate_generate_if(
   const exprt &statement,
-  exprt::operandst &dest)
+  module_itemst &dest)
 {
   if(statement.operands().size()!=3 &&
      statement.operands().size()!=2)
@@ -141,7 +142,7 @@ Function: verilog_typecheckt::elaborate_generate_assign
 
 void verilog_typecheckt::elaborate_generate_assign(
   const exprt &statement,
-  exprt::operandst &dest)
+  module_itemst &dest)
 {
   if(statement.operands().size()!=2)
   {
@@ -197,7 +198,7 @@ Function: verilog_typecheckt::elaborate_generate_for
 
 void verilog_typecheckt::elaborate_generate_for(
   const exprt &statement,
-  exprt::operandst &dest)
+  module_itemst &dest)
 {
   if(statement.operands().size()!=4)
   {

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -2906,13 +2906,16 @@ Function: verilog_synthesist::convert_module_items
 
  Outputs:
 
- Purpose:
+ Purpose: Turn the verilog_module_exprt into a transition system
+          expression
 
 \*******************************************************************/
 
 void verilog_synthesist::convert_module_items(symbolt &symbol)
 {
-  assert(symbol.value.id()==ID_verilog_module);
+  PRECONDITION(symbol.value.id() == ID_verilog_module);
+
+  const auto &verilog_module = to_verilog_module_expr(symbol.value);
 
   // clean up
   assignments.clear();
@@ -2930,11 +2933,8 @@ void verilog_synthesist::convert_module_items(symbolt &symbol)
   transt trans{ID_trans, conjunction({}), conjunction({}), conjunction({}),
                symbol.type};
 
-  for(const auto & it : symbol.value.operands())
-  {
-    const auto & module_item=static_cast<const verilog_module_itemt &>(it);
+  for(const auto &module_item : verilog_module.module_items())
     synth_module_item(module_item, trans);
-  }
 
   synth_assignments(trans);
   
@@ -2966,7 +2966,7 @@ void verilog_synthesist::convert_module_items(symbolt &symbol)
   }
   #endif
 
-  symbol.value=trans;
+  symbol.value = std::move(trans);
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1549,26 +1549,27 @@ Function: verilog_typecheckt::convert_statements
 
 void verilog_typecheckt::convert_statements()
 {
-  exprt &value=module_symbol.value;
-  
-  value.id(ID_verilog_module);
+  verilog_module_exprt verilog_module_expr;
 
   const irept &module_source=
     module_symbol.type.find(ID_module_source);
 
   const irept &module_items=module_source.find(ID_module_items);
 
-  value.reserve_operands(module_items.get_sub().size());
+  verilog_module_expr.module_items().reserve(module_items.get_sub().size());
 
-  // do the generate stuff
+  // do the generate stuff, copying the module items
 
   for(auto &item : module_items.get_sub())
-    elaborate_generate_item(static_cast<const exprt &>(item), value.operands());
+    elaborate_generate_item(
+      static_cast<const exprt &>(item), verilog_module_expr.module_items());
 
-  // typecheck
-  
-  Forall_operands(it, value)
-    convert_module_item(static_cast<verilog_module_itemt &>(*it));
+  // typecheck the new module items
+  for(auto &item : verilog_module_expr.module_items())
+    convert_module_item(item);
+
+  // store the module expression in module_symbol.value
+  module_symbol.value = std::move(verilog_module_expr);
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -170,13 +170,15 @@ protected:
   bool implicit_wire(const irep_idt &identifier,
                      const symbolt *&symbol) override;
 
+  using module_itemst = std::vector<verilog_module_itemt>;
+
   // generate constructs
-  void elaborate_generate_assign(const exprt &statement, exprt::operandst &dest);
-  void elaborate_generate_block(const exprt &statement, exprt::operandst &dest);
-  void elaborate_generate_item(const exprt &statement, exprt::operandst &dest);
-  void elaborate_generate_if(const exprt &statement, exprt::operandst &dest);
-  void elaborate_generate_case(const exprt &statement, exprt::operandst &dest);
-  void elaborate_generate_for(const exprt &statement, exprt::operandst &dest);
+  void elaborate_generate_assign(const exprt &statement, module_itemst &dest);
+  void elaborate_generate_block(const exprt &statement, module_itemst &dest);
+  void elaborate_generate_item(const exprt &statement, module_itemst &dest);
+  void elaborate_generate_if(const exprt &statement, module_itemst &dest);
+  void elaborate_generate_case(const exprt &statement, module_itemst &dest);
+  void elaborate_generate_for(const exprt &statement, module_itemst &dest);
 
   // generate state
   typedef std::map<irep_idt, mp_integer> genvarst;


### PR DESCRIPTION
This adds `verilog_module_exprt` to improve typing in the Verilog frontend.