### PR TITLE
ebmc: set verbosity when not using ebmc_baset

### DIFF
--- a/src/ebmc/ebmc_base.cpp
+++ b/src/ebmc/ebmc_base.cpp
@@ -56,11 +56,6 @@ ebmc_baset::ebmc_baset(
   ui_message_handlert &_ui_message_handler)
   : message(_ui_message_handler), cmdline(_cmdline)
 {
-  if(cmdline.isset("verbosity"))
-    _ui_message_handler.set_verbosity(
-      unsafe_string2unsigned(cmdline.get_value("verbosity")));
-  else
-    _ui_message_handler.set_verbosity(messaget::M_STATUS); // default
 }
 
 /*******************************************************************\

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -49,6 +49,12 @@ Function: ebmc_parse_optionst::doit
 
 int ebmc_parse_optionst::doit()
 {
+  if(cmdline.isset("verbosity"))
+    ui_message_handler.set_verbosity(
+      unsafe_string2unsigned(cmdline.get_value("verbosity")));
+  else
+    ui_message_handler.set_verbosity(messaget::M_STATUS); // default
+
   if(config.set(cmdline))
   {
     usage_error();


### PR DESCRIPTION
This sets the message handler verbosity when not using `ebmc_baset`.