### PR TITLE
Verilog: parameter port declarations

### DIFF
--- a/regression/verilog/modules/parameter_ports1.v
+++ b/regression/verilog/modules/parameter_ports1.v
@@ -1,5 +1,5 @@
 module my_zero_tester
-#(parameter WIDTH = 32)
+#(parameter WIDTH = 32, parameter P2 = 10, P3 = 20)
 (input [WIDTH-1:0] i, output is_zero);
 
   assign is_zero = i == 0;
@@ -9,8 +9,9 @@ endmodule // my_zero_tester
 module main;
 
   wire [7:0] data = 123;
-  my_zero_tester t(data, zero);
+  wire is_zero;
+  my_zero_tester t(data, is_zero);
 
-  always assert p1: !zero;
+  always assert p1: !is_zero;
 
 endmodule // main


### PR DESCRIPTION
This extends the set of variants of supported parameter port declarations.