### PR TITLE
Verilog: parameters may be typed

### DIFF
--- a/regression/verilog/modules/localparam3.desc
+++ b/regression/verilog/modules/localparam3.desc
@@ -1,0 +1,7 @@
+CORE
+localparam3.v
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/modules/localparam3.v
+++ b/regression/verilog/modules/localparam3.v
@@ -1,0 +1,9 @@
+module main;
+
+  localparam [7:0] foo = 1;
+  parameter [7:0] bar = 2;
+
+  always assert property1: $bits(foo) == 8;
+  always assert property2: $bits(bar) == 8;
+
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -849,12 +849,16 @@ package_item:
 
 local_parameter_declaration:
           TOK_LOCALPARAM data_type_or_implicit list_of_param_assignments
-		{ init($$, ID_local_parameter_decl); swapop($$, $3); }
+		{ init($$, ID_local_parameter_decl);
+		  stack_expr($$).type() = std::move(stack_type($2));
+		  swapop($$, $3); }
 	;
 
 parameter_declaration:
           TOK_PARAMETER data_type_or_implicit list_of_param_assignments
-		{ init($$, ID_parameter_decl); swapop($$, $3); }
+		{ init($$, ID_parameter_decl);
+		  stack_expr($$).type() = std::move(stack_type($2));
+		  swapop($$, $3); }
 	;
 
 specparam_declaration:


### PR DESCRIPTION
This adds support for explicit types for parameters.