### PR TITLE
ebmc: split up show_trans_trace by format

### DIFF
--- a/src/ebmc/ebmc_base.cpp
+++ b/src/ebmc/ebmc_base.cpp
@@ -1166,9 +1166,7 @@ void ebmc_baset::report_results()
          cmdline.isset("trace"))
       {
         status() << "Counterexample:\n" << eom;
-        show_trans_trace(
-            property.counterexample, *this, ns,
-            static_cast<ui_message_handlert *>(message_handler)->get_ui());
+        show_trans_trace(property.counterexample, *this, ns, std::cout);
       }
     }
   }

--- a/src/ebmc/random_traces.cpp
+++ b/src/ebmc/random_traces.cpp
@@ -314,11 +314,7 @@ void random_tracest::operator()()
       else
       {
         consolet::out() << "*** Trace " << (trace_nr + 1) << '\n';
-        show_trans_trace(
-          trace,
-          *this,
-          ns,
-          static_cast<ui_message_handlert *>(message_handler)->get_ui());
+        show_trans_trace(trace, *this, ns, consolet::out());
       }
     }
     break;

--- a/src/hw-cbmc/hw_cbmc_parse_options.cpp
+++ b/src/hw-cbmc/hw_cbmc_parse_options.cpp
@@ -318,5 +318,18 @@ void hw_cbmc_parse_optionst::show_unwind_trace(const optionst &options,
     }
   }
 
-  show_trans_trace(trans_trace, log, ns, ui_message_handler.get_ui());
+  switch(ui_message_handler.get_ui())
+  {
+  case ui_message_handlert::uit::PLAIN:
+    show_trans_trace(trans_trace, log, ns, std::cout);
+    break;
+
+  case ui_message_handlert::uit::XML_UI:
+    show_trans_trace_xml(trans_trace, log, ns, std::cout);
+    break;
+
+  case ui_message_handlert::uit::JSON_UI:
+    show_trans_trace_json(trans_trace, log, ns, std::cout);
+    break;
+  }
 }

--- a/src/trans-netlist/trans_trace.cpp
+++ b/src/trans-netlist/trans_trace.cpp
@@ -168,6 +168,32 @@ void show_trans_state(
 
 /*******************************************************************\
 
+Function: show_trans_trace
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void show_trans_trace(
+  const trans_tracet &trace,
+  messaget &message,
+  const namespacet &ns,
+  std::ostream &out)
+{
+  PRECONDITION(!trace.states.empty());
+
+  auto l = trace.get_min_failing_timeframe().value_or(trace.states.size() - 1);
+
+  for(std::size_t t = 0; t <= l; t++)
+    show_trans_state(t, trace.states[t], ns);
+}
+
+/*******************************************************************\
+
 Function: xml
 
   Inputs:
@@ -180,6 +206,8 @@ Function: xml
 
 xmlt xml(const trans_tracet &trace, const namespacet &ns)
 {
+  PRECONDITION(!trace.states.empty());
+
   auto min_failing_timeframe_opt = trace.get_min_failing_timeframe();
 
   auto last_time_frame =
@@ -294,7 +322,7 @@ jsont json(const trans_tracet &trace, const namespacet &ns)
 
 /*******************************************************************\
 
-Function: show_trans_trace
+Function: show_trans_trace_xml
 
   Inputs:
 
@@ -304,32 +332,34 @@ Function: show_trans_trace
 
 \*******************************************************************/
 
-void show_trans_trace(
+void show_trans_trace_xml(
   const trans_tracet &trace,
-  messaget &message,
+  messaget &,
   const namespacet &ns,
-  ui_message_handlert::uit ui)
+  std::ostream &out)
 {
-  switch(ui)
-  {
-  case ui_message_handlert::uit::PLAIN:
-    {
-      auto l =
-        trace.get_min_failing_timeframe().value_or(trace.states.size() - 1);
+  xml(trace, ns).output(out);
+}
 
-      for(std::size_t t = 0; t <= l; t++)
-        show_trans_state(t, trace.states[t], ns);
-    }
-    break;
-    
-  case ui_message_handlert::uit::XML_UI:
-      xml(trace, ns).output(std::cout);
-      break;
+/*******************************************************************\
 
-  case ui_message_handlert::uit::JSON_UI:
-  default:
-      assert(false);
-  }
+Function: show_trans_trace_json
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void show_trans_trace_json(
+  const trans_tracet &trace,
+  messaget &,
+  const namespacet &ns,
+  std::ostream &out)
+{
+  out << json(trace, ns);
 }
 
 /*******************************************************************\

--- a/src/trans-netlist/trans_trace.h
+++ b/src/trans-netlist/trans_trace.h
@@ -65,15 +65,27 @@ jsont json(const trans_tracet &, const namespacet &);
 xmlt xml(const trans_tracet &, const namespacet &);
 
 void show_trans_trace(
+  const trans_tracet &,
+  messaget &,
+  const namespacet &,
+  std::ostream &);
+
+void show_trans_trace_xml(
   const trans_tracet &trace,
-  messaget &message,
-  const namespacet &ns,
-  ui_message_handlert::uit ui);  
+  messaget &,
+  const namespacet &,
+  std::ostream &);
+
+void show_trans_trace_json(
+  const trans_tracet &,
+  messaget &,
+  const namespacet &,
+  std::ostream &);
 
 void show_trans_trace_vcd(
-  const trans_tracet &trace,
-  messaget &message,
-  const namespacet &ns,
-  std::ostream &out);
+  const trans_tracet &,
+  messaget &,
+  const namespacet &,
+  std::ostream &);
 
 #endif


### PR DESCRIPTION
This splits up `show_trans_trace` by format, i.e., console output, XML and JSON, and hence, the existing VCD output is no longer asymmetric.