### PR TITLE
ebmc: revise property status output

### DIFF
--- a/regression/ebmc/BDD/BDD1.desc
+++ b/regression/ebmc/BDD/BDD1.desc
@@ -3,6 +3,6 @@ BDD1.smv
 --bdd
 ^EXIT=0$
 ^SIGNAL=0$
-^\[smv::main::spec1\] AG \(!main::var::some_var = off\): SUCCESS$
+^\[smv::main::spec1\] AG \(!main::var::some_var = off\): PROVED$
 --
 ^warning: ignoring

--- a/regression/ebmc/BDD/BDD2.desc
+++ b/regression/ebmc/BDD/BDD2.desc
@@ -3,6 +3,6 @@ BDD2.sv
 --module main --bdd
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.property.my_prop1\] always main.counter < 199: SUCCESS$
-^\[main.property.my_prop2\] always main.counter < 198: FAILURE$
+^\[main.property.my_prop1\] always main.counter < 199: PROVED$
+^\[main.property.my_prop2\] always main.counter < 198: REFUTED$
 --

--- a/regression/ebmc/BDD/BDD4.desc
+++ b/regression/ebmc/BDD/BDD4.desc
@@ -3,6 +3,6 @@ BDD4.smv
 --bdd
 ^EXIT=10$
 ^SIGNAL=0$
-^\[smv::main::spec1\] AG .*: FAILURE
+^\[smv::main::spec1\] AG .*: REFUTED$
 --
 ^warning: ignoring

--- a/regression/ebmc/BDD/BDD5.desc
+++ b/regression/ebmc/BDD/BDD5.desc
@@ -3,6 +3,6 @@ BDD5.smv
 --bdd
 ^EXIT=0$
 ^SIGNAL=0$
-^\[smv::main::spec1\] AG .*: SUCCESS
+^\[smv::main::spec1\] AG .*: PROVED$
 --
 ^warning: ignoring

--- a/regression/ebmc/BDD3/test.desc
+++ b/regression/ebmc/BDD3/test.desc
@@ -3,6 +3,6 @@ main.sv
 --module main --bdd
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.property.my_prop1\] always main.counter <= 10: SUCCESS$
-^\[main.property.my_prop2\] always main.counter < 10: FAILURE$
+^\[main.property.my_prop1\] always main.counter <= 10: PROVED$
+^\[main.property.my_prop2\] always main.counter < 10: REFUTED$
 --

--- a/regression/ebmc/Include1/test.desc
+++ b/regression/ebmc/Include1/test.desc
@@ -4,6 +4,6 @@ main.v
 ^EXIT=10$
 ^SIGNAL=0$
 ^Counterexample:$
-^\[main.property.property1\] always main.x != 10: FAILURE
+^\[main.property.property1\] always main.x != 10: REFUTED$
 --
 ^warning: ignoring

--- a/regression/ebmc/Properties1/test.desc
+++ b/regression/ebmc/Properties1/test.desc
@@ -3,7 +3,7 @@ main.smv
 --bound 10 --property smv::main::spec2
 ^EXIT=0$
 ^SIGNAL=0$
-^\[smv::main::spec2\] .* SUCCESS$
+^\[smv::main::spec2\] .* PROVED up to bound 10$
 --
 ^warning: ignoring
 $\[smv::main::spec1\] .*$

--- a/regression/ebmc/SVA-LTL/lasso1-counterexample.desc
+++ b/regression/ebmc/SVA-LTL/lasso1-counterexample.desc
@@ -3,7 +3,7 @@ lasso1.sv
 --bound 10 --waveform
 ^EXIT=10$
 ^SIGNAL=0$
-^\[top\.property\.p0\] .* FAILURE$
+^\[top\.property\.p0\] .* REFUTED$
 ^             0  1  2  3  4  5  6  7  8  9 10$
 ^top\.counter  0  1  2  3  4  5  6  7  8  9  3$
 --

--- a/regression/ebmc/SVA-LTL/lasso1-small-bound.desc
+++ b/regression/ebmc/SVA-LTL/lasso1-small-bound.desc
@@ -3,6 +3,6 @@ lasso1.sv
 --bound 5
 ^EXIT=0$
 ^SIGNAL=0$
-^\[top\.property\.p0\] .* SUCCESS$
+^\[top\.property\.p0\] .* PROVED up to bound 5$
 --
 --

--- a/regression/ebmc/SVA-LTL/simple_counterexamples_to_Fp.p0.desc
+++ b/regression/ebmc/SVA-LTL/simple_counterexamples_to_Fp.p0.desc
@@ -4,5 +4,5 @@ simple_counterexamples_to_Fp.sv
 ^Adding lasso constraints$
 ^EXIT=10$
 ^SIGNAL=0$
-^\[top\.property\.p0\] .* FAILURE$
+^\[top\.property\.p0\] .* REFUTED$
 --

