### PR TITLE
ebmc: rename get_model to get_transition_system

### DIFF
--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -131,7 +131,7 @@ int bdd_enginet::operator()()
 {
   try
   {
-    int result=get_model();
+    int result = get_transition_system();
     if(result!=-1) return result;
 
     {  

--- a/src/ebmc/ebmc_base.cpp
+++ b/src/ebmc/ebmc_base.cpp
@@ -689,7 +689,7 @@ int ebmc_baset::preprocess()
 
 /*******************************************************************\
 
-Function: ebmc_baset::get_model
+Function: ebmc_baset::get_transition_system
 
   Inputs:
 
@@ -699,7 +699,7 @@ Function: ebmc_baset::get_model
 
 \*******************************************************************/
 
-int ebmc_baset::get_model()
+int ebmc_baset::get_transition_system()
 {
   // do -I
   if(cmdline.isset('I'))

--- a/src/ebmc/ebmc_base.h
+++ b/src/ebmc/ebmc_base.h
@@ -31,7 +31,7 @@ public:
              ui_message_handlert &_ui_message_handler);
   virtual ~ebmc_baset() { }
 
-  int get_model();
+  int get_transition_system();
 
 protected:
   symbol_tablet symbol_table;

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -197,8 +197,8 @@ int ebmc_parse_optionst::doit()
  
   {
     ebmc_baset ebmc_base(cmdline, ui_message_handler);
-  
-    int result=ebmc_base.get_model();
+
+    int result = ebmc_base.get_transition_system();
 
     if(result!=-1) return result;
 

--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -75,7 +75,7 @@ int k_inductiont::operator()()
 {
   if(get_bound()) return 1;
 
-  int result=get_model();
+  int result = get_transition_system();
   if(result!=-1) return result;
 
   if(properties.empty())

--- a/src/ebmc/random_traces.cpp
+++ b/src/ebmc/random_traces.cpp
@@ -260,7 +260,7 @@ int random_tracest::operator()()
 
   auto number_of_timeframes = bound + 1;
 
-  int result = get_model();
+  int result = get_transition_system();
   if(result != -1)
     return result;
 

--- a/src/ebmc/show_trans.cpp
+++ b/src/ebmc/show_trans.cpp
@@ -235,7 +235,7 @@ Function: show_transt::show_trans
 
 int show_transt::show_trans()
 {
-  int result=get_model();
+  int result = get_transition_system();
   if(result!=-1) return result;
   PRECONDITION(trans_expr.has_value());
 
@@ -268,7 +268,7 @@ Function: show_transt::show_trans_verilog_rtl
 
 int show_transt::show_trans_verilog_rtl()
 {
-  int result=get_model();
+  int result = get_transition_system();
   if(result!=-1) return result;
 
   if(cmdline.isset("outfile"))
@@ -306,7 +306,7 @@ Function: show_transt::show_trans_verilog_netlist
 
 int show_transt::show_trans_verilog_netlist()
 {
-  int result=get_model();
+  int result = get_transition_system();
   if(result!=-1) return result;
 
   if(cmdline.isset("outfile"))

--- a/src/ic3/m1ain.cc
+++ b/src/ic3/m1ain.cc
@@ -53,7 +53,7 @@ int ic3_enginet::operator()()
   read_parameters();
 
   try    {
-    int result=get_model();
+    int result = get_transition_system();
     if(result!=-1) return result;
 
     if(make_netlist(netlist))     {


### PR DESCRIPTION
The term 'transition system' is more specific than 'model'.