### PR TITLE
random traces: use --trace-steps instead of --bound

### DIFF
--- a/regression/ebmc/random-traces/boolean1.desc
+++ b/regression/ebmc/random-traces/boolean1.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
 boolean1.v
---bound 0 --random-traces 2
+--trace-steps 0 --random-traces 2
 ^\*\*\* Trace 1$
 ^  main\.some_wire = 0$
 ^  main\.input1 = 0$

--- a/regression/ebmc/random-traces/bv1.desc
+++ b/regression/ebmc/random-traces/bv1.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
 bv1.v
---bound 1 --random-traces 1
+--trace-steps 1 --random-traces 1
 ^Transition system state 0$
 ^  main\.some_reg = 0 .*$
 ^  main\.input1 = 'h6FE4167A .*$

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -291,6 +291,7 @@ void ebmc_parse_optionst::help()
     "    {y--aiger}                  \t print out the instance in aiger format\n"
     " {y--random-traces} {unumber}   \t generate the given number of random traces\n"
     "       {y--random-seed} {unumber}\t use the given random seed\n"
+    "       {y--trace-steps} {unumber}\t set the number of random transitions (default: 10 steps)\n"
     " {y--ranking-function} {uf}     \t prove a liveness property using given ranking funnction (experimental)\n"
     "    {y--property} {uid}         \t the liveness property to prove\n"
 

--- a/src/ebmc/ebmc_parse_options.h
+++ b/src/ebmc/ebmc_parse_options.h
@@ -39,7 +39,7 @@ public:
         "(smt2)(boolector)(z3)(cvc4)(yices)(mathsat)(prover)(lifter)"
         "(aig)(stop-induction)(stop-minimize)(start):(coverage)(naive)"
         "(compute-ct)(dot-netlist)(smv-netlist)(vcd):"
-        "(random-traces):(random-seed):"
+        "(random-traces):(trace-steps):(random-seed):"
         "I:(preprocess)",
         argc,
         argv,

--- a/src/ebmc/random_traces.cpp
+++ b/src/ebmc/random_traces.cpp
@@ -251,10 +251,22 @@ void random_tracest::operator()()
   else
     generator.seed(0);
 
-  if(get_bound())
-    throw ebmc_errort();
+  std::size_t trace_steps;
 
-  auto number_of_timeframes = bound + 1;
+  if(cmdline.isset("trace-steps"))
+  {
+    auto trace_steps_opt =
+      string2optional_size_t(cmdline.get_value("trace-steps"));
+
+    if(!trace_steps_opt.has_value())
+      throw ebmc_errort() << "failed to parse number of trace steps";
+
+    trace_steps = trace_steps_opt.value();
+  }
+  else
+    trace_steps = 10; // default
+
+  auto number_of_timeframes = trace_steps + 1;
 
   int result = get_transition_system();
   if(result != -1)


### PR DESCRIPTION
The term 'bound' is uncommon in random simulation.  Use the common term 'trace steps' instead of bound.  Note that this counts transition steps, not transition system states.  A trace with one step has two states.