### PR TITLE
ebmc: get_transition_system now returns by value

### DIFF
--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -132,9 +132,8 @@ int bdd_enginet::operator()()
 {
   try
   {
-    int result = get_transition_system(
-      cmdline, message.get_message_handler(), transition_system);
-    if(result!=-1) return result;
+    transition_system =
+      get_transition_system(cmdline, message.get_message_handler());
 
     {  
       if(make_netlist(netlist))
@@ -146,7 +145,7 @@ int bdd_enginet::operator()()
       message.status() << "Building netlist for atomic propositions"
                        << messaget::eom;
 
-      result = get_properties();
+      auto result = get_properties();
       if(result != -1)
         return result;
 

--- a/src/ebmc/ebmc_error.h
+++ b/src/ebmc/ebmc_error.h
@@ -25,8 +25,20 @@ public:
     return message;
   }
 
+  optionalt<int> exit_code() const
+  {
+    return __exit_code;
+  }
+
+  ebmc_errort with_exit_code(int exit_code) &&
+  {
+    __exit_code = exit_code;
+    return std::move(*this);
+  }
+
 protected:
   std::ostringstream message;
+  optionalt<int> __exit_code = {};
 };
 
 /// add to the diagnostic information in the given ebmc_error exception

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -96,6 +96,18 @@ int ebmc_parse_optionst::doit()
       return 0;
     }
 
+    if(cmdline.isset("preprocess"))
+      return preprocess(cmdline, ui_message_handler);
+
+    if(cmdline.isset("show-parse"))
+      return show_parse(cmdline, ui_message_handler);
+
+    if(cmdline.isset("show-modules") || cmdline.isset("modules-xml"))
+      show_modules(cmdline, ui_message_handler);
+
+    if(cmdline.isset("show-symbol-table"))
+      show_symbol_table(cmdline, ui_message_handler);
+
     if(cmdline.isset("cegar"))
     {
       throw ebmc_errort() << "This option is currently disabled";
@@ -214,13 +226,7 @@ int ebmc_parse_optionst::doit()
       return show_trans_verilog_netlist(cmdline, ui_message_handler);
 
     // get the transition system
-    transition_systemt transition_system;
-
-    int result =
-      get_transition_system(cmdline, ui_message_handler, transition_system);
-
-    if(result != -1)
-      return result;
+    auto transition_system = get_transition_system(cmdline, ui_message_handler);
 
     {
       ebmc_baset ebmc_base(cmdline, ui_message_handler);
@@ -274,7 +280,7 @@ int ebmc_parse_optionst::doit()
         return 0;
       }
 
-      result = ebmc_base.get_properties();
+      auto result = ebmc_base.get_properties();
 
       if(result != -1)
         return result;
@@ -295,7 +301,7 @@ int ebmc_parse_optionst::doit()
       message.error() << "error: " << messaget::red << ebmc_error.what()
                       << messaget::reset << messaget::eom;
     }
-    return CPROVER_EXIT_EXCEPTION;
+    return ebmc_error.exit_code().value_or(CPROVER_EXIT_EXCEPTION);
   }
 }
 

--- a/src/ebmc/ebmc_solver_factory.h
+++ b/src/ebmc/ebmc_solver_factory.h
@@ -13,12 +13,11 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <util/message.h>
 #include <util/namespace.h>
 
+#include <solvers/prop/prop.h>
 #include <solvers/stack_decision_procedure.h>
 
 #include <iosfwd>
 #include <memory>
