### PR TITLE
Verilog: class scope operator

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -421,6 +421,7 @@ int yyverilogerror(const char *error)
 %token TOK_LESSLESSLESSEQUAL "<<<="
 %token TOK_GREATERGREATERGREATEREQUAL ">>>="
 %token TOK_HASHHASH         "##"
+%token TOK_COLONCOLON       "::"
 
 /* System Verilog Keywords */
 %token TOK_ACCEPT_ON        "accept_on"

--- a/src/verilog/scanner.l
+++ b/src/verilog/scanner.l
@@ -247,6 +247,7 @@ void verilog_scanner_init()
 "<->"           { SYSTEM_VERILOG_OPERATOR(TOK_LESSMINUSGREATER, "<->"); }
 "->"            { SYSTEM_VERILOG_OPERATOR(TOK_MINUSGREATER, "->"); }
 "'"             { SYSTEM_VERILOG_OPERATOR('\'', "'"); }
+"::"            { SYSTEM_VERILOG_OPERATOR(TOK_COLONCOLON, "::"); }
 
                 /* Verilog keywords */
 


### PR DESCRIPTION
This add the System Verilog class scope operator `::`.