### PR TITLE
Verilog: introduce to_be_elaborated_typet

### DIFF
--- a/src/verilog/verilog_elaborate_constants.cpp
+++ b/src/verilog/verilog_elaborate_constants.cpp
@@ -7,6 +7,7 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 #include "verilog_typecheck.h"
+#include "verilog_types.h"
 
 /*******************************************************************\
 
@@ -42,7 +43,7 @@ void verilog_typecheckt::elaborate_constants()
       const verilog_parameter_declt::declaratort &declarator) {
       symbolt symbol{
         hierarchical_identifier(declarator.identifier()),
-        type_with_subtypet(ID_to_be_elaborated, type),
+        to_be_elaborated_typet(type),
         mode};
 
       symbol.module = module_identifier;

--- a/src/verilog/verilog_types.h
+++ b/src/verilog/verilog_types.h
@@ -11,6 +11,17 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/std_types.h>
 
+/// Used during elaboration only,
+/// to signal that a symbol is yet to be elaborated.
+class to_be_elaborated_typet : public type_with_subtypet
+{
+public:
+  explicit to_be_elaborated_typet(typet type)
+    : type_with_subtypet(ID_to_be_elaborated, std::move(type))
+  {
+  }
+};
+
 class verilog_signedbv_typet:public bitvector_typet
 {
 public:


### PR DESCRIPTION
This adds a class for an irep used during Verilog elaboration.