### PR TITLE
Verilog: use verilog_module_sourcet when checking the ports

### DIFF
--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -34,13 +34,13 @@ void verilog_typecheckt::module_interface(
   for(auto &module_item : module_source.module_items())
     interface_module_item(module_item);
 
-  // now check port names
-  interface_ports(module_symbol.type.add(ID_ports).get_sub());
+  // Check the typing of the ports
+  check_module_ports(module_source);
 }
 
 /*******************************************************************\
 
-Function: verilog_typecheckt::interface_ports
+Function: verilog_typecheckt::check_module_ports
 
   Inputs:
 
@@ -50,17 +50,18 @@ Function: verilog_typecheckt::interface_ports
 
 \*******************************************************************/
 
-void verilog_typecheckt::interface_ports(irept::subt &ports)
+void verilog_typecheckt::check_module_ports(
+  const verilog_module_sourcet &module_source)
 {
-  const irept &module_source=module_symbol.type.find(ID_module_source);
-  const irept &module_ports=module_source.find(ID_ports);
+  const auto &module_ports = module_source.ports();
 
-  ports.resize(module_ports.get_sub().size());
+  auto &ports = module_symbol.type.add(ID_ports).get_sub();
+  ports.resize(module_ports.size());
   std::map<irep_idt, unsigned> port_names;
 
   unsigned nr=0;
 
-  for(auto &port : module_ports.get_sub())
+  for(auto &port : module_ports)
   {
     assert(port.id() == ID_decl);
 

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1716,7 +1716,7 @@ void verilog_typecheckt::typecheck()
   const auto &module_source =
     to_verilog_module_source(module_symbol.type.find(ID_module_source));
 
-  // Create symbols for the ports, registers/variables and wires.
+  // Create symbols for the functions, tasks, registers/variables and wires.
   module_interface(module_source);
 
   auto verilog_module_expr = elaborate_generate_constructs(module_source);

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -100,7 +100,7 @@ protected:
 
   // interfaces
   void module_interface(const verilog_module_sourcet &);
-  void interface_ports(irept::subt &ports);
+  void check_module_ports(const verilog_module_sourcet &);
   void interface_module_decl(const class verilog_declt &);
   void interface_function_or_task_decl(const class verilog_declt &);
   void interface_inst(const class verilog_module_itemt &);


### PR DESCRIPTION
This strengthens the typing in the Verilog front-end.