### PR TITLE
ebmc: add --json-result command line option

### DIFF
--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -280,6 +280,7 @@ void ebmc_parse_optionst::help()
     " {y--top} {umodule}             \t set top module\n"
     " {y-p} {uexpr}                  \t specify a property\n"
     " {y--outfile} {ufile name}      \t set output file name (default: stdout)\n"
+    " {y--json-result} {ufile name}  \t use JSON for property status and traces\n"
     " {y--trace}                     \t generate a trace for failing properties\n"
     " {y--vcd} {ufile name}          \t generate traces in VCD format\n"
     " {y--show-properties}           \t list the properties in the model\n"

--- a/src/ebmc/ebmc_parse_options.h
+++ b/src/ebmc/ebmc_parse_options.h
@@ -29,7 +29,7 @@ public:
         "(show-properties)(property):p:(trace)"
         "(dimacs)(module):(top):"
         "(po)(cegar)(k-induction)(2pi)(bound2):"
-        "(outfile):(xml-ui)(verbosity):(gui)"
+        "(outfile):(xml-ui)(verbosity):(gui)(json-result):"
         "(reset):"
         "(version)(verilog-rtl)(verilog-netlist)"
         "(compute-interpolant)(interpolation)(interpolation-vmcai)"

--- a/src/trans-netlist/trans_trace.h
+++ b/src/trans-netlist/trans_trace.h
@@ -14,6 +14,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/threeval.h>
 #include <util/ui_message.h>
 
+class jsont;
+
 class trans_tracet
 {
 public:
@@ -57,6 +59,8 @@ public:
 };
 
 // outputting traces
+
+jsont json(const trans_tracet &, const namespacet &);
 
 void convert(
   const namespacet &,


### PR DESCRIPTION
This adds a new command line option `--json-result`, which outputs the analysis results, including traces, if any, into a file as JSON.