### PR TITLE
Verilog: fix module port binding

### DIFF
--- a/regression/verilog/modules/ports4.desc
+++ b/regression/verilog/modules/ports4.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 ports4.v
 --bound 0
 ^EXIT=0$
@@ -6,4 +6,3 @@ ports4.v
 --
 ^warning: ignoring
 --
-The parameter in the module instance port binding is not expanded.

--- a/regression/verilog/modules/ports4.desc
+++ b/regression/verilog/modules/ports4.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+ports4.v
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The parameter in the module instance port binding is not expanded.

--- a/regression/verilog/modules/ports4.v
+++ b/regression/verilog/modules/ports4.v
@@ -1,0 +1,13 @@
+module submodule(input [7:0] data);
+
+  always assert p0: data == 123;
+
+endmodule
+
+module main#(parameter MY_PARAMETER = 123)();
+
+  submodule instance(MY_PARAMETER);
+
+  always assert p1: MY_PARAMETER == 123;
+
+endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -964,8 +964,11 @@ void verilog_synthesist::instantiate_port(
     throw 0;
   }
 
+  auto value_synthesized = synth_expr(value, symbol_statet::SYMBOL);
+
   trans.invar().add_to_operands(equal_exprt(
-    typecast_exprt::conditional_cast(it->second, value.type()), value));
+    typecast_exprt::conditional_cast(it->second, value_synthesized.type()),
+    value_synthesized));
 }
 
 /*******************************************************************\


### PR DESCRIPTION
The parameter is not expanded to its value in the port binding.