-
-class propt;
 
 class ebmc_solvert final
 {

--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -82,11 +82,10 @@ int k_inductiont::operator()()
 {
   if(get_bound()) return 1;
 
-  int result = get_transition_system(
-    cmdline, message.get_message_handler(), transition_system);
-  if(result!=-1) return result;
+  transition_system =
+    get_transition_system(cmdline, message.get_message_handler());
 
-  result = get_properties();
+  auto result = get_properties();
   if(result != -1)
     return result;
 

--- a/src/ebmc/neural_liveness.cpp
+++ b/src/ebmc/neural_liveness.cpp
@@ -60,10 +60,8 @@ int neural_livenesst::operator()()
   if(!cmdline.isset("neural-engine"))
     throw ebmc_errort() << "give a neural engine";
 
-  int result = get_transition_system(
-    cmdline, message.get_message_handler(), transition_system);
-  if(result != -1)
-    return result;
+  transition_system =
+    get_transition_system(cmdline, message.get_message_handler());
 
   // Get the properties
   properties = ebmc_propertiest::from_command_line(

--- a/src/ebmc/random_traces.cpp
+++ b/src/ebmc/random_traces.cpp
@@ -145,13 +145,8 @@ int random_traces(const cmdlinet &cmdline, message_handlert &message_handler)
       return {};
   }();
 
-  transition_systemt transition_system;
-
-  int result =
-    get_transition_system(cmdline, message_handler, transition_system);
-
-  if(result != -1)
-    throw ebmc_errort();
+  transition_systemt transition_system =
+    get_transition_system(cmdline, message_handler);
 
   random_tracest(transition_system, message_handler)(
     outfile_prefix, random_seed, number_of_traces, number_of_trace_steps);

--- a/src/ebmc/ranking_function.cpp
+++ b/src/ebmc/ranking_function.cpp
@@ -89,13 +89,8 @@ int do_ranking_function(
   message_handlert &message_handler)
 {
   // get the transition system
-  transition_systemt transition_system;
-
-  int exit_code =
-    get_transition_system(cmdline, message_handler, transition_system);
-
-  if(exit_code != -1)
-    throw ebmc_errort();
+  transition_systemt transition_system =
+    get_transition_system(cmdline, message_handler);
 
   CHECK_RETURN(transition_system.trans_expr.has_value());
 

--- a/src/ebmc/show_trans.cpp
+++ b/src/ebmc/show_trans.cpp
@@ -238,9 +238,9 @@ Function: show_transt::show_trans
 
 int show_transt::show_trans()
 {
-  int result = get_transition_system(
-    cmdline, message.get_message_handler(), transition_system);
-  if(result!=-1) return result;
+  transition_system =
+    get_transition_system(cmdline, message.get_message_handler());
+
   PRECONDITION(transition_system.trans_expr.has_value());
 
   std::cout << "Initial state constraints:\n\n";
@@ -272,9 +272,8 @@ Function: show_transt::show_trans_verilog_rtl
 
 int show_transt::show_trans_verilog_rtl()
 {
-  int result = get_transition_system(
-    cmdline, message.get_message_handler(), transition_system);
-  if(result!=-1) return result;
+  transition_system =
+    get_transition_system(cmdline, message.get_message_handler());
 
   if(cmdline.isset("outfile"))
   {
@@ -311,9 +310,8 @@ Function: show_transt::show_trans_verilog_netlist
 
 int show_transt::show_trans_verilog_netlist()
 {
-  int result = get_transition_system(
-    cmdline, message.get_message_handler(), transition_system);
-  if(result!=-1) return result;
+  transition_system =
+    get_transition_system(cmdline, message.get_message_handler());
 
   if(cmdline.isset("outfile"))
   {

--- a/src/ebmc/transition_system.cpp
+++ b/src/ebmc/transition_system.cpp
@@ -255,3 +255,38 @@ int get_transition_system(
 
   return -1; // done with the transition system
 }
+
+transition_systemt get_transition_system(
+  const cmdlinet &cmdline,
+  message_handlert &message_handler)
+{
+  transition_systemt transition_system;
+  auto exit_code =
+    get_transition_system(cmdline, message_handler, transition_system);
+  if(exit_code != -1)
+    throw ebmc_errort().with_exit_code(exit_code);
+  return transition_system;
+}
+
+int show_parse(const cmdlinet &cmdline, message_handlert &message_handler)
+{
+  transition_systemt dummy_transition_system;
+  return get_transition_system(
+    cmdline, message_handler, dummy_transition_system);
+}
+
+int show_modules(const cmdlinet &cmdline, message_handlert &message_handler)
+{
+  transition_systemt dummy_transition_system;
+  return get_transition_system(
+    cmdline, message_handler, dummy_transition_system);
+}
+
+int show_symbol_table(
+  const cmdlinet &cmdline,
+  message_handlert &message_handler)
+{
+  transition_systemt dummy_transition_system;
+  return get_transition_system(
+    cmdline, message_handler, dummy_transition_system);
+}

--- a/src/ebmc/transition_system.h
+++ b/src/ebmc/transition_system.h
@@ -23,9 +23,11 @@ public:
   optionalt<transt> trans_expr; // transition system expression
 };
 
-int get_transition_system(
-  const cmdlinet &,
-  message_handlert &,
-  transition_systemt &);
+transition_systemt get_transition_system(const cmdlinet &, message_handlert &);
+
+int preprocess(const cmdlinet &, message_handlert &);
+int show_parse(const cmdlinet &, message_handlert &);
+int show_modules(const cmdlinet &, message_handlert &);
+int show_symbol_table(const cmdlinet &, message_handlert &);
 
 #endif // CPROVER_EBMC_TRANSITION_SYSTEM_H

--- a/src/ic3/m1ain.cc
+++ b/src/ic3/m1ain.cc
@@ -53,11 +53,8 @@ int ic3_enginet::operator()()
   read_parameters();
 
   try    {
-    int result = get_transition_system(
-      cmdline,
-      static_cast<ui_message_handlert &>(message.get_message_handler()),
-      transition_system);
-    if(result!=-1) return result;
+    transition_system =
+      get_transition_system(cmdline, message.get_message_handler());
 
     if(make_netlist(netlist))     {
       message.error() << "Failed to build netlist" << messaget::eom;


### PR DESCRIPTION
`get_transition_system` now returns the transition system by value, as opposed to via a reference.