### PR TITLE
ebmc: properties are now returned by value

### DIFF
--- a/src/ebmc/ebmc_base.cpp
+++ b/src/ebmc/ebmc_base.cpp
@@ -348,9 +348,8 @@ Function: ebmc_baset::get_model_properties
 
 bool ebmc_baset::get_model_properties()
 {
-  if(properties.from_transition_system(
-       transition_system, properties, message.get_message_handler()))
-    return true;
+  properties = ebmc_propertiest::from_transition_system(
+    transition_system, message.get_message_handler());
 
   if(properties.select_property(cmdline, message.get_message_handler()))
     return true;

--- a/src/ebmc/ebmc_properties.cpp
+++ b/src/ebmc/ebmc_properties.cpp
@@ -10,12 +10,12 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include <langapi/language_util.h>
 
-bool ebmc_propertiest::from_transition_system(
+ebmc_propertiest ebmc_propertiest::from_transition_system(
   const transition_systemt &transition_system,
-  ebmc_propertiest &properties,
   message_handlert &message_handler)
 {
   messaget message(message_handler);
+  ebmc_propertiest properties;
 
   for(auto it = transition_system.symbol_table.symbol_module_map.lower_bound(
         transition_system.main_symbol->name);
@@ -28,48 +28,28 @@ bool ebmc_propertiest::from_transition_system(
 
     if(symbol.is_property)
     {
-      try
-      {
-        std::string value_as_string = from_expr(ns, symbol.name, symbol.value);
+      std::string value_as_string = from_expr(ns, symbol.name, symbol.value);
 
-        message.debug() << "Property: " << value_as_string << messaget::eom;
+      message.debug() << "Property: " << value_as_string << messaget::eom;
 
-        properties.properties.push_back(propertyt());
-        properties.properties.back().number = properties.properties.size() - 1;
+      properties.properties.push_back(propertyt());
+      properties.properties.back().number = properties.properties.size() - 1;
 
-        if(symbol.pretty_name.empty())
-          properties.properties.back().name = symbol.name;
-        else
-          properties.properties.back().name = symbol.pretty_name;
+      if(symbol.pretty_name.empty())
+        properties.properties.back().name = symbol.name;
+      else
+        properties.properties.back().name = symbol.pretty_name;
 
-        properties.properties.back().expr = symbol.value;
-        properties.properties.back().location = symbol.location;
-        properties.properties.back().expr_string = value_as_string;
-        properties.properties.back().mode = symbol.mode;
-        properties.properties.back().description =
-          id2string(symbol.location.get_comment());
-      }
-
-      catch(const char *e)
-      {
-        message.error() << e << messaget::eom;
-        return true;
-      }
-
-      catch(const std::string &e)
-      {
-        message.error() << e << messaget::eom;
-        return true;
-      }
-
-      catch(int)
-      {
-        return true;
-      }
+      properties.properties.back().expr = symbol.value;
+      properties.properties.back().location = symbol.location;
+      properties.properties.back().expr_string = value_as_string;
+      properties.properties.back().mode = symbol.mode;
+      properties.properties.back().description =
+        id2string(symbol.location.get_comment());
     }
   }
 
-  return false;
+  return properties;
 }
 
 bool ebmc_propertiest::select_property(

--- a/src/ebmc/ebmc_properties.h
+++ b/src/ebmc/ebmc_properties.h
@@ -88,10 +88,8 @@ public:
     return false;
   }
 
-  static bool from_transition_system(
-    const transition_systemt &,
-    ebmc_propertiest &,
-    message_handlert &);
+  static ebmc_propertiest
+  from_transition_system(const transition_systemt &, message_handlert &);
 
   bool select_property(const cmdlinet &, message_handlert &);
 };


### PR DESCRIPTION
`ebmc_propertiest::from_transition_system` now returns the properties extracted from the transition system by value.