--- a/regression/ebmc/SVA-LTL/simple_counterexamples_to_Fp.p1.desc
+++ b/regression/ebmc/SVA-LTL/simple_counterexamples_to_Fp.p1.desc
@@ -4,5 +4,5 @@ simple_counterexamples_to_Fp.sv
 ^Adding lasso constraints$
 ^EXIT=10$
 ^SIGNAL=0$
-^\[top\.property\.p1\] .* FAILURE$
+^\[top\.property\.p1\] .* REFUTED$
 --

--- a/regression/ebmc/SVA-LTL/simple_counterexamples_to_Fp.p2.desc
+++ b/regression/ebmc/SVA-LTL/simple_counterexamples_to_Fp.p2.desc
@@ -4,5 +4,5 @@ simple_counterexamples_to_Fp.sv
 ^Adding lasso constraints$
 ^EXIT=10$
 ^SIGNAL=0$
-^\[top\.property\.p2\] .* FAILURE$
+^\[top\.property\.p2\] .* REFUTED$
 --

--- a/regression/ebmc/SVA-LTL/simple_passing_LTL_properties.desc
+++ b/regression/ebmc/SVA-LTL/simple_passing_LTL_properties.desc
@@ -4,13 +4,13 @@ simple_passing_LTL_properties.sv
 ^Adding lasso constraints$
 ^EXIT=0$
 ^SIGNAL=0$
-^\[top.property.p0\] .* SUCCESS$
-^\[top.property.p1\] .* SUCCESS$
-^\[top.property.p2\] .* SUCCESS$
-^\[top.property.p3\] .* SUCCESS$
-^\[top.property.p4\] .* SUCCESS$
-^\[top.property.p5\] .* SUCCESS$
-^\[top.property.p6\] .* SUCCESS$
-^\[top.property.p7\] .* SUCCESS$
-^\[top.property.p8\] .* SUCCESS$
+^\[top.property.p0\] .* PROVED up to bound 10$
+^\[top.property.p1\] .* PROVED up to bound 10$
+^\[top.property.p2\] .* PROVED up to bound 10$
+^\[top.property.p3\] .* PROVED up to bound 10$
+^\[top.property.p4\] .* PROVED up to bound 10$
+^\[top.property.p5\] .* PROVED up to bound 10$
+^\[top.property.p6\] .* PROVED up to bound 10$
+^\[top.property.p7\] .* PROVED up to bound 10$
+^\[top.property.p8\] .* PROVED up to bound 10$
 --

--- a/regression/ebmc/elbtunnel/test.desc
+++ b/regression/ebmc/elbtunnel/test.desc
@@ -3,13 +3,13 @@ elbtunnel.aig.smv
 --bound 12
 ^EXIT=10$
 ^SIGNAL=0$
-\[smv::main::spec1\] .* FAILURE
-\[smv::main::spec2\] .* SUCCESS
-\[smv::main::spec3\] .* FAILURE
-\[smv::main::spec4\] .* FAILURE
-\[smv::main::spec5\] .* SUCCESS
-\[smv::main::spec6\] .* SUCCESS
-\[smv::main::spec7\] .* FAILURE
-\[smv::main::spec8\] .* FAILURE
+^\[smv::main::spec1\] .* REFUTED$
+^\[smv::main::spec2\] .* PROVED up to bound 12$
+^\[smv::main::spec3\] .* REFUTED$
+^\[smv::main::spec4\] .* REFUTED$
+^\[smv::main::spec5\] .* PROVED up to bound 12$
+^\[smv::main::spec6\] .* PROVED up to bound 12$
+^\[smv::main::spec7\] .* REFUTED$
+^\[smv::main::spec8\] .* REFUTED$
 --
 ^warning: ignoring

--- a/regression/ebmc/example1/test.desc
+++ b/regression/ebmc/example1/test.desc
@@ -1,7 +1,7 @@
 CORE
 example1.sv
 --bound 10
-SUCCESS$
+PROVED up to bound 10$
 ^EXIT=0$
 ^SIGNAL=0$
 

--- a/regression/ebmc/example3/test.desc
+++ b/regression/ebmc/example3/test.desc
@@ -1,8 +1,8 @@
 CORE
 example3.sv
 --bound 10
-SUCCESS$
-FAILURE$
+^\[counter\.property\.1\] .* PROVED up to bound 10$
+^\[counter\.property\.2\] .* REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 

--- a/regression/ebmc/example4_reset/test.desc
+++ b/regression/ebmc/example4_reset/test.desc
@@ -1,8 +1,8 @@
 CORE
 example4.sv
 --bound 10 --reset "reset==1"
-SUCCESS$
-SUCCESS$
+^\[counter\.property\.1\] .* PROVED up to bound 10$
+^\[counter\.property\.2\] .* PROVED up to bound 10$
 ^EXIT=0$
 ^SIGNAL=0$
 

