### PR TITLE
ebmc: add API for ranking function checking

### DIFF
--- a/src/ebmc/ebmc_base.cpp
+++ b/src/ebmc/ebmc_base.cpp
@@ -348,9 +348,8 @@ Function: ebmc_baset::get_model_properties
 
 bool ebmc_baset::get_model_properties()
 {
-  if(properties.from_transition_system(
-       transition_system, properties, message.get_message_handler()))
-    return true;
+  properties = ebmc_propertiest::from_transition_system(
+    transition_system, message.get_message_handler());
 
   if(properties.select_property(cmdline, message.get_message_handler()))
     return true;

--- a/src/ebmc/ebmc_properties.cpp
+++ b/src/ebmc/ebmc_properties.cpp
@@ -10,12 +10,12 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include <langapi/language_util.h>
 
-bool ebmc_propertiest::from_transition_system(
+ebmc_propertiest ebmc_propertiest::from_transition_system(
   const transition_systemt &transition_system,
-  ebmc_propertiest &properties,
   message_handlert &message_handler)
 {
   messaget message(message_handler);
+  ebmc_propertiest properties;
 
   for(auto it = transition_system.symbol_table.symbol_module_map.lower_bound(
         transition_system.main_symbol->name);
@@ -28,48 +28,28 @@ bool ebmc_propertiest::from_transition_system(
 
     if(symbol.is_property)
     {
-      try
-      {
-        std::string value_as_string = from_expr(ns, symbol.name, symbol.value);
+      std::string value_as_string = from_expr(ns, symbol.name, symbol.value);
 
-        message.debug() << "Property: " << value_as_string << messaget::eom;
+      message.debug() << "Property: " << value_as_string << messaget::eom;
 
-        properties.properties.push_back(propertyt());
-        properties.properties.back().number = properties.properties.size() - 1;
+      properties.properties.push_back(propertyt());
+      properties.properties.back().number = properties.properties.size() - 1;
 
-        if(symbol.pretty_name.empty())
-          properties.properties.back().name = symbol.name;
-        else
-          properties.properties.back().name = symbol.pretty_name;
+      if(symbol.pretty_name.empty())
+        properties.properties.back().name = symbol.name;
+      else
+        properties.properties.back().name = symbol.pretty_name;
 
-        properties.properties.back().expr = symbol.value;
-        properties.properties.back().location = symbol.location;
-        properties.properties.back().expr_string = value_as_string;
-        properties.properties.back().mode = symbol.mode;
-        properties.properties.back().description =
-          id2string(symbol.location.get_comment());
-      }
-
-      catch(const char *e)
-      {
-        message.error() << e << messaget::eom;
-        return true;
-      }
-
-      catch(const std::string &e)
-      {
-        message.error() << e << messaget::eom;
-        return true;
-      }
-
-      catch(int)
-      {
-        return true;
-      }
+      properties.properties.back().expr = symbol.value;
+      properties.properties.back().location = symbol.location;
+      properties.properties.back().expr_string = value_as_string;
+      properties.properties.back().mode = symbol.mode;
+      properties.properties.back().description =
+        id2string(symbol.location.get_comment());
     }
   }
 
-  return false;
+  return properties;
 }
 
 bool ebmc_propertiest::select_property(

--- a/src/ebmc/ebmc_properties.h
+++ b/src/ebmc/ebmc_properties.h
@@ -88,10 +88,8 @@ public:
     return false;
   }
 
-  static bool from_transition_system(
-    const transition_systemt &,
-    ebmc_propertiest &,
-    message_handlert &);
+  static ebmc_propertiest
+  from_transition_system(const transition_systemt &, message_handlert &);
 
   bool select_property(const cmdlinet &, message_handlert &);
 };

--- a/src/ebmc/ranking_function.cpp
+++ b/src/ebmc/ranking_function.cpp
@@ -26,50 +26,20 @@ Author: Daniel Kroening, dkr@amazon.com
 #include "ebmc_error.h"
 #include "report_results.h"
 
-/*******************************************************************\
-
-   Class: ranking_function_checkt
-
- Purpose:
-
-\*******************************************************************/
-
-class ranking_function_checkt : public ebmc_baset
-{
-public:
-  ranking_function_checkt(
-    const cmdlinet &_cmdline,
-    ui_message_handlert &_ui_message_handler)
-    : ebmc_baset(_cmdline, _ui_message_handler),
-      ns{transition_system.symbol_table}
-  {
-  }
-
-  int operator()();
-
-protected:
-  namespacet ns;
-
-  exprt parse_ranking_function();
-  propertyt &find_property();
-};
-
-int do_ranking_function(
-  const cmdlinet &cmdline,
-  ui_message_handlert &ui_message_handler)
-{
-  return ranking_function_checkt(cmdline, ui_message_handler)();
-}
-
-exprt ranking_function_checkt::parse_ranking_function()
+exprt parse_ranking_function(
+  const std::string &string_to_be_parsed,
+  const transition_systemt &transition_system,
+  message_handlert &message_handler)
 {
   auto language = get_language_from_mode(transition_system.main_symbol->mode);
   exprt expr;
 
-  language->set_message_handler(message.get_message_handler());
+  language->set_message_handler(message_handler);
+
+  const namespacet ns{transition_system.symbol_table};
 
   if(language->to_expr(
-       cmdline.get_value("ranking-function"),
+       string_to_be_parsed,
        id2string(transition_system.main_symbol->module),
        expr,
        ns))
@@ -83,6 +53,7 @@ exprt ranking_function_checkt::parse_ranking_function()
 
   std::string expr_as_string;
   language->from_expr(expr, expr_as_string, ns);
+  messaget message(message_handler);
   message.debug() << "Ranking function: " << expr_as_string << messaget::eom;
   message.debug() << "Mode: " << transition_system.main_symbol->mode
                   << messaget::eom;
@@ -90,7 +61,7 @@ exprt ranking_function_checkt::parse_ranking_function()
   return expr;
 }
 
-ebmc_baset::propertyt &ranking_function_checkt::find_property()
+ebmc_propertiest::propertyt &find_property(ebmc_propertiest &properties)
 {
   std::size_t count = 0;
   for(auto &p : properties.properties)
@@ -114,11 +85,15 @@ ebmc_baset::propertyt &ranking_function_checkt::find_property()
   UNREACHABLE;
 }
 
-int ranking_function_checkt::operator()()
+int do_ranking_function(
+  const cmdlinet &cmdline,
+  message_handlert &message_handler)
 {
   // get the transition system
-  int exit_code = get_transition_system(
-    cmdline, message.get_message_handler(), transition_system);
+  transition_systemt transition_system;
+
+  int exit_code =
+    get_transition_system(cmdline, message_handler, transition_system);
 
   if(exit_code != -1)
     throw ebmc_errort();
@@ -126,39 +101,60 @@ int ranking_function_checkt::operator()()
   CHECK_RETURN(transition_system.trans_expr.has_value());
 
   // parse the ranking function
-  const auto ranking_function = parse_ranking_function();
+  if(!cmdline.isset("ranking-function"))
+    throw ebmc_errort() << "no candidate ranking function given";
+
+  const auto ranking_function = parse_ranking_function(
+    cmdline.get_value("ranking-function"), transition_system, message_handler);
 
   // find the property
-  exit_code = get_properties();
+  auto properties = ebmc_propertiest::from_transition_system(
+    transition_system, message_handler);
 
-  if(exit_code != -1)
-    return exit_code;
+  auto &property = find_property(properties);
 
-  auto &property = find_property();
+  auto result = is_ranking_function(
+    transition_system, property.expr, ranking_function, message_handler);
 
-  satcheckt satcheck{message.get_message_handler()};
-  boolbvt solver(ns, satcheck, message.get_message_handler());
+  if(result.is_true())
+  {
+    property.make_success();
+  }
+  else
+  {
+    property.make_unknown();
+  }
+
+  const namespacet ns(transition_system.symbol_table);
+  report_results(cmdline, properties, ns, message_handler);
+
+  return properties.property_failure() ? 10 : 0;
+}
+
+tvt is_ranking_function(
+  const transition_systemt &transition_system,
+  const exprt &property,
+  const exprt &ranking_function,
+  message_handlert &message_handler)
+{
+  const namespacet ns{transition_system.symbol_table};
+  satcheckt satcheck{message_handler};
+  boolbvt solver(ns, satcheck, message_handler);
 
   // *no* initial state, two time frames
-  unwind(
-    *transition_system.trans_expr,
-    message.get_message_handler(),
-    solver,
-    2,
-    ns,
-    false);
+  unwind(*transition_system.trans_expr, message_handler, solver, 2, ns, false);
 
   const auto p = [&property]() -> exprt
   {
-    if(property.expr.id() == ID_AF)
+    if(property.id() == ID_AF)
     {
-      return to_unary_expr(property.expr).op();
+      return to_unary_expr(property).op();
     }
     else if(
-      property.expr.id() == ID_sva_always &&
-      to_unary_expr(property.expr).op().id() == ID_sva_eventually)
+      property.id() == ID_sva_always &&
+      to_unary_expr(property).op().id() == ID_sva_eventually)
     {
-      return to_unary_expr(to_unary_expr(property.expr).op()).op();
+      return to_unary_expr(to_unary_expr(property).op()).op();
     }
     else
     {
@@ -185,19 +181,21 @@ int ranking_function_checkt::operator()()
 
   decision_proceduret::resultt dec_result = solver.dec_solve();
 
+  messaget message(message_handler);
+
   switch(dec_result)
   {
   case decision_proceduret::resultt::D_SATISFIABLE:
-    message.result() << "SAT: inductive proof failed, check is inconclusive"
-                     << messaget::eom;
-    property.make_unknown();
-    break;
+    message.result()
+      << "SAT: inductive proof failed, ranking function check is inconclusive"
+      << messaget::eom;
+    return tvt::unknown();
 
   case decision_proceduret::resultt::D_UNSATISFIABLE:
-    message.result() << "UNSAT: inductive proof successful, property holds"
-                     << messaget::eom;
-    property.make_success();
-    break;
+    message.result()
+      << "UNSAT: inductive proof successful, function is a ranking function"
+      << messaget::eom;
+    return tvt(true);
 
   case decision_proceduret::resultt::D_ERROR:
     throw ebmc_errort() << "Error from decision procedure";
@@ -205,8 +203,4 @@ int ranking_function_checkt::operator()()
   default:
     throw ebmc_errort() << "Unexpected result from decision procedure";
   }
-
-  report_results(cmdline, properties, ns, message.get_message_handler());
-
-  return properties.property_failure() ? 10 : 0;
 }

--- a/src/ebmc/ranking_function.h
+++ b/src/ebmc/ranking_function.h
@@ -12,9 +12,24 @@ Author: Daniel Kroening, dkr@amazon.com
 #ifndef EBMC_RANKING_FUNCTION_H
 #define EBMC_RANKING_FUNCTION_H
 
-#include <util/cmdline.h>
-#include <util/ui_message.h>
+#include <util/threeval.h>
 
-int do_ranking_function(const cmdlinet &, ui_message_handlert &);
+class cmdlinet;
+class exprt;
+class message_handlert;
+class transition_systemt;
+
+int do_ranking_function(const cmdlinet &, message_handlert &);
+
+exprt parse_ranking_function(
+  const std::string &,
+  const transition_systemt &,
+  message_handlert &);
+
+tvt is_ranking_function(
+  const transition_systemt &,
+  const exprt &property,
+  const exprt &ranking_function,
+  message_handlert &);
 
 #endif // EBMC_RANKING_FUNCTION_H


### PR DESCRIPTION
This exposes two functions, `parse_ranking_function` and `is_ranking_function`, to enable the use of ranking function checking as a component.