### PR TITLE
Verilog: typedefs inside modules

### DIFF
--- a/regression/verilog/data-types/typedef1.desc
+++ b/regression/verilog/data-types/typedef1.desc
@@ -1,0 +1,7 @@
+CORE
+typedef1.sv
+
+^EXIT=10$
+^SIGNAL=0$
+^no properties$
+--

--- a/regression/verilog/data-types/typedef1.sv
+++ b/regression/verilog/data-types/typedef1.sv
@@ -1,0 +1,16 @@
+// as 'description'
+typedef bit my_type1;
+
+module main();
+
+  // as 'module_item'
+  typedef bit my_type2;
+
+  function some_function;
+    // as 'block_item'
+    typedef bit my_type3;
+    begin
+    end
+  endfunction
+
+endmodule

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -338,6 +338,10 @@ void verilog_typecheckt::interface_function_or_task_decl(const verilog_declt &de
       error() << "wires are not allowed here" << eom;
       throw 0;
     }
+    else if(port_class == ID_typedef)
+    {
+      symbol.is_type = true;
+    }
     else
     {
       if(
@@ -502,6 +506,10 @@ void verilog_typecheckt::interface_module_decl(
     }
     else if(port_class == ID_supply1)
     {
+    }
+    else if(port_class == ID_typedef)
+    {
+      symbol.is_type = true;
     }
     else
     {

--- a/src/verilog/verilog_parse_tree.h
+++ b/src/verilog/verilog_parse_tree.h
@@ -80,12 +80,12 @@ public:
     exprt &ports,
     exprt &statements);
 
-  void create_typedef(irept &type, irept &symbol)
+  void create_typedef(irept &declaration)
   {
     items.push_back(itemt());
     items.back().type=itemt::TYPEDEF;
-    items.back().verilog_typedef.symbol.swap(symbol);
-    items.back().verilog_typedef.type.swap(type);
+    items.back().verilog_typedef.symbol.swap(declaration.get_sub()[0]);
+    items.back().verilog_typedef.type.swap(declaration.add(ID_type));
   }
   
   void swap(verilog_parse_treet &parse_tree)


### PR DESCRIPTION
Following IEEE 1800 2017, this allows typedefs as `block_item` or `package_or_generate_item`.