### PR TITLE
Verilog: add a KNOWNBUG test for a parameter dependency

### DIFF
--- a/regression/verilog/modules/parameters6.desc
+++ b/regression/verilog/modules/parameters6.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+parameters6.v
+
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+We currently evaluate parameters in the order in which they appear.

--- a/regression/verilog/modules/parameters6.v
+++ b/regression/verilog/modules/parameters6.v
@@ -1,0 +1,7 @@
+// A parameter may depend on a parameter that is declared later.
+module my_module;
+
+  parameter p = q;
+  parameter q = 31;
+
+endmodule


### PR DESCRIPTION
Verilog parameters may depend on parameters declared later in the module.