### PR TITLE
Verilog: remove duplicate ns member

### DIFF
--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -3106,7 +3106,8 @@ bool verilog_synthesis(
   message_handlert &message_handler,
   const optionst &options)
 {
+  const namespacet ns(symbol_table);
   verilog_synthesist verilog_synthesis(
-    symbol_table, module, options, message_handler);
+    ns, symbol_table, module, options, message_handler);
   return verilog_synthesis.typecheck_main();
 }

--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -42,13 +42,13 @@ class verilog_synthesist:
 {
 public:
   verilog_synthesist(
+    const namespacet &_ns,
     symbol_table_baset &_symbol_table,
     const irep_idt &_module,
     const optionst &_options,
     message_handlert &_message_handler)
-    : verilog_typecheck_baset(ns, _message_handler),
+    : verilog_typecheck_baset(_ns, _message_handler),
       verilog_symbol_tablet(_symbol_table),
-      ns(_symbol_table),
       options(_options),
       value_map(NULL),
       module(_module),
@@ -59,7 +59,6 @@ public:
   virtual void typecheck();
 
 protected:
-  const namespacet ns;
   const optionst &options;
  
   enum class event_guardt { NONE, CLOCK, COMBINATIONAL };


### PR DESCRIPTION
The `ns` reference member is already in the base class of `verilog_synthesist`; this removes the duplication.