### PR TITLE
Verilog: strengthen typing of .convert_type(...)

### DIFF
--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -58,7 +58,7 @@ protected:
 
   void propagate_type(exprt &expr, const typet &type);
 
-  typet convert_type(const irept &src);
+  typet convert_type(const typet &);
 
   void convert_range(
     const exprt &range,

--- a/src/verilog/verilog_typecheck_type.cpp
+++ b/src/verilog/verilog_typecheck_type.cpp
@@ -26,9 +26,9 @@ Function: verilog_typecheck_exprt::convert_type
 
 \*******************************************************************/
 
-typet verilog_typecheck_exprt::convert_type(const irept &src)
+typet verilog_typecheck_exprt::convert_type(const typet &src)
 {
-  auto source_location = static_cast<const typet &>(src).source_location();
+  auto source_location = src.source_location();
 
   if(src.is_nil() || src.id()==ID_reg)
   {


### PR DESCRIPTION
The type of the argument is now `typet`, not `irept`.