### PR TITLE
Verilog: implement System Verilog arrays with size

### DIFF
--- a/regression/verilog/arrays/array1.desc
+++ b/regression/verilog/arrays/array1.desc
@@ -1,0 +1,6 @@
+CORE
+array1.sv
+--module main --bound 0
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/verilog/arrays/array1.sv
+++ b/regression/verilog/arrays/array1.sv
@@ -1,0 +1,16 @@
+module main;
+
+  reg [7:0] my_array0[10];
+  reg [7:0] my_array1[9:0];
+  reg [7:0] my_array2[4:-5];
+  reg [7:0] my_array3[0:9];
+  reg [7:0] my_array4[-10:-1];
+
+  // Icarus Verilog says 8, but that's wrong.
+  always assert p0: ($bits(my_array0) == 8*10);
+  always assert p1: ($bits(my_array1) == 8*10);
+  always assert p2: ($bits(my_array2) == 8*10);
+  always assert p3: ($bits(my_array3) == 8*10);
+  always assert p4: ($bits(my_array4) == 8*10);
+
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1669,9 +1669,10 @@ unpacked_dimension:
 		  range.add_to_operands(stack_expr($2));
 		  range.add_to_operands(stack_expr($4)); }
 	| '[' expression ']'
-	{
-	  $$=$2;
-	}
+		{ init($$, ID_array);
+		  stack_type($$).add_subtype().make_nil();
+		  stack_type($$).set(ID_size, std::move(stack_expr($2)));
+		}
 	;
 
 variable_dimension:

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -40,22 +40,42 @@ array_typet verilog_typecheckt::array_type(
   const irept &src,
   const typet &element_type)
 {
-  assert(src.id()==ID_array);
-  
-  mp_integer msb, lsb;
-  const exprt &range=static_cast<const exprt &>(src.find(ID_range));
+  // int whatnot[x:y];
+  // 'src' is yet to be converted, but 'element_type' is already converted.
+  PRECONDITION(src.id() == ID_array);
 
-  convert_range(range, msb, lsb);
+  // Unpacked arrays may have a range [x:y],
+  // or a size [s], equivalent to [0:s-1]
+  const exprt &range_expr = static_cast<const exprt &>(src.find(ID_range));
+  const exprt &size_expr = static_cast<const exprt &>(src.find(ID_size));
 
-  bool little_endian=(lsb<=msb);
+  mp_integer size, offset;
+  bool little_endian;
 
-  mp_integer size=(little_endian?msb-lsb:lsb-msb)+1;
-  mp_integer offset=little_endian?lsb:msb;
-
-  if(size<=0)
+  if(range_expr.is_not_nil())
   {
-    error().source_location=range.find_source_location();
-    error() << "array size must be positive" << eom;
+    // these may be negative
+    mp_integer msb, lsb;
+    convert_range(range_expr, msb, lsb);
+    little_endian = (lsb <= msb);
+    size = (little_endian ? msb - lsb : lsb - msb) + 1;
+    offset = little_endian ? lsb : msb;
+  }
+  else if(size_expr.is_not_nil())
+  {
+    little_endian = true;
+    size = convert_integer_constant_expression(size_expr);
+    offset = 0;
+    if(size < 0)
+    {
+      error().source_location = size_expr.find_source_location();
+      error() << "array size must be nonnegative" << eom;
+      throw 0;
+    }
+  }
+  else
+  {
+    throw errort() << "array must have range or size";
   }
 
   const typet src_subtype =
@@ -71,9 +91,9 @@ array_typet verilog_typecheckt::array_type(
   else
     array_subtype=array_type(src_subtype, element_type);
 
-  const exprt size_expr=from_integer(size, natural_typet());
-  array_typet result(array_subtype, size_expr);
-  result.set(ID_offset, from_integer(offset, natural_typet()));
+  const exprt final_size_expr = from_integer(size, natural_typet());
+  array_typet result(array_subtype, final_size_expr);
+  result.set(ID_offset, from_integer(offset, integer_typet()));
   result.set(ID_C_little_endian, little_endian);
   
   return result;

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -136,6 +136,7 @@ private:
   void no_bool_ops(exprt &);
 
   exprt bits(const exprt &);
+  std::optional<mp_integer> bits_rec(const typet &) const;
 };
 
 bool verilog_typecheck(


### PR DESCRIPTION
System Verilog allows arrays that have a size, as opposed to a range.