### PR TITLE
ebmc: 'general constraints' -> 'in-state constraints'

### DIFF
--- a/src/trans-word-level/unwind.cpp
+++ b/src/trans-word-level/unwind.cpp
@@ -33,9 +33,9 @@ void unwind(const transt &trans, message_handlert &message_handler,
   const exprt &op_init=trans.init();
   const exprt &op_trans=trans.trans();
 
-  // general constraints
+  // in-state constraints
 
-  message.status() << "General constraints" << messaget::eom;
+  message.status() << "In-state constraints" << messaget::eom;
 
   if(!op_invar.is_true())
     for(unsigned c=0; c<no_timeframes; c++)


### PR DESCRIPTION
This changes the status output when unwinding transition systems to use the term 'in-state constraints' to refer to state invariant constraints, as opposed to 'general constraints'.