### PR TITLE
ebmc: --random-traces now uses --number-of-traces

### DIFF
--- a/regression/ebmc/random-traces/boolean1.desc
+++ b/regression/ebmc/random-traces/boolean1.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
 boolean1.v
---trace-steps 0 --random-traces 2
+--random-traces --trace-steps 0 --number-of-traces 2
 ^\*\*\* Trace 1$
 ^  main\.some_wire = 0$
 ^  main\.input1 = 0$

--- a/regression/ebmc/random-traces/bv1.desc
+++ b/regression/ebmc/random-traces/bv1.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
 bv1.v
---trace-steps 1 --random-traces 1
+--random-traces --trace-steps 1 --number-of-traces 1
 ^Transition system state 0$
 ^  main\.some_reg = 0 .*$
 ^  main\.input1 = 'h6FE4167A .*$

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -356,9 +356,10 @@ void ebmc_parse_optionst::help()
     "    {y--constr}                 \t use constraints specified in 'file.cnstr'\n"
     "    {y--new-mode}               \t new mode is switched on\n"
     "    {y--aiger}                  \t print out the instance in aiger format\n"
-    " {y--random-traces} {unumber}   \t generate the given number of random traces\n"
-    "       {y--random-seed} {unumber}\t use the given random seed\n"
-    "       {y--trace-steps} {unumber}\t set the number of random transitions (default: 10 steps)\n"
+    " {y--random-traces}             \t generate random traces\n"
+    "    {y--number-of-traces} {unumber}\t generate the given number of traces\n"
+    "    {y--random-seed} {unumber}  \t use the given random seed\n"
+    "    {y--trace-steps} {unumber}  \t set the number of random transitions (default: 10 steps)\n"
     " {y--ranking-function} {uf}     \t prove a liveness property using given ranking funnction (experimental)\n"
     "    {y--property} {uid}         \t the liveness property to prove\n"
 

--- a/src/ebmc/ebmc_parse_options.h
+++ b/src/ebmc/ebmc_parse_options.h
@@ -40,7 +40,7 @@ public:
         "(smt2)(boolector)(z3)(cvc4)(yices)(mathsat)(prover)(lifter)"
         "(aig)(stop-induction)(stop-minimize)(start):(coverage)(naive)"
         "(compute-ct)(dot-netlist)(smv-netlist)(vcd):"
-        "(random-traces):(trace-steps):(random-seed):"
+        "(random-traces)(trace-steps):(random-seed):(number-of-traces):"
         "I:(preprocess)",
         argc,
         argv,

--- a/src/ebmc/random_traces.cpp
+++ b/src/ebmc/random_traces.cpp
@@ -233,11 +233,21 @@ Function: random_tracest::operator()()
 
 void random_tracest::operator()()
 {
-  auto number_of_traces_opt =
-    string2optional_size_t(cmdline.get_value("random-traces"));
+  const auto number_of_traces = [this]() -> std::size_t
+  {
+    if(cmdline.isset("number-of-traces"))
+    {
+      auto number_of_traces_opt =
+        string2optional_size_t(cmdline.get_value("number-of-traces"));
 
-  if(!number_of_traces_opt.has_value())
-    throw ebmc_errort() << "failed to parse number of traces";
+      if(!number_of_traces_opt.has_value())
+        throw ebmc_errort() << "failed to parse number of traces";
+
+      return number_of_traces_opt.value();
+    }
+    else
+      return 10; // default
+  }();
 
   if(cmdline.isset("random-seed"))
   {
@@ -297,8 +307,7 @@ void random_tracest::operator()()
   message.status() << "Solving with " << solver.decision_procedure_text()
                    << messaget::eom;
 
-  for(std::size_t trace_nr = 0; trace_nr < number_of_traces_opt.value();
-      trace_nr++)
+  for(std::size_t trace_nr = 0; trace_nr < number_of_traces; trace_nr++)
   {
     auto input_constraints =
       random_input_constraints(solver, inputs, number_of_timeframes);


### PR DESCRIPTION
The `--random-traces` option can now be given an additional option `--number-of-traces` to specify how many traces to generate.