### PR TITLE
Verilog: fix generate begin ... end

### DIFF
--- a/regression/verilog/generate/generate-for2.desc
+++ b/regression/verilog/generate/generate-for2.desc
@@ -1,0 +1,6 @@
+CORE
+generate-for2.v
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/verilog/generate/generate-for2.v
+++ b/regression/verilog/generate/generate-for2.v
@@ -1,0 +1,25 @@
+`define BITS 4
+
+module main(input [`BITS-1:0] data);
+
+  reg [`BITS-1:0] result;
+
+  generate
+    genvar i;
+    for (i = 0; i < `BITS; i=i+1) begin
+      always @(data) result[i] = data[i];
+    end
+  endgenerate
+
+  /* equivalent to
+  always @(data) result[0] = data[0];
+  always @(data) result[1] = data[1];
+  always @(data) result[2] = data[2];
+  always @(data) result[3] = data[3];
+  */
+
+  // should pass
+  always assert p0: result[0] == data[0];
+  always assert p1: result[`BITS-1] == data[`BITS-1];
+
+endmodule // main

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1810,9 +1810,9 @@ genvar_assignment:
 
 generate_block:
 	  TOK_BEGIN generate_item_brace TOK_END
-	  	{ init($$, ID_generate_block); }
+		{ init($$, ID_generate_block); swapop($$, $2); }
 	| TOK_BEGIN TOK_COLON generate_block_identifier generate_item_brace TOK_END
-		{ init($$, ID_generate_block); stack_expr($$).operands().swap(stack_expr($4).operands()); }
+		{ init($$, ID_generate_block); swapop($$, $4); }
 	;
 
 port_declaration:


### PR DESCRIPTION
This fixes generate blocks without label, which the parser has simply dropped.