### PR TITLE
ebmc: remove --smt1

### DIFF
--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -282,7 +282,6 @@ void ebmc_parse_optionst::help()
     "Solvers:\n"
     " {y--aig}                       \t bit-level SAT with AIGs\n"
     " {y--dimacs}                    \t output bit-level CNF in DIMACS format\n"
-    " {y--smt1}                      \t output word-level SMT 1 formula\n"
     " {y--smt2}                      \t output word-level SMT 2 formula\n"
     " {y--boolector}                 \t use Boolector as solver\n"
     " {y--cvc4}                      \t use CVC4 as solver\n"

--- a/src/ebmc/ebmc_parse_options.h
+++ b/src/ebmc/ebmc_parse_options.h
@@ -35,7 +35,7 @@ public:
         "(compute-interpolant)(interpolation)(interpolation-vmcai)"
         "(ic3)(property):(constr)(h)(new-mode)(aiger)"
         "(interpolation-word)(interpolator):(bdd)"
-        "(smt1)(smt2)(boolector)(z3)(cvc4)(yices)(mathsat)(prover)(lifter)"
+        "(smt2)(boolector)(z3)(cvc4)(yices)(mathsat)(prover)(lifter)"
         "(aig)(stop-induction)(stop-minimize)(start):(coverage)(naive)"
         "(compute-ct)(dot-netlist)(smv-netlist)(vcd):"
         "I:(preprocess)",


### PR DESCRIPTION
This removes the command line option and the help entry.  The code for it was removed in 2018 with f7db43518eace6a3404c8007f9c4516b02964088.