### PR TITLE
Verilog: genvar_value now returns the value

### DIFF
--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -205,13 +205,13 @@ protected:
   typedef std::map<irep_idt, mp_integer> genvarst;
   genvarst genvars;
 
-  // to be overridden
-  void genvar_value(const irep_idt &identifier, mp_integer &value) override {
+  mp_integer genvar_value(const irep_idt &identifier) override
+  {
     genvarst::const_iterator it=genvars.find(identifier);
     if(it==genvars.end())
-      value=-1;
+      return -1;
     else
-      value=it->second;
+      return it->second;
   }
 
   // interpreter state

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -736,9 +736,7 @@ void verilog_typecheck_exprt::convert_symbol(exprt &expr)
     else if(symbol->type.id() == ID_genvar)
     {
       // This must be a constant.
-      mp_integer int_value;
-
-      genvar_value(identifier, int_value);
+      mp_integer int_value = genvar_value(identifier);
 
       if(int_value<0)
       {

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -65,8 +65,10 @@ protected:
     mp_integer &msb,
     mp_integer &lsb);
 
-  virtual void genvar_value(const irep_idt &identifier, mp_integer &value) {
-    assert(false);
+  // to be overridden
+  virtual mp_integer genvar_value(const irep_idt &identifier)
+  {
+    PRECONDITION(false);
   }
 
   virtual void elaborate_parameter(irep_idt)
@@ -74,7 +76,11 @@ protected:
     PRECONDITION(false);
   }
 
-  virtual exprt var_value(const irep_idt &identifier) { assert(false); }
+  // to be overridden
+  virtual exprt var_value(const irep_idt &identifier)
+  {
+    PRECONDITION(false);
+  }
 
   virtual bool implicit_wire(const irep_idt &identifier,
                              const symbolt *&symbol) {


### PR DESCRIPTION
`genvar_value` now returns the value, instead of writing it to a supplied reference.