### PR TITLE
ebmc: create transition_systemt class and member

### DIFF
--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -350,8 +350,8 @@ void bdd_enginet::compute_counterexample(
 
   satcheckt solver{*message_handler};
   bmc_map.map_timeframes(netlist, number_of_timeframes, solver);
-  
-  const namespacet ns(symbol_table);
+
+  const namespacet ns(transition_system.symbol_table);
 
   ::unwind(netlist, bmc_map, *this, solver);
   ::unwind_property(property.expr, property.timeframe_literals,
@@ -702,8 +702,8 @@ void bdd_enginet::get_atomic_propositions(const exprt &expr)
 
     aig_prop_constraintt aig_prop(netlist, *message_handler);
 
-    const namespacet ns(symbol_table);
-    
+    const namespacet ns(transition_system.symbol_table);
+
     literalt l=instantiate_convert(
       aig_prop, netlist.var_map, expr, ns, get_message_handler());
     

--- a/src/ebmc/ebmc_base.h
+++ b/src/ebmc/ebmc_base.h
@@ -34,12 +34,16 @@ public:
   int get_transition_system();
 
 protected:
-  symbol_tablet symbol_table;
   const cmdlinet &cmdline;
   language_filest language_files;
 
-  const symbolt *main_symbol;
-  optionalt<transt> trans_expr; // transition system expression
+  class transition_systemt
+  {
+  public:
+    symbol_tablet symbol_table;
+    const symbolt *main_symbol;
+    optionalt<transt> trans_expr; // transition system expression
+  } transition_system;
 
   int preprocess();
 

--- a/src/ebmc/ebmc_solvers.cpp
+++ b/src/ebmc/ebmc_solvers.cpp
@@ -82,7 +82,7 @@ Function: ebmc_baset::do_smt2
 
 int ebmc_baset::do_smt2()
 {
-  const namespacet ns(symbol_table);
+  const namespacet ns(transition_system.symbol_table);
 
   if(cmdline.isset("outfile"))
   {
@@ -133,7 +133,7 @@ Function: ebmc_baset::do_show_formula
 
 int ebmc_baset::do_show_formula()
 {
-  const namespacet ns(symbol_table);
+  const namespacet ns(transition_system.symbol_table);
 
   if(cmdline.isset("outfile"))
   {
@@ -168,7 +168,7 @@ Function: ebmc_baset::do_mathsat
 
 int ebmc_baset::do_mathsat()
 {
-  const namespacet ns(symbol_table);
+  const namespacet ns(transition_system.symbol_table);
 
   smt2_dect smt2_dec(
     ns,
@@ -195,7 +195,7 @@ Function: ebmc_baset::do_z3
 
 int ebmc_baset::do_z3()
 {
-  const namespacet ns(symbol_table);
+  const namespacet ns(transition_system.symbol_table);
 
   smt2_dect smt2_dec(
     ns,
@@ -222,7 +222,7 @@ Function: ebmc_baset::do_cvc4
 
 int ebmc_baset::do_cvc4()
 {
-  const namespacet ns(symbol_table);
+  const namespacet ns(transition_system.symbol_table);
 
   smt2_dect smt2_dec(
     ns,
@@ -249,7 +249,7 @@ Function: ebmc_baset::do_yices
 
 int ebmc_baset::do_yices()
 {
-  const namespacet ns(symbol_table);
+  const namespacet ns(transition_system.symbol_table);
 
   smt2_dect smt2_dec(
     ns,
@@ -276,7 +276,7 @@ Function: ebmc_baset::do_boolector
 
 int ebmc_baset::do_boolector()
 {
-  const namespacet ns(symbol_table);
+  const namespacet ns(transition_system.symbol_table);
 
   smt2_dect smt2_dec(
     ns,
@@ -313,7 +313,7 @@ int ebmc_baset::do_sat()
   }
   else
   {
-    const namespacet ns(symbol_table);
+    const namespacet ns(transition_system.symbol_table);
     boolbvt boolbv(ns, satcheck, *message_handler);
     return do_word_level_bmc(boolbv, false);
   }
@@ -334,7 +334,7 @@ Function: ebmc_baset::do_prover
 int ebmc_baset::do_prover()
 {
 #ifdef HAVE_PROVER
-  const namespacet ns(symbol_table);
+  const namespacet ns(transition_system.symbol_table);
   prover_satt prover_sat(ns);
   return do_word_level_bmc(prover_sat, false);
 #else
@@ -358,7 +358,7 @@ Function: ebmc_baset::do_lifter
 int ebmc_baset::do_lifter()
 {
 #ifdef HAVE_PROVER
-  const namespacet ns(symbol_table);
+  const namespacet ns(transition_system.symbol_table);
   liftert lifter(ns);
   return do_word_level_bmc(lifter.prop_conv(), false);
 #else

--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -28,9 +28,13 @@ Author: Daniel Kroening, daniel.kroening@inf.ethz.ch
 class k_inductiont:public ebmc_baset
 {
 public:
-  k_inductiont(const cmdlinet &_cmdline,
-               ui_message_handlert &_ui_message_handler)
-      : ebmc_baset(_cmdline, _ui_message_handler), ns{symbol_table} {}
+  k_inductiont(
+    const cmdlinet &_cmdline,
+    ui_message_handlert &_ui_message_handler)
+    : ebmc_baset(_cmdline, _ui_message_handler),
+      ns{transition_system.symbol_table}
+  {
+  }
 
   int operator()();
 
@@ -110,14 +114,20 @@ Function: k_inductiont::induction_base
 
 int k_inductiont::induction_base()
 {
-  PRECONDITION(trans_expr.has_value());
+  PRECONDITION(transition_system.trans_expr.has_value());
   status() << "Induction Base" << eom;
 
   satcheckt satcheck{*message_handler};
   boolbvt solver(ns, satcheck, *message_handler);
 
   // convert the transition system
-  ::unwind(*trans_expr, *message_handler, solver, bound + 1, ns, true);
+  ::unwind(
+    *transition_system.trans_expr,
+    *message_handler,
+    solver,
+    bound + 1,
+    ns,
+    true);
 
   // convert the properties
   word_level_properties(solver);
@@ -144,7 +154,7 @@ Function: k_inductiont::induction_step
 
 int k_inductiont::induction_step()
 {
-  PRECONDITION(trans_expr.has_value());
+  PRECONDITION(transition_system.trans_expr.has_value());
   status() << "Induction Step" << eom;
 
   unsigned no_timeframes=bound+1;
@@ -159,7 +169,13 @@ int k_inductiont::induction_step()
     boolbvt solver(ns, satcheck, *message_handler);
 
     // *no* initial state
-    unwind(*trans_expr, *message_handler, solver, no_timeframes, ns, false);
+    unwind(
+      *transition_system.trans_expr,
+      *message_handler,
+      solver,
+      no_timeframes,
+      ns,
+      false);
 
     exprt property(p_it.expr);
 

--- a/src/ebmc/ranking_function.cpp
+++ b/src/ebmc/ranking_function.cpp
@@ -40,7 +40,8 @@ public:
   ranking_function_checkt(
     const cmdlinet &_cmdline,
     ui_message_handlert &_ui_message_handler)
-    : ebmc_baset(_cmdline, _ui_message_handler), ns{symbol_table}
+    : ebmc_baset(_cmdline, _ui_message_handler),
+      ns{transition_system.symbol_table}
   {
   }
 
@@ -62,14 +63,14 @@ int do_ranking_function(
 
 optionalt<exprt> ranking_function_checkt::parse_ranking_function()
 {
-  auto language = get_language_from_mode(main_symbol->mode);
+  auto language = get_language_from_mode(transition_system.main_symbol->mode);
   exprt expr;
 
   language->set_message_handler(get_message_handler());
 
   if(language->to_expr(
        cmdline.get_value("ranking-function"),
-       id2string(main_symbol->module),
+       id2string(transition_system.main_symbol->module),
        expr,
        ns))
   {
@@ -87,7 +88,7 @@ optionalt<exprt> ranking_function_checkt::parse_ranking_function()
   std::string expr_as_string;
   language->from_expr(expr, expr_as_string, ns);
   debug() << "Ranking function: " << expr_as_string << eom;
-  debug() << "Mode: " << main_symbol->mode << eom;
+  debug() << "Mode: " << transition_system.main_symbol->mode << eom;
 
   return expr;
 }
@@ -130,7 +131,7 @@ int ranking_function_checkt::operator()()
   if(exit_code != -1)
     return exit_code;
 
-  CHECK_RETURN(trans_expr.has_value());
+  CHECK_RETURN(transition_system.trans_expr.has_value());
 
   // parse the ranking function
   const auto ranking_function_opt = parse_ranking_function();
@@ -147,7 +148,7 @@ int ranking_function_checkt::operator()()
   boolbvt solver(ns, satcheck, *message_handler);
 
   // *no* initial state, two time frames
-  unwind(*trans_expr, *message_handler, solver, 2, ns, false);
+  unwind(*transition_system.trans_expr, *message_handler, solver, 2, ns, false);
 
   const auto p = [&property]() -> optionalt<exprt>
   {

--- a/src/ebmc/show_trans.cpp
+++ b/src/ebmc/show_trans.cpp
@@ -100,12 +100,12 @@ Function: show_transt::show_trans_verilog_netlist
 int show_transt::show_trans_verilog_netlist(std::ostream &out)
 {
   output_verilog_netlistt output_verilog(
-    symbol_table, out, get_message_handler());
+    transition_system.symbol_table, out, get_message_handler());
 
   try
   {
     verilog_header(out, "Verilog netlist");
-    output_verilog(*main_symbol);
+    output_verilog(*transition_system.main_symbol);
   }
   
   catch(const std::string &e)
@@ -144,12 +144,12 @@ Function: show_transt::show_trans_verilog_rtl
 int show_transt::show_trans_verilog_rtl(std::ostream &out)
 {
   output_verilog_rtlt output_verilog(
-    symbol_table, out, get_message_handler());
+    transition_system.symbol_table, out, get_message_handler());
 
   try
   {
     verilog_header(out, "Verilog RTL");
-    output_verilog(*main_symbol);
+    output_verilog(*transition_system.main_symbol);
   }
   
   catch(const std::string &e)
@@ -237,19 +237,19 @@ int show_transt::show_trans()
 {
   int result = get_transition_system();
   if(result!=-1) return result;
-  PRECONDITION(trans_expr.has_value());
+  PRECONDITION(transition_system.trans_expr.has_value());
 
   std::cout << "Initial state constraints:\n\n";
 
-  print_verilog_constraints(trans_expr->init(), std::cout);
+  print_verilog_constraints(transition_system.trans_expr->init(), std::cout);
 
   std::cout << "State constraints:\n\n";
 
-  print_verilog_constraints(trans_expr->invar(), std::cout);
+  print_verilog_constraints(transition_system.trans_expr->invar(), std::cout);
 
   std::cout << "Transition constraints:\n\n";
 
-  print_verilog_constraints(trans_expr->trans(), std::cout);
+  print_verilog_constraints(transition_system.trans_expr->trans(), std::cout);
 
   return 0;
 }


### PR DESCRIPTION
This groups the symbol table, the main symbol pointer and the transition system expression into one type.