### PR TITLE
ebmc: error k-induction when given liveness property

### DIFF
--- a/regression/ebmc/k-induction/k-induction-unsupported1.desc
+++ b/regression/ebmc/k-induction/k-induction-unsupported1.desc
@@ -1,0 +1,8 @@
+CORE
+k-induction-unsupported1.sv
+--module main --k-induction
+^EXIT=6$
+^SIGNAL=0$
+^file k-induction-unsupported1\.sv line 14: error: k-induction does not support liveness properties$
+--
+^warning: ignoring

--- a/regression/ebmc/k-induction/k-induction-unsupported1.sv
+++ b/regression/ebmc/k-induction/k-induction-unsupported1.sv
@@ -1,0 +1,14 @@
+module main(input clk);
+
+  reg [31:0] x;
+  
+  initial x=1;
+  
+  always @(posedge clk)
+    if(x<10)
+      x<=x+1;
+
+  // true, but not supported by k-induction
+  p0: assert property (eventually x == 10);
+
+endmodule

--- a/src/ebmc/ebmc_error.h
+++ b/src/ebmc/ebmc_error.h
@@ -42,6 +42,11 @@ public:
     return std::move(*this);
   }
 
+  const source_locationt &location() const
+  {
+    return __location;
+  }
+
 protected:
   std::ostringstream message;
   optionalt<int> __exit_code = {};

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -310,6 +310,9 @@ int ebmc_parse_optionst::doit()
     if(!ebmc_error.what().empty())
     {
       messaget message(ui_message_handler);
+      if(ebmc_error.location().is_not_nil())
+        message.error().source_location = ebmc_error.location();
+
       message.error() << "error: " << messaget::red << ebmc_error.what()
                       << messaget::reset << messaget::eom;
     }

--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, daniel.kroening@inf.ethz.ch
 #include <trans-word-level/unwind.h>
 
 #include "ebmc_base.h"
+#include "ebmc_error.h"
 #include "ebmc_solver_factory.h"
 #include "liveness_to_safety.h"
 #include "report_results.h"
@@ -99,6 +100,14 @@ int k_inductiont::operator()()
     message.error() << "no properties" << messaget::eom;
     return 1;
   }
+
+  // Check whether the properties are suitable for k-induction.
+  for(const auto &property : properties.properties)
+    if(property.requires_lasso_constraints())
+    {
+      throw ebmc_errort().with_location(property.location)
+        << "k-induction does not support liveness properties";
+    }
 
   // do induction base
   result=induction_base();


### PR DESCRIPTION
Return an error when k-induction is given a liveness property.