### PR TITLE
Concurrent assertion statements

### DIFF
--- a/regression/verilog/system_verilog_assertion/initial1.desc
+++ b/regression/verilog/system_verilog_assertion/initial1.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+initial1.sv
+--module main --bound 1
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Syntax is missing for initial label: assert property (...);

--- a/regression/verilog/system_verilog_assertion/initial1.sv
+++ b/regression/verilog/system_verilog_assertion/initial1.sv
@@ -1,0 +1,20 @@
+module main(input clk);
+
+  // count up from 0 to 10
+  reg [7:0] counter;
+
+  initial counter = 0;
+
+  always @(posedge clk)
+    if(counter == 10)
+      counter = 0;
+    else
+      counter = counter + 1;
+
+  // expected to pass
+  initial p0: assert property (counter == 0);
+
+  // expected to pass if there are timeframes 0 and 1
+  initial p1: assert property (s_nexttime counter == 1);
+
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2074,6 +2074,40 @@ always_construct: TOK_ALWAYS statement
 		{ init($$, ID_always); mto($$, $2); }
 	;
 
+blocking_assignment:
+	  variable_lvalue '=' delay_or_event_control expression
+		{ init($$, ID_blocking_assign); mto($$, $1); mto($$, $4); }
+        | operator_assignment
+	;
+
+operator_assignment:
+          variable_lvalue assignment_operator expression
+		{ init($$, ID_blocking_assign); mto($$, $1); mto($$, $3); }
+        ;
+
+assignment_operator:
+          '='
+        | TOK_PLUSEQUAL
+        | TOK_MINUSEQUAL
+        | TOK_ASTERICEQUAL
+        | TOK_SLASHEQUAL
+        | TOK_PERCENTEQUAL
+        | TOK_AMPEREQUAL
+        | TOK_VERTBAREQUAL
+        | TOK_CARETEQUAL
+        | TOK_LESSLESSEQUAL
+        | TOK_GREATERGREATEREQUAL
+        | TOK_LESSLESSLESSEQUAL
+        | TOK_GREATERGREATERGREATEREQUAL
+        ;
+
+nonblocking_assignment:
+	  variable_lvalue TOK_LESSEQUAL expression
+		{ init($$, ID_non_blocking_assign); mto($$, $1); mto($$, $3); }
+	| variable_lvalue TOK_LESSEQUAL delay_or_event_control expression
+		{ init($$, ID_non_blocking_assign); mto($$, $1); mto($$, $4); }
+	;
+
 // The extra rule to allow block_item_declaration is to avoid an ambiguity
 // caused by the attribute_instance_brace.
 statement: 
@@ -2352,40 +2386,6 @@ procedural_continuous_assignments:
 	| TOK_RELEASE variable_lvalue
 		{ init($$, ID_release); mto($$, $2); }
 	/* | TOK_RELEASE net_lvalue */
-	;
-
-blocking_assignment:
-	  variable_lvalue '=' delay_or_event_control expression
-		{ init($$, ID_blocking_assign); mto($$, $1); mto($$, $4); }
-        | operator_assignment
-	;
-	
-operator_assignment:
-          variable_lvalue assignment_operator expression
-		{ init($$, ID_blocking_assign); mto($$, $1); mto($$, $3); }
-        ;
-
-assignment_operator:
-          '='
-        | TOK_PLUSEQUAL
-        | TOK_MINUSEQUAL
-        | TOK_ASTERICEQUAL
-        | TOK_SLASHEQUAL
-        | TOK_PERCENTEQUAL
-        | TOK_AMPEREQUAL
-        | TOK_VERTBAREQUAL
-        | TOK_CARETEQUAL
-        | TOK_LESSLESSEQUAL
-        | TOK_GREATERGREATEREQUAL
-        | TOK_LESSLESSLESSEQUAL
-        | TOK_GREATERGREATERGREATEREQUAL
-        ;
-
-nonblocking_assignment:
-	  variable_lvalue TOK_LESSEQUAL expression
-		{ init($$, ID_non_blocking_assign); mto($$, $1); mto($$, $3); }
-	| variable_lvalue TOK_LESSEQUAL delay_or_event_control expression
-		{ init($$, ID_non_blocking_assign); mto($$, $1); mto($$, $4); }
 	;
 
 procedural_timing_control_statement:


### PR DESCRIPTION
This moves the Verilog grammar closer to the standard around the rules for assertion statements and module items.
