### PR TITLE
Add clang-format GitHub action

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+lib/cbmc/.clang-format

--- a/.github/workflows/syntax-checks.yaml
+++ b/.github/workflows/syntax-checks.yaml
@@ -1,0 +1,56 @@
+name: Syntactic checks
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  # This job takes approximately 1 minute
+  check-clang-format:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Fetch dependencies
+        env:
+          # This is needed in addition to -yq to prevent apt-get from asking for
+          # user input
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -yq clang-format-11
+      - name: Check updated lines of code match clang-format-11 style
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
+          MERGE_BRANCH: ${{ github.ref }}
+        run: |
+          # Log information about the run of this check.
+          echo "Pull request's base branch is: ${BASE_BRANCH}"
+          echo "Pull request's merge branch is: ${MERGE_BRANCH}"
+          echo "Pull request's source branch is: ${GITHUB_HEAD_REF}"
+          clang-format-11 --version
+
+          # The checkout action leaves us in detatched head state. The following line
+          # names the checked out commit, for simpler reference later.
+          git checkout -b ${MERGE_BRANCH}
+
+          # Make sure we can refer to ${BASE_BRANCH} by name
+          git checkout ${BASE_BRANCH}
+          git checkout ${MERGE_BRANCH}
+
+          # Find the commit on which the PR is based.
+          MERGE_BASE=$(git merge-base ${BASE_BRANCH} ${MERGE_BRANCH})
+          echo "Checking for formatting errors introduced since $MERGE_BASE"
+
+          # Do the checking. "eval" is used so that quotes (as inserted into $EXCLUDES
+          # above) are not interpreted as parts of file names.
+          git-clang-format-11 --binary clang-format-11 $MERGE_BASE
+          git diff > formatted.diff
+          if [[ -s formatted.diff ]] ; then
+            echo 'Formatting error! The following diff shows the required changes'
+            echo 'Use the raw log to get a version of the diff that preserves spacing'
+            cat formatted.diff
+            exit 1
+          fi
+          echo 'No formatting errors found'


### PR DESCRIPTION
Use the same configuration as CBMC by symlinking to it.