### PR TITLE
Verilog: typechecking for all System Verilog integer types

### DIFF
--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -446,6 +446,8 @@ exprt verilog_typecheck_exprt::bits(const exprt &expr)
       return to_unsignedbv_type(type).get_width();
     else if(type.id() == ID_signedbv)
       return to_signedbv_type(type).get_width();
+    else if(type.id() == ID_integer)
+      return 32;
     else
     {
       throw errort().with_location(expr.source_location())

--- a/src/verilog/verilog_typecheck_type.cpp
+++ b/src/verilog/verilog_typecheck_type.cpp
@@ -41,6 +41,42 @@ typet verilog_typecheck_exprt::convert_type(const typet &src)
     result.add_source_location() = std::move(source_location);
     return result;
   }
+  else if(src.id() == ID_verilog_byte)
+  {
+    return signedbv_typet{8};
+  }
+  else if(src.id() == ID_verilog_shortint)
+  {
+    return signedbv_typet{16};
+  }
+  else if(src.id() == ID_verilog_int)
+  {
+    return signedbv_typet{32};
+  }
+  else if(src.id() == ID_verilog_longint)
+  {
+    return signedbv_typet{64};
+  }
+  else if(src.id() == ID_verilog_integer)
+  {
+    return signedbv_typet{32};
+  }
+  else if(src.id() == ID_verilog_time)
+  {
+    return unsignedbv_typet{64};
+  }
+  else if(src.id() == ID_verilog_bit)
+  {
+    return unsignedbv_typet{1};
+  }
+  else if(src.id() == ID_verilog_logic)
+  {
+    return unsignedbv_typet{1};
+  }
+  else if(src.id() == ID_verilog_reg)
+  {
+    return unsignedbv_typet{1};
+  }
   else if(src.id() == ID_verilog_shortreal)
   {
     typet result = verilog_shortreal_typet();


### PR DESCRIPTION
This adds typechecking for `byte`, `shortint`, `int`, etc.