### PR TITLE
ebmc: use handles

### DIFF
--- a/src/ebmc/ebmc_base.h
+++ b/src/ebmc/ebmc_base.h
@@ -12,8 +12,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <fstream>
 
 #include <langapi/language_file.h>
-#include <solvers/prop/prop_conv_solver.h>
 #include <solvers/sat/cnf.h>
+#include <solvers/stack_decision_procedure.h>
 #include <trans-netlist/bmc_map.h>
 #include <trans-netlist/netlist.h>
 #include <trans-netlist/trans_trace.h>
@@ -47,8 +47,8 @@ protected:
   bool get_bound();
 
   // word-level
-  int do_word_level_bmc(prop_conv_solvert &solver, bool convert_only);
-  int finish_word_level_bmc(prop_conv_solvert &solver);
+  int do_word_level_bmc(stack_decision_proceduret &, bool convert_only);
+  int finish_word_level_bmc(stack_decision_proceduret &);
 
   // bit-level
   int do_bit_level_bmc(cnft &solver, bool convert_only);
@@ -73,7 +73,8 @@ protected:
     std::string expr_string;
     irep_idt mode;
     exprt expr;
-    bvt timeframe_literals;
+    bvt timeframe_literals;             // bit level
+    exprt::operandst timeframe_handles; // word level
     std::string description;
     enum class statust { DISABLED, SUCCESS, FAILURE, UNKNOWN } status;
     

--- a/src/trans-word-level/property.cpp
+++ b/src/trans-word-level/property.cpp
@@ -26,14 +26,19 @@ Function: property
 
 \*******************************************************************/
 
-void property(const exprt &property_expr, bvt &prop_bv,
-              message_handlert &message_handler, prop_conv_solvert &solver,
-              unsigned no_timeframes, const namespacet &ns) {
+void property(
+  const exprt &property_expr,
+  exprt::operandst &prop_handles,
+  message_handlert &message_handler,
+  decision_proceduret &solver,
+  unsigned no_timeframes,
+  const namespacet &ns)
+{
   messaget message(message_handler);
 
   if(property_expr.is_true())
   {
-    prop_bv.resize(no_timeframes, const_literal(true));
+    prop_handles.resize(no_timeframes, true_exprt());
     return;
   }
 
@@ -52,7 +57,7 @@ void property(const exprt &property_expr, bvt &prop_bv,
     exprt tmp=
       instantiate(p, c, no_timeframes, ns);
 
-    literalt l=solver.convert(tmp);
-    prop_bv.push_back(l);
+    auto handle = solver.handle(tmp);
+    prop_handles.push_back(std::move(handle));
   }
 }

--- a/src/trans-word-level/property.h
+++ b/src/trans-word-level/property.h
@@ -13,11 +13,14 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/message.h>
 #include <util/namespace.h>
 
-#include <solvers/prop/literal.h>
-#include <solvers/prop/prop_conv_solver.h>
+#include <solvers/decision_procedure.h>
 
-void property(const exprt &property_expr, bvt &prop_bv, message_handlert &,
-              prop_conv_solvert &solver, unsigned no_timeframes,
-              const namespacet &);
+void property(
+  const exprt &property_expr,
+  exprt::operandst &prop_handles,
+  message_handlert &,
+  decision_proceduret &solver,
+  unsigned no_timeframes,
+  const namespacet &);
 
 #endif

--- a/src/trans-word-level/trans_trace_word_level.cpp
+++ b/src/trans-word-level/trans_trace_word_level.cpp
@@ -92,8 +92,8 @@ Function: compute_trans_trace
 \*******************************************************************/
 
 trans_tracet compute_trans_trace(
-  const bvt &prop_bv,
-  const class prop_convt &solver,
+  const exprt::operandst &prop_handles,
+  const decision_proceduret &solver,
   unsigned no_timeframes,
   const namespacet &ns,
   const irep_idt &module)
@@ -104,11 +104,12 @@ trans_tracet compute_trans_trace(
 
   for(unsigned t=0; t<no_timeframes; t++)
   {
-    assert(t<prop_bv.size());
-    tvt result=solver.l_get(prop_bv[t]);
+    DATA_INVARIANT(
+      t < prop_handles.size(),
+      "There must be exactly one prop_handles element per time frame");
+    auto result = solver.get(prop_handles[t]);
     trace.states[t].property_failed = result.is_false();
   }
 
   return trace;
 }
-

--- a/src/trans-word-level/trans_trace_word_level.h
+++ b/src/trans-word-level/trans_trace_word_level.h
@@ -12,7 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <solvers/decision_procedure.h>
 
 #include "../trans-netlist/trans_trace.h"
-#include <solvers/prop/prop.h>
 
 // word-level without properties
 
@@ -25,8 +24,8 @@ trans_tracet compute_trans_trace(
 // word-level with properties
 
 trans_tracet compute_trans_trace(
-  const bvt &prop_bv,
-  const class prop_convt &solver,
+  const exprt::operandst &prop_handles,
+  const decision_proceduret &solver,
   unsigned no_timeframes,
   const namespacet &ns,
   const irep_idt &module);


### PR DESCRIPTION
To enable the use of decision procedures that do not expose a CNF-style API, switch the use of literalt to handle expressions.
