### PR TITLE
ebmc: add --show-formula

### DIFF
--- a/src/ebmc/Makefile
+++ b/src/ebmc/Makefile
@@ -16,6 +16,7 @@ SRC = \
       main.cpp \
       negate_property.cpp \
       random_traces.cpp \
+      show_formula_solver.cpp \
       show_properties.cpp \
       show_trans.cpp \
       #empty line

--- a/src/ebmc/ebmc_base.h
+++ b/src/ebmc/ebmc_base.h
@@ -145,6 +145,7 @@ public:
   int do_sat();
   int do_prover();
   int do_lifter();
+  int do_show_formula();
 };
 
 #endif

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -214,6 +214,8 @@ int ebmc_parse_optionst::doit()
       return ebmc_base.do_mathsat();
     else if(cmdline.isset("yices"))
       return ebmc_base.do_yices();
+    else if(cmdline.isset("show-formula"))
+      return ebmc_base.do_show_formula();
     else if(cmdline.isset("smt2"))
       return ebmc_base.do_smt2();
     else if(cmdline.isset("prover"))
@@ -298,6 +300,7 @@ void ebmc_parse_optionst::help()
     " {y--show-varmap}               \t show variable map\n"
     " {y--show-netlist}              \t show netlist\n"
     " {y--show-ldg}                  \t show latch dependencies\n"
+    " {y--show-formula}              \t show the formula that is generated\n"
     " {y--smv-netlist}               \t show netlist in SMV format\n"
     " {y--dot-netlist}               \t show netlist in DOT format\n"
     " {y--show-trans}                \t show transition system\n"

--- a/src/ebmc/ebmc_parse_options.h
+++ b/src/ebmc/ebmc_parse_options.h
@@ -25,7 +25,7 @@ public:
         "(diameter)(ediameter)"
         "(diatest)(statebits):(bound):(max-bound):"
         "(show-parse)(show-varmap)(show-symbol-table)(show-netlist)"
-        "(show-ldg)(show-modules)(show-trans)(show-bdds)"
+        "(show-ldg)(show-modules)(show-trans)(show-bdds)(show-formula)"
         "(show-properties)(property):p:(trace)"
         "(dimacs)(module):(top):"
         "(po)(cegar)(k-induction)(2pi)(bound2):"

--- a/src/ebmc/ebmc_solvers.cpp
+++ b/src/ebmc/ebmc_solvers.cpp
@@ -23,6 +23,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "ebmc_base.h"
 #include "ebmc_version.h"
+#include "show_formula_solver.h"
 
 /*******************************************************************\
 
@@ -116,6 +117,41 @@ int ebmc_baset::do_smt2()
     std::cout);
 
   return do_word_level_bmc(smt2_conv, true);
+}
+
+/*******************************************************************\
+
+Function: ebmc_baset::do_show_formula
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+int ebmc_baset::do_show_formula()
+{
+  const namespacet ns(symbol_table);
+
+  if(cmdline.isset("outfile"))
+  {
+    const std::string filename = cmdline.get_value("outfile");
+    std::ofstream out(filename);
+
+    if(!out)
+    {
+      std::cerr << "Failed to open `" << filename << "'" << '\n';
+      return 1;
+    }
+
+    show_formula_solvert show_formula_solver(out);
+    return do_word_level_bmc(show_formula_solver, true);
+  }
+
+  show_formula_solvert show_formula_solver;
+  return do_word_level_bmc(show_formula_solver, true);
 }
 
 /*******************************************************************\

--- a/src/ebmc/show_formula_solver.cpp
+++ b/src/ebmc/show_formula_solver.cpp
@@ -1,0 +1,55 @@
+/*******************************************************************\
+
+Module: Show Formula Solver
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+/// \file
+/// Show Formula Solver
+
+#include "show_formula_solver.h"
+
+#include <util/console.h>
+#include <util/format_expr.h>
+#include <util/std_expr.h>
+
+show_formula_solvert::show_formula_solvert()
+  : out(consolet::out()), console(true)
+{
+}
+
+void show_formula_solvert::set_to(const exprt &expr, bool value)
+{
+  if(console)
+    out << consolet::faint;
+
+  out << '(' << (++conjunct_counter) << ") ";
+
+  if(console)
+    out << consolet::reset;
+
+  if(value)
+    out << format(expr) << '\n';
+  else
+    out << format(not_exprt(expr)) << '\n';
+}
+
+exprt show_formula_solvert::handle(const exprt &expr)
+{
+  return expr;
+}
+
+exprt show_formula_solvert::get(const exprt &) const
+{
+  return nil_exprt();
+}
+
+void show_formula_solvert::push(const std::vector<exprt> &)
+{
+}
+
+void show_formula_solvert::push()
+{
+}

--- a/src/ebmc/show_formula_solver.h
+++ b/src/ebmc/show_formula_solver.h
@@ -1,0 +1,65 @@
+/*******************************************************************\
+
+Module: Show Formula Solver
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+/// \file
+/// Show Formula Solver
+
+#ifndef EBMC_SHOW_FORMULA_SOLVER_H
+#define EBMC_SHOW_FORMULA_SOLVER_H
+
+#include <solvers/stack_decision_procedure.h>
+
+class show_formula_solvert : public stack_decision_proceduret
+{
+public:
+  // console
+  show_formula_solvert();
+
+  // file
+  explicit show_formula_solvert(std::ostream &_out) : out(_out), console(false)
+  {
+  }
+
+  void set_to(const exprt &, bool value) override;
+  exprt handle(const exprt &) override;
+  exprt get(const exprt &) const override;
+  void print_assignment(std::ostream &) const override
+  {
+  }
+
+  std::string decision_procedure_text() const override
+  {
+    return "show-formula solver";
+  }
+
+  std::size_t get_number_of_solver_calls() const override
+  {
+    return 0;
+  }
+
+  ~show_formula_solvert() = default;
+
+  void push(const std::vector<exprt> &) override;
+  void push() override;
+
+  void pop() override
+  {
+  }
+
+protected:
+  resultt dec_solve() override
+  {
+    return resultt::D_ERROR;
+  }
+
+  std::ostream &out;
+  bool console;
+  std::size_t conjunct_counter = 0;
+};
+
+#endif // EBMC_SHOW_FORMULA_SOLVER_H


### PR DESCRIPTION
This prints the formula generated by BMC in a syntax designed for readability.