### PR TITLE
Verilog: elaborate parameter values that have not been overridden

### DIFF
--- a/regression/verilog/modules/localparam2.desc
+++ b/regression/verilog/modules/localparam2.desc
@@ -1,0 +1,7 @@
+CORE
+localparam2.v
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/modules/localparam2.v
+++ b/regression/verilog/modules/localparam2.v
@@ -1,0 +1,11 @@
+module main;
+
+  wire clk;
+  localparam WIDTH = 8 - 1;
+
+  reg [WIDTH:0] counter;
+  always @(posedge clk) counter = counter + 1;
+
+  always assert p1: $bits(counter)==8;
+
+endmodule

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1199,8 +1199,9 @@ exprt verilog_typecheck_exprt::elaborate_constant_expression(exprt expr)
 
     if(symbol.is_macro)
     {
-      // a parameter
-      return symbol.value;
+      // A parameter or local parameter. It may not have been overridden,
+      // and hence may not have been constant folded.
+      return elaborate_constant_expression(symbol.value);
     }
 
     exprt value=var_value(identifier);


### PR DESCRIPTION
Parameters have default values, which are not overridden.  These must be constant folded.