### PR TITLE
ebmc: add liveness-to-safety translation to k-induction

### DIFF
--- a/regression/ebmc/liveness-to-safety/failing1.k-1.desc
+++ b/regression/ebmc/liveness-to-safety/failing1.k-1.desc
@@ -1,0 +1,7 @@
+CORE
+failing1.sv
+--k-induction --bound 1 --liveness-to-safety
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.property\.p0\] always eventually main\.my_bit: REFUTED$
+--

--- a/regression/ebmc/liveness-to-safety/failing2.k-6.desc
+++ b/regression/ebmc/liveness-to-safety/failing2.k-6.desc
@@ -1,0 +1,8 @@
+CORE
+failing2.sv
+--k-induction --bound 6 --liveness-to-safety
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.property\.p0\] always eventually main\.counter == 0: REFUTED$
+^\[main\.property\.p1\] always eventually main\.counter == 6: REFUTED$
+--

--- a/regression/ebmc/liveness-to-safety/passing1.k-10.desc
+++ b/regression/ebmc/liveness-to-safety/passing1.k-10.desc
@@ -1,0 +1,7 @@
+CORE
+passing1.sv
+--k-induction --bound 10 --liveness-to-safety
+^EXIT=0$
+^SIGNAL=0$
+^\[main\.property\.p0\] always eventually main\.my_bit: PROVED$
+--

--- a/regression/ebmc/liveness-to-safety/passing2.k-10.desc
+++ b/regression/ebmc/liveness-to-safety/passing2.k-10.desc
@@ -1,0 +1,8 @@
+CORE
+passing2.sv
+--k-induction --bound 10 --liveness-to-safety
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.property\.p0\] always eventually main\.counter == 0: INCONCLUSIVE$
+^\[main\.property\.p1\] always eventually main\.counter == 8: INCONCLUSIVE$
+--

--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, daniel.kroening@inf.ethz.ch
 
 #include "ebmc_base.h"
 #include "ebmc_solver_factory.h"
+#include "liveness_to_safety.h"
 #include "report_results.h"
 
 /*******************************************************************\
@@ -88,6 +89,10 @@ int k_inductiont::operator()()
   auto result = get_properties();
   if(result != -1)
     return result;
+
+  // liveness to safety translation, if requested
+  if(cmdline.isset("liveness-to-safety"))
+    liveness_to_safety(transition_system, properties);
 
   if(properties.properties.empty())
   {


### PR DESCRIPTION
This enables the combination of liveness to safety translation followed by k-induction.