### PR TITLE
Verilog: KNOWNBUG test for parameter instantiation

### DIFF
--- a/regression/verilog/modules/parameters8.desc
+++ b/regression/verilog/modules/parameters8.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+parameters8.v
+
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+module names are mismatched, resulting in a parameter evaluation error

--- a/regression/verilog/modules/parameters8.v
+++ b/regression/verilog/modules/parameters8.v
@@ -1,0 +1,8 @@
+module submodule;
+  parameter P1 = 1;
+  parameter P2 = P1 + 1;
+endmodule
+
+module main;
+  submodule #(10) s1();
+endmodule


### PR DESCRIPTION
This adds a test that triggers a bug in the module parameterization.
