### PR TITLE
ebmc: return trans_tracet

### DIFF
--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -377,14 +377,8 @@ void bdd_enginet::compute_counterexample(
     throw "unexpected result from SAT solver";
   }
 
-  trans_tracet trans_trace;
-
-  compute_trans_trace(
-    property.timeframe_literals,
-    bmc_map,
-    solver,
-    ns,
-    property.counterexample);
+  property.counterexample =
+    compute_trans_trace(property.timeframe_literals, bmc_map, solver, ns);
 }
 
 /*******************************************************************\

--- a/src/ebmc/ebmc_base.cpp
+++ b/src/ebmc/ebmc_base.cpp
@@ -150,14 +150,13 @@ int ebmc_baset::finish_bmc(prop_conv_solvert &solver) {
         result() << "SAT: counterexample found" << messaget::eom;
 
         namespacet ns(symbol_table);
-    
-        compute_trans_trace(
+
+        property.counterexample = compute_trans_trace(
           property.timeframe_literals,
           solver,
-          bound+1,
+          bound + 1,
           ns,
-          main_symbol->name,
-          property.counterexample);
+          main_symbol->name);
       }
       break;
 
@@ -248,12 +247,8 @@ int ebmc_baset::finish_bmc(const bmc_mapt &bmc_map, propt &solver)
 
         namespacet ns(symbol_table);
 
-        compute_trans_trace(
-          property.timeframe_literals,
-          bmc_map,
-          solver,
-          ns,
-          property.counterexample);
+        property.counterexample =
+          compute_trans_trace(property.timeframe_literals, bmc_map, solver, ns);
       }
       break;
 

--- a/src/hw-cbmc/hw_cbmc_parse_options.cpp
+++ b/src/hw-cbmc/hw_cbmc_parse_options.cpp
@@ -305,10 +305,9 @@ void hw_cbmc_parse_optionst::show_unwind_trace(const optionst &options,
   if (unwind_module == "" || unwind_no_timeframes == 0)
     return;
 
-  trans_tracet trans_trace;
   namespacet ns{goto_model.symbol_table};
-  compute_trans_trace(prop_conv, unwind_no_timeframes, ns, unwind_module,
-                      trans_trace);
+  auto trans_trace =
+    compute_trans_trace(prop_conv, unwind_no_timeframes, ns, unwind_module);
 
   if (options.get_option("vcd") != "") {
     if (options.get_option("vcd") == "-")

--- a/src/trans-netlist/trans_trace_netlist.cpp
+++ b/src/trans-netlist/trans_trace_netlist.cpp
@@ -97,13 +97,14 @@ Function: compute_trans_trace
 
 \*******************************************************************/
 
-void compute_trans_trace(
+trans_tracet compute_trans_trace(
   const bvt &prop_bv,
   const bmc_mapt &bmc_map,
   const propt &solver,
-  const namespacet &ns,
-  trans_tracet &dest)
+  const namespacet &ns)
 {
+  trans_tracet dest;
+
   dest.states.reserve(bmc_map.get_no_timeframes());
   
   for(unsigned t=0; t<bmc_map.get_no_timeframes(); t++)
@@ -159,5 +160,7 @@ void compute_trans_trace(
     tvt result=solver.l_get(prop_bv[t]);
     state.property_failed=result.is_false();
   }
+
+  return dest;
 }         
           

--- a/src/trans-netlist/trans_trace_netlist.h
+++ b/src/trans-netlist/trans_trace_netlist.h
@@ -12,11 +12,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "bmc_map.h"
 #include "trans_trace.h"
 
-void compute_trans_trace(
+trans_tracet compute_trans_trace(
   const bvt &prop_bv,
-  const bmc_mapt &bmc_map,
+  const bmc_mapt &,
   const class propt &solver,
-  const namespacet &ns,
-  trans_tracet &dest);
+  const namespacet &);
 
 #endif

--- a/src/trans-word-level/trans_trace_word_level.cpp
+++ b/src/trans-word-level/trans_trace_word_level.cpp
@@ -24,13 +24,14 @@ Function: compute_trans_trace
 
 \*******************************************************************/
 
-void compute_trans_trace(
+trans_tracet compute_trans_trace(
   const decision_proceduret &decision_procedure,
   unsigned no_timeframes,
   const namespacet &ns,
-  const irep_idt &module,
-  trans_tracet &dest)
+  const irep_idt &module)
 {
+  trans_tracet dest;
+
   // look up the module symbol
   {
     const symbolt &symbol=ns.lookup(module);
@@ -74,6 +75,8 @@ void compute_trans_trace(
       }
     }
   }
+
+  return dest;
 }
 
 /*******************************************************************\
@@ -88,28 +91,24 @@ Function: compute_trans_trace
 
 \*******************************************************************/
 
-void compute_trans_trace(
+trans_tracet compute_trans_trace(
   const bvt &prop_bv,
   const class prop_convt &solver,
   unsigned no_timeframes,
   const namespacet &ns,
-  const irep_idt &module,
-  trans_tracet &dest)  
+  const irep_idt &module)
 {
-  compute_trans_trace(
-    solver,
-    no_timeframes,
-    ns,
-    module,
-    dest);
-    
+  trans_tracet trace = compute_trans_trace(solver, no_timeframes, ns, module);
+
   // check the properties that got violated
 
   for(unsigned t=0; t<no_timeframes; t++)
   {
     assert(t<prop_bv.size());
     tvt result=solver.l_get(prop_bv[t]);
-    dest.states[t].property_failed=result.is_false();
+    trace.states[t].property_failed = result.is_false();
   }
+
+  return trace;
 }
 

--- a/src/trans-word-level/trans_trace_word_level.h
+++ b/src/trans-word-level/trans_trace_word_level.h
@@ -16,21 +16,19 @@ Author: Daniel Kroening, kroening@kroening.com
 
 // word-level without properties
 
-void compute_trans_trace(
-  const decision_proceduret &decision_procedure,
+trans_tracet compute_trans_trace(
+  const decision_proceduret &,
   unsigned no_timeframes,
-  const namespacet &ns,
-  const irep_idt &module,
-  trans_tracet &dest);
+  const namespacet &,
+  const irep_idt &module);
 
 // word-level with properties
-  
-void compute_trans_trace(
+
+trans_tracet compute_trans_trace(
   const bvt &prop_bv,
   const class prop_convt &solver,
   unsigned no_timeframes,
   const namespacet &ns,
-  const irep_idt &module,
-  trans_tracet &dest);
+  const irep_idt &module);
 
 #endif


### PR DESCRIPTION
We now have rvalues, and can hence return a larger data structure without the cost of copying.