### PR TITLE
ebmc: use console colors for --show-formula

### DIFF
--- a/src/ebmc/ebmc_solver_factory.cpp
+++ b/src/ebmc/ebmc_solver_factory.cpp
@@ -49,9 +49,8 @@ ebmc_solver_factoryt ebmc_solver_factory(const cmdlinet &cmdline)
     }
     else
     {
-      return [](const namespacet &, message_handlert &)
-      {
-        auto dec = std::make_unique<show_formula_solvert>(std::cout);
+      return [](const namespacet &, message_handlert &) {
+        auto dec = std::make_unique<show_formula_solvert>();
         return ebmc_solvert{std::move(dec)};
       };
     }


### PR DESCRIPTION
This enables the use of console colors when `--show-formula` is used without `--outfile`.