--- a/regression/ebmc/example4_trace/test.desc
+++ b/regression/ebmc/example4_trace/test.desc
@@ -1,8 +1,8 @@
 CORE broken-smt-backend
 example4.sv
 --bound 10 --trace
-SUCCESS$
-FAILURE$
+^\[counter\.property\.1\] .* PROVED up to bound 10$
+^\[counter\.property\.2\] .* REFUTED$
 ^  counter\.state = 254 \(11111110\)$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/ebmc/example5/test.desc
+++ b/regression/ebmc/example5/test.desc
@@ -1,7 +1,7 @@
 CORE
 example5.sv
 --bound 10
-SUCCESS$
+PROVED up to bound 10$
 ^EXIT=0$
 ^SIGNAL=0$
 

--- a/regression/ebmc/k-induction/k-induction1.desc
+++ b/regression/ebmc/k-induction/k-induction1.desc
@@ -1,9 +1,9 @@
 CORE
 k-induction1.v
 --module main --bound 1 --k-induction
-^EXIT=0$
+^EXIT=10$
 ^SIGNAL=0$
-^\[main.property.property1\] .* SUCCESS$
-^\[main.property.property2\] .* UNKNOWN$
+^\[main.property.property1\] .* PROVED$
+^\[main.property.property2\] .* INCONCLUSIVE$
 --
 ^warning: ignoring

--- a/regression/ebmc/k-induction/k-induction2.desc
+++ b/regression/ebmc/k-induction/k-induction2.desc
@@ -3,6 +3,6 @@ k-induction2.v
 --module main --bound 3 --k-induction
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.property.p1] .* SUCCESS$
+^\[main.property.p1] .* PROVED$
 --
 ^warning: ignoring

--- a/regression/ebmc/k-induction/k-induction3.desc
+++ b/regression/ebmc/k-induction/k-induction3.desc
@@ -3,6 +3,6 @@ k-induction3.v
 --module main --bound 9 --k-induction
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.property.p1] .* FAILURE$
+^\[main.property.p1] .* INCONCLUSIVE$
 --
 ^warning: ignoring

--- a/regression/ebmc/k-induction/k-induction4.desc
+++ b/regression/ebmc/k-induction/k-induction4.desc
@@ -1,8 +1,8 @@
 CORE
 k-induction4.sv
 --module main --bound 1 --k-induction
-^EXIT=0$
+^EXIT=10$
 ^SIGNAL=0$
-^\[main.property.p1] .* UNKNOWN$
+^\[main.property.p1] .* INCONCLUSIVE$
 --
 ^warning: ignoring

--- a/regression/ebmc/netlist/netlist-trace1.desc
+++ b/regression/ebmc/netlist/netlist-trace1.desc
@@ -1,7 +1,7 @@
 CORE
 netlist-trace1.sv
 --bound 10 --trace --aig
-^\[counter\.property\.1\] always counter\.state != 3: FAILURE$
+^\[counter\.property\.1\] always counter\.state != 3: REFUTED$
 ^  counter\.state = 3 \(00000011\)$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/ebmc/neural-liveness/counter1.desc
+++ b/regression/ebmc/neural-liveness/counter1.desc
@@ -1,7 +1,7 @@
 CORE
 counter1.sv
 --number-of-traces 2 --neural-liveness --neural-engine "echo Candidate: counter\\\\n"
-^\[main\.property\.p0\] always \(eventually main.counter == 0\): SUCCESS$
+^\[main\.property\.p0\] always \(eventually main.counter == 0\): PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/range_type/range_type1.desc
+++ b/regression/ebmc/range_type/range_type1.desc
@@ -3,6 +3,6 @@ range_type1.smv
 --bound 10
 ^EXIT=0$
 ^SIGNAL=0$
-^\[smv::main::spec1\] AG main::var::x != 4: SUCCESS$
+^\[smv::main::spec1\] AG main::var::x != 4: PROVED up to bound 10$
 --
 ^warning: ignoring

--- a/regression/ebmc/range_type/range_type2.desc
+++ b/regression/ebmc/range_type/range_type2.desc
@@ -3,7 +3,7 @@ range_type2.smv
 --bound 10
 ^EXIT=0$
 ^SIGNAL=0$
-^\[smv::main::spec1\] AG TRUE: SUCCESS$
-^\[smv::main::spec2\] AG main::var::NET_tmp9: SUCCESS$
+^\[smv::main::spec1\] AG TRUE: PROVED up to bound 10$
+^\[smv::main::spec2\] AG main::var::NET_tmp9: PROVED up to bound 10$
 --
 ^warning: ignoring

--- a/regression/ebmc/range_type/range_type3.desc
+++ b/regression/ebmc/range_type/range_type3.desc
@@ -3,7 +3,7 @@ range_type3.smv
 --bound 10 --trace
 ^EXIT=10$
 ^SIGNAL=0$
