### PR TITLE
Verilog: out-of-bounds bit-extract is x or 0

### DIFF
--- a/regression/verilog/bit-extract/bit-extract3.desc
+++ b/regression/verilog/bit-extract/bit-extract3.desc
@@ -1,0 +1,12 @@
+CORE
+bit-extract3.sv
+--module main --bound 0
+^EXIT=0$
+^SIGNAL=0$
+^\[main\.property\.property1\] .*: PROVED up to bound 0$
+^\[main\.property\.property2\] .*: PROVED up to bound 0$
+^\[main\.property\.property3\] .*: PROVED up to bound 0$
+^\[main\.property\.property4\] .*: PROVED up to bound 0$
+^\[main\.property\.property5\] .*: PROVED up to bound 0$
+--
+^warning: ignoring

--- a/regression/verilog/bit-extract/bit-extract3.sv
+++ b/regression/verilog/bit-extract/bit-extract3.sv
@@ -1,0 +1,13 @@
+module main;
+
+  wire bit [7:0] x = 'hff;
+
+  // 1800-2017 sec 11.5.1: out-of-bounds bit-select is
+  // x for 4-state and 0 for 2-state values.
+  always assert property1: x[7] == 1;
+  always assert property2: x[8] == 0;
+  always assert property3: x[-1] == 0;
+  always assert property4: x[8:7] == 1;
+  always assert property5: x[8:-1] == 'b0111111110;
+
+endmodule


### PR DESCRIPTION
This removes the error on out-of-bounds bit-extract, to align with the standard.