### PR TITLE
Verilog: allow parentheses in property expressions

### DIFF
--- a/regression/verilog/system_verilog_assertion/system_verilog_assertion4.sv
+++ b/regression/verilog/system_verilog_assertion/system_verilog_assertion4.sv
@@ -20,5 +20,6 @@ module main(input clk);
   p10: assert property (x==0 |-> ##1 x==1 and ##2 x==2);
   p11: assert property (x==0 |-> ##1 x==1 and not ##2 x==3);
   p12: assert property (x==0 |-> ##1 x==1 && y==2);
+  p13: assert property ((x==0 |-> y==0) |=> y != 0);
 
 endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1552,8 +1552,18 @@ property_declaration:
           TOK_PROPERTY property_identifier TOK_ENDPROPERTY
         ;
 
+// The 1800-2017 grammar has an ambiguity where
+// '(' expression ')' can either be an expression or a property_expr,
+// which yields a reduce/reduce conflict. Hence, we split the rules
+// for property_expr into property_expr and property_expr_proper.
+
 property_expr:
-          sequence_expr
+	  sequence_expr
+	| property_expr_proper
+	;
+
+property_expr_proper:
+          '(' property_expr_proper ')'      { $$ = $2; }
         | "not" property_expr               { init($$, ID_not); mto($$, $2); }
         | property_expr "or" property_expr  { init($$, ID_or); mto($$, $1); mto($$, $3); }
         | property_expr "and" property_expr { init($$, ID_and); mto($$, $1); mto($$, $3); }


### PR DESCRIPTION
The SystemVerilog grammar allows parentheses around property expressions. This changes the Verilog grammar accordingly.