### PR TITLE
Verilog: delay values can be identifiers

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1120,6 +1120,7 @@ delay3:   '#' delay_value { $$=$2; }
 
 delay_value:
           unsigned_number
+	| variable_identifier
         ;
 
 // System Verilog standard 1800-2017
@@ -2091,8 +2092,6 @@ delay_or_event_control:
 delay_control:
 	  '#' delay_value
 		{ init($$, ID_delay); mto($$, $2); }
-	// | '#' variable_identifier
-	// 	{ init($$, ID_delay); mto($$, $2); }
 	| '#' '(' mintypmax_expression ')'
 		{ init($$, ID_delay); mto($$, $2); }
 	;


### PR DESCRIPTION
This adds a case from the Verilog grammar that allows variables as delay values.  Constructs like that will now be parsed, but not synthesized.