### PR TITLE
Verilog: cleanup constant expression typechecking

### DIFF
--- a/src/verilog/Makefile
+++ b/src/verilog/Makefile
@@ -1,4 +1,5 @@
 SRC = expr2verilog.cpp \
+      verilog_expr.cpp \
       verilog_generate.cpp \
       verilog_interfaces.cpp \
       verilog_interpreter.cpp \

--- a/src/verilog/verilog_expr.cpp
+++ b/src/verilog/verilog_expr.cpp
@@ -1,0 +1,18 @@
+/*******************************************************************\
+
+Module: Verilog Expressions
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#include "verilog_expr.h"
+
+#include <util/prefix.h>
+
+bool function_call_exprt::is_system_function_call() const
+{
+  return function().id() == ID_symbol &&
+         has_prefix(
+           id2string(to_symbol_expr(function()).get_identifier()), "$");
+}

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -11,7 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <cassert>
 
-#include <util/expr.h>
+#include <util/std_expr.h>
 
 /// The syntax for these A.B, where A is a module identifier and B
 /// is an identifier within that module. B is given als symbol_exprt.
@@ -71,6 +71,8 @@ public:
   {
     return op1().operands();
   }
+
+  bool is_system_function_call() const;
 };
 
 extern inline const function_call_exprt &to_function_call_expr(const exprt &expr)

--- a/src/verilog/verilog_generate.cpp
+++ b/src/verilog/verilog_generate.cpp
@@ -117,7 +117,7 @@ void verilog_typecheckt::elaborate_generate_if(
   }
 
   mp_integer condition =
-    convert_const_expression(to_multi_ary_expr(statement).op0());
+    convert_constant_expression(to_multi_ary_expr(statement).op0());
 
   if(condition==0)
   {
@@ -170,7 +170,7 @@ void verilog_typecheckt::elaborate_generate_assign(
     throw 0;
   }
 
-  mp_integer rhs = convert_const_expression(to_binary_expr(statement).rhs());
+  mp_integer rhs = convert_constant_expression(to_binary_expr(statement).rhs());
 
   if(rhs<0)
   {
@@ -210,7 +210,7 @@ void verilog_typecheckt::elaborate_generate_for(
   while(true)
   {
     mp_integer condition =
-      convert_const_expression(to_multi_ary_expr(statement).op1());
+      convert_constant_expression(to_multi_ary_expr(statement).op1());
 
     if(condition==0) break;
     

--- a/src/verilog/verilog_generate.cpp
+++ b/src/verilog/verilog_generate.cpp
@@ -117,7 +117,7 @@ void verilog_typecheckt::elaborate_generate_if(
   }
 
   mp_integer condition =
-    convert_constant_expression(to_multi_ary_expr(statement).op0());
+    convert_integer_constant_expression(to_multi_ary_expr(statement).op0());
 
   if(condition==0)
   {
@@ -170,7 +170,8 @@ void verilog_typecheckt::elaborate_generate_assign(
     throw 0;
   }
 
-  mp_integer rhs = convert_constant_expression(to_binary_expr(statement).rhs());
+  mp_integer rhs =
+    convert_integer_constant_expression(to_binary_expr(statement).rhs());
 
   if(rhs<0)
   {
@@ -210,7 +211,7 @@ void verilog_typecheckt::elaborate_generate_for(
   while(true)
   {
     mp_integer condition =
-      convert_constant_expression(to_multi_ary_expr(statement).op1());
+      convert_integer_constant_expression(to_multi_ary_expr(statement).op1());
 
     if(condition==0) break;
     

--- a/src/verilog/verilog_interpreter.cpp
+++ b/src/verilog/verilog_interpreter.cpp
@@ -31,7 +31,7 @@ void verilog_typecheckt::verilog_interpreter(
     const verilog_blocking_assignt &assign=
       to_verilog_blocking_assign(statement);
 
-    exprt rhs=elaborate_const_expression(assign.rhs());
+    exprt rhs = elaborate_constant_expression(assign.rhs());
     if(!rhs.is_constant())
     {
       error().source_location=assign.rhs().source_location();
@@ -63,8 +63,8 @@ void verilog_typecheckt::verilog_interpreter(
     
     while(true)
     {
-      exprt cond=elaborate_const_expression(verilog_for.condition());
-      
+      exprt cond = elaborate_constant_expression(verilog_for.condition());
+
       if(cond.is_false())
         break;
       else if(cond.is_true())

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -557,13 +557,13 @@ void verilog_typecheckt::convert_inst(verilog_instt &inst)
     // these must be constants
     if(it->id()==ID_named_parameter_assignment)
     {
-      mp_integer v_int =
-        convert_constant_expression(static_cast<exprt &>(it->add(ID_value)));
+      mp_integer v_int = convert_integer_constant_expression(
+        static_cast<exprt &>(it->add(ID_value)));
       it->add(ID_value)=from_integer(v_int, integer_typet());
     }
     else
     {
-      mp_integer v_int = convert_constant_expression(*it);
+      mp_integer v_int = convert_integer_constant_expression(*it);
       *it=from_integer(v_int, integer_typet());
     }
   }
@@ -1019,7 +1019,7 @@ void verilog_typecheckt::convert_parameter_override(
 
     // The rhs must be a constant at this point.
     auto rhs_value =
-      from_integer(convert_constant_expression(rhs), integer_typet());
+      from_integer(convert_integer_constant_expression(rhs), integer_typet());
 
     // store the assignment
     defparams[module_instance][parameter_name] = rhs_value;

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -337,7 +337,7 @@ void verilog_typecheckt::convert_function_or_task(verilog_declt &decl)
 
 /*******************************************************************\
 
-Function: verilog_typecheckt::convert_decl
+Function: verilog_typecheckt::elaborate_constant_function_call
 
   Inputs:
 
@@ -347,7 +347,7 @@ Function: verilog_typecheckt::convert_decl
 
 \*******************************************************************/
 
