### PR TITLE
ebmc: fix encoding of 'eventually'

### DIFF
--- a/regression/verilog/system_verilog_assertion/eventually2.desc
+++ b/regression/verilog/system_verilog_assertion/eventually2.desc
@@ -1,0 +1,7 @@
+CORE
+eventually2.sv
+--module main --bound 20
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/system_verilog_assertion/eventually2.sv
+++ b/regression/verilog/system_verilog_assertion/eventually2.sv
@@ -1,0 +1,18 @@
+// count up from 0 to 10, with option to reset
+
+module main(input clk, input reset);
+
+  reg [7:0] counter;
+
+  initial counter = 0;
+
+  always @(posedge clk)
+    if(reset)
+      counter = 0;
+    else if(counter != 10)
+      counter = counter + 1;
+
+  // expected to pass for any bound
+  p0: assert property (eventually (reset || counter == 10));
+
+endmodule

--- a/regression/verilog/system_verilog_assertion/eventually3.desc
+++ b/regression/verilog/system_verilog_assertion/eventually3.desc
@@ -1,0 +1,8 @@
+CORE
+eventually3.sv
+--module main --bound 11
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.property\.p0\] always \(eventually main\.counter <= 5\): FAILURE$
+--
+^warning: ignoring

--- a/regression/verilog/system_verilog_assertion/eventually3.sv
+++ b/regression/verilog/system_verilog_assertion/eventually3.sv
@@ -1,0 +1,16 @@
+module main(input clk);
+
+  reg [7:0] counter;
+
+  initial counter = 0;
+
+  always @(posedge clk)
+    if(counter < 10)
+      counter = counter + 1;
+    else
+      counter = 6;
+
+  // expected to fail with any bound greater or equal 11
+  p0: assert property (eventually counter<=5);
+
+endmodule

--- a/src/trans-word-level/property.h
+++ b/src/trans-word-level/property.h
@@ -31,7 +31,9 @@ void lasso_constraints(
   const namespacet &,
   const irep_idt &module_identifier);
 
-symbol_exprt lasso_symbol(std::size_t);
+/// Is there a loop from i back to k?
+/// Precondition: k<i
+symbol_exprt lasso_symbol(std::size_t k, std::size_t i);
 
 /// Returns true iff the given property requires lasso constraints.
 bool requires_lasso_constraints(const exprt &);


### PR DESCRIPTION
This strengthens the constraints for `eventually p` to prevent wrong counterexamples where `p` is satisfied somewhere on the lasso.