### PR TITLE
introduce a repo-local common file

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,9 +1,7 @@
 DIRS = ebmc hw-cbmc trans-word-level trans-netlist verilog vhdl smvlang ic3 aiger
 
 EBMC_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-CPROVER_DIR = $(EBMC_DIR)/../lib/cbmc/src
-export CPROVER_DIR
-export EBMC_DIR
+CPROVER_DIR:=../lib/cbmc/src
 
 all: hw-cbmc.dir ebmc.dir
 

--- a/src/aiger/Makefile
+++ b/src/aiger/Makefile
@@ -1,9 +1,7 @@
 SRC = aiger_language.cpp
 
-include $(CPROVER_DIR)/config.inc
-include $(CPROVER_DIR)/common
-
-INCLUDES= -I $(CPROVER_DIR)
+include ../config.inc
+include ../common
 
 CLEANFILES = 
 

--- a/src/common
+++ b/src/common
@@ -1,0 +1,7 @@
+CPROVER_DIR = ../../lib/cbmc/src
+
+include $(CPROVER_DIR)/config.inc
+include $(CPROVER_DIR)/common
+
+INCLUDES= -I $(CPROVER_DIR) -I ..
+CXXFLAGS += -D'LOCAL_IREP_IDS=<hw_cbmc_irep_ids.h>'

--- a/src/config.inc
+++ b/src/config.inc
@@ -1,5 +1,0 @@
-CBMC = ../../lib/cbmc
-
-include $(CBMC)/src/config.inc
-include $(CBMC)/src/common
-

--- a/src/ebmc/Makefile
+++ b/src/ebmc/Makefile
@@ -61,10 +61,7 @@ ifneq ($(wildcard ../vhdl/Makefile),)
 endif
 
 include ../config.inc
-
-INCLUDES= -I $(CPROVER_DIR) -I ..
-
-CXXFLAGS += -D'LOCAL_IREP_IDS=<hw_cbmc_irep_ids.h>'
+include ../common
 
 LIBS = ../ic3/minisat/build/release/lib/libminisat.a
 

--- a/src/hw-cbmc/Makefile
+++ b/src/hw-cbmc/Makefile
@@ -39,10 +39,7 @@ OBJ+= $(CPROVER_DIR)/goto-checker/goto-checker$(LIBEXT) \
       ../trans-word-level/trans-word-level$(LIBEXT)
 
 include ../config.inc
-
-INCLUDES= -I $(CPROVER_DIR) -I ..
-
-CXXFLAGS += -D'LOCAL_IREP_IDS=<hw_cbmc_irep_ids.h>'
+include ../common
 
 LIBS =
 

--- a/src/ic3/Makefile
+++ b/src/ic3/Makefile
@@ -15,9 +15,9 @@ vpath %.cc build_prob
 vpath %.hh build_prob
 
 include ../config.inc
+include ../common
 
 MINISAT_INC = minisat
-CXXFLAGS += -D'LOCAL_IREP_IDS=<hw_cbmc_irep_ids.h>'
 
 INC_DIR = -I . -I build_prob -I seq_circ -I $(MINISAT_INC) -I $(CPROVER_DIR) -I ..
 

--- a/src/satqe/Makefile
+++ b/src/satqe/Makefile
@@ -11,7 +11,7 @@ ifneq ($(MINISAT),)
 MINISAT_INCLUDE=-I ../$(MINISAT)
 endif
 
-INCLUDES= $(MINISAT_INCLUDE) -I .. -I ../util
+INCLUDES+= $(MINISAT_INCLUDE)
 
 ###############################################################################
 

--- a/src/smvlang/Makefile
+++ b/src/smvlang/Makefile
@@ -1,11 +1,8 @@
 SRC = smv_language.cpp smv_parser.cpp smv_typecheck.cpp expr2smv.cpp \
       smv_y.tab.cpp lex.yy.cpp smv_parse_tree.cpp
 
