### PR TITLE
Verilog: synth_expr now returns the result

### DIFF
--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -226,7 +226,7 @@ protected:
   void synth_while(const class verilog_whilet &);
   void synth_repeat(const class verilog_repeatt &);
   void synth_function_call_or_task_enable(const class verilog_function_callt &);
-  void synth_expr(exprt &expr, symbol_statet symbol_state);
+  [[nodiscard]] exprt synth_expr(exprt expr, symbol_statet symbol_state);
   void synth_assign(const exprt &, bool blocking);
   void synth_assert(const class verilog_assertt &);
   void synth_assume(const class verilog_assumet &);


### PR DESCRIPTION
Return the result of expression synthesis instead of modifying in place.