### PR TITLE
ebmc: generate random traces

### DIFF
--- a/regression/ebmc/random-traces/boolean1.desc
+++ b/regression/ebmc/random-traces/boolean1.desc
@@ -1,0 +1,12 @@
+CORE broken-smt-backend
+boolean1.v
+--bound 0 --random-traces 2
+^\*\*\* Trace 1$
+^  main\.some_wire = 0$
+^  main\.input1 = 0$
+^\*\*\* Trace 2$
+^  main\.some_wire = 1$
+^  main\.input1 = 1$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/random-traces/boolean1.v
+++ b/regression/ebmc/random-traces/boolean1.v
@@ -1,0 +1,5 @@
+module main(input input1);
+
+  wire some_wire = input1;
+
+endmodule

--- a/regression/ebmc/random-traces/bv1.desc
+++ b/regression/ebmc/random-traces/bv1.desc
@@ -1,0 +1,12 @@
+CORE broken-smt-backend
+bv1.v
+--bound 1 --random-traces 1
+^Transition system state 0$
+^  main\.some_reg = 0 .*$
+^  main\.input1 = 'h6FE4167A .*$
+^Transition system state 1$
+^  main\.some_reg = 'h6FE4167A .*$
+^  main\.input1 = 'hB65F5E9A .*$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/random-traces/bv1.v
+++ b/regression/ebmc/random-traces/bv1.v
@@ -1,0 +1,9 @@
+module main(input [31:0] input1);
+
+  wire clk;
+  reg [31:0] some_reg = 0;
+
+  always @(posedge clk)
+    some_reg  = input1;
+
+endmodule

--- a/src/ebmc/Makefile
+++ b/src/ebmc/Makefile
@@ -15,6 +15,7 @@ SRC = \
       k_induction.cpp \
       main.cpp \
       negate_property.cpp \
+      random_traces.cpp \
       show_properties.cpp \
       show_trans.cpp \
       #empty line

