### PR TITLE
introduce verilog_generate_blockt

### DIFF
--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -164,6 +164,59 @@ extern inline verilog_module_itemt &to_verilog_module_item(irept &irep)
   return static_cast<verilog_module_itemt &>(irep);
 }
 
+class verilog_generate_blockt : public verilog_module_itemt
+{
+public:
+  explicit verilog_generate_blockt(
+    verilog_module_exprt::module_itemst _module_items)
+    : verilog_module_itemt(ID_generate_block)
+  {
+    module_items() = std::move(_module_items);
+  }
+
+  verilog_generate_blockt(
+    irep_idt _identifier,
+    verilog_module_exprt::module_itemst _module_items)
+    : verilog_module_itemt(ID_generate_block)
+  {
+    set(ID_identifier, _identifier);
+    module_items() = std::move(_module_items);
+  }
+
+  const irep_idt &identifier() const
+  {
+    return get(ID_identifier);
+  }
+
+  bool is_named() const
+  {
+    return !identifier().empty();
+  }
+
+  const verilog_module_exprt::module_itemst &module_items() const
+  {
+    return (const verilog_module_exprt::module_itemst &)operands();
+  }
+
+  verilog_module_exprt::module_itemst &module_items()
+  {
+    return (verilog_module_exprt::module_itemst &)operands();
+  }
+};
+
+extern inline const verilog_generate_blockt &
+to_verilog_generate_block(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_generate_block);
+  return static_cast<const verilog_generate_blockt &>(expr);
+}
+
+extern inline verilog_generate_blockt &to_verilog_generate_block(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_generate_block);
+  return static_cast<verilog_generate_blockt &>(expr);
+}
+
 class verilog_parameter_declt : public verilog_module_itemt
 {
 public:

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -795,8 +795,9 @@ void verilog_typecheckt::interface_module_item(
     interface_statement(to_verilog_initial(module_item).statement());
   else if(module_item.id()==ID_generate_block)
   {
-    for(auto &item : module_item.get_sub())
-      interface_module_item(static_cast<const verilog_module_itemt &>(item));
+    auto &generate_block = to_verilog_generate_block(module_item);
+    for(auto &item : generate_block.module_items())
+      interface_module_item(item);
   }
 }
 


### PR DESCRIPTION
This introduces a class for generate block module items, to strengthen typing in the Verilog frontend.