### PR TITLE
Verilog: introduce verilog_parameter_declt::declaratort

### DIFF
--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -11,7 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <cassert>
 
-#include <util/expr.h>
+#include <util/std_expr.h>
 
 /// The syntax for these A.B, where A is a module identifier and B
 /// is an identifier within that module. B is given als symbol_exprt.
@@ -169,14 +169,30 @@ public:
   {
   }
 
-  const exprt::operandst &declarations() const
+  class declaratort : public irept
   {
-    return operands();
+  public:
+    const irep_idt &identifier() const
+    {
+      return get(ID_identifier);
+    }
+
+    const exprt &value() const
+    {
+      return static_cast<const exprt &>(find(ID_value));
+    }
+  };
+
+  using declarators = std::vector<declaratort>;
+
+  const declarators &declarations() const
+  {
+    return (const declarators &)operands();
   }
 
-  exprt::operandst &declarations()
+  declarators &declarations()
   {
-    return operands();
+    return (declarators &)operands();
   }
 };
 

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -14,9 +14,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/symbol_table_base.h>
 #include <util/typecheck.h>
 
-#include "verilog_typecheck_expr.h"
+#include "verilog_expr.h"
 #include "verilog_parse_tree.h"
 #include "verilog_symbol_table.h"
+#include "verilog_typecheck_expr.h"
 
 bool verilog_typecheck(
   const verilog_parse_treet &parse_tree,
@@ -75,6 +76,9 @@ protected:
     const irep_idt &module_identifier,
     const exprt::operandst &parameter_assignment,
     const std::map<irep_idt, exprt> &defparams);
+
+  std::vector<verilog_parameter_declt::declaratort>
+  get_parameter_declarators(const irept &module_source);
 
   std::list<exprt> get_parameter_values(
     const irept &module_source,


### PR DESCRIPTION
This strengthens the typing when dealing with parameter declarators.