### PR TITLE
Verilog: add KNOWNBUG test for access to parameters of an instance

### DIFF
--- a/regression/verilog/modules/parameters5.desc
+++ b/regression/verilog/modules/parameters5.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+parameters5.v
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/modules/parameters5.v
+++ b/regression/verilog/modules/parameters5.v
@@ -1,0 +1,16 @@
+module my_module#(p0 = 0)();
+
+  localparam p1 = 1;
+  parameter p2 = 2;
+
+endmodule
+
+module main;
+
+  my_module #(10, 20) instance();
+
+  always assert p0: instance.p0==10;
+  always assert p1: instance.p1==1;
+  always assert p2: instance.p2==20;
+
+endmodule


### PR DESCRIPTION
This adds a failing test for accessing module parameters from the outside of a module via the instance identifier.