### PR TITLE
Verilog: fix for derived parameters

### DIFF
--- a/regression/verilog/modules/parameters8.desc
+++ b/regression/verilog/modules/parameters8.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE
 parameters8.v
 
 ^EXIT=10$
 ^SIGNAL=0$
 --
 --
-module names are mismatched, resulting in a parameter evaluation error

--- a/regression/verilog/modules/parameters8.desc
+++ b/regression/verilog/modules/parameters8.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+parameters8.v
+
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+module names are mismatched, resulting in a parameter evaluation error

--- a/regression/verilog/modules/parameters8.v
+++ b/regression/verilog/modules/parameters8.v
@@ -1,0 +1,8 @@
+module submodule;
+  parameter P1 = 1;
+  parameter P2 = P1 + 1;
+endmodule
+
+module main;
+  submodule #(10) s1();
+endmodule

--- a/regression/verilog/modules/parameters9.desc
+++ b/regression/verilog/modules/parameters9.desc
@@ -1,0 +1,8 @@
+CORE
+parameters9.v
+
+^file .* line 9: expected constant expression, but got `main\.some_wire'$
+^EXIT=2$
+^SIGNAL=0$
+--
+--

--- a/regression/verilog/modules/parameters9.v
+++ b/regression/verilog/modules/parameters9.v
@@ -1,0 +1,10 @@
+module submodule;
+  parameter P1 = 1;
+  parameter P2 = P1 + 1;
+endmodule
+
+module main;
+  // error: parameter value must be constant
+  wire [31:0] some_wire;
+  submodule #(some_wire) s1();
+endmodule

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -310,6 +310,11 @@ public:
       return get(ID_identifier);
     }
 
+    const irep_idt &base_name() const
+    {
+      return get(ID_identifier);
+    }
+
     const exprt &value() const
     {
       return static_cast<const exprt &>(find(ID_value));


### PR DESCRIPTION
This fixes the name generation for parameterized modules when parameter
values are derived from others.