--- a/src/ebmc/ebmc_base.cpp
+++ b/src/ebmc/ebmc_base.cpp
@@ -505,8 +505,8 @@ int ebmc_baset::do_word_level_bmc(
       if(convert_only)
         throw "please set a specific bound";
         
-      const unsigned max_bound=
-        unsafe_string2unsigned(cmdline.get_value("max-bound"));
+      const std::size_t max_bound=
+        unsafe_string2size_t(cmdline.get_value("max-bound"));
     
       for(bound=1; bound<=max_bound; bound++)
       {

--- a/src/ebmc/ebmc_base.h
+++ b/src/ebmc/ebmc_base.h
@@ -62,7 +62,7 @@ protected:
   bool parse(const std::string &filename);
   bool typecheck();
 
-  unsigned bound;
+  std::size_t bound;
 
   struct propertyt
   {

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -8,13 +8,14 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <iostream>
 
-#include "ebmc_version.h"
-#include "show_trans.h"
-#include "k_induction.h"
 #include "bdd_engine.h"
-#include "ic3_engine.h"
 #include "ebmc_base.h"
 #include "ebmc_parse_options.h"
+#include "ebmc_version.h"
+#include "ic3_engine.h"
+#include "k_induction.h"
+#include "random_traces.h"
+#include "show_trans.h"
 
 #include <util/config.h>
 #include <util/exit_codes.h>
@@ -110,7 +111,9 @@ int ebmc_parse_optionst::doit()
     //    }
     #endif
   }
-  
+
+  if(cmdline.isset("random-traces"))
+    return random_traces(cmdline, ui_message_handler);
 
   if(cmdline.isset("ic3"))
     return do_ic3(cmdline, ui_message_handler);
@@ -247,7 +250,7 @@ void ebmc_parse_optionst::help()
     "\n";
 
   std::cout << help_formatter(
-    "Usage:                             Purpose:\n"
+    "Usage:\tPurpose:\n"
     "\n"
     " {bebmc} [{y-?}] [{y-h}] [{y--help}] \t show help\n"
     " {bebmc} {ufile} {u...}         \t source file names\n"
@@ -272,6 +275,8 @@ void ebmc_parse_optionst::help()
     "       {y--constr}              \t use constraints specified in 'file.cnstr'\n"
     "       {y--new-mode}            \t new mode is switched on\n"
     "       {y--aiger}               \t print out the instance in aiger format\n"
+    " {y--random-traces} {unumber}   \t generate the given number of random traces\n"
+    "       {y--random-seed} {unumber}\t use the given random seed\n"
     
     //" --interpolation                \t use bit-level interpolants\n"
     //" --interpolation-word           \t use word-level interpolants\n"

--- a/src/ebmc/ebmc_parse_options.h
+++ b/src/ebmc/ebmc_parse_options.h
@@ -38,6 +38,7 @@ public:
         "(smt2)(boolector)(z3)(cvc4)(yices)(mathsat)(prover)(lifter)"
         "(aig)(stop-induction)(stop-minimize)(start):(coverage)(naive)"
         "(compute-ct)(dot-netlist)(smv-netlist)(vcd):"
+        "(random-traces):(random-seed):"
         "I:(preprocess)",
         argc,
         argv,

--- a/src/ebmc/random_traces.cpp
+++ b/src/ebmc/random_traces.cpp
@@ -1,0 +1,340 @@
+/*******************************************************************\
+
+Module: Random Trace Generation
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#include "random_traces.h"
+
+#include "ebmc_base.h"
+
+#include <trans-word-level/instantiate_word_level.h>
+#include <trans-word-level/property.h>
+#include <trans-word-level/trans_trace_word_level.h>
+#include <trans-word-level/unwind.h>
+
+#include <solvers/flattening/boolbv.h>
+#include <solvers/sat/satcheck.h>
+
+#include <util/arith_tools.h>
+#include <util/bitvector_types.h>
+#include <util/console.h>
+#include <util/expr_util.h>
+#include <util/string2int.h>
+
+#include <algorithm>
+#include <random>
+
+/*******************************************************************\
+
+   Class: random_tracest
+
+ Purpose:
+
+\*******************************************************************/
+
+class random_tracest : public ebmc_baset
+{
+public:
+  random_tracest(
+    const cmdlinet &_cmdline,
+    ui_message_handlert &_ui_message_handler)
+    : ebmc_baset(_cmdline, _ui_message_handler), ns{symbol_table}
+  {
+  }
+
+  int operator()();
+
+protected:
+  namespacet ns;
+
+  std::vector<exprt> random_input_constraints(
+    decision_proceduret &,
+    const std::vector<symbol_exprt> &inputs,
+    size_t number_of_timeframes);
+
+  constant_exprt random_value(const typet &);
+
+  std::vector<symbol_exprt> inputs() const;
+
+  // Random number generator. These are fully specified in
+  // the C++ standard, and produce the same values on compliant
+  // implementations.
+  std::mt19937 generator;
+  bool random_bit();
+};
+
+/*******************************************************************\
+
+Function: random_traces
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+int random_traces(
+  const cmdlinet &cmdline,
+  ui_message_handlert &ui_message_handler)
+{
+  return random_tracest(cmdline, ui_message_handler)();
+}
+
+/*******************************************************************\
+
+Function: random_tracest::random_bit
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+bool random_tracest::random_bit()
+{
+  // We do not use std::uniform_int_distribution, as the results
+  // are implementation-dependent.
+  return generator() & 1;
+}
+
+/*******************************************************************\
+
+Function: random_tracest::random_value
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+constant_exprt random_tracest::random_value(const typet &type)
+{
+  if(type.id() == ID_unsignedbv || type.id() == ID_signedbv)
+  {
+    auto width = to_bitvector_type(type).get_width();
+    std::string binary_string;
+    binary_string.reserve(width);
+    for(std::size_t index = 0; index < width; index++)
+      binary_string.push_back(random_bit() ? '1' : '0');
+
+    return from_integer(
+      binary2integer(binary_string, type.id() == ID_signedbv), type);
+  }
+  else if(type.id() == ID_bool)
+  {
+    return make_boolean_expr(random_bit());
+  }
+  else
+    PRECONDITION(false);
+}
+
+/*******************************************************************\
+
+Function: random_tracest::inputs
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+std::vector<symbol_exprt> random_tracest::inputs() const
+{
+  std::vector<symbol_exprt> inputs;
+  const symbol_tablet &symbol_table = ns.get_symbol_table();
+
+  auto module_identifier = main_symbol->name;
+  auto lower = symbol_table.symbol_module_map.lower_bound(module_identifier);
+  auto upper = symbol_table.symbol_module_map.upper_bound(module_identifier);
+
+  // We need a deterministic ordering of the inputs that's
+  // portable accross implementations. We use irep_idt::compare.
+  std::vector<irep_idt> input_identifiers;
+
+  for(auto it = lower; it != upper; it++)
+  {
+    const symbolt &symbol = ns.lookup(it->second);
+
+    if(symbol.is_input)
+      input_identifiers.push_back(symbol.name);
+  }
+
+  // sort by identifier
+  std::sort(
+    input_identifiers.begin(),
+    input_identifiers.end(),
+    [](const irep_idt &a, const irep_idt &b) { return a.compare(b) < 0; });
+
+  // turn into symbol_exprt
+  for(auto identifier : input_identifiers)
+    inputs.push_back(ns.lookup(identifier).symbol_expr());
+
+  return inputs;
+}
+
+/*******************************************************************\
+
+Function: random_tracest::random_input_constraints
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+std::vector<exprt> random_tracest::random_input_constraints(
+  decision_proceduret &solver,
+  const std::vector<symbol_exprt> &inputs,
+  std::size_t number_of_timeframes)
+{
+  std::vector<exprt> result;
+
+  for(std::size_t i = 0; i < number_of_timeframes; i++)
+  {
+    for(auto &input : inputs)
+    {
+      auto input_in_timeframe = instantiate(input, i, number_of_timeframes, ns);
+      auto constraint =
+        equal_exprt(input_in_timeframe, random_value(input.type()));
+      result.push_back(solver.handle(constraint));
+    }
+  }
+
+  return result;
+}
+
+/*******************************************************************\
+
+Function: random_tracest::operator()()
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+int random_tracest::operator()()
+{
+  auto number_of_traces_opt =
+    string2optional_size_t(cmdline.get_value("random-traces"));
+
+  if(!number_of_traces_opt.has_value())
+  {
+    error() << "failed to parse number of traces" << eom;
+    return 1;
+  }
+
+  if(cmdline.isset("random-seed"))
+  {
+    auto random_seed_opt =
+      string2optional_size_t(cmdline.get_value("random-seed"));
+
+    if(!random_seed_opt.has_value())
+    {
+      error() << "failed to parse random seed" << eom;
+      return 1;
+    }
+
+    generator.seed(random_seed_opt.value());
+  }
+  else
+    generator.seed(0);
+
+  if(get_bound())
+    return 1;
+
+  auto number_of_timeframes = bound + 1;
+
+  int result = get_model();
+  if(result != -1)
+    return result;
+
+  CHECK_RETURN(trans_expr.has_value());
+
+  status() << "Passing transition system to solver" << eom;
+
+  satcheckt satcheck{*message_handler};
+  boolbvt solver(ns, satcheck, *message_handler);
+
+  ::unwind(
+    *trans_expr, *message_handler, solver, number_of_timeframes, ns, true);
+
+  auto inputs = this->inputs();
+
+  statistics() << "Found " << inputs.size() << " input(s)" << eom;
+
+  status() << "Solving with " << solver.decision_procedure_text() << eom;
+
+  for(std::size_t trace_nr = 0; trace_nr < number_of_traces_opt.value();
+      trace_nr++)
+  {
+    auto input_constraints =
+      random_input_constraints(solver, inputs, number_of_timeframes);
+
+    solver.push(input_constraints);
+    auto dec_result = solver();
+    solver.pop();
+
+    switch(dec_result)
+    {
+    case decision_proceduret::resultt::D_SATISFIABLE:
+    {
+      auto trace = compute_trans_trace(
+        solver, number_of_timeframes, ns, main_symbol->name);
+      if(cmdline.isset("vcd"))
+      {
+        auto filename =
+          cmdline.get_value("vcd") + "." + std::to_string(trace_nr + 1);
+        std::ofstream out(filename);
+        if(!out)
+        {
+          error() << "failed to write trace to " << filename << eom;
+          return 1;
+        }
+
+        consolet::out() << "*** Writing " << filename << '\n';
+
+        show_trans_trace_vcd(trace, *this, ns, out);
+      }
+      else
+      {
+        consolet::out() << "*** Trace " << (trace_nr + 1) << '\n';
+        show_trans_trace(
+          trace,
+          *this,
+          ns,
+          static_cast<ui_message_handlert *>(message_handler)->get_ui());
+      }
+    }
+    break;
+
+    case decision_proceduret::resultt::D_UNSATISFIABLE:
+      break;
+
+    case decision_proceduret::resultt::D_ERROR:
+      error() << "Error from decision procedure" << messaget::eom;
+      return 2;
+
+    default:
+      error() << "Unexpected result from decision procedure" << messaget::eom;
+      return 1;
+    }
+  }
+
+  return 0;
+}

--- a/src/ebmc/random_traces.h
+++ b/src/ebmc/random_traces.h
@@ -1,0 +1,17 @@
+/*******************************************************************\
+
+Module: Random Trace Generation
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#ifndef EBMC_RANDOM_TRACES_H
+#define EBMC_RANDOM_TRACES_H
+
+class cmdlinet;
+class ui_message_handlert;
+
+int random_traces(const cmdlinet &, ui_message_handlert &);
+
+#endif

--- a/src/hw-cbmc/map_vars.cpp
+++ b/src/hw-cbmc/map_vars.cpp
@@ -32,7 +32,7 @@ Function: instantiate_symbol
 
 \*******************************************************************/
 
-void instantiate_symbol(exprt &expr, unsigned timeframe)
+void instantiate_symbol(exprt &expr, std::size_t timeframe)
 {
   if(expr.id()==ID_symbol)
   {
@@ -65,7 +65,7 @@ public:
     symbol_table_baset &_symbol_table,
     std::list<exprt> &_constraints,
     message_handlert &_message,
-    unsigned _no_timeframes)
+    std::size_t _no_timeframes)
     : messaget(_message),
       symbol_table(_symbol_table),
       constraints(_constraints),
@@ -77,7 +77,7 @@ public:
 protected:
   symbol_table_baset &symbol_table;
   std::list<exprt> &constraints;
-  unsigned no_timeframes;
+  std::size_t no_timeframes;
   std::set<irep_idt> top_level_inputs;
 
   symbolt &lookup(const irep_idt &identifier);
@@ -96,7 +96,7 @@ protected:
   void map_var(
     const exprt &program_symbol,
     const symbolt &module_symbol,
-    unsigned transition);
+    std::size_t transition);
 
   void add_constraint_rec(
     const exprt &program_symbol,
@@ -111,8 +111,8 @@ protected:
     std::string &error_msg);
     
   std::string show_member(const exprt &expr);
-  void set_transition(exprt &expr, unsigned transition);
-  
+  void set_transition(exprt &expr, std::size_t transition);
+
   mp_integer get_size(const array_typet &type)
   {
     const exprt &size_expr=type.size();
@@ -166,7 +166,7 @@ Function: map_varst::set_transition
 
 \*******************************************************************/
 
-void map_varst::set_transition(exprt &expr, unsigned transition)
+void map_varst::set_transition(exprt &expr, std::size_t transition)
 {
   if(expr.id()==ID_member)
   {
@@ -390,7 +390,7 @@ Function: map_varst::map_var
 void map_varst::map_var(
   const exprt &program_symbol,
   const symbolt &module_symbol,
-  unsigned transition)
+  std::size_t transition)
 {
   // we have s[0].a.b.c
   // make that s#0[transition].a.b.c
@@ -614,7 +614,7 @@ void map_varst::map_var(
       
   // map values
 
-  for(unsigned t=0; t<no_timeframes; t++)
+  for(std::size_t t = 0; t < no_timeframes; t++)
     map_var(program_symbol, module_symbol, t);
 }
 
@@ -760,7 +760,7 @@ void map_vars(
   const irep_idt &module,
   std::list<exprt> &constraints,
   message_handlert &message,
-  unsigned no_timeframes)
+  std::size_t no_timeframes)
 {
   map_varst map_vars(symbol_table, constraints, message, no_timeframes);
   map_vars.map_vars(module);

--- a/src/hw-cbmc/map_vars.h
+++ b/src/hw-cbmc/map_vars.h
@@ -17,6 +17,6 @@ void map_vars(
   const irep_idt &module,
   std::list<exprt> &constraints,
   message_handlert &message,
-  unsigned no_timeframes);
+  std::size_t no_timeframes);
 
 #endif

--- a/src/trans-netlist/bmc_map.cpp
+++ b/src/trans-netlist/bmc_map.cpp
@@ -26,18 +26,18 @@ Function: bmc_mapt::map_timeframes
 
 void bmc_mapt::map_timeframes(
   const netlistt &netlist,
-  unsigned no_timeframes,
+  std::size_t no_timeframes,
   propt &solver)
 {
   var_map=netlist.var_map;
   timeframe_map.resize(no_timeframes);
-  
-  for(unsigned t=0; t<timeframe_map.size(); t++)
+
+  for(std::size_t t = 0; t < timeframe_map.size(); t++)
   {
     timeframet &timeframe=timeframe_map[t];
     timeframe.resize(netlist.number_of_nodes());
 
-    for(unsigned n=0; n<timeframe.size(); n++)
+    for(std::size_t n = 0; n < timeframe.size(); n++)
     {
       literalt solver_literal=solver.new_variable();
       timeframe[n].solver_literal=solver_literal;

--- a/src/trans-netlist/bmc_map.h
+++ b/src/trans-netlist/bmc_map.h
@@ -16,14 +16,16 @@ Author: Daniel Kroening, kroening@kroening.com
 class bmc_mapt
 {
 public:
-  inline literalt get(unsigned timeframe, const var_mapt::vart::bitt &bit) const
+  inline literalt
+  get(std::size_t timeframe, const var_mapt::vart::bitt &bit) const
   {
     literalt l=bit.current;
     if(l.is_constant()) return l;
     return get(timeframe, l.var_no())^l.sign();
   }
 
-  inline literalt get(unsigned timeframe, const irep_idt &id, unsigned bit_nr) const
+  inline literalt
+  get(std::size_t timeframe, const irep_idt &id, unsigned bit_nr) const
   {
     literalt l=var_map.get_current(id, bit_nr);
     if(l.is_constant()) return l;
@@ -31,7 +33,7 @@ public:
   }
 
   // translate netlist variable to solver literal
-  inline literalt get(unsigned timeframe, unsigned var_no) const
+  inline literalt get(std::size_t timeframe, unsigned var_no) const
   {
     assert(timeframe<timeframe_map.size());
     assert(var_no<timeframe_map[timeframe].size());
@@ -39,14 +41,14 @@ public:
   }
 
   // translate netlist literal to solver literal
-  inline literalt translate(unsigned timeframe, literalt l) const
+  inline literalt translate(std::size_t timeframe, literalt l) const
   {
     if(l.is_constant()) return l;
     return get(timeframe, l.var_no())^l.sign();
   }
 
   // set the solver literal for a netlist variable
-  void set(unsigned timeframe, unsigned var_no, literalt l)
+  void set(std::size_t timeframe, unsigned var_no, literalt l)
   {
     assert(timeframe<timeframe_map.size());
     assert(var_no<timeframe_map[timeframe].size());
@@ -57,7 +59,7 @@ public:
   // this is number of cycles +1!
   void map_timeframes(
     const netlistt &netlist,
-    unsigned no_timeframes,
+    std::size_t no_timeframes,
     propt &solver);
 
   var_mapt var_map;
@@ -75,13 +77,13 @@ public:
   {
     // this is the netlist literal
     literalt netlist_literal;
-    unsigned timeframe;
+    std::size_t timeframe;
   };
 
   typedef std::map<literalt, reverse_entryt> reverse_mapt;
   reverse_mapt reverse_map;
-  
-  unsigned get_no_timeframes() const
+
+  std::size_t get_no_timeframes() const
   {
     return timeframe_map.size();
   }

--- a/src/trans-netlist/trans_trace.cpp
+++ b/src/trans-netlist/trans_trace.cpp
@@ -38,11 +38,11 @@ Function: trans_tracet::get_max_failing_timeframe
 
 \*******************************************************************/
 
-unsigned trans_tracet::get_max_failing_timeframe() const
+std::size_t trans_tracet::get_max_failing_timeframe() const
 {
-  unsigned max=0;
-  
-  for(unsigned t=0; t<states.size(); t++)
+  std::size_t max = 0;
+
+  for(std::size_t t = 0; t < states.size(); t++)
   {
     if(states[t].property_failed)
       max=t;
@@ -63,9 +63,9 @@ Function: trans_tracet::get_min_failing_timeframe
 
 \*******************************************************************/
 
-unsigned trans_tracet::get_min_failing_timeframe() const
+std::size_t trans_tracet::get_min_failing_timeframe() const
 {
-  for(unsigned t=0; t<states.size(); t++)
+  for(std::size_t t = 0; t < states.size(); t++)
     if(states[t].property_failed)
       return t;
 
@@ -109,7 +109,7 @@ Function: show_trans_state
 \*******************************************************************/
 
 void show_trans_state(
-  unsigned timeframe,
+  std::size_t timeframe,
   const trans_tracet::statet &state,
   const namespacet &ns)
 {
@@ -180,13 +180,13 @@ void convert(
   const trans_tracet &trace,
   xmlt &dest)
 {
-  unsigned last_time_frame=trace.get_min_failing_timeframe();
+  std::size_t last_time_frame = trace.get_min_failing_timeframe();
 
   dest=xmlt("trans_trace");
   
   dest.new_element("mode").data=trace.mode;
 
-  for(unsigned t=0; t<=last_time_frame; t++)
+  for(std::size_t t = 0; t <= last_time_frame; t++)
   {
     assert(t<trace.states.size());
   
@@ -253,9 +253,9 @@ void show_trans_trace(
   {
   case ui_message_handlert::uit::PLAIN:
     {
-      unsigned l=trace.get_min_failing_timeframe();
+      std::size_t l = trace.get_min_failing_timeframe();
 
-      for(unsigned t=0; t<=l; t++)
+      for(std::size_t t = 0; t <= l; t++)
         show_trans_state(t, trace.states[t], ns);
     }
     break;
@@ -458,7 +458,7 @@ Function: show_trans_state_vcd
 \*******************************************************************/
 
 void show_trans_state_vcd(
-  unsigned timeframe,
+  std::size_t timeframe,
   const trans_tracet::statet &previous_state,
   const trans_tracet::statet &current_state,
   const namespacet &ns,
@@ -599,7 +599,7 @@ void vcd_hierarchy_rec(
   const std::set<irep_idt> &ids,
   const std::string &prefix,
   std::ostream &out,
-  unsigned depth)
+  std::size_t depth)
 {
   std::set<std::string> sub_modules;
   std::set<irep_idt> signals;
@@ -716,16 +716,16 @@ void show_trans_trace_vcd(
   out << "$upscope $end\n";  
 
   out << "$enddefinitions $end\n";
-  
-  unsigned l=trace.get_min_failing_timeframe();
-  
+
+  std::size_t l = trace.get_min_failing_timeframe();
+
   // initial state
 
   show_trans_state_vcd(0, trace.states[0], trace.states[0], ns, out);
   
   // following ones
 
-  for(unsigned t=1; t<=l; t++)
+  for(std::size_t t = 1; t <= l; t++)
     show_trans_state_vcd(t, trace.states[t-1], trace.states[t], ns, out);
 }
 

--- a/src/trans-netlist/trans_trace.cpp
+++ b/src/trans-netlist/trans_trace.cpp
@@ -38,9 +38,9 @@ Function: trans_tracet::get_max_failing_timeframe
 
 \*******************************************************************/
 
-std::size_t trans_tracet::get_max_failing_timeframe() const
+optionalt<std::size_t> trans_tracet::get_max_failing_timeframe() const
 {
-  std::size_t max = 0;
+  optionalt<std::size_t> max = {};
 
   for(std::size_t t = 0; t < states.size(); t++)
   {
@@ -63,13 +63,13 @@ Function: trans_tracet::get_min_failing_timeframe
 
 \*******************************************************************/
 
-std::size_t trans_tracet::get_min_failing_timeframe() const
+optionalt<std::size_t> trans_tracet::get_min_failing_timeframe() const
 {
   for(std::size_t t = 0; t < states.size(); t++)
     if(states[t].property_failed)
       return t;
 
-  return 0;
+  return {};
 }
 
 /*******************************************************************\
@@ -180,7 +180,10 @@ void convert(
   const trans_tracet &trace,
   xmlt &dest)
 {
-  std::size_t last_time_frame = trace.get_min_failing_timeframe();
+  auto min_failing_timeframe_opt = trace.get_min_failing_timeframe();
+
+  auto last_time_frame =
+    min_failing_timeframe_opt.value_or(trace.states.size() - 1);
 
   dest=xmlt("trans_trace");
   
@@ -253,7 +256,8 @@ void show_trans_trace(
   {
   case ui_message_handlert::uit::PLAIN:
     {
-      std::size_t l = trace.get_min_failing_timeframe();
+      auto l =
+        trace.get_min_failing_timeframe().value_or(trace.states.size() - 1);
 
       for(std::size_t t = 0; t <= l; t++)
         show_trans_state(t, trace.states[t], ns);
@@ -717,7 +721,7 @@ void show_trans_trace_vcd(
 
   out << "$enddefinitions $end\n";
 
-  std::size_t l = trace.get_min_failing_timeframe();
+  auto l = trace.get_min_failing_timeframe().value_or(trace.states.size() - 1);
 
   // initial state
 

--- a/src/trans-netlist/trans_trace.h
+++ b/src/trans-netlist/trans_trace.h
@@ -49,11 +49,11 @@ public:
   // mode of whole trace
   std::string mode;
 
-  // returns the latest failing timeframe
-  std::size_t get_max_failing_timeframe() const;
+  // returns the latest failing timeframe, if any
+  optionalt<std::size_t> get_max_failing_timeframe() const;
 
-  // returns the earliest failing timeframe
-  std::size_t get_min_failing_timeframe() const;
+  // returns the earliest failing timeframe, if any
+  optionalt<std::size_t> get_min_failing_timeframe() const;
 };
 
 // outputting traces

--- a/src/trans-netlist/trans_trace.h
+++ b/src/trans-netlist/trans_trace.h
@@ -48,12 +48,12 @@ public:
   
   // mode of whole trace
   std::string mode;
-  
-  // returns the latest failing timeframe  
-  unsigned get_max_failing_timeframe() const;
 
-  // returns the earliest failing timeframe  
-  unsigned get_min_failing_timeframe() const;
+  // returns the latest failing timeframe
+  std::size_t get_max_failing_timeframe() const;
+
+  // returns the earliest failing timeframe
+  std::size_t get_min_failing_timeframe() const;
 };
 
 // outputting traces

--- a/src/trans-word-level/counterexample_word_level.h
+++ b/src/trans-word-level/counterexample_word_level.h
@@ -12,9 +12,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/namespace.h>
 #include <util/message.h>
 
-void show_counterexample(message_handlert &,
-                         const class decision_proceduret &solver,
-                         unsigned no_timeframes, const namespacet &ns,
-                         const std::string &module);
+void show_counterexample(
+  message_handlert &,
+  const class decision_proceduret &solver,
+  std::size_t no_timeframes,
+  const namespacet &ns,
+  const std::string &module);
 
 #endif

--- a/src/trans-word-level/instantiate_word_level.cpp
+++ b/src/trans-word-level/instantiate_word_level.cpp
@@ -24,9 +24,8 @@ Function: timeframe_identifier
 
 \*******************************************************************/
 
-std::string timeframe_identifier(
-  unsigned timeframe,
-  const irep_idt &identifier)
+std::string
+timeframe_identifier(std::size_t timeframe, const irep_idt &identifier)
 {
   return id2string(identifier)+"@"+std::to_string(timeframe);
 }
@@ -47,11 +46,10 @@ class wl_instantiatet
 {
 public:
   wl_instantiatet(
-    unsigned _current, unsigned _no_timeframes,
-    const namespacet &_ns):
-    current(_current),
-    no_timeframes(_no_timeframes),
-    ns(_ns)
+    std::size_t _current,
+    std::size_t _no_timeframes,
+    const namespacet &_ns)
+    : current(_current), no_timeframes(_no_timeframes), ns(_ns)
   {
   }
   
@@ -63,7 +61,7 @@ public:
   }
 
 protected:
-  unsigned current, no_timeframes;
+  std::size_t current, no_timeframes;
   const namespacet &ns;
   
   void instantiate_rec(exprt &);
@@ -72,7 +70,7 @@ protected:
   class save_currentt
   {
   public:
-    inline explicit save_currentt(unsigned &_c):c(_c), saved(c)
+    inline explicit save_currentt(std::size_t &_c) : c(_c), saved(c)
     {
     }
     
@@ -80,8 +78,8 @@ protected:
     {
       c=saved; // restore
     }
-    
-    unsigned &c, saved;
+
+    std::size_t &c, saved;
   };
 };
 
@@ -358,7 +356,8 @@ Function: instantiate
 
 exprt instantiate(
   const exprt &expr,
-  unsigned current, unsigned no_timeframes,
+  std::size_t current,
+  std::size_t no_timeframes,
   const namespacet &ns)
 {
   wl_instantiatet wl_instantiate(current, no_timeframes, ns);

--- a/src/trans-word-level/instantiate_word_level.h
+++ b/src/trans-word-level/instantiate_word_level.h
@@ -15,11 +15,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 exprt instantiate(
   const exprt &expr,
-  unsigned current, unsigned no_timeframes,
+  std::size_t current,
+  std::size_t no_timeframes,
   const namespacet &);
 
-std::string timeframe_identifier(
-  unsigned timeframe,
-  const irep_idt &identifier);
+std::string
+timeframe_identifier(std::size_t timeframe, const irep_idt &identifier);
 
 #endif

--- a/src/trans-word-level/property.cpp
+++ b/src/trans-word-level/property.cpp
@@ -31,7 +31,7 @@ void property(
   exprt::operandst &prop_handles,
   message_handlert &message_handler,
   decision_proceduret &solver,
-  unsigned no_timeframes,
+  std::size_t no_timeframes,
   const namespacet &ns)
 {
   messaget message(message_handler);
@@ -52,7 +52,7 @@ void property(
 
   const exprt &p = to_unary_expr(property_expr).op();
 
-  for(unsigned c=0; c<no_timeframes; c++)
+  for(std::size_t c = 0; c < no_timeframes; c++)
   {
     exprt tmp=
       instantiate(p, c, no_timeframes, ns);

--- a/src/trans-word-level/property.h
+++ b/src/trans-word-level/property.h
@@ -20,7 +20,7 @@ void property(
   exprt::operandst &prop_handles,
   message_handlert &,
   decision_proceduret &solver,
-  unsigned no_timeframes,
+  std::size_t no_timeframes,
   const namespacet &);
 
 #endif

--- a/src/trans-word-level/trans_trace_word_level.cpp
+++ b/src/trans-word-level/trans_trace_word_level.cpp
@@ -26,7 +26,7 @@ Function: compute_trans_trace
 
 trans_tracet compute_trans_trace(
   const decision_proceduret &decision_procedure,
-  unsigned no_timeframes,
+  std::size_t no_timeframes,
   const namespacet &ns,
   const irep_idt &module)
 {
@@ -40,7 +40,7 @@ trans_tracet compute_trans_trace(
 
   dest.states.resize(no_timeframes);
 
-  for(unsigned t=0; t<no_timeframes; t++)
+  for(std::size_t t = 0; t < no_timeframes; t++)
   {
     const symbol_tablet &symbol_table=ns.get_symbol_table();
 
@@ -94,7 +94,7 @@ Function: compute_trans_trace
 trans_tracet compute_trans_trace(
   const exprt::operandst &prop_handles,
   const decision_proceduret &solver,
-  unsigned no_timeframes,
+  std::size_t no_timeframes,
   const namespacet &ns,
   const irep_idt &module)
 {
@@ -102,7 +102,7 @@ trans_tracet compute_trans_trace(
 
   // check the properties that got violated
 
-  for(unsigned t=0; t<no_timeframes; t++)
+  for(std::size_t t = 0; t < no_timeframes; t++)
   {
     DATA_INVARIANT(
       t < prop_handles.size(),

--- a/src/trans-word-level/trans_trace_word_level.h
+++ b/src/trans-word-level/trans_trace_word_level.h
@@ -17,7 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 trans_tracet compute_trans_trace(
   const decision_proceduret &,
-  unsigned no_timeframes,
+  std::size_t no_timeframes,
   const namespacet &,
   const irep_idt &module);
 
@@ -26,7 +26,7 @@ trans_tracet compute_trans_trace(
 trans_tracet compute_trans_trace(
   const exprt::operandst &prop_handles,
   const decision_proceduret &solver,
-  unsigned no_timeframes,
+  std::size_t no_timeframes,
   const namespacet &ns,
   const irep_idt &module);
 

--- a/src/trans-word-level/unwind.cpp
+++ b/src/trans-word-level/unwind.cpp
@@ -25,9 +25,14 @@ Function: unwind
 
 \*******************************************************************/
 
-void unwind(const transt &trans, message_handlert &message_handler,
-            decision_proceduret &decision_procedure, unsigned no_timeframes,
-            const namespacet &ns, bool initial_state) {
+void unwind(
+  const transt &trans,
+  message_handlert &message_handler,
+  decision_proceduret &decision_procedure,
+  std::size_t no_timeframes,
+  const namespacet &ns,
+  bool initial_state)
+{
   messaget message{message_handler};
   const exprt &op_invar=trans.invar();
   const exprt &op_init=trans.init();
@@ -38,7 +43,7 @@ void unwind(const transt &trans, message_handlert &message_handler,
   message.status() << "General constraints" << messaget::eom;
 
   if(!op_invar.is_true())
-    for(unsigned c=0; c<no_timeframes; c++)
+    for(std::size_t c = 0; c < no_timeframes; c++)
       decision_procedure.set_to_true(
         instantiate(op_invar, c, no_timeframes, ns));
 
@@ -58,7 +63,7 @@ void unwind(const transt &trans, message_handlert &message_handler,
   message.status() << "Transition relation" << messaget::eom;
 
   if(!op_trans.is_true())
-    for(unsigned t=0; t<no_timeframes; t++)
+    for(std::size_t t = 0; t < no_timeframes; t++)
     {
       // do transitions
       bool last=(t==no_timeframes-1);

--- a/src/trans-word-level/unwind.h
+++ b/src/trans-word-level/unwind.h
@@ -15,9 +15,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 // word-level
 
-void unwind(const transt &trans, message_handlert &message_handler,
-            class decision_proceduret &decision_procedure,
-            unsigned no_timeframes, const class namespacet &ns,
-            bool initial_state = true);
+void unwind(
+  const transt &,
+  message_handlert &,
+  class decision_proceduret &,
+  std::size_t no_timeframes,
+  const class namespacet &,
+  bool initial_state = true);
 
 #endif


### PR DESCRIPTION
This adds a facility to generate a given number of random traces, using the solver, with a given length, and using a given random seed.

By default, traces are written to the console, but may alternatively be stored in VCD format, one file per trace.

Depends on #108.