### PR TITLE
Verilog: KNOWNBUG test for mixed function contexts

### DIFF
--- a/regression/verilog/functioncall/functioncall5.desc
+++ b/regression/verilog/functioncall/functioncall5.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+functioncall5.v
+--module main --bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/functioncall/functioncall5.v
+++ b/regression/verilog/functioncall/functioncall5.v
@@ -1,0 +1,23 @@
+module main(input clk);
+
+  function isUpper;
+  input [7:0] in;
+  begin
+      isUpper = ~in[5];
+  end
+  endfunction
+
+  // same function used in combinational and clocked logic  
+
+  wire [7:0] my_wire1;
+  reg my_wire2;
+
+  always @my_wire1
+    my_wire2 <= isUpper(my_wire1);
+
+  reg my_reg;
+
+  always @(posedge clk)
+    my_reg = isUpper(my_wire1);
+
+endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -190,7 +190,7 @@ void verilog_synthesist::expand_function_call(function_call_exprt &call)
   {
     const symbolt &a_symbol=ns.lookup(parameters[i].get_identifier());
     verilog_blocking_assignt assignment;
-    assignment.lhs()=a_symbol.symbol_expr();
+    assignment.lhs() = a_symbol.symbol_expr().with_source_location<exprt>(call);
     assignment.rhs()=actuals[i];
     assignment.add_source_location()=call.source_location();
     synth_statement(assignment);


### PR DESCRIPTION
This adds a KNOWNBUG test for mixed function contexts, and adds location output for the error.