### PR TITLE
Verilog: test functioncall1 passes

### DIFF
--- a/regression/verilog/functioncall/functioncall1.desc
+++ b/regression/verilog/functioncall/functioncall1.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
+CORE
 functioncall1.v
---module main --bound 1
+--module main --bound 0
 ^EXIT=0$
 ^SIGNAL=0$
-^UNSAT: No bug found within bound$
+^\[main\.property\.test1\] always .*: PROVED up to bound 0$
 --
 ^warning: ignoring


### PR DESCRIPTION
The test is now marked as CORE.