### PR TITLE
Verilog: fix for module instances in generate loops

### DIFF
--- a/regression/verilog/generate/generate-inst1.desc
+++ b/regression/verilog/generate/generate-inst1.desc
@@ -1,0 +1,7 @@
+CORE
+generate-inst1.v
+
+^EXIT=10$
+^SIGNAL=0$
+^no properties$
+--

--- a/regression/verilog/generate/generate-inst1.v
+++ b/regression/verilog/generate/generate-inst1.v
@@ -1,0 +1,18 @@
+module moduleA();
+endmodule
+
+module moduleB();
+endmodule
+
+module main();
+
+  parameter cond = 1;
+
+  generate
+    if(cond)
+      moduleA inst();
+    else
+      moduleB inst();
+  endgenerate
+
+endmodule // main

--- a/regression/verilog/generate/generate-inst2.desc
+++ b/regression/verilog/generate/generate-inst2.desc
@@ -1,0 +1,7 @@
+CORE
+generate-inst2.v
+--module main --bound 0
+^EXIT=10$
+^SIGNAL=0$
+^no properties$
+--

--- a/regression/verilog/generate/generate-inst2.v
+++ b/regression/verilog/generate/generate-inst2.v
@@ -1,0 +1,17 @@
+module M;
+
+  parameter some_parameter = 1;
+
+endmodule
+
+module main;
+
+  generate
+    genvar i;
+
+    for(i = 0; i < 2; i = i + 1) begin : my_block
+      M #(i) M_instance();
+    end
+  endgenerate
+
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2025,7 +2025,7 @@ gate_instance_brace:
 
 gate_instance:
 	  name_of_gate_instance_opt range_opt '(' list_of_module_connections_opt ')'
-		{ init($$, ID_inst); addswap($$, ID_instance, $1);
+		{ init($$, ID_inst); addswap($$, ID_base_name, $1);
                   swapop($$, $4);
                   addswap($$, ID_range, $2);
                 }
@@ -2096,7 +2096,7 @@ module_instance_brace:
 
 module_instance:
 	  name_of_instance '(' list_of_module_connections_opt ')'
-		{ init($$, ID_inst); addswap($$, ID_instance, $1); swapop($$, $3); }
+		{ init($$, ID_inst); addswap($$, ID_base_name, $1); swapop($$, $3); }
 	;
 
 name_of_instance:
@@ -2215,11 +2215,6 @@ generate_block:
 
 generate_item:
 	  module_or_generate_item
-	;
-
-generate_item_or_null:
-	  generate_item
-	| ';' { init($$, ID_generate_skip); }
 	;
 
 constant_expression: expression;

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -406,9 +406,19 @@ public:
   class instancet : public exprt
   {
   public:
-    const irep_idt &name() const
+    const irep_idt &base_name() const
     {
-      return get(ID_instance);
+      return get(ID_base_name);
+    }
+
+    const irep_idt &identifier() const
+    {
+      return get(ID_identifier);
+    }
+
+    void identifier(irep_idt _identifier)
+    {
+      return set(ID_identifier, _identifier);
     }
 
     const exprt::operandst &connections() const
@@ -456,6 +466,20 @@ public:
   }
   
   inline irep_idt get_module() const { return get(ID_module); }
+
+  using instancet = verilog_instt::instancet;
+
+  using instancest = std::vector<instancet>;
+
+  const instancest &instances() const
+  {
+    return (const instancest &)(operands());
+  }
+
+  instancest &instances()
+  {
+    return (instancest &)(operands());
+  }
 };
 
 inline const verilog_inst_builtint &to_verilog_inst_builtin(const exprt &expr)

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -573,10 +573,12 @@ void verilog_typecheckt::convert_inst(verilog_instt &inst)
   // get the instance symbols
   for(auto &instance : inst.instances())
   {
-    const auto instance_name = instance.name();
+    const auto instance_base_name = instance.base_name();
 
     const irep_idt instance_identifier =
-      id2string(module_symbol.name) + "." + id2string(instance_name);
+      hierarchical_identifier(instance_base_name);
+
+    instance.identifier(instance_identifier);
 
     // add relevant defparam assignments
     auto &instance_defparams = defparams[instance_identifier];

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -112,8 +112,10 @@ protected:
   void check_module_ports(const verilog_module_sourcet &);
   void interface_module_decl(const class verilog_declt &);
   void interface_function_or_task_decl(const class verilog_declt &);
-  void interface_inst(const class verilog_module_itemt &);
-  void interface_inst(const class verilog_module_itemt &, const exprt &op);
+  void interface_inst(const verilog_module_itemt &);
+  void interface_inst(
+    const verilog_module_itemt &,
+    const verilog_instt::instancet &op);
   void interface_module_item(const class verilog_module_itemt &);
   void interface_block(const class verilog_blockt &);
   void interface_generate_block(const class verilog_generate_blockt &);


### PR DESCRIPTION
When expanding module instances in generate loops the block name must be used to derive a new instance identifier, and derived from that, instantiated identifiers.