### PR TITLE
Verilog: strenthen typing of verilog_declt::declarations()

### DIFF
--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -306,17 +306,21 @@ public:
   {
     set(ID_class, _class);
   }
-  
-  inline irept::subt &declarations()
+
+  // Function and task declarations may contain further declarations.
+  using declarationst = std::vector<verilog_declt>;
+
+  inline declarationst &declarations()
   {
-    return add("declarations").get_sub();
+    return (declarationst &)(add("declarations").get_sub());
   }
 
-  inline const irept::subt &declarations() const
+  inline const declarationst &declarations() const
   {
-    return find("declarations").get_sub();
+    return (const declarationst &)(find("declarations").get_sub());
   }
 
+  // Function and task declarations have a body.
   inline verilog_statementt &body()
   {
     return static_cast<verilog_statementt &>(add(ID_body));

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -274,11 +274,10 @@ void verilog_typecheckt::interface_function_or_task(
   }
 
   // do the declarations within the task/function
-
-  const irept::subt &declarations=decl.declarations();
+  auto &declarations = decl.declarations();
 
   for(auto &decl : declarations)
-    interface_module_item(to_verilog_module_item(decl));
+    interface_function_or_task_decl(decl);
 
   interface_statement(decl.body());
     

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -323,13 +323,10 @@ void verilog_typecheckt::convert_function_or_task(verilog_declt &decl)
   
   decl.set_identifier(symbol.name);
 
-  irept::subt &declarations=decl.declarations();
+  auto &declarations = decl.declarations();
 
-  for(auto &decl : declarations)
-  {
-    assert(decl.id() == ID_decl);
-    convert_decl(static_cast<verilog_declt &>(decl));
-  }
+  for(auto &inner_decl : declarations)
+    convert_decl(inner_decl);
 
   function_or_task_name=symbol.name;
   convert_statement(decl.body());
@@ -371,10 +368,10 @@ exprt verilog_typecheckt::elaborate_const_function_call(
   // typecheck it
   verilog_declt decl=to_verilog_decl(function_symbol.value);
 
-  irept::subt &declarations=decl.declarations();
+  auto &declarations = decl.declarations();
 
-  for(auto &decl : declarations)
-    convert_decl(static_cast<verilog_declt &>(decl));
+  for(auto &inner_decl : declarations)
+    convert_decl(inner_decl);
 
   function_or_task_name=function_symbol.name;
   convert_statement(decl.body());


### PR DESCRIPTION
`verilog_declt::declarations()` returns a vector that always contains declarations.  This commit changes the return type of the method to reflect this.