### PR TITLE
introduce verilog_parameter_declt

### DIFF
--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -112,6 +112,37 @@ extern inline verilog_module_itemt &to_verilog_module_item(irept &irep)
   return static_cast<verilog_module_itemt &>(irep);
 }
 
+class verilog_parameter_declt : public verilog_module_itemt
+{
+public:
+  inline verilog_parameter_declt() : verilog_module_itemt(ID_parameter_decl)
+  {
+  }
+
+  const exprt::operandst &declarations() const
+  {
+    return operands();
+  }
+
+  exprt::operandst &declarations()
+  {
+    return operands();
+  }
+};
+
+extern inline const verilog_parameter_declt &
+to_verilog_parameter_decl(const irept &irep)
+{
+  PRECONDITION(irep.id() == ID_parameter_decl);
+  return static_cast<const verilog_parameter_declt &>(irep);
+}
+
+extern inline verilog_parameter_declt &to_verilog_parameter_decl(irept &irep)
+{
+  PRECONDITION(irep.id() == ID_parameter_decl);
+  return static_cast<verilog_parameter_declt &>(irep);
+}
+
 class verilog_instt:public verilog_module_itemt
 {
 public:

--- a/src/verilog/verilog_parameterize_module.cpp
+++ b/src/verilog/verilog_parameterize_module.cpp
@@ -12,6 +12,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "verilog_typecheck.h"
 
+#include "verilog_expr.h"
+
 /*******************************************************************\
 
 Function: verilog_typecheckt::get_parameter_values
@@ -48,16 +50,16 @@ void verilog_typecheckt::get_parameter_values(
     for(auto &item : module_items.get_sub())
       if(item.id() == ID_parameter_decl)
       {
-        forall_operands(o_it, static_cast<const exprt &>(item))
+        for(auto &decl : to_verilog_parameter_decl(item).declarations())
         {
-          const irep_idt &identifier=o_it->get(ID_identifier);
+          const irep_idt &identifier = decl.get(ID_identifier);
           exprt value;
 
           if(map.find(identifier)!=map.end())
             value=map[identifier];
           else
-          {          
-            value=static_cast<const exprt &>(o_it->find(ID_value));
+          {
+            value = static_cast<const exprt &>(decl.find(ID_value));
             // substitute other parameters
             replace_symbol.replace(value);
             simplify(value, ns);
@@ -84,9 +86,9 @@ void verilog_typecheckt::get_parameter_values(
     for(auto &item : module_items.get_sub())
       if(item.id() == ID_parameter_decl)
       {
-        forall_operands(o_it, static_cast<const exprt &>(item))
+        for(auto &decl : to_verilog_parameter_decl(item).declarations())
         {
-          const irep_idt &identifier=o_it->get(ID_identifier);
+          const irep_idt &identifier = decl.get(ID_identifier);
           exprt value;
           
           if(p_it!=parameter_assignment.end())
@@ -96,7 +98,7 @@ void verilog_typecheckt::get_parameter_values(
           }
           else
           {
-            value=static_cast<const exprt &>(o_it->find(ID_value));
+            value = static_cast<const exprt &>(decl.find(ID_value));
             // substitute other parameters
             replace_symbol.replace(value);
             simplify(value, ns);
@@ -147,11 +149,11 @@ void verilog_typecheckt::set_parameter_values(
   for(auto &module_item : module_items.get_sub())
     if(module_item.id() == ID_parameter_decl)
     {
-      Forall_operands(o_it, static_cast<exprt &>(module_item))
+      for(auto &decl : to_verilog_parameter_decl(module_item).declarations())
       {
         if(p_it!=parameter_values.end())
         {
-          exprt &value=static_cast<exprt &>(o_it->add(ID_value));
+          exprt &value = static_cast<exprt &>(decl.add(ID_value));
           value=*p_it;
           p_it++;
         }


### PR DESCRIPTION
To strengthen the typing in the Verilog frontend, this introduces a class `verilog_parameter_declt`.