### PR TITLE
Verilog: allow EOF in single line comments

### DIFF
--- a/regression/verilog/comments/eof-in-comment1.desc
+++ b/regression/verilog/comments/eof-in-comment1.desc
@@ -1,0 +1,7 @@
+CORE
+eof-in-comment1.v
+
+^no module found$
+^EXIT=1$
+^SIGNAL=0$
+--

--- a/regression/verilog/comments/eof-in-comment1.v
+++ b/regression/verilog/comments/eof-in-comment1.v
@@ -1,0 +1,2 @@
+// We are ok with EOF at the end of a single-line comment
+// EOF here ->

--- a/src/verilog/verilog_preprocessor_tokenizer.l
+++ b/src/verilog/verilog_preprocessor_tokenizer.l
@@ -38,7 +38,7 @@ String		\"(\\.|[^"\\])*\"
 <INITIAL>.|\n		{ TOKENIZER.text(yytext[0]); return yytext[0]; /* anything else */ }
 <SLCOMMENT>\n		{ BEGIN INITIAL; TOKENIZER.text('\n'); return '\n'; }
 <SLCOMMENT>.		{ /* just eat up */ }
-<SLCOMMENT><<EOF>>      { throw verilog_preprocessor_errort() << "EOF inside a comment"; }
+<SLCOMMENT><<EOF>>      { /* we allow that */ BEGIN INITIAL; }
 <MLCOMMENT>\n		{ TOKENIZER.text('\n'); return '\n'; }
 <MLCOMMENT>"*/"         { BEGIN INITIAL; /* comment done */ }
 <MLCOMMENT>.		{ /* just eat up */ }


### PR DESCRIPTION
This changes the tokenizer of the Verilog preprocessor to allow single line comments to end on EOF.