### PR TITLE
ebmc: bugfix for binary values in trace

### DIFF
--- a/regression/ebmc/example4_trace/test.desc
+++ b/regression/ebmc/example4_trace/test.desc
@@ -1,8 +1,9 @@
 CORE
 example4.sv
---bound 10 
+--bound 10 --trace
 SUCCESS$
 FAILURE$
+^  counter\.state = 254 \(11111110\)$
 ^EXIT=10$
 ^SIGNAL=0$
 

--- a/regression/ebmc/netlist/netlist-trace1.desc
+++ b/regression/ebmc/netlist/netlist-trace1.desc
@@ -1,0 +1,8 @@
+CORE
+netlist-trace1.sv
+--bound 10 --trace --aig
+^\[counter\.property\.1\] always counter\.state != 3: FAILURE$
+^  counter\.state = 3 \(00000011\)$
+^EXIT=10$
+^SIGNAL=0$
+

--- a/regression/ebmc/netlist/netlist-trace1.sv
+++ b/regression/ebmc/netlist/netlist-trace1.sv
@@ -1,0 +1,16 @@
+module counter(
+  output [7:0] out,
+  input enable, input clk);
+
+  reg [7:0] state;
+  assign out = state;
+
+  initial state = 0;
+
+  always @(posedge clk)
+    if(enable)
+      state = state + 1;
+
+  assert property (state!=3);
+
+endmodule

--- a/src/trans-netlist/trans_trace.cpp
+++ b/src/trans-netlist/trans_trace.cpp
@@ -74,6 +74,30 @@ unsigned trans_tracet::get_min_failing_timeframe() const
 
 /*******************************************************************\
 
+Function: bvrep2binary
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+std::string bvrep2binary(const constant_exprt &expr)
+{
+  const auto &value = expr.get_value();
+  std::size_t width = to_bitvector_type(expr.type()).get_width();
+  std::string result;
+  result.reserve(width);
+  for(std::size_t dest_index = 0; dest_index < width; dest_index++)
+    result.push_back(
+      get_bvrep_bit(value, width, width - dest_index - 1) ? '1' : '0');
+  return result;
+}
+
+/*******************************************************************\
+
 Function: show_trans_state
 
   Inputs:
@@ -109,20 +133,30 @@ void show_trans_state(
       std::cout << "?";
     else
       std::cout << from_expr(ns, symbol.name, rhs);
-    
-    if(rhs.type().id()==ID_unsignedbv ||
-       rhs.type().id()==ID_signedbv ||
-       rhs.type().id()==ID_bv)
+
+    if(rhs.type().id() == ID_unsignedbv || rhs.type().id() == ID_signedbv)
     {
       std::size_t width=to_bitvector_type(rhs.type()).get_width();
-      
+
+      if(width >= 2 && width <= 32 && rhs.id() == ID_constant)
+      {
+        std::cout << " ("
+                  << integer2binary(
+                       numeric_cast_v<mp_integer>(to_constant_expr(rhs)), width)
+                  << ')';
+      }
+    }
+    else if(rhs.type().id() == ID_bv)
+    {
+      std::size_t width = to_bv_type(rhs.type()).get_width();
+
       if(width>=2 && width<=32 &&
          rhs.id()==ID_constant)
       {
-        std::cout << " (" << to_constant_expr(rhs).get_value() << ")";
+        std::cout << " (" << bvrep2binary(to_constant_expr(rhs)) << ')';
       }
     }
-    
+
     std::cout << '\n';
   }
 


### PR DESCRIPTION
After switching to a hexadecimal bitvector representation, we need to convert the value in the counterexample trace to get a binary output.