-exprt verilog_typecheckt::elaborate_const_function_call(
+exprt verilog_typecheckt::elaborate_constant_function_call(
   const function_call_exprt &function_call)
 {
   const function_call_exprt::argumentst &arguments=
@@ -394,7 +394,7 @@ exprt verilog_typecheckt::elaborate_const_function_call(
   
   for(std::size_t i=0; i<arguments.size(); i++)
   {
-    exprt value=elaborate_const_expression(arguments[i]);
+    exprt value = elaborate_constant_expression(arguments[i]);
 
     if(!value.is_constant())
     {
@@ -558,12 +558,12 @@ void verilog_typecheckt::convert_inst(verilog_instt &inst)
     if(it->id()==ID_named_parameter_assignment)
     {
       mp_integer v_int =
-        convert_const_expression(static_cast<exprt &>(it->add(ID_value)));
+        convert_constant_expression(static_cast<exprt &>(it->add(ID_value)));
       it->add(ID_value)=from_integer(v_int, integer_typet());
     }
     else
     {
-      mp_integer v_int = convert_const_expression(*it);
+      mp_integer v_int = convert_constant_expression(*it);
       *it=from_integer(v_int, integer_typet());
     }
   }
@@ -1018,7 +1018,8 @@ void verilog_typecheckt::convert_parameter_override(
     auto parameter_name = hierarchical_identifier.item().get_identifier();
 
     // The rhs must be a constant at this point.
-    auto rhs_value = from_integer(convert_const_expression(rhs), integer_typet());
+    auto rhs_value =
+      from_integer(convert_constant_expression(rhs), integer_typet());
 
     // store the assignment
     defparams[module_instance][parameter_name] = rhs_value;

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -213,8 +213,10 @@ protected:
       return it->second;
   }
 
-  // const functions
-  exprt elaborate_const_function_call(const class function_call_exprt &) override;
+  // constant function calls, 13.4.3 IEEE 1800-2017
+  exprt
+  elaborate_constant_function_call(const class function_call_exprt &) override;
+
   void verilog_interpreter(const class verilog_statementt &);
   
   // counter for assertions

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1092,7 +1092,7 @@ void verilog_typecheck_exprt::convert_constant(constant_exprt &expr)
 
 /*******************************************************************\
 
-Function: verilog_typecheck_exprt::convert_constant_expression
+Function: verilog_typecheck_exprt::convert_integer_constant_expression
 
   Inputs:
 
@@ -1103,7 +1103,7 @@ Function: verilog_typecheck_exprt::convert_constant_expression
 \*******************************************************************/
 
 mp_integer
-verilog_typecheck_exprt::convert_constant_expression(const exprt &expr)
+verilog_typecheck_exprt::convert_integer_constant_expression(const exprt &expr)
 {
   exprt tmp(expr);
 
@@ -1426,8 +1426,8 @@ void verilog_typecheck_exprt::convert_range(
     throw 0;
   }
 
-  msb = convert_constant_expression(to_binary_expr(range).op0());
-  lsb = convert_constant_expression(to_binary_expr(range).op1());
+  msb = convert_integer_constant_expression(to_binary_expr(range).op0());
+  lsb = convert_integer_constant_expression(to_binary_expr(range).op1());
 }
 
 /*******************************************************************\
@@ -1730,7 +1730,7 @@ void verilog_typecheck_exprt::convert_replication_expr(replication_exprt &expr)
 
   unsigned width=get_width(expr.op1().type());
 
-  mp_integer op0 = convert_constant_expression(expr.op0());
+  mp_integer op0 = convert_integer_constant_expression(expr.op0());
 
   if(op0<0)
   {
@@ -1975,8 +1975,8 @@ void verilog_typecheck_exprt::convert_trinary_expr(ternary_exprt &expr)
     unsigned width=get_width(op0.type());
     unsigned offset=atoi(op0.type().get(ID_C_offset).c_str());
 
-    mp_integer op1 = convert_constant_expression(expr.op1());
-    mp_integer op2 = convert_constant_expression(expr.op2());
+    mp_integer op1 = convert_integer_constant_expression(expr.op1());
+    mp_integer op2 = convert_integer_constant_expression(expr.op2());
 
     if(op1<op2)
       std::swap(op1, op2);

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1092,7 +1092,7 @@ void verilog_typecheck_exprt::convert_constant(constant_exprt &expr)
 
 /*******************************************************************\
 
-Function: verilog_typecheck_exprt::convert_const_expression
+Function: verilog_typecheck_exprt::convert_constant_expression
 
   Inputs:
 
@@ -1102,7 +1102,8 @@ Function: verilog_typecheck_exprt::convert_const_expression
 
 \*******************************************************************/
 
-mp_integer verilog_typecheck_exprt::convert_const_expression(const exprt &expr)
+mp_integer
+verilog_typecheck_exprt::convert_constant_expression(const exprt &expr)
 {
   exprt tmp(expr);
 
@@ -1111,8 +1112,8 @@ mp_integer verilog_typecheck_exprt::convert_const_expression(const exprt &expr)
 
   // this could be large
   propagate_type(tmp, integer_typet());
-  
-  tmp=elaborate_const_expression(tmp);
+
+  tmp = elaborate_constant_expression(tmp);
 
   if(!tmp.is_constant())
   {
@@ -1145,7 +1146,7 @@ mp_integer verilog_typecheck_exprt::convert_const_expression(const exprt &expr)
 
 /*******************************************************************\
 
-Function: verilog_typecheck_exprt::elaborate_const_expression
+Function: verilog_typecheck_exprt::elaborate_constant_expression
 
   Inputs:
 
@@ -1155,7 +1156,7 @@ Function: verilog_typecheck_exprt::elaborate_const_expression
 
 \*******************************************************************/
 
-exprt verilog_typecheck_exprt::elaborate_const_expression(const exprt &expr)
+exprt verilog_typecheck_exprt::elaborate_constant_expression(const exprt &expr)
 {
   if(expr.id()==ID_constant)
     return expr;
@@ -1184,14 +1185,14 @@ exprt verilog_typecheck_exprt::elaborate_const_expression(const exprt &expr)
     const function_call_exprt &function_call=
       to_function_call_expr(expr);
 
-    return elaborate_const_function_call(function_call);  
+    return elaborate_constant_function_call(function_call);
   }
   else
   {
     exprt tmp=expr;
     
     for(auto & e : tmp.operands())
-      e=elaborate_const_expression(e);
+      e = elaborate_constant_expression(e);
 
     simplify(tmp, ns);
 
@@ -1201,7 +1202,7 @@ exprt verilog_typecheck_exprt::elaborate_const_expression(const exprt &expr)
 
 /*******************************************************************\
 
-Function: verilog_typecheck_exprt::is_const_expression
+Function: verilog_typecheck_exprt::is_constant_expression
 
   Inputs:
 
@@ -1211,7 +1212,7 @@ Function: verilog_typecheck_exprt::is_const_expression
 
 \*******************************************************************/
 
-bool verilog_typecheck_exprt::is_const_expression(
+bool verilog_typecheck_exprt::is_constant_expression(
   const exprt &expr,
   mp_integer &value)
 {
@@ -1425,8 +1426,8 @@ void verilog_typecheck_exprt::convert_range(
     throw 0;
   }
 
-  msb = convert_const_expression(to_binary_expr(range).op0());
-  lsb = convert_const_expression(to_binary_expr(range).op1());
+  msb = convert_constant_expression(to_binary_expr(range).op0());
+  lsb = convert_constant_expression(to_binary_expr(range).op1());
 }
 
 /*******************************************************************\
@@ -1668,7 +1669,7 @@ void verilog_typecheck_exprt::convert_extractbit_expr(extractbit_exprt &expr)
 
     mp_integer op1;
 
-    if(is_const_expression(to_extractbit_expr(expr).op1(), op1))
+    if(is_constant_expression(to_extractbit_expr(expr).op1(), op1))
     {
       if(op1<offset)
       {
@@ -1729,7 +1730,7 @@ void verilog_typecheck_exprt::convert_replication_expr(replication_exprt &expr)
 
   unsigned width=get_width(expr.op1().type());
 
-  mp_integer op0 = convert_const_expression(expr.op0());
+  mp_integer op0 = convert_constant_expression(expr.op0());
 
   if(op0<0)
   {
@@ -1974,8 +1975,8 @@ void verilog_typecheck_exprt::convert_trinary_expr(ternary_exprt &expr)
     unsigned width=get_width(op0.type());
     unsigned offset=atoi(op0.type().get(ID_C_offset).c_str());
 
-    mp_integer op1 = convert_const_expression(expr.op1());
-    mp_integer op2 = convert_const_expression(expr.op2());
+    mp_integer op1 = convert_constant_expression(expr.op1());
+    mp_integer op2 = convert_constant_expression(expr.op2());
 
     if(op1<op2)
       std::swap(op1, op2);

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -20,6 +20,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cassert>
 #include <stack>
 
+class function_call_exprt;
+
 class verilog_typecheck_exprt:public verilog_typecheck_baset
 {
 public:
@@ -40,7 +42,9 @@ public:
   { }
 
   virtual void convert_expr(exprt &expr);
-  mp_integer convert_integer_constant_expression(const exprt &);
+  mp_integer convert_integer_constant_expression(exprt);
+
+  exprt elaborate_constant_system_function_call(function_call_exprt);
 
 protected:
   irep_idt module_identifier;
@@ -80,13 +84,12 @@ protected:
   named_blockst named_blocks;
   void enter_named_block(const irep_idt &);
 
-  // elaboration (expansion) of constant expressions and functions
+  // elaboration (expansion and folding) of constant expressions and functions
   bool is_constant_expression(const exprt &, mp_integer &value);
-  exprt elaborate_constant_expression(const exprt &);
+  exprt elaborate_constant_expression(exprt);
 
-  // to be overridden
-  virtual exprt
-  elaborate_constant_function_call(const class function_call_exprt &)
+  // To be overridden, requires a Verilog interpreter.
+  virtual exprt elaborate_constant_function_call(const function_call_exprt &)
   {
     assert(false);
   }
@@ -99,10 +102,9 @@ private:
   void convert_unary_expr  (unary_exprt &);
   void convert_binary_expr (binary_exprt &);
   void convert_trinary_expr(ternary_exprt &);
-  NODISCARD exprt convert_expr_function_call(class function_call_exprt);
-  NODISCARD exprt convert_system_function(
-    const irep_idt &identifier,
-    class function_call_exprt);
+  NODISCARD exprt convert_expr_function_call(function_call_exprt);
+  NODISCARD exprt
+  convert_system_function(const irep_idt &identifier, function_call_exprt);
   void convert_constraint_select_one(exprt &);
   void convert_extractbit_expr(extractbit_exprt &);
   void convert_replication_expr(replication_exprt &);

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -40,7 +40,7 @@ public:
   { }
 
   virtual void convert_expr(exprt &expr);
-  virtual mp_integer convert_const_expression(const exprt &);
+  virtual mp_integer convert_constant_expression(const exprt &);
 
 protected:
   irep_idt module_identifier;
@@ -81,11 +81,12 @@ protected:
   void enter_named_block(const irep_idt &);
 
   // elaboration (expansion) of constant expressions and functions
-  bool is_const_expression(const exprt &, mp_integer &value);
-  exprt elaborate_const_expression(const exprt &);
+  bool is_constant_expression(const exprt &, mp_integer &value);
+  exprt elaborate_constant_expression(const exprt &);
 
   // to be overridden
-  virtual exprt elaborate_const_function_call(const class function_call_exprt &)
+  virtual exprt
+  elaborate_constant_function_call(const class function_call_exprt &)
   {
     assert(false);
   }

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -40,7 +40,7 @@ public:
   { }
 
   virtual void convert_expr(exprt &expr);
-  virtual mp_integer convert_constant_expression(const exprt &);
+  mp_integer convert_integer_constant_expression(const exprt &);
 
 protected:
   irep_idt module_identifier;


### PR DESCRIPTION
This renames three methods in the Verilog frontend to use the term `constant_expression` instead of `const_expression`, to match the term used in the Verilog standard.