### PR TITLE
ebmc: force inputs to be equal when comparing states

### DIFF
--- a/regression/verilog/system_verilog_assertion/eventually1.desc
+++ b/regression/verilog/system_verilog_assertion/eventually1.desc
@@ -1,0 +1,12 @@
+CORE
+eventually1.sv
+--module main --bound 1 --trace
+^EXIT=10$
+^SIGNAL=0$
+^Counterexample:$
+--
+^  main\.reset = 0$
+^warning: ignoring
+--
+The last state must be identical to the first state on the trace.
+In both states reset must be 1.

--- a/regression/verilog/system_verilog_assertion/eventually1.sv
+++ b/regression/verilog/system_verilog_assertion/eventually1.sv
@@ -1,0 +1,18 @@
+// count up from 0 to 10
+
+module main(input clk, input reset);
+
+  reg [3:0] counter;
+
+  initial counter = 0;
+
+  always @(posedge clk)
+    if(reset)
+      counter = 0;
+    else if(counter != 10)
+      counter = counter + 1;
+
+  // expected to fail, owing to reset
+  p0: assert property (eventually counter == 10);
+
+endmodule


### PR DESCRIPTION
The definition of a counterexample with a lasso requires two states to be equal.  This must include the top-level inputs, or otherwise the lasso is not demonstrated.