### PR TITLE
Verilog: use display_name in two warnings

### DIFF
--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -2790,7 +2790,8 @@ void verilog_synthesist::synth_assignments(transt &trans)
 
       if(assignment.type==event_guardt::COMBINATIONAL)
       {
-        warning() << "Making " << symbol.name << " a wire" << eom;
+        warning().source_location = symbol.location;
+        warning() << "Making " << symbol.display_name() << " a wire" << eom;
         symbol.is_state_var=false;
       }
 

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -763,8 +763,7 @@ void verilog_typecheck_exprt::convert_symbol(exprt &expr)
   {
     // this should become an error
     warning().source_location=expr.source_location();
-    warning() << "implicit definition of wire "
-              << full_identifier << eom;
+    warning() << "implicit wire " << symbol->display_name() << eom;
     expr.type()=symbol->type;
     expr.set(ID_identifier, symbol->name);
   }


### PR DESCRIPTION
This uses the slightly shorter `display_name` instead of the full identifier in two Verilog frontend warnings.