### PR TITLE
Verilog: add KNOWNBUG test for ANSI-style module headers

### DIFF
--- a/regression/verilog/modules/ports3.desc
+++ b/regression/verilog/modules/ports3.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+ports3.v
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/modules/ports3.v
+++ b/regression/verilog/modules/ports3.v
@@ -1,0 +1,7 @@
+module main(input [3:0] data);
+
+  reg [$bits(data)-1:0] copy = data;
+
+  always assert property1: $bits(copy) == 4;
+
+endmodule


### PR DESCRIPTION
This adds a failing test that exposes a bug where the type of a register depends on the type of a module input.