-^\[smv::main::spec1\] .* FAILURE$
+^\[smv::main::spec1\] .* REFUTED$
 ^Counterexample:$
 --
 ^warning: ignoring

--- a/regression/ebmc/range_type/range_type4.desc
+++ b/regression/ebmc/range_type/range_type4.desc
@@ -3,6 +3,6 @@ range_type4.smv
 --bound 10
 ^EXIT=0$
 ^SIGNAL=0$
-^\[smv::main::spec1\] AG \(!main::var::x = 6\): SUCCESS$
+^\[smv::main::spec1\] AG \(!main::var::x = 6\): PROVED up to bound 10$
 --
 ^warning: ignoring

--- a/regression/ebmc/range_type/range_type5.desc
+++ b/regression/ebmc/range_type/range_type5.desc
@@ -3,6 +3,6 @@ range_type5.smv
 --bound 3
 ^EXIT=0$
 ^SIGNAL=0$
-^\[smv::main::spec1\] AG \(!main::var::x = 6\): SUCCESS$
+^\[smv::main::spec1\] AG \(!main::var::x = 6\): PROVED up to bound 3$
 --
 ^warning: ignoring

--- a/regression/ebmc/ranking-function/counter1.fail.desc
+++ b/regression/ebmc/ranking-function/counter1.fail.desc
@@ -1,7 +1,7 @@
 CORE
 counter1.sv
 --ranking-function "(-counter)"
-^\[main\.property\.p0\] always \(eventually main.counter == 0\): UNKNOWN$
-^EXIT=0$
+^\[main\.property\.p0\] always \(eventually main.counter == 0\): INCONCLUSIVE$
+^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/counter1.pass.desc
+++ b/regression/ebmc/ranking-function/counter1.pass.desc
@@ -1,7 +1,7 @@
 CORE
 counter1.sv
 --ranking-function counter
-^\[main\.property\.p0\] always \(eventually main.counter == 0\): SUCCESS$
+^\[main\.property\.p0\] always \(eventually main.counter == 0\): PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/counter2.fail.desc
+++ b/regression/ebmc/ranking-function/counter2.fail.desc
@@ -1,7 +1,7 @@
 CORE
 counter2.sv
 --ranking-function counter
-^\[main\.property\.p0\] always \(eventually main.counter == 10\): UNKNOWN$
-^EXIT=0$
+^\[main\.property\.p0\] always \(eventually main.counter == 10\): INCONCLUSIVE$
+^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/counter2.pass.desc
+++ b/regression/ebmc/ranking-function/counter2.pass.desc
@@ -1,7 +1,7 @@
 CORE
 counter2.sv
 --ranking-function 10-counter
-^\[main\.property\.p0\] always \(eventually main.counter == 10\): SUCCESS$
+^\[main\.property\.p0\] always \(eventually main.counter == 10\): PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/counter_in_module1.desc
+++ b/regression/ebmc/ranking-function/counter_in_module1.desc
@@ -1,7 +1,7 @@
 CORE
 counter_in_module1.sv
 --ranking-function instance.counter
-^\[main\.property\.p0\] always \(eventually main.instance.counter == 0\): SUCCESS$
+^\[main\.property\.p0\] always \(eventually main.instance.counter == 0\): PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/counter_with_reset1.fail.desc
+++ b/regression/ebmc/ranking-function/counter_with_reset1.fail.desc
@@ -1,7 +1,7 @@
 CORE
 counter_with_reset1.sv
 --property main.property.p0 --ranking-function 10-counter
-^\[main\.property\.p0\] always \(eventually main.counter == 10\): UNKNOWN$
-^EXIT=0$
+^\[main\.property\.p0\] always \(eventually main.counter == 10\): INCONCLUSIVE$
+^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/counter_with_reset1.pass.desc
+++ b/regression/ebmc/ranking-function/counter_with_reset1.pass.desc
@@ -1,7 +1,7 @@
 CORE
 counter_with_reset1.sv
 --property main.property.p1 --ranking-function 10-counter
-^\[main\.property\.p1\] always \(eventually main.reset \|\| main.counter == 10\): SUCCESS$
+^\[main\.property\.p1\] always \(eventually main.reset \|\| main.counter == 10\): PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/lexicographic_ranking_function1.desc
+++ b/regression/ebmc/ranking-function/lexicographic_ranking_function1.desc
@@ -1,7 +1,7 @@
 CORE
 lexicographic_ranking_function1.sv
 --ranking-function "{digit1, digit2}"
-^\[main\.property\.p0\] always \(eventually main\.digit1 == 0\): SUCCESS$
+^\[main\.property\.p0\] always \(eventually main\.digit1 == 0\): PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ring_buffer_bdd/test.desc
+++ b/regression/ebmc/ring_buffer_bdd/test.desc
@@ -1,7 +1,7 @@
 CORE
 ring_buffer.sv
 --bdd
