### PR TITLE
Verilog: rename elaborate_parameters to elaborate_constants

### DIFF
--- a/src/verilog/Makefile
+++ b/src/verilog/Makefile
@@ -1,5 +1,5 @@
 SRC = expr2verilog.cpp \
-      verilog_elaborate_parameters.cpp \
+      verilog_elaborate_constants.cpp \
       verilog_expr.cpp \
       verilog_generate.cpp \
       verilog_interfaces.cpp \

--- a/src/verilog/verilog_elaborate_constants.cpp
+++ b/src/verilog/verilog_elaborate_constants.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************\
 
-Module: Verilog Parameter Elaboration
+Module: Verilog Elaboration Time Constants
 
 Author: Daniel Kroening, kroening@kroening.com
 
@@ -10,7 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 /*******************************************************************\
 
-Function: verilog_typecheckt::elaborate_parameters
+Function: verilog_typecheckt::elaborate_constants
 
   Inputs:
 
@@ -20,11 +20,18 @@ Function: verilog_typecheckt::elaborate_parameters
 
 \*******************************************************************/
 
-void verilog_typecheckt::elaborate_parameters()
+void verilog_typecheckt::elaborate_constants()
 {
-  // Parameters may depend on each other, in any order.
+  // This refers to "elaboration-time constants" as defined
+  // in System Verilog 1800-2017, and includes
+  // * parameters (including parameter ports)
+  // * localparam
+  // * specparam
+  // * enum constants
+  //
+  // These may depend on each other, in any order.
   // We traverse these dependencies recursively.
-  // First collect all parameter declarators into the symbol table,
+  // First collect all constant identifiers into the symbol table,
   // with type "to_be_elaborated".
 
   std::vector<irep_idt> to_be_elaborated;

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1717,9 +1717,10 @@ void verilog_typecheckt::typecheck()
 {
   module_identifier = module_symbol.name;
 
-  // We first elaborate the parameters. Everything else (types
-  // of port, generate constructs) may depend on parameters.
-  elaborate_parameters();
+  // We first elaborate the named constants (parameters, enums).
+  // Everything else (types of ports, generate constructs) may
+  // depend on these.
+  elaborate_constants();
 
   const auto &module_source =
     to_verilog_module_source(module_symbol.type.find(ID_module_source));

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -76,7 +76,7 @@ protected:
   using defparamst = std::map<irep_idt, std::map<irep_idt, exprt>>;
   defparamst defparams;
 
-  void elaborate_parameters();
+  void elaborate_constants();
   void elaborate_parameter(irep_idt) override;
 
   // instances


### PR DESCRIPTION
System Verilog introduces enum constants, which are elaborated like parameters.  Hence rename the method that elaborates them to the more general `elaborate_constants`.