### PR TITLE
Verilog: add a KNOWNBUG for registers in generate blocks

### DIFF
--- a/regression/verilog/generate/generate-reg1.desc
+++ b/regression/verilog/generate/generate-reg1.desc
@@ -1,0 +1,6 @@
+KNOWNBUG
+generate-reg1.v
+--module main --bound 0
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/verilog/generate/generate-reg1.v
+++ b/regression/verilog/generate/generate-reg1.v
@@ -1,0 +1,23 @@
+`define BITS 4
+
+module main(input [`BITS-1:0] data);
+
+  reg [`BITS-1:0] result;
+
+  generate
+    genvar i;
+    for (i = 0; i < `BITS; i=i+1) begin : label
+      reg my_reg;
+
+      always @(data) begin
+        my_reg = data[i];
+        result[i] = my_reg;
+      end
+    end
+  endgenerate
+
+  // should pass
+  always assert p0: result[0] == data[0];
+  always assert p1: result[`BITS-1] == data[`BITS-1];
+
+endmodule // main


### PR DESCRIPTION
Registers in generate blocks get named after the block identifier.  This adds a test for this scenario.