### PR TITLE
ebmc: rename do_bmc and related methods

### DIFF
--- a/src/ebmc/ebmc_base.cpp
+++ b/src/ebmc/ebmc_base.cpp
@@ -85,7 +85,7 @@ ebmc_baset::ebmc_baset(const cmdlinet &_cmdline,
 
 /*******************************************************************\
 
-Function: ebmc_baset::finish_bmc
+Function: ebmc_baset::finish_word_level_bmc
 
   Inputs:
 
@@ -95,7 +95,8 @@ Function: ebmc_baset::finish_bmc
 
 \*******************************************************************/
 
-int ebmc_baset::finish_bmc(prop_conv_solvert &solver) {
+int ebmc_baset::finish_word_level_bmc(prop_conv_solvert &solver)
+{
   // convert the properties
   
   for(propertyt &property : properties)
@@ -185,12 +186,12 @@ int ebmc_baset::finish_bmc(prop_conv_solvert &solver) {
 
   // We return '0' if the property holds,
   // and '10' if it is violated.
-  return property_failure()?10:0; 
+  return property_failure() ? 10 : 0;
 }
 
 /*******************************************************************\
 
-Function: ebmc_baset::finish_bmc
+Function: ebmc_baset::finish_bit_level_bmc
 
   Inputs:
 
@@ -200,7 +201,7 @@ Function: ebmc_baset::finish_bmc
 
 \*******************************************************************/
 
-int ebmc_baset::finish_bmc(const bmc_mapt &bmc_map, propt &solver)
+int ebmc_baset::finish_bit_level_bmc(const bmc_mapt &bmc_map, propt &solver)
 {
   // convert the properties
   for(propertyt &property : properties)
@@ -486,7 +487,7 @@ bool ebmc_baset::get_main()
 
 /*******************************************************************\
 
-Function: ebmc_baset::do_bmc
+Function: ebmc_baset::do_word_level_bmc
 
   Inputs:
 
@@ -496,7 +497,8 @@ Function: ebmc_baset::do_bmc
 
 \*******************************************************************/
 
-int ebmc_baset::do_bmc(prop_conv_solvert &solver, bool convert_only) {
+int ebmc_baset::do_word_level_bmc(prop_conv_solvert &solver, bool convert_only)
+{
   int result=0;
 
   try
@@ -512,13 +514,13 @@ int ebmc_baset::do_bmc(prop_conv_solvert &solver, bool convert_only) {
       for(bound=1; bound<=max_bound; bound++)
       {
         status() << "Doing BMC with bound " << bound << eom;
-        
-        #if 0
+
+#if 0
         const namespacet ns(symbol_table);
         CHECK_RETURN(trans_expr.has_value());
         ::unwind(*trans_expr, *message_handler, solver, bound+1, ns, true);
-        result=finish_bmc(solver);
-        #endif
+        result=finish_word_level_bmc(solver);
+#endif
       }
 
       report_results();
@@ -541,7 +543,7 @@ int ebmc_baset::do_bmc(prop_conv_solvert &solver, bool convert_only) {
         result=0;
       else
       {
-        result=finish_bmc(solver);
+        result = finish_word_level_bmc(solver);
         report_results();
       }
     }
@@ -569,7 +571,7 @@ int ebmc_baset::do_bmc(prop_conv_solvert &solver, bool convert_only) {
 
 /*******************************************************************\
 
-Function: ebmc_baset::do_bmc
+Function: ebmc_baset::do_bit_level_bmc
 
   Inputs:
 
@@ -579,7 +581,7 @@ Function: ebmc_baset::do_bmc
 
 \*******************************************************************/
 
-int ebmc_baset::do_bmc(cnft &solver, bool convert_only)
+int ebmc_baset::do_bit_level_bmc(cnft &solver, bool convert_only)
 {
   if(get_bound()) return 1;
 
@@ -607,7 +609,7 @@ int ebmc_baset::do_bmc(cnft &solver, bool convert_only)
       result=0;
     else
     {
-      result=finish_bmc(bmc_map, solver);
+      result = finish_bit_level_bmc(bmc_map, solver);
       report_results();
     }
   }

--- a/src/ebmc/ebmc_base.h
+++ b/src/ebmc/ebmc_base.h
@@ -47,13 +47,13 @@ protected:
   bool get_bound();
 
   // word-level
-  int do_bmc(prop_conv_solvert &solver, bool convert_only);
-  int finish_bmc(prop_conv_solvert &solver);
+  int do_word_level_bmc(prop_conv_solvert &solver, bool convert_only);
+  int finish_word_level_bmc(prop_conv_solvert &solver);
 
   // bit-level
-  int do_bmc(cnft &solver, bool convert_only);
-  int finish_bmc(const bmc_mapt &bmc_map, propt &solver);
-  
+  int do_bit_level_bmc(cnft &solver, bool convert_only);
+  int finish_bit_level_bmc(const bmc_mapt &bmc_map, propt &solver);
+
   bool parse_property(const std::string &property);
   bool get_model_properties();
   void show_properties();

--- a/src/ebmc/ebmc_solvers.cpp
+++ b/src/ebmc/ebmc_solvers.cpp
@@ -43,7 +43,7 @@ int ebmc_baset::do_dimacs()
 {
   dimacs_cnft dimacs_cnf{*message_handler};
 
-  int result=do_bmc(dimacs_cnf, true);
+  int result = do_bit_level_bmc(dimacs_cnf, true);
   if(result!=0) return result;
 
   statistics() << dimacs_cnf.no_variables() << " variables and "
@@ -107,7 +107,7 @@ int ebmc_baset::do_smt2()
       smt2_convt::solvert::Z3,
       out);
 
-    return do_bmc(smt2_conv, true);
+    return do_word_level_bmc(smt2_conv, true);
   }
 
   smt2_convt smt2_conv(
@@ -118,7 +118,7 @@ int ebmc_baset::do_smt2()
     smt2_convt::solvert::Z3,
     std::cout);
 
-  return do_bmc(smt2_conv, true);
+  return do_word_level_bmc(smt2_conv, true);
 }
 */
 /*******************************************************************\
@@ -144,7 +144,7 @@ int ebmc_baset::do_mathsat()
     "QF_AUFBV",
     smt2_dect::solvert::MATHSAT);
 
-  return do_bmc(smt2_dec, false);
+  return do_word_level_bmc(smt2_dec, false);
 }
 */
 /*******************************************************************\
@@ -170,7 +170,7 @@ int ebmc_baset::do_z3()
     "QF_AUFBV",
     smt2_dect::solvert::Z3);
 
-  return do_bmc(smt2_dec, false);
+  return do_word_level_bmc(smt2_dec, false);
 }
 */
 /*******************************************************************\
@@ -196,7 +196,7 @@ int ebmc_baset::do_cvc4()
     "QF_AUFBV",
     smt2_dect::solvert::CVC4);
 
-  return do_bmc(smt2_dec, false);
+  return do_word_level_bmc(smt2_dec, false);
 }
 */
 /*******************************************************************\
@@ -222,7 +222,7 @@ int ebmc_baset::do_yices()
     "QF_AUFBV",
     smt2_dect::solvert::YICES);
 
-  return do_bmc(smt2_dec, false);
+  return do_word_level_bmc(smt2_dec, false);
 }
 */
 /*******************************************************************\
@@ -248,7 +248,7 @@ int ebmc_baset::do_boolector()
     "QF_AUFBV",
     smt2_dect::solvert::BOOLECTOR);
 
-  return do_bmc(smt2_dec, false);
+  return do_word_level_bmc(smt2_dec, false);
 }
 */
 /*******************************************************************\
@@ -271,13 +271,13 @@ int ebmc_baset::do_sat()
 
   if(cmdline.isset("aig"))
   {
-    return do_bmc(satcheck, false);
+    return do_bit_level_bmc(satcheck, false);
   }
   else
   {
     const namespacet ns(symbol_table);
     boolbvt boolbv(ns, satcheck, *message_handler);
-    return do_bmc(boolbv, false);
+    return do_word_level_bmc(boolbv, false);
   }
 }
 
@@ -295,14 +295,14 @@ Function: ebmc_baset::do_prover
 
 int ebmc_baset::do_prover()
 {
-  #ifdef HAVE_PROVER
+#ifdef HAVE_PROVER
   const namespacet ns(symbol_table);
   prover_satt prover_sat(ns);
-  return do_bmc(prover_sat, false);
-  #else
+  return do_word_level_bmc(prover_sat, false);
+#else
   error() << "Support for prover not linked in" << eom;
   return 1;
-  #endif
+#endif
 }
 
 /*******************************************************************\
@@ -319,12 +319,12 @@ Function: ebmc_baset::do_lifter
 
 int ebmc_baset::do_lifter()
 {
-  #ifdef HAVE_PROVER
+#ifdef HAVE_PROVER
   const namespacet ns(symbol_table);
   liftert lifter(ns);
-  return do_bmc(lifter.prop_conv(), false);
-  #else
+  return do_word_level_bmc(lifter.prop_conv(), false);
+#else
   error() << "Support for lifter not linked in" << eom;
   return 1;
-  #endif
+#endif
 }

--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -118,8 +118,8 @@ int k_inductiont::induction_base()
 
   ::unwind(*trans_expr, *message_handler, solver, bound + 1, ns, true);
 
-  int result=finish_bmc(solver);
-  
+  int result = finish_word_level_bmc(solver);
+
   if(result!=0 && result!=10)
     return result;
   else


### PR DESCRIPTION
This renames the `do_bmc` and `finish_bmc` methods to make it obvious which one is bit level and which one is word level.