-SUCCESS$
+PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 

--- a/regression/ebmc/ring_buffer_induction/test.desc
+++ b/regression/ebmc/ring_buffer_induction/test.desc
@@ -1,7 +1,7 @@
 CORE
 ring_buffer.sv
 --k-induction
-SUCCESS$
+PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 

--- a/regression/ebmc/small-test1/test.desc
+++ b/regression/ebmc/small-test1/test.desc
@@ -3,6 +3,6 @@ main.smv
 --bound 10 --trace
 ^EXIT=10$
 ^SIGNAL=0$
-^\[smv::main::spec1\] AG main::var::x = 1: FAILURE$
+^\[smv::main::spec1\] AG main::var::x = 1: REFUTED$
 --
 ^warning: ignoring

--- a/regression/ebmc/small-test2/test.desc
+++ b/regression/ebmc/small-test2/test.desc
@@ -3,6 +3,6 @@ main.smv
 --bound 2
 ^EXIT=10$
 ^SIGNAL=0$
-^\[smv::main::spec1\] AG main::var::z: FAILURE$
+^\[smv::main::spec1\] AG main::var::z: REFUTED$
 --
 ^warning: ignoring

--- a/regression/ebmc/small-test3/test.desc
+++ b/regression/ebmc/small-test3/test.desc
@@ -3,6 +3,6 @@ main.v
 --bound 2
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.property.prop1\] always main.x == 3: SUCCESS$
+^\[main.property.prop1\] always main.x == 3: PROVED up to bound 2$
 --
 ^warning: ignoring

--- a/regression/ebmc/smv/smv1.desc
+++ b/regression/ebmc/smv/smv1.desc
@@ -3,6 +3,6 @@ smv1.smv
 --bdd
 ^EXIT=0$
 ^SIGNAL=0$
-^\[smv::main::spec1\] .* SUCCESS$
+^\[smv::main::spec1\] .* PROVED$
 --
 ^warning: ignoring

--- a/regression/ebmc/smv/smv2.desc
+++ b/regression/ebmc/smv/smv2.desc
@@ -3,6 +3,6 @@ smv2.smv
 --module main --bound 2 --k-induction
 ^EXIT=0$
 ^SIGNAL=0$
-^\[smv::main::spec1\] .* SUCCESS$
+^\[smv::main::spec1\] .* PROVED$
 --
 ^warning: ignoring

--- a/regression/ebmc/smv/smv3.desc
+++ b/regression/ebmc/smv/smv3.desc
@@ -3,6 +3,6 @@ smv3.smv
 --module main --bound 2 --k-induction
 ^EXIT=0$
 ^SIGNAL=0$
-^\[smv::main::spec1\] .* SUCCESS$
+^\[smv::main::spec1\] .* PROVED$
 --
 ^warning: ignoring

--- a/regression/ebmc/traces/waveform1.desc
+++ b/regression/ebmc/traces/waveform1.desc
@@ -3,7 +3,7 @@ waveform1.smv
 --bound 20 --waveform
 ^EXIT=10$
 ^SIGNAL=0$
-^\[smv::main::spec1\] .* FAILURE$
+^\[smv::main::spec1\] .* REFUTED$
 ^Counterexample:$
 ^                   0  1  2  3  4  5  6  7  8  9  10  11  12  13  14  15  16  17  18  19  20$
 ^smv::main::var::x  0  1  2  3  4  5  6  7  8  9  10  11  12  13  14  15  16  17  18  19  20$

--- a/regression/verilog/Memory1/test.desc
+++ b/regression/verilog/Memory1/test.desc
@@ -3,6 +3,6 @@ main.v
 --module main --bound 1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.property.property1\] .* SUCCESS$
+^\[main.property.property1\] .* PROVED up to bound 1$
 --
 ^warning: ignoring

--- a/regression/verilog/Memory2/test.desc
+++ b/regression/verilog/Memory2/test.desc
@@ -3,6 +3,6 @@ main.v
 --module main --bound 1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.property.property1\] .* SUCCESS$
+^\[main.property.property1\] .* PROVED up to bound 1$
 --
 ^warning: ignoring

--- a/regression/verilog/arbiter1/test.desc
+++ b/regression/verilog/arbiter1/test.desc
@@ -3,6 +3,6 @@ arbiter_change.v
 --bound 5
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.property.p1\] .* SUCCESS$
+^\[main.property.p1\] .* PROVED up to bound 5$
 --
 ^warning: ignoring

--- a/regression/verilog/assert1/test.desc
+++ b/regression/verilog/assert1/test.desc
@@ -4,6 +4,6 @@ main.v
 ^EXIT=10$
 ^SIGNAL=0$
 ^Counterexample:$
-\[main.property.property1\] .* FAILURE$
+\[main.property.property1\] .* REFUTED$
 --
 ^warning: ignoring

