### PR TITLE
ebmc: split out property parsing from get_transition_system

### DIFF
--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -143,6 +143,10 @@ int bdd_enginet::operator()()
       
       status() << "Building netlist for atomic propositions" << eom;
       
+      result = get_properties();
+      if(result != -1)
+        return result;
+
       for(const propertyt &p : properties)
         get_atomic_propositions(p.expr);
         

--- a/src/ebmc/ebmc_base.cpp
+++ b/src/ebmc/ebmc_base.cpp
@@ -855,26 +855,6 @@ int ebmc_baset::get_transition_system()
     *transition_system.trans_expr = new_trans_expr;
   }
 
-  // Property given on command line?
-  if(cmdline.isset('p'))
-  {
-    // NuSMV also uses -p
-    if(parse_property(cmdline.get_value('p')))
-      return 1;
-  }
-  else
-  {
-    // get properties from file
-    if(get_model_properties())
-      return 1;
-  }
-
-  if(cmdline.isset("show-properties"))
-  {
-    show_properties();
-    return 0;
-  }
-
   if(cmdline.isset("show-netlist"))
   {
     netlistt netlist;
@@ -906,6 +886,43 @@ int ebmc_baset::get_transition_system()
   }
   
   return -1; // done with the model
+}
+
+/*******************************************************************\
+
+Function: ebmc_baset::get_properties
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+int ebmc_baset::get_properties()
+{
+  // Property given on command line?
+  if(cmdline.isset('p'))
+  {
+    // NuSMV also uses -p
+    if(parse_property(cmdline.get_value('p')))
+      return 1;
+  }
+  else
+  {
+    // get properties from the model files
+    if(get_model_properties())
+      return 1;
+  }
+
+  if(cmdline.isset("show-properties"))
+  {
+    show_properties();
+    return 0;
+  }
+
+  return -1; // done
 }
 
 /*******************************************************************\

--- a/src/ebmc/ebmc_base.h
+++ b/src/ebmc/ebmc_base.h
@@ -32,6 +32,7 @@ public:
   virtual ~ebmc_baset() { }
 
   int get_transition_system();
+  int get_properties();
 
 protected:
   const cmdlinet &cmdline;

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -203,6 +203,11 @@ int ebmc_parse_optionst::doit()
       if(result != -1)
         return result;
 
+      result = ebmc_base.get_properties();
+
+      if(result != -1)
+        return result;
+
       if(cmdline.isset("dimacs"))
         return ebmc_base.do_dimacs();
       else if(cmdline.isset("cvc4"))

--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -82,6 +82,10 @@ int k_inductiont::operator()()
   int result = get_transition_system();
   if(result!=-1) return result;
 
+  result = get_properties();
+  if(result != -1)
+    return result;
+
   if(properties.empty())
   {
     error() << "no properties" << eom;

--- a/src/ebmc/ranking_function.cpp
+++ b/src/ebmc/ranking_function.cpp
@@ -126,6 +126,11 @@ int ranking_function_checkt::operator()()
   const auto ranking_function = parse_ranking_function();
 
   // find the property
+  exit_code = get_properties();
+
+  if(exit_code != -1)
+    return exit_code;
+
   auto &property = find_property();
 
   satcheckt satcheck{*message_handler};


### PR DESCRIPTION
A 'transition system' does not include properties, hence we split out the code that discovers the properties into a new function.