### PR TITLE
Verilog: add missing operators and keywords

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -270,6 +270,7 @@ int yyverilogerror(const char *error)
 %token TOK_GREATERGREATERGREATER ">>>"
 %token TOK_LESSLESS         "<<"
 %token TOK_LESSLESSLESS     "<<<"
+%token TOK_LESSMINUSGREATER "<->"
 
 /* Unary or binary */
 %token TOK_PLUS             "+"
@@ -436,6 +437,7 @@ int yyverilogerror(const char *error)
 %token TOK_BYTE             "byte"
 %token TOK_CHANDLE          "chandle"
 %token TOK_CHECKER          "checker"
+%token TOK_CELL             "cell"
 %token TOK_CLASS            "class"
 %token TOK_CLOCKING         "clocking"
 %token TOK_CONFIG           "config"
@@ -447,8 +449,10 @@ int yyverilogerror(const char *error)
 %token TOK_COVERGROUP       "covergroup"
 %token TOK_COVERPOINT       "coverpoint"
 %token TOK_CROSS            "cross"
+%token TOK_DESIGN           "design"
 %token TOK_DIST             "dist"
 %token TOK_DO               "do"
+%token TOK_ENDCHECKER       "endchecker"
 %token TOK_ENDCLASS         "endclass"
 %token TOK_ENDCLOCKING      "endclocking"
 %token TOK_ENDCONFIG        "endconfig"
@@ -470,6 +474,8 @@ int yyverilogerror(const char *error)
 %token TOK_IFF              "iff"
 %token TOK_IGNORE_BINS      "ignore_bins"
 %token TOK_ILLEGAL_BINS     "illegal_bins"
+%token TOK_IMPLEMENTS       "implements"
+%token TOK_IMPLIES          "implies"
 %token TOK_IMPORT           "import"
 %token TOK_INSIDE           "inside"
 %token TOK_INT              "int"
@@ -506,6 +512,7 @@ int yyverilogerror(const char *error)
 %token TOK_SEQUENCE         "sequence"
 %token TOK_SHORTINT         "shortint"
 %token TOK_SHORTREAL        "shortreal"
+%token TOK_SHOWCANCELLED    "showcancelled"
 %token TOK_SOLVE            "solve"
 %token TOK_STATIC           "static"
 %token TOK_STRING           "string"
@@ -520,8 +527,10 @@ int yyverilogerror(const char *error)
 %token TOK_TYPEDEF          "typedef"
 %token TOK_UNION            "union"
 %token TOK_UNIQUE           "unique"
+%token TOK_UNIQUE0          "unique0"
 %token TOK_UNTIL            "until"
 %token TOK_UNTIL_WITH       "until_with"
+%token TOK_UNTYPED          "untyped"
 %token TOK_VAR              "var"
 %token TOK_VIRTUAL          "virtual"
 %token TOK_VOID             "void"
@@ -1560,8 +1569,8 @@ property_expr:
         | property_expr "until_with" property_expr   { init($$, "sva_until_with"); mto($$, $1); mto($$, $3); }
         | property_expr "s_until" property_expr      { init($$, "sva_s_until"); mto($$, $1); mto($$, $3); }
         | property_expr "s_until_with" property_expr { init($$, "sva_s_until_with"); mto($$, $1); mto($$, $3); }
-//        | property_expr "implies" property_expr       { init($$, ID_implies); mto($$, $1); mto($$, $3); }
-//        | property_expr "iff" property_expr           { init($$, ID_iff); mto($$, $1); mto($$, $3); }
+        | property_expr "implies" property_expr       { init($$, ID_implies); mto($$, $1); mto($$, $3); }
+        | property_expr "iff" property_expr           { init($$, ID_iff); mto($$, $1); mto($$, $3); }
         | "accept_on" '(' expression_or_dist ')'      { init($$, "sva_accept_on"); mto($$, $3); }
         | "reject_on" '(' expression_or_dist ')'      { init($$, "sva_reject_on"); mto($$, $3); }
         | "sync_accept_on" '(' expression_or_dist ')' { init($$, "sva_sync_accept_on"); mto($$, $3); }
@@ -2640,6 +2649,10 @@ expression:
         | unary_operator attribute_instance_brace primary
                 { $$=$1; mto($$, $3); }
         | inc_or_dec_expression
+	| expression "->" expression
+		{ init($$, ID_implies); mto($$, $1); mto($$, $3); }
+	| expression "<->" expression
+		{ init($$, ID_iff); mto($$, $1); mto($$, $3); }
 	| expression TOK_PLUS expression
 		{ init($$, ID_plus); mto($$, $1); mto($$, $3); }
 	| expression TOK_MINUS expression

--- a/src/verilog/scanner.l
+++ b/src/verilog/scanner.l
@@ -204,6 +204,7 @@ void verilog_scanner_init()
 ">>>"           { return TOK_GREATERGREATERGREATER; }
 "<<"            { return TOK_LESSLESS; }
 "<<<"           { return TOK_LESSLESSLESS; }
+"<->"           { return TOK_LESSMINUSGREATER; }
 
                 /* Trinary operators */
 
@@ -442,10 +443,12 @@ binsof          { SYSTEM_VERILOG_KEYWORD(TOK_BINSOF); }
 bit             { SYSTEM_VERILOG_KEYWORD(TOK_BIT); }
 break           { SYSTEM_VERILOG_KEYWORD(TOK_BREAK); }
 byte            { SYSTEM_VERILOG_KEYWORD(TOK_BYTE); }