--- a/regression/verilog/assert2/test.desc
+++ b/regression/verilog/assert2/test.desc
@@ -3,7 +3,7 @@ main.v
 --module main --bound 20
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.s_ok.property.eq\] .* SUCCESS$
-^\[main.s_fail.property.eq\] .* FAILURE$
+^\[main.s_ok.property.eq\] .* PROVED up to bound 20$
+^\[main.s_fail.property.eq\] .* REFUTED$
 --
 ^warning: ignoring

--- a/regression/verilog/assignment-to-concatenation/test.desc
+++ b/regression/verilog/assignment-to-concatenation/test.desc
@@ -3,7 +3,7 @@ main.v
 --bound 1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.property.property1\] .* SUCCESS$
-^\[main.property.property2\] .* SUCCESS$
+^\[main.property.property1\] .* PROVED up to bound 1$
+^\[main.property.property2\] .* PROVED up to bound 1$
 --
 ^warning: ignoring

--- a/regression/verilog/assignment-to-range1/test.desc
+++ b/regression/verilog/assignment-to-range1/test.desc
@@ -3,6 +3,6 @@ main.v
 --bound 1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[top.property.p1\] .* SUCCESS$
+^\[top.property.p1\] .* PROVED up to bound 1$
 --
 ^warning: ignoring

--- a/regression/verilog/bit-extract/bit-extract1.desc
+++ b/regression/verilog/bit-extract/bit-extract1.desc
@@ -3,6 +3,6 @@ bit-extract1.v
 --bound 1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.property.property1\] .* SUCCESS$
+^\[main.property.property1\] .* PROVED up to bound 1$
 --
 ^warning: ignoring

--- a/regression/verilog/bit-extract/bit-extract2.desc
+++ b/regression/verilog/bit-extract/bit-extract2.desc
@@ -4,6 +4,6 @@ bit-extract2.v
 ^EXIT=10$
 ^SIGNAL=0$
 ^Counterexample:$
-^\[main.property.property1\] .* FAILURE$
+^\[main.property.property1\] .* REFUTED$
 --
 ^warning: ignoring

--- a/regression/verilog/case/case1.desc
+++ b/regression/verilog/case/case1.desc
@@ -4,6 +4,6 @@ case1.v
 ^EXIT=10$
 ^SIGNAL=0$
 ^Counterexample:$
-^\[main.property.p1\] .* FAILURE$
+^\[main.property.p1\] .* REFUTED$
 --
 ^warning: ignoring

--- a/regression/verilog/case/case2.desc
+++ b/regression/verilog/case/case2.desc
@@ -3,6 +3,6 @@ case2.v
 --module main --bound 1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.property.p1\] .* SUCCESS$
+^\[main.property.p1\] .* PROVED up to bound 1$
 --
 ^warning: ignoring

--- a/regression/verilog/case/case3.desc
+++ b/regression/verilog/case/case3.desc
@@ -4,6 +4,6 @@ case3.v
 ^EXIT=10$
 ^SIGNAL=0$
 ^Counterexample:$
-^\[main.property.p1\] .* FAILURE$
+^\[main.property.p1\] .* REFUTED$
 --
 ^warning: ignoring

--- a/regression/verilog/case/case4.desc
+++ b/regression/verilog/case/case4.desc
@@ -3,6 +3,6 @@ case4.v
 --module main --bound 1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.property.p1\] .* SUCCESS$
+^\[main.property.p1\] .* PROVED up to bound 1$
 --
 ^warning: ignoring

--- a/regression/verilog/system-functions/clog2.desc
+++ b/regression/verilog/system-functions/clog2.desc
@@ -3,12 +3,12 @@ clog2.v
 
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.property.p0\] .* SUCCESS$
-^\[main.property.p1\] .* SUCCESS$
-^\[main.property.p2\] .* SUCCESS$
-^\[main.property.p3\] .* SUCCESS$
-^\[main.property.p4\] .* SUCCESS$
-^\[main.property.p5\] .* SUCCESS$
-^\[main.property.p6\] .* SUCCESS$
+^\[main.property.p0\] .* PROVED up to bound 1$
+^\[main.property.p1\] .* PROVED up to bound 1$
+^\[main.property.p2\] .* PROVED up to bound 1$
+^\[main.property.p3\] .* PROVED up to bound 1$
+^\[main.property.p4\] .* PROVED up to bound 1$
+^\[main.property.p5\] .* PROVED up to bound 1$
+^\[main.property.p6\] .* PROVED up to bound 1$
 --
 ^warning: ignoring

--- a/regression/verilog/system_verilog_assertion/eventually3.desc
+++ b/regression/verilog/system_verilog_assertion/eventually3.desc
@@ -3,6 +3,6 @@ eventually3.sv
 --module main --bound 11
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main\.property\.p0\] always \(eventually main\.counter <= 5\): FAILURE$
+^\[main\.property\.p0\] always \(eventually main\.counter <= 5\): REFUTED$
 --
 ^warning: ignoring

--- a/regression/verilog/system_verilog_assertion/system_verilog_assertion2.desc
+++ b/regression/verilog/system_verilog_assertion/system_verilog_assertion2.desc
@@ -4,6 +4,6 @@ system_verilog_assertion2.sv
 ^EXIT=10$
 ^SIGNAL=0$
 ^Counterexample:$
-^\[main.property.my_label\] .* FAILURE$
+^\[main.property.my_label\] .* REFUTED$
 --
 ^warning: ignoring

--- a/regression/verilog/tasks/tasks1.desc
+++ b/regression/verilog/tasks/tasks1.desc
@@ -3,6 +3,6 @@ tasks1.v
 --bound 1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.property.p1\] .* SUCCESS$
+^\[main.property.p1\] .* PROVED up to bound 1$
 --
 ^warning: ignoring

--- a/regression/verilog/tasks/tasks2.desc
+++ b/regression/verilog/tasks/tasks2.desc
@@ -4,6 +4,6 @@ tasks2.v
 ^EXIT=10$
 ^SIGNAL=0$
 ^Counterexample:$
-^\[main.property.property1\] .* FAILURE$
+^\[main.property.property1\] .* REFUTED$
 --
 ^warning: ignoring

--- a/regression/verilog/tasks/tasks4.desc
+++ b/regression/verilog/tasks/tasks4.desc
@@ -4,6 +4,6 @@ tasks4.v
 ^EXIT=10$
 ^SIGNAL=0$
 ^Counterexample:$
-^\[main.property.property1\] .* FAILURE$
+^\[main.property.property1\] .* REFUTED$
 --
 ^warning: ignoring

--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -190,9 +190,9 @@ int bdd_enginet::operator()()
     const namespacet ns(transition_system.symbol_table);
     report_results(cmdline, properties, ns, message.get_message_handler());
 
-    // We return '0' if the property holds,
-    // and '10' if it is violated.
-    return properties.property_failure() ? 10 : 0;
+    // We return '0' if all properties are proven,
+    // and '10' otherwise.
+    return properties.all_properties_proved() ? 0 : 10;
   }
   catch(const char *error_msg)
   {
@@ -447,7 +447,7 @@ void bdd_enginet::check_property(propertyt &property)
 
       if(!intersection.is_false())
       {
-        property.make_failure();
+        property.refuted();
         message.status() << "Property refuted" << messaget::eom;
         compute_counterexample(property, iteration);
         break;
@@ -474,8 +474,8 @@ void bdd_enginet::check_property(propertyt &property)
       // have we saturated?
       if((set_union==states).is_true())
       {
-        property.make_success();
-        message.status() << "Property holds" << messaget::eom;
+        property.proved();
+        message.status() << "Property proved" << messaget::eom;
         break;
       }
 
@@ -502,13 +502,13 @@ void bdd_enginet::check_property(propertyt &property)
 
     if(!intersection.is_false())
     {
-      property.make_failure();
+      property.refuted();
       message.status() << "Property refuted" << messaget::eom;
     }
     else
     {
-      property.make_success();
-      message.status() << "Property holds" << messaget::eom;
+      property.proved();
+      message.status() << "Property proved" << messaget::eom;
     }
   }
 }

--- a/src/ebmc/ebmc_base.cpp
+++ b/src/ebmc/ebmc_base.cpp
@@ -163,7 +163,7 @@ int ebmc_baset::finish_word_level_bmc(stack_decision_proceduret &solver)
     {
     case decision_proceduret::resultt::D_SATISFIABLE:
       {
-        property.make_failure();
+        property.refuted();
         message.result() << "SAT: counterexample found" << messaget::eom;
 
         property.counterexample = compute_trans_trace(
@@ -178,16 +178,18 @@ int ebmc_baset::finish_word_level_bmc(stack_decision_proceduret &solver)
     case decision_proceduret::resultt::D_UNSATISFIABLE:
         message.result() << "UNSAT: No counterexample found within bound"
                          << messaget::eom;
-        property.make_success();
+        property.proved_with_bound(bound);
         break;
 
     case decision_proceduret::resultt::D_ERROR:
         message.error() << "Error from decision procedure" << messaget::eom;
+        property.failure();
         return 2;
 
     default:
         message.error() << "Unexpected result from decision procedure"
                         << messaget::eom;
+        property.failure();
         return 1;
     }
   }
@@ -199,9 +201,9 @@ int ebmc_baset::finish_word_level_bmc(stack_decision_proceduret &solver)
     << std::chrono::duration<double>(sat_stop_time - sat_start_time).count()
     << messaget::eom;
 
-  // We return '0' if the property holds,
-  // and '10' if it is violated.
-  return properties.property_failure() ? 10 : 0;
+  // We return '0' if all properties are proved,
+  // and '10' otherwise.
+  return properties.all_properties_proved() ? 0 : 10;
 }
 
 /*******************************************************************\
@@ -240,7 +242,7 @@ int ebmc_baset::finish_bit_level_bmc(const bmc_mapt &bmc_map, propt &solver)
     {
     case propt::resultt::P_SATISFIABLE:
       {
-        property.make_failure();
+        property.refuted();
         message.result() << "SAT: counterexample found" << messaget::eom;
 
         namespacet ns(transition_system.symbol_table);
@@ -253,7 +255,7 @@ int ebmc_baset::finish_bit_level_bmc(const bmc_mapt &bmc_map, propt &solver)
     case propt::resultt::P_UNSATISFIABLE:
         message.result() << "UNSAT: No counterexample found within bound"
                          << messaget::eom;
-        property.make_success();
+        property.proved_with_bound(bound);
         break;
 
     case propt::resultt::P_ERROR:
@@ -274,9 +276,9 @@ int ebmc_baset::finish_bit_level_bmc(const bmc_mapt &bmc_map, propt &solver)
     << std::chrono::duration<double>(sat_stop_time - sat_start_time).count()
     << messaget::eom;
 
-  // We return '0' if the property holds,
-  // and '10' if it is violated.
-  return properties.property_failure() ? 10 : 0;
+  // We return '0' if all properties are proved,
+  // and '10' otherwise.
+  return properties.all_properties_proved() ? 0 : 10;
 }
 
 /*******************************************************************\

--- a/src/ebmc/ebmc_properties.cpp
+++ b/src/ebmc/ebmc_properties.cpp
@@ -14,6 +14,30 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include "ebmc_error.h"
 
+std::string ebmc_propertiest::propertyt::status_as_string() const
+{
+  switch(status)
+  {
+  case statust::PROVED:
+    return "PROVED";
+  case statust::PROVED_WITH_BOUND:
+    return "PROVED up to bound " + std::to_string(bound);
+  case statust::REFUTED:
+    return "REFUTED";
+  case statust::UNKNOWN:
+    return "UNKNOWN";
+  case statust::INCONCLUSIVE:
+    return "INCONCLUSIVE";
+  case statust::FAILURE:
+    return "FAILURE";
+  case statust::DROPPED:
+    return "DROPPED";
+  case statust::DISABLED:
+  default:
+    UNREACHABLE;
+  }
+}
+
 ebmc_propertiest ebmc_propertiest::from_transition_system(
   const transition_systemt &transition_system,
   message_handlert &message_handler)

--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -221,27 +221,29 @@ int k_inductiont::induction_step()
       message.result()
         << "SAT: inductive proof failed, k-induction is inconclusive"
         << messaget::eom;
-      p_it.make_unknown();
+      p_it.inconclusive();
       break;
 
     case decision_proceduret::resultt::D_UNSATISFIABLE:
       message.result() << "UNSAT: inductive proof successful, property holds"
                        << messaget::eom;
-      p_it.make_success();
+      p_it.proved();
       break;
 
     case decision_proceduret::resultt::D_ERROR:
       message.error() << "Error from decision procedure" << messaget::eom;
+      p_it.failure();
       return 2;
 
     default:
       message.error() << "Unexpected result from decision procedure"
                       << messaget::eom;
+      p_it.failure();
       return 1;
     }
   }
 
-  // We return '0' if the property holds,
-  // and '10' if it is violated.
-  return properties.property_failure() ? 10 : 0;
+  // We return '0' if all properties are proved,
+  // and '10' otherwise.
+  return properties.all_properties_proved() ? 0 : 10;
 }

--- a/src/ebmc/neural_liveness.cpp
+++ b/src/ebmc/neural_liveness.cpp
@@ -229,7 +229,9 @@ tvt neural_livenesst::verify(
     message.get_message_handler());
 
   if(result.is_true())
-    property.make_success();
+    property.proved();
+  else
+    property.inconclusive();
 
   return result;
 }

--- a/src/ebmc/ranking_function.cpp
+++ b/src/ebmc/ranking_function.cpp
@@ -118,17 +118,17 @@ int do_ranking_function(
 
   if(result.is_true())
   {
-    property.make_success();
+    property.proved();
   }
   else
   {
-    property.make_unknown();
+    property.inconclusive();
   }
 
   const namespacet ns(transition_system.symbol_table);
   report_results(cmdline, properties, ns, message_handler);
 
-  return properties.property_failure() ? 10 : 0;
+  return properties.all_properties_proved() ? 0 : 10;
 }
 
 tvt is_ranking_function(


### PR DESCRIPTION
This changes the property status output to make it clear that a property was proven without bound, with a bound, or when property was refuted, or when the proof attempt as inconclusive.