-include $(CPROVER_DIR)/config.inc
-include $(CPROVER_DIR)/common
-
-INCLUDES= -I $(CPROVER_DIR) -I ..
-CXXFLAGS += -D'LOCAL_IREP_IDS=<hw_cbmc_irep_ids.h>'
+include ../config.inc
+include ../common
 
 CLEANFILES = smvlang$(LIBEXT) smv_y.tab.h smv_y.tab.cpp lex.yy.cpp smv_y.output
 

--- a/src/trans-netlist/Makefile
+++ b/src/trans-netlist/Makefile
@@ -4,11 +4,8 @@ SRC = aig.cpp aig_prop.cpp bmc_map.cpp counterexample_netlist.cpp \
       trans_trace.cpp trans_to_netlist.cpp \
       map_aigs.cpp bv_varid.cpp
 
-include $(CPROVER_DIR)/config.inc
-include $(CPROVER_DIR)/common
-
-INCLUDES= -I $(CPROVER_DIR) -I ..
-CXXFLAGS += -D'LOCAL_IREP_IDS=<hw_cbmc_irep_ids.h>'
+include ../config.inc
+include ../common
 
 CLEANFILES = trans-netlist$(LIBEXT)
 

--- a/src/trans-word-level/Makefile
+++ b/src/trans-word-level/Makefile
@@ -2,11 +2,8 @@ SRC = get_trans.cpp show_modules.cpp unwind.cpp	word_level_trans.cpp \
       property.cpp counterexample_word_level.cpp \
       trans_trace_word_level.cpp instantiate_word_level.cpp
 
-include $(CPROVER_DIR)/config.inc
-include $(CPROVER_DIR)/common
-
-INCLUDES= -I $(CPROVER_DIR) -I ..
-CXXFLAGS += -D'LOCAL_IREP_IDS=<hw_cbmc_irep_ids.h>'
+include ../config.inc
+include ../common
 
 CLEANFILES = trans-word-level$(LIBEXT)
 

--- a/src/vcegar/Makefile
+++ b/src/vcegar/Makefile
@@ -18,8 +18,7 @@ OBJ = $(SRC:.cpp=$(OBJEXT)) \
       ../trans/trans$(LIBEXT)
 
 include ../config.inc
-
-INCLUDES= -I $(CBMC)/src/ -I ../
+include ../common
 
 LIBS =
 

--- a/src/verilog/Makefile
+++ b/src/verilog/Makefile
@@ -20,11 +20,8 @@ SRC = expr2verilog.cpp \
       verilog_y.tab.cpp \
       vtype.cpp
 
-include $(CPROVER_DIR)/config.inc
-include $(CPROVER_DIR)/common
-
-INCLUDES= -I $(CPROVER_DIR) -I ..
-CXXFLAGS += -D'LOCAL_IREP_IDS=<hw_cbmc_irep_ids.h>'
+include ../config.inc
+include ../common
 
 CLEANFILES = verilog$(LIBEXT) verilog_y.tab.h verilog_y.tab.cpp \
              verilog_lex.yy.cpp verilog_y.output

--- a/src/vhdl/Makefile
+++ b/src/vhdl/Makefile
@@ -2,11 +2,8 @@ SRC = vhdl_language.cpp expr2vhdl.cpp vhdl_y.tab.cpp vhdl_lex.yy.cpp \
       vhdl_parser.cpp vhdl_parse_tree.cpp vhdl_typecheck.cpp \
       vhdl_synthesis.cpp vhdl_std_packages.cpp vhdl_libraries.cpp
 
-include $(CPROVER_DIR)/config.inc
-include $(CPROVER_DIR)/common
-
-INCLUDES= -I $(CPROVER_DIR) -I ..
-CXXFLAGS += -D'LOCAL_IREP_IDS=<hw_cbmc_irep_ids.h>'
+include ../config.inc
+include ../common
 
 CLEANFILES = vhdl$(LIBEXT) vhdl_y.tab.cpp vhdl_y.tab.h vhdl_lex.yy.cpp vhdl_y.output
 


### PR DESCRIPTION
This reduces replication between Makefiles in the repo by moving shared lines into a new file 'common'.

This also enables partial builds by locally calling 'make' in any directory.