### PR TITLE
ebmc: fix -p command line option

### DIFF
--- a/regression/ebmc/p-command-line-option/p-command-line-option1.desc
+++ b/regression/ebmc/p-command-line-option/p-command-line-option1.desc
@@ -1,0 +1,8 @@
+CORE
+p-command-line-option1.v
+--bound 1 -p "some_value >= 1"
+^EXIT=0$
+^SIGNAL=0$
+^\[command-line assertion\] always main\.some_value >= 1: SUCCESS$
+--
+^warning: ignoring

--- a/regression/ebmc/p-command-line-option/p-command-line-option1.v
+++ b/regression/ebmc/p-command-line-option/p-command-line-option1.v
@@ -1,0 +1,10 @@
+module main(input clk);
+
+  reg [31:0] some_value;
+
+  initial some_value = 1;
+
+  always @(posedge clk)
+    some_value = some_value + 1;
+
+endmodule

--- a/src/ebmc/ebmc_properties.cpp
+++ b/src/ebmc/ebmc_properties.cpp
@@ -104,6 +104,8 @@ ebmc_propertiest ebmc_propertiest::from_command_line(
 
     auto property_string = cmdline.get_value('p');
 
+    language->set_message_handler(message_handler);
+
     exprt expr;
     if(language->to_expr(
          property_string,


### PR DESCRIPTION
This sets the message handler, which fixes `-p`.