### PR TITLE
Verilog: append integer as decimal, not binary

### DIFF
--- a/regression/verilog/modules/module_instance_identifier1.desc
+++ b/regression/verilog/modules/module_instance_identifier1.desc
@@ -1,0 +1,7 @@
+CORE
+module_instance_identifier1.v
+--show-symbol-table
+module: Verilog::my_module\(8\)$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/verilog/modules/module_instance_identifier1.v
+++ b/regression/verilog/modules/module_instance_identifier1.v
@@ -1,0 +1,13 @@
+module my_module#(BITS = 32)(input clk);
+
+  reg [BITS-1:0] counter;
+  always @(posedge clk) counter = counter + 1;
+
+endmodule
+
+module main;
+
+  wire clk;
+  my_module #(8) m8(clk);
+
+endmodule

--- a/src/verilog/verilog_parameterize_module.cpp
+++ b/src/verilog/verilog_parameterize_module.cpp
@@ -264,8 +264,9 @@ irep_idt verilog_typecheckt::parameterize_module(
         error() << "parameter expected to be constant, but got `"
                 << to_string(pv) << "'" << eom;
         throw 0;
-      } else
-        suffix += i.to_ulong();
+      }
+      else
+        suffix += integer2string(i);
     }
     
   suffix+=')';


### PR DESCRIPTION
This partially reverts f374bd54197a19d117f1258e32c4242109449831, which has replaced `integer2string` by `.to_long`, and which has caused characters instead of digits to be appended to a module identifier.