### PR TITLE
ebmc: --modules--xml

### DIFF
--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -132,9 +132,7 @@ int bdd_enginet::operator()()
   try
   {
     int result = get_transition_system(
-      cmdline,
-      static_cast<ui_message_handlert &>(message.get_message_handler()),
-      transition_system);
+      cmdline, message.get_message_handler(), transition_system);
     if(result!=-1) return result;
 
     {  

--- a/src/ebmc/ebmc_parse_options.h
+++ b/src/ebmc/ebmc_parse_options.h
@@ -26,6 +26,7 @@ public:
         "(diatest)(statebits):(bound):(max-bound):"
         "(show-parse)(show-varmap)(show-symbol-table)(show-netlist)"
         "(show-ldg)(show-modules)(show-trans)(show-bdds)(show-formula)"
+        "(modules-xml):"
         "(show-properties)(property):p:(trace)"
         "(dimacs)(module):(top):"
         "(po)(cegar)(k-induction)(2pi)(bound2):"

--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -80,9 +80,7 @@ int k_inductiont::operator()()
   if(get_bound()) return 1;
 
   int result = get_transition_system(
-    cmdline,
-    static_cast<ui_message_handlert &>(message.get_message_handler()),
-    transition_system);
+    cmdline, message.get_message_handler(), transition_system);
   if(result!=-1) return result;
 
   result = get_properties();

--- a/src/ebmc/random_traces.cpp
+++ b/src/ebmc/random_traces.cpp
@@ -270,9 +270,7 @@ void random_tracest::operator()()
   auto number_of_timeframes = trace_steps + 1;
 
   int result = get_transition_system(
-    cmdline,
-    static_cast<ui_message_handlert &>(message.get_message_handler()),
-    transition_system);
+    cmdline, message.get_message_handler(), transition_system);
   if(result != -1)
     throw ebmc_errort();
 

--- a/src/ebmc/ranking_function.cpp
+++ b/src/ebmc/ranking_function.cpp
@@ -117,9 +117,7 @@ int ranking_function_checkt::operator()()
 {
   // get the transition system
   int exit_code = get_transition_system(
-    cmdline,
-    static_cast<ui_message_handlert &>(message.get_message_handler()),
-    transition_system);
+    cmdline, message.get_message_handler(), transition_system);
 
   if(exit_code != -1)
     throw ebmc_errort();

--- a/src/ebmc/show_trans.cpp
+++ b/src/ebmc/show_trans.cpp
@@ -239,9 +239,7 @@ Function: show_transt::show_trans
 int show_transt::show_trans()
 {
   int result = get_transition_system(
-    cmdline,
-    static_cast<ui_message_handlert &>(message.get_message_handler()),
-    transition_system);
+    cmdline, message.get_message_handler(), transition_system);
   if(result!=-1) return result;
   PRECONDITION(transition_system.trans_expr.has_value());
 
@@ -275,9 +273,7 @@ Function: show_transt::show_trans_verilog_rtl
 int show_transt::show_trans_verilog_rtl()
 {
   int result = get_transition_system(
-    cmdline,
-    static_cast<ui_message_handlert &>(message.get_message_handler()),
-    transition_system);
+    cmdline, message.get_message_handler(), transition_system);
   if(result!=-1) return result;
 
   if(cmdline.isset("outfile"))
@@ -316,9 +312,7 @@ Function: show_transt::show_trans_verilog_netlist
 int show_transt::show_trans_verilog_netlist()
 {
   int result = get_transition_system(
-    cmdline,
-    static_cast<ui_message_handlert &>(message.get_message_handler()),
-    transition_system);
+    cmdline, message.get_message_handler(), transition_system);
   if(result!=-1) return result;
 
   if(cmdline.isset("outfile"))

--- a/src/ebmc/transition_system.cpp
+++ b/src/ebmc/transition_system.cpp
@@ -11,8 +11,8 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <util/cmdline.h>
 #include <util/config.h>
 #include <util/get_module.h>
+#include <util/message.h>
 #include <util/namespace.h>
-#include <util/ui_message.h>
 #include <util/unicode.h>
 
 #include <langapi/language.h>
@@ -21,6 +21,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <langapi/mode.h>
 #include <trans-word-level/show_modules.h>
 
+#include "ebmc_error.h"
 #include "ebmc_version.h"
 
 #include <fstream>
@@ -166,7 +167,7 @@ void make_next_state(exprt &expr)
 
 int get_transition_system(
   const cmdlinet &cmdline,
-  ui_message_handlert &message_handler,
+  message_handlert &message_handler,
   transition_systemt &transition_system)
 {
   messaget message(message_handler);
@@ -206,7 +207,17 @@ int get_transition_system(
 
   if(cmdline.isset("show-modules"))
   {
-    show_modules(transition_system.symbol_table, message_handler.get_ui());
+    show_modules(transition_system.symbol_table, std::cout);
+    return 0;
+  }
+
+  if(cmdline.isset("modules-xml"))
+  {
+    auto filename = cmdline.get_value("modules-xml");
+    std::ofstream out(widen_if_needed(filename));
+    if(!out)
+      throw ebmc_errort() << "failed to open " << filename;
+    show_modules_xml(transition_system.symbol_table, out);
     return 0;
   }
 

--- a/src/ebmc/transition_system.h
+++ b/src/ebmc/transition_system.h
@@ -13,7 +13,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <util/symbol_table.h>
 
 class cmdlinet;
-class ui_message_handlert;
+class message_handlert;
 
 class transition_systemt
 {
@@ -25,7 +25,7 @@ public:
 
 int get_transition_system(
   const cmdlinet &,
-  ui_message_handlert &,
+  message_handlert &,
   transition_systemt &);
 
 #endif // CPROVER_EBMC_TRANSITION_SYSTEM_H

--- a/src/hw-cbmc/hw_cbmc_parse_options.cpp
+++ b/src/hw-cbmc/hw_cbmc_parse_options.cpp
@@ -246,7 +246,7 @@ int hw_cbmc_parse_optionst::get_modules(std::list<exprt> &bmc_constraints) {
   }
   else if(cmdline.isset("show-modules"))
   {
-    show_modules(goto_model.symbol_table, ui_message_handler.get_ui());
+    show_modules(goto_model.symbol_table, std::cout);
     return 0; // done
   }
     

--- a/src/trans-word-level/show_modules.cpp
+++ b/src/trans-word-level/show_modules.cpp
@@ -6,13 +6,57 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-#include <cassert>
-#include <iostream>
-
 #include <util/xml.h>
 #include <util/xml_irep.h>
 
 #include "show_modules.h"
+
+/*******************************************************************\
+
+Function: show_modules_xml
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void show_modules_xml(const symbol_table_baset &symbol_table, std::ostream &out)
+{
+  std::size_t count = 0;
+
+  for(const auto &s : symbol_table.symbols)
+  {
+    const symbolt &symbol = s.second;
+
+    if(symbol.type.id() == ID_module)
+    {
+      count++;
+
+      xmlt xml("module");
+      xml.new_element("number").data = std::to_string(count); // will go away
+      xml.set_attribute("number", std::to_string(count));
+
+      xmlt &l = xml.new_element();
+      convert(symbol.location, l);
+      l.name = "location";
+
+      // these go away
+      xml.new_element("identifier").data = id2string(symbol.name);
+      xml.new_element("mode").data = id2string(symbol.mode);
+      xml.new_element("name").data = id2string(symbol.display_name());
+
+      // these stay
+      xml.set_attribute("identifier", id2string(symbol.name));
+      xml.set_attribute("mode", id2string(symbol.mode));
+      xml.set_attribute("name", id2string(symbol.display_name()));
+
+      out << xml;
+    }
+  }
+}
 
 /*******************************************************************\
 
@@ -26,11 +70,9 @@ Function: show_modules
 
 \*******************************************************************/
 
-void show_modules(
-  const symbol_table_baset &symbol_table,
-  ui_message_handlert::uit ui)
+void show_modules(const symbol_table_baset &symbol_table, std::ostream &out)
 {
-  unsigned count=0;
+  std::size_t count = 0;
 
   for(const auto &s : symbol_table.symbols)
   {
@@ -40,50 +82,12 @@ void show_modules(
     {
       count++;
 
-      switch(ui)
-      {
-      case ui_message_handlert::uit::XML_UI:
-        {
-          xmlt xml("module");
-          xml.new_element("number").data=std::to_string(count); // will go away
-          xml.set_attribute("number", std::to_string(count));
-        
-          xmlt &l=xml.new_element();
-          convert(symbol.location, l);
-          l.name="location";
-        
-          // these go away
-          xml.new_element("identifier").data=id2string(symbol.name);
-          xml.new_element("mode").data=id2string(symbol.mode);
-          xml.new_element("name").data=id2string(symbol.display_name());
+      out << "Module " << count << ":" << '\n';
 
-          // these stay
-          xml.set_attribute("identifier", id2string(symbol.name));
-          xml.set_attribute("mode", id2string(symbol.mode));
-          xml.set_attribute("name", id2string(symbol.display_name()));
-          
-          std::cout << xml << std::endl;
-        }
-  
-        break;
-      
-      case ui_message_handlert::uit::PLAIN:
-        std::cout << "Module " << count << ":" << std::endl;
-
-        std::cout << "  Location:   " << symbol.location << std::endl;
-        std::cout << "  Mode:       " << symbol.mode << std::endl;
-        std::cout << "  Identifier: " << symbol.name << std::endl;
-        std::cout << "  Name:       " << symbol.display_name() << std::endl
-                  << std::endl;
-        break;
-
-      case ui_message_handlert::uit::JSON_UI:
-        UNREACHABLE;
-        break;
-
-      default:
-        UNREACHABLE;
-      }
+      out << "  Location:   " << symbol.location << '\n';
+      out << "  Mode:       " << symbol.mode << '\n';
+      out << "  Identifier: " << symbol.name << '\n';
+      out << "  Name:       " << symbol.display_name() << '\n' << '\n';
     }
   }
 }

--- a/src/trans-word-level/show_modules.h
+++ b/src/trans-word-level/show_modules.h
@@ -10,8 +10,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_TRANS_SHOW_MODULES_H
 
 #include <util/symbol_table_base.h>
-#include <util/ui_message.h>
 
-void show_modules(const symbol_table_baset &, ui_message_handlert::uit ui);
+void show_modules(const symbol_table_baset &, std::ostream &);
+
+void show_modules_xml(const symbol_table_baset &, std::ostream &);
 
 #endif


### PR DESCRIPTION
This adds a new command line option, `--modules-xml`, which offers a facility to get a structured list of modules in XML format.