+cell            { SYSTEM_VERILOG_KEYWORD(TOK_CELL); }
 chandle         { SYSTEM_VERILOG_KEYWORD(TOK_CHANDLE); }
 checker         { SYSTEM_VERILOG_KEYWORD(TOK_CHECKER); }
 class           { SYSTEM_VERILOG_KEYWORD(TOK_CLASS); }
 clocking        { SYSTEM_VERILOG_KEYWORD(TOK_CLOCKING); }
+config          { SYSTEM_VERILOG_KEYWORD(TOK_CONFIG); }
 const           { SYSTEM_VERILOG_KEYWORD(TOK_CONST); }
 constraint      { SYSTEM_VERILOG_KEYWORD(TOK_CONSTRAINT); }
 context         { SYSTEM_VERILOG_KEYWORD(TOK_CONTEXT); }
@@ -454,8 +457,10 @@ cover           { SYSTEM_VERILOG_KEYWORD(TOK_COVER); }
 covergroup      { SYSTEM_VERILOG_KEYWORD(TOK_COVERGROUP); }
 coverpoint      { SYSTEM_VERILOG_KEYWORD(TOK_COVERPOINT); }
 cross           { SYSTEM_VERILOG_KEYWORD(TOK_CROSS); }
+design          { SYSTEM_VERILOG_KEYWORD(TOK_DESIGN); }
 dist            { SYSTEM_VERILOG_KEYWORD(TOK_DIST); }
 do              { SYSTEM_VERILOG_KEYWORD(TOK_DO); }
+endchecker      { SYSTEM_VERILOG_KEYWORD(TOK_ENDCHECKER); }
 endclass        { SYSTEM_VERILOG_KEYWORD(TOK_ENDCLASS); }
 endclocking     { SYSTEM_VERILOG_KEYWORD(TOK_ENDCLOCKING); }
 endgroup        { SYSTEM_VERILOG_KEYWORD(TOK_ENDGROUP); }
@@ -476,6 +481,8 @@ foreach         { SYSTEM_VERILOG_KEYWORD(TOK_FOREACH); }
 iff             { SYSTEM_VERILOG_KEYWORD(TOK_IFF); }
 ignore_bins     { SYSTEM_VERILOG_KEYWORD(TOK_IGNORE_BINS); }
 illegal_bins    { SYSTEM_VERILOG_KEYWORD(TOK_ILLEGAL_BINS); }
+implements      { SYSTEM_VERILOG_KEYWORD(TOK_IMPLEMENTS); }
+implies         { SYSTEM_VERILOG_KEYWORD(TOK_IMPLIES); }
 import          { SYSTEM_VERILOG_KEYWORD(TOK_IMPORT); }
 inside          { SYSTEM_VERILOG_KEYWORD(TOK_INSIDE); }
 int             { SYSTEM_VERILOG_KEYWORD(TOK_INT); }
@@ -512,6 +519,7 @@ s_until_with    { SYSTEM_VERILOG_KEYWORD(TOK_S_UNTIL_WITH); }
 sequence        { SYSTEM_VERILOG_KEYWORD(TOK_SEQUENCE); }
 shortint        { SYSTEM_VERILOG_KEYWORD(TOK_SHORTINT); }
 shortreal       { SYSTEM_VERILOG_KEYWORD(TOK_SHORTREAL); }
+showcancelled   { SYSTEM_VERILOG_KEYWORD(TOK_SHOWCANCELLED); }
 solve           { SYSTEM_VERILOG_KEYWORD(TOK_SOLVE); }
 static          { SYSTEM_VERILOG_KEYWORD(TOK_STATIC); }
 string          { SYSTEM_VERILOG_KEYWORD(TOK_STRING); }
@@ -526,8 +534,10 @@ type            { SYSTEM_VERILOG_KEYWORD(TOK_TYPE); }
 typedef         { VIS_VERILOG_KEYWORD(TOK_TYPEDEF); }
 union           { SYSTEM_VERILOG_KEYWORD(TOK_UNION); }
 unique          { SYSTEM_VERILOG_KEYWORD(TOK_UNIQUE); }
+unique0         { SYSTEM_VERILOG_KEYWORD(TOK_UNIQUE0); }
 until           { SYSTEM_VERILOG_KEYWORD(TOK_UNTIL); }
 until_with      { SYSTEM_VERILOG_KEYWORD(TOK_UNTIL_WITH); }
+untyped         { SYSTEM_VERILOG_KEYWORD(TOK_UNTYPED); }
 var             { SYSTEM_VERILOG_KEYWORD(TOK_VAR); }
 virtual         { SYSTEM_VERILOG_KEYWORD(TOK_VIRTUAL); }
 void            { SYSTEM_VERILOG_KEYWORD(TOK_VOID); }

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1906,7 +1906,9 @@ void verilog_typecheck_exprt::convert_binary_expr(binary_exprt &expr)
     convert_extractbit_expr(to_extractbit_expr(expr));
   else if(expr.id()==ID_replication)
     convert_replication_expr(to_replication_expr(expr));
-  else if(expr.id()==ID_and || expr.id()==ID_or)
+  else if(
+    expr.id() == ID_and || expr.id() == ID_or || expr.id() == ID_iff ||
+    expr.id() == ID_implies)
   {
     Forall_operands(it, expr)
     {


### PR DESCRIPTION
This adds missing keywords and operators given in System Verilog 1800-2017.