### PR TITLE
Verilog: strengthen typing of verilog_module_sourcet::ports

### DIFF
--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -1422,9 +1422,11 @@ public:
     return (parameter_port_listt &)(add(ID_parameter_port_list).get_sub());
   }
 
-  const exprt::operandst &ports() const
+  using port_listt = std::vector<verilog_declt>;
+
+  const port_listt &ports() const
   {
-    return (const exprt::operandst &)(find(ID_ports).get_sub());
+    return (const port_listt &)(find(ID_ports).get_sub());
   }
 
   using module_itemst = std::vector<class verilog_module_itemt>;


### PR DESCRIPTION
This now returns a vector of declarations, as opposed to a vector of expressions.