### PR TITLE
Verilog: ignore genvar variables when outputting RTL

### DIFF
--- a/src/ebmc/output_verilog.cpp
+++ b/src/ebmc/output_verilog.cpp
@@ -787,6 +787,7 @@ void output_verilog_baset::wires(const irep_idt &module)
        !symbol.is_property &&
        !symbol.is_macro &&
        symbol.type.id()!=ID_integer &&
+       symbol.type.id()!=ID_genvar &&
        symbol.type.id()!=ID_module &&
        symbol.type.id()!=ID_module_instance &&
        symbol.type.id()!=ID_code &&


### PR DESCRIPTION
The Verilog RTL output happens after elaboration, and any generate constructs have been expanded.