### PR TITLE
ebmc: timeframe indices are now size_t

### DIFF
--- a/src/ebmc/ebmc_base.cpp
+++ b/src/ebmc/ebmc_base.cpp
@@ -505,8 +505,8 @@ int ebmc_baset::do_word_level_bmc(
       if(convert_only)
         throw "please set a specific bound";
         
-      const unsigned max_bound=
-        unsafe_string2unsigned(cmdline.get_value("max-bound"));
+      const std::size_t max_bound=
+        unsafe_string2size_t(cmdline.get_value("max-bound"));
     
       for(bound=1; bound<=max_bound; bound++)
       {

--- a/src/ebmc/ebmc_base.h
+++ b/src/ebmc/ebmc_base.h
@@ -62,7 +62,7 @@ protected:
   bool parse(const std::string &filename);
   bool typecheck();
 
-  unsigned bound;
+  std::size_t bound;
 
   struct propertyt
   {

--- a/src/hw-cbmc/map_vars.cpp
+++ b/src/hw-cbmc/map_vars.cpp
@@ -32,7 +32,7 @@ Function: instantiate_symbol
 
 \*******************************************************************/
 
-void instantiate_symbol(exprt &expr, unsigned timeframe)
+void instantiate_symbol(exprt &expr, std::size_t timeframe)
 {
   if(expr.id()==ID_symbol)
   {
@@ -65,7 +65,7 @@ public:
     symbol_table_baset &_symbol_table,
     std::list<exprt> &_constraints,
     message_handlert &_message,
-    unsigned _no_timeframes)
+    std::size_t _no_timeframes)
     : messaget(_message),
       symbol_table(_symbol_table),
       constraints(_constraints),
@@ -77,7 +77,7 @@ public:
 protected:
   symbol_table_baset &symbol_table;
   std::list<exprt> &constraints;
-  unsigned no_timeframes;
+  std::size_t no_timeframes;
   std::set<irep_idt> top_level_inputs;
 
   symbolt &lookup(const irep_idt &identifier);
@@ -96,7 +96,7 @@ protected:
   void map_var(
     const exprt &program_symbol,
     const symbolt &module_symbol,
-    unsigned transition);
+    std::size_t transition);
 
   void add_constraint_rec(
     const exprt &program_symbol,
@@ -111,8 +111,8 @@ protected:
     std::string &error_msg);
     
   std::string show_member(const exprt &expr);
-  void set_transition(exprt &expr, unsigned transition);
-  
+  void set_transition(exprt &expr, std::size_t transition);
+
   mp_integer get_size(const array_typet &type)
   {
     const exprt &size_expr=type.size();
@@ -166,7 +166,7 @@ Function: map_varst::set_transition
 
 \*******************************************************************/
 
-void map_varst::set_transition(exprt &expr, unsigned transition)
+void map_varst::set_transition(exprt &expr, std::size_t transition)
 {
   if(expr.id()==ID_member)
   {
@@ -390,7 +390,7 @@ Function: map_varst::map_var
 void map_varst::map_var(
   const exprt &program_symbol,
   const symbolt &module_symbol,
-  unsigned transition)
+  std::size_t transition)
 {
   // we have s[0].a.b.c
   // make that s#0[transition].a.b.c
@@ -614,7 +614,7 @@ void map_varst::map_var(
       
   // map values
 
-  for(unsigned t=0; t<no_timeframes; t++)
+  for(std::size_t t = 0; t < no_timeframes; t++)
     map_var(program_symbol, module_symbol, t);
 }
 
@@ -760,7 +760,7 @@ void map_vars(
   const irep_idt &module,
   std::list<exprt> &constraints,
   message_handlert &message,
-  unsigned no_timeframes)
+  std::size_t no_timeframes)
 {
   map_varst map_vars(symbol_table, constraints, message, no_timeframes);
   map_vars.map_vars(module);

--- a/src/hw-cbmc/map_vars.h
+++ b/src/hw-cbmc/map_vars.h
@@ -17,6 +17,6 @@ void map_vars(
   const irep_idt &module,
   std::list<exprt> &constraints,
   message_handlert &message,
-  unsigned no_timeframes);
+  std::size_t no_timeframes);
 
 #endif

--- a/src/trans-netlist/bmc_map.cpp
+++ b/src/trans-netlist/bmc_map.cpp
@@ -26,18 +26,18 @@ Function: bmc_mapt::map_timeframes
 
 void bmc_mapt::map_timeframes(
   const netlistt &netlist,
-  unsigned no_timeframes,
+  std::size_t no_timeframes,
   propt &solver)
 {
   var_map=netlist.var_map;
   timeframe_map.resize(no_timeframes);
-  
-  for(unsigned t=0; t<timeframe_map.size(); t++)
+
+  for(std::size_t t = 0; t < timeframe_map.size(); t++)
   {
     timeframet &timeframe=timeframe_map[t];
     timeframe.resize(netlist.number_of_nodes());
 
-    for(unsigned n=0; n<timeframe.size(); n++)
+    for(std::size_t n = 0; n < timeframe.size(); n++)
     {
       literalt solver_literal=solver.new_variable();
       timeframe[n].solver_literal=solver_literal;

--- a/src/trans-netlist/bmc_map.h
+++ b/src/trans-netlist/bmc_map.h
@@ -16,14 +16,16 @@ Author: Daniel Kroening, kroening@kroening.com
 class bmc_mapt
 {
 public:
-  inline literalt get(unsigned timeframe, const var_mapt::vart::bitt &bit) const
+  inline literalt
+  get(std::size_t timeframe, const var_mapt::vart::bitt &bit) const
   {
     literalt l=bit.current;
     if(l.is_constant()) return l;
     return get(timeframe, l.var_no())^l.sign();
   }
 
-  inline literalt get(unsigned timeframe, const irep_idt &id, unsigned bit_nr) const
+  inline literalt
+  get(std::size_t timeframe, const irep_idt &id, unsigned bit_nr) const
   {
     literalt l=var_map.get_current(id, bit_nr);
     if(l.is_constant()) return l;
@@ -31,7 +33,7 @@ public:
   }
 
   // translate netlist variable to solver literal
-  inline literalt get(unsigned timeframe, unsigned var_no) const
+  inline literalt get(std::size_t timeframe, unsigned var_no) const
   {
     assert(timeframe<timeframe_map.size());
     assert(var_no<timeframe_map[timeframe].size());
@@ -39,14 +41,14 @@ public:
   }
 
   // translate netlist literal to solver literal
-  inline literalt translate(unsigned timeframe, literalt l) const
+  inline literalt translate(std::size_t timeframe, literalt l) const
   {
     if(l.is_constant()) return l;
     return get(timeframe, l.var_no())^l.sign();
   }
 
   // set the solver literal for a netlist variable
-  void set(unsigned timeframe, unsigned var_no, literalt l)
+  void set(std::size_t timeframe, unsigned var_no, literalt l)
   {
     assert(timeframe<timeframe_map.size());
     assert(var_no<timeframe_map[timeframe].size());
@@ -57,7 +59,7 @@ public:
   // this is number of cycles +1!
   void map_timeframes(
     const netlistt &netlist,
-    unsigned no_timeframes,
+    std::size_t no_timeframes,
     propt &solver);
 
   var_mapt var_map;
@@ -75,13 +77,13 @@ public:
   {
     // this is the netlist literal
     literalt netlist_literal;
-    unsigned timeframe;
+    std::size_t timeframe;
   };
 
   typedef std::map<literalt, reverse_entryt> reverse_mapt;
   reverse_mapt reverse_map;
-  
-  unsigned get_no_timeframes() const
+
+  std::size_t get_no_timeframes() const
   {
     return timeframe_map.size();
   }

--- a/src/trans-netlist/trans_trace.cpp
+++ b/src/trans-netlist/trans_trace.cpp
@@ -38,11 +38,11 @@ Function: trans_tracet::get_max_failing_timeframe
 
 \*******************************************************************/
 
-unsigned trans_tracet::get_max_failing_timeframe() const
+std::size_t trans_tracet::get_max_failing_timeframe() const
 {
-  unsigned max=0;
-  
-  for(unsigned t=0; t<states.size(); t++)
+  std::size_t max = 0;
+
+  for(std::size_t t = 0; t < states.size(); t++)
   {
     if(states[t].property_failed)
       max=t;
@@ -63,9 +63,9 @@ Function: trans_tracet::get_min_failing_timeframe
 
 \*******************************************************************/
 
-unsigned trans_tracet::get_min_failing_timeframe() const
+std::size_t trans_tracet::get_min_failing_timeframe() const
 {
-  for(unsigned t=0; t<states.size(); t++)
+  for(std::size_t t = 0; t < states.size(); t++)
     if(states[t].property_failed)
       return t;
 
@@ -109,7 +109,7 @@ Function: show_trans_state
 \*******************************************************************/
 
 void show_trans_state(
-  unsigned timeframe,
+  std::size_t timeframe,
   const trans_tracet::statet &state,
   const namespacet &ns)
 {
@@ -180,13 +180,13 @@ void convert(
   const trans_tracet &trace,
   xmlt &dest)
 {
-  unsigned last_time_frame=trace.get_min_failing_timeframe();
+  std::size_t last_time_frame = trace.get_min_failing_timeframe();
 
   dest=xmlt("trans_trace");
   
   dest.new_element("mode").data=trace.mode;
 
-  for(unsigned t=0; t<=last_time_frame; t++)
+  for(std::size_t t = 0; t <= last_time_frame; t++)
   {
     assert(t<trace.states.size());
   
@@ -253,9 +253,9 @@ void show_trans_trace(
   {
   case ui_message_handlert::uit::PLAIN:
     {
-      unsigned l=trace.get_min_failing_timeframe();
+      std::size_t l = trace.get_min_failing_timeframe();
 
-      for(unsigned t=0; t<=l; t++)
+      for(std::size_t t = 0; t <= l; t++)
         show_trans_state(t, trace.states[t], ns);
     }
     break;
@@ -458,7 +458,7 @@ Function: show_trans_state_vcd
 \*******************************************************************/
 
 void show_trans_state_vcd(
-  unsigned timeframe,
+  std::size_t timeframe,
   const trans_tracet::statet &previous_state,
   const trans_tracet::statet &current_state,
   const namespacet &ns,
@@ -599,7 +599,7 @@ void vcd_hierarchy_rec(
   const std::set<irep_idt> &ids,
   const std::string &prefix,
   std::ostream &out,
-  unsigned depth)
+  std::size_t depth)
 {
   std::set<std::string> sub_modules;
   std::set<irep_idt> signals;
@@ -716,16 +716,16 @@ void show_trans_trace_vcd(
   out << "$upscope $end\n";  
 
   out << "$enddefinitions $end\n";
-  
-  unsigned l=trace.get_min_failing_timeframe();
-  
+
+  std::size_t l = trace.get_min_failing_timeframe();
+
   // initial state
 
   show_trans_state_vcd(0, trace.states[0], trace.states[0], ns, out);
   
   // following ones
 
-  for(unsigned t=1; t<=l; t++)
+  for(std::size_t t = 1; t <= l; t++)
     show_trans_state_vcd(t, trace.states[t-1], trace.states[t], ns, out);
 }
 

--- a/src/trans-netlist/trans_trace.h
+++ b/src/trans-netlist/trans_trace.h
@@ -48,12 +48,12 @@ public:
   
   // mode of whole trace
   std::string mode;
-  
-  // returns the latest failing timeframe  
-  unsigned get_max_failing_timeframe() const;
 
-  // returns the earliest failing timeframe  
-  unsigned get_min_failing_timeframe() const;
+  // returns the latest failing timeframe
+  std::size_t get_max_failing_timeframe() const;
+
+  // returns the earliest failing timeframe
+  std::size_t get_min_failing_timeframe() const;
 };
 
 // outputting traces

--- a/src/trans-word-level/counterexample_word_level.h
+++ b/src/trans-word-level/counterexample_word_level.h
@@ -12,9 +12,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/namespace.h>
 #include <util/message.h>
 
-void show_counterexample(message_handlert &,
-                         const class decision_proceduret &solver,
-                         unsigned no_timeframes, const namespacet &ns,
-                         const std::string &module);
+void show_counterexample(
+  message_handlert &,
+  const class decision_proceduret &solver,
+  std::size_t no_timeframes,
+  const namespacet &ns,
+  const std::string &module);
 
 #endif

--- a/src/trans-word-level/instantiate_word_level.cpp
+++ b/src/trans-word-level/instantiate_word_level.cpp
@@ -24,9 +24,8 @@ Function: timeframe_identifier
 
 \*******************************************************************/
 
-std::string timeframe_identifier(
-  unsigned timeframe,
-  const irep_idt &identifier)
+std::string
+timeframe_identifier(std::size_t timeframe, const irep_idt &identifier)
 {
   return id2string(identifier)+"@"+std::to_string(timeframe);
 }
@@ -47,11 +46,10 @@ class wl_instantiatet
 {
 public:
   wl_instantiatet(
-    unsigned _current, unsigned _no_timeframes,
-    const namespacet &_ns):
-    current(_current),
-    no_timeframes(_no_timeframes),
-    ns(_ns)
+    std::size_t _current,
+    std::size_t _no_timeframes,
+    const namespacet &_ns)
+    : current(_current), no_timeframes(_no_timeframes), ns(_ns)
   {
   }
   
@@ -63,7 +61,7 @@ public:
   }
 
 protected:
-  unsigned current, no_timeframes;
+  std::size_t current, no_timeframes;
   const namespacet &ns;
   
   void instantiate_rec(exprt &);
@@ -72,7 +70,7 @@ protected:
   class save_currentt
   {
   public:
-    inline explicit save_currentt(unsigned &_c):c(_c), saved(c)
+    inline explicit save_currentt(std::size_t &_c) : c(_c), saved(c)
     {
     }
     
@@ -80,8 +78,8 @@ protected:
     {
       c=saved; // restore
     }
-    
-    unsigned &c, saved;
+
+    std::size_t &c, saved;
   };
 };
 
@@ -358,7 +356,8 @@ Function: instantiate
 
 exprt instantiate(
   const exprt &expr,
-  unsigned current, unsigned no_timeframes,
+  std::size_t current,
+  std::size_t no_timeframes,
   const namespacet &ns)
 {
   wl_instantiatet wl_instantiate(current, no_timeframes, ns);

--- a/src/trans-word-level/instantiate_word_level.h
+++ b/src/trans-word-level/instantiate_word_level.h
@@ -15,11 +15,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 exprt instantiate(
   const exprt &expr,
-  unsigned current, unsigned no_timeframes,
+  std::size_t current,
+  std::size_t no_timeframes,
   const namespacet &);
 
-std::string timeframe_identifier(
-  unsigned timeframe,
-  const irep_idt &identifier);
+std::string
+timeframe_identifier(std::size_t timeframe, const irep_idt &identifier);
 
 #endif

--- a/src/trans-word-level/property.cpp
+++ b/src/trans-word-level/property.cpp
@@ -31,7 +31,7 @@ void property(
   exprt::operandst &prop_handles,
   message_handlert &message_handler,
   decision_proceduret &solver,
-  unsigned no_timeframes,
+  std::size_t no_timeframes,
   const namespacet &ns)
 {
   messaget message(message_handler);
@@ -52,7 +52,7 @@ void property(
 
   const exprt &p = to_unary_expr(property_expr).op();
 
-  for(unsigned c=0; c<no_timeframes; c++)
+  for(std::size_t c = 0; c < no_timeframes; c++)
   {
     exprt tmp=
       instantiate(p, c, no_timeframes, ns);

--- a/src/trans-word-level/property.h
+++ b/src/trans-word-level/property.h
@@ -20,7 +20,7 @@ void property(
   exprt::operandst &prop_handles,
   message_handlert &,
   decision_proceduret &solver,
-  unsigned no_timeframes,
+  std::size_t no_timeframes,
   const namespacet &);
 
 #endif

--- a/src/trans-word-level/trans_trace_word_level.cpp
+++ b/src/trans-word-level/trans_trace_word_level.cpp
@@ -26,7 +26,7 @@ Function: compute_trans_trace
 
 trans_tracet compute_trans_trace(
   const decision_proceduret &decision_procedure,
-  unsigned no_timeframes,
+  std::size_t no_timeframes,
   const namespacet &ns,
   const irep_idt &module)
 {
@@ -40,7 +40,7 @@ trans_tracet compute_trans_trace(
 
   dest.states.resize(no_timeframes);
 
-  for(unsigned t=0; t<no_timeframes; t++)
+  for(std::size_t t = 0; t < no_timeframes; t++)
   {
     const symbol_tablet &symbol_table=ns.get_symbol_table();
 
@@ -94,7 +94,7 @@ Function: compute_trans_trace
 trans_tracet compute_trans_trace(
   const exprt::operandst &prop_handles,
   const decision_proceduret &solver,
-  unsigned no_timeframes,
+  std::size_t no_timeframes,
   const namespacet &ns,
   const irep_idt &module)
 {
@@ -102,7 +102,7 @@ trans_tracet compute_trans_trace(
 
   // check the properties that got violated
 
-  for(unsigned t=0; t<no_timeframes; t++)
+  for(std::size_t t = 0; t < no_timeframes; t++)
   {
     DATA_INVARIANT(
       t < prop_handles.size(),

--- a/src/trans-word-level/trans_trace_word_level.h
+++ b/src/trans-word-level/trans_trace_word_level.h
@@ -17,7 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 trans_tracet compute_trans_trace(
   const decision_proceduret &,
-  unsigned no_timeframes,
+  std::size_t no_timeframes,
   const namespacet &,
   const irep_idt &module);
 
@@ -26,7 +26,7 @@ trans_tracet compute_trans_trace(
 trans_tracet compute_trans_trace(
   const exprt::operandst &prop_handles,
   const decision_proceduret &solver,
-  unsigned no_timeframes,
+  std::size_t no_timeframes,
   const namespacet &ns,
   const irep_idt &module);
 

--- a/src/trans-word-level/unwind.cpp
+++ b/src/trans-word-level/unwind.cpp
@@ -25,9 +25,14 @@ Function: unwind
 
 \*******************************************************************/
 
-void unwind(const transt &trans, message_handlert &message_handler,
-            decision_proceduret &decision_procedure, unsigned no_timeframes,
-            const namespacet &ns, bool initial_state) {
+void unwind(
+  const transt &trans,
+  message_handlert &message_handler,
+  decision_proceduret &decision_procedure,
+  std::size_t no_timeframes,
+  const namespacet &ns,
+  bool initial_state)
+{
   messaget message{message_handler};
   const exprt &op_invar=trans.invar();
   const exprt &op_init=trans.init();
@@ -38,7 +43,7 @@ void unwind(const transt &trans, message_handlert &message_handler,
   message.status() << "General constraints" << messaget::eom;
 
   if(!op_invar.is_true())
-    for(unsigned c=0; c<no_timeframes; c++)
+    for(std::size_t c = 0; c < no_timeframes; c++)
       decision_procedure.set_to_true(
         instantiate(op_invar, c, no_timeframes, ns));
 
@@ -58,7 +63,7 @@ void unwind(const transt &trans, message_handlert &message_handler,
   message.status() << "Transition relation" << messaget::eom;
 
   if(!op_trans.is_true())
-    for(unsigned t=0; t<no_timeframes; t++)
+    for(std::size_t t = 0; t < no_timeframes; t++)
     {
       // do transitions
       bool last=(t==no_timeframes-1);

--- a/src/trans-word-level/unwind.h
+++ b/src/trans-word-level/unwind.h
@@ -15,9 +15,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 // word-level
 
-void unwind(const transt &trans, message_handlert &message_handler,
-            class decision_proceduret &decision_procedure,
-            unsigned no_timeframes, const class namespacet &ns,
-            bool initial_state = true);
+void unwind(
+  const transt &,
+  message_handlert &,
+  class decision_proceduret &,
+  std::size_t no_timeframes,
+  const class namespacet &,
+  bool initial_state = true);
 
 #endif


### PR DESCRIPTION
There are numerous vectors that have the same size as the number of timeframes, and hence, the natural type for the number of timeframes or timeframe indices is `std::size_t`.