### PR TITLE
Verilog: Modules with nonansi headers

### DIFF
--- a/regression/verilog/modules/nonansi1.v
+++ b/regression/verilog/modules/nonansi1.v
@@ -1,0 +1,16 @@
+module my_zero_tester
+#(parameter WIDTH = 32)
+(input [WIDTH-1:0] i, output is_zero);
+
+  assign is_zero = i == 0;
+
+endmodule // my_zero_tester
+
+module main;
+
+  wire [7:0] data = 123;
+  my_zero_tester t(data, zero);
+
+  always assert p1: !zero;
+
+endmodule // main

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -923,7 +923,13 @@ list_of_ports_opt:
 
 module_parameter_port_list_opt:
 	 /* Optional */
-	      { init($$); }
+	        { init($$); }
+        | '#' '(' list_of_param_assignments ')'
+	        { $$ = $3; }
+        | '#' '(' parameter_port_declaration ')'
+	        { $$ = $3; }
+        | '#' '(' ')'
+	        { init($$); }
 	;
 
 module_keyword:
@@ -1225,6 +1231,10 @@ hierarchical_parameter_identifier: hierarchical_identifier
 defparam_assignment:
 	  hierarchical_parameter_identifier '=' constant_expression
 		{ init($$, ID_parameter_assignment); mto($$, $1); mto($$, $3); }
+	;
+
+parameter_port_declaration:
+	  parameter_declaration
 	;
 
 list_of_defparam_assignments:


### PR DESCRIPTION
This adds support for `parameter_port_list` in the module header.