### PR TITLE
Verilog: add symbols for variables in generate constructs

### DIFF
--- a/regression/verilog/generate/generate-reg2.desc
+++ b/regression/verilog/generate/generate-reg2.desc
@@ -1,0 +1,6 @@
+CORE
+generate-reg2.v
+--module main --bound 0
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/verilog/generate/generate-reg2.v
+++ b/regression/verilog/generate/generate-reg2.v
@@ -1,0 +1,21 @@
+`define BITS 4
+
+module main(input [`BITS-1:0] data);
+
+  reg [`BITS-1:0] result;
+
+  generate
+    if(1) begin
+      reg [`BITS-1:0] my_reg;
+      always @(data) begin
+        my_reg = data;
+        result = my_reg;
+      end
+    end
+  endgenerate
+
+  // should pass
+  always assert p0: result[0] == data[0];
+  always assert p1: result[`BITS-1] == data[`BITS-1];
+
+endmodule // main

--- a/src/verilog/verilog_generate.cpp
+++ b/src/verilog/verilog_generate.cpp
@@ -85,6 +85,14 @@ void verilog_typecheckt::elaborate_generate_decl(
   }
   else
   {
+    if(decl_class == ID_reg || decl_class == ID_wire)
+    {
+      // verilog_typecheckt::module_interfaces does not add
+      // symbols in generate blocks, since the generate blocks
+      // have not yet been elaborated. Do so now.
+      interface_module_decl(decl);
+    }
+
     // Preserve the declaration for any initializers.
     verilog_module_itemt tmp(ID_set_genvars);
     tmp.add_to_operands(decl);


### PR DESCRIPTION
This fixes the Verilog front-end to add symbols for variables that are declared in generate constructs.