### PR TITLE
ebmc: move parse_property into ebmc_propertiest

### DIFF
--- a/src/ebmc/ebmc_properties.h
+++ b/src/ebmc/ebmc_properties.h
@@ -88,6 +88,11 @@ public:
     return false;
   }
 
+  static ebmc_propertiest from_command_line(
+    const cmdlinet &,
+    const transition_systemt &,
+    message_handlert &);
+
   static ebmc_propertiest
   from_transition_system(const transition_systemt &, message_handlert &);
 


### PR DESCRIPTION
This moves the code in `ebmc_baset::parse_property`, which parses a property expression string,
into `ebmc_propertiest`, to enable re-use by other modules.