### PR TITLE
Verilog: fix error message when arguments do not match port numbers

### DIFF
--- a/regression/verilog/modules/missing_connection1.desc
+++ b/regression/verilog/modules/missing_connection1.desc
@@ -1,0 +1,7 @@
+CORE
+missing_connection1.v
+
+^file missing_connection1\.v line 7: wrong number of arguments: expected 2 but got 1$
+^EXIT=2$
+^SIGNAL=0$
+--

--- a/regression/verilog/modules/missing_connection1.v
+++ b/regression/verilog/modules/missing_connection1.v
@@ -1,0 +1,9 @@
+module my_module(input x, y);
+
+endmodule
+
+module main();
+
+  my_module m(1);
+
+endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -1014,6 +1014,8 @@ void verilog_synthesist::instantiate_ports(
 
     for(const auto &o_it : inst.operands())
     {
+      DATA_INVARIANT(o_it.is_not_nil(), "all ports must be connected");
+
       instantiate_port((exprt &)(*p_it), o_it,
                        replace_map, trans);
       p_it++;

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -228,8 +228,8 @@ void verilog_typecheckt::typecheck_port_connections(
     if(inst.operands().size()!=ports.size())
     {
       error().source_location=inst.source_location();
-      error() << "wrong number of arguments: expected " << ports.size() 
-          << " but got " << inst.operands().size(); 
+      error() << "wrong number of arguments: expected " << ports.size()
+              << " but got " << inst.operands().size() << eom;
       throw 0;
     }
 


### PR DESCRIPTION
This fixes the error message that is emitted when the number of module instance arguments does not match the number of ports of the instantiated module.