### PR TITLE
ebmc: add --random-waveform and --random-trace

### DIFF
--- a/regression/ebmc/random-traces/long_trace1.random-waveform.desc
+++ b/regression/ebmc/random-traces/long_trace1.random-waveform.desc
@@ -1,0 +1,10 @@
+CORE broken-smt-backend
+long_trace1.v
+--random-waveform
+^                0  1  2  3  4  5  6  7  8  9 10$
+^      main\.clk                                 $
+^main\.increment  0  1  1  0  1  1  1  1  1  1  1$
+^ main\.some_reg  0  0  1  2  2  3  4  5  6  7  8$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -149,6 +149,9 @@ int ebmc_parse_optionst::doit()
     if(cmdline.isset("random-traces"))
       return random_traces(cmdline, ui_message_handler);
 
+    if(cmdline.isset("random-trace") || cmdline.isset("random-waveform"))
+      return random_trace(cmdline, ui_message_handler);
+
     if(cmdline.isset("ic3"))
       return do_ic3(cmdline, ui_message_handler);
 

--- a/src/ebmc/ebmc_parse_options.h
+++ b/src/ebmc/ebmc_parse_options.h
@@ -43,6 +43,7 @@ public:
         "(aig)(stop-induction)(stop-minimize)(start):(coverage)(naive)"
         "(compute-ct)(dot-netlist)(smv-netlist)(vcd):"
         "(random-traces)(trace-steps):(random-seed):(number-of-traces):"
+        "(random-trace)(random-waveform)"
         "I:(preprocess)",
         argc,
         argv,

--- a/src/ebmc/random_traces.h
+++ b/src/ebmc/random_traces.h
@@ -14,7 +14,11 @@ Author: Daniel Kroening, kroening@kroening.com
 class cmdlinet;
 class message_handlert;
 
+// many traces
 int random_traces(const cmdlinet &, message_handlert &);
+
+// just one trace
+int random_trace(const cmdlinet &, message_handlert &);
 
 class transition_systemt;
 


### PR DESCRIPTION
This adds two command-line options `--random-waveform` and `--random-trace`, which print a single random trace to the console.