### PR TITLE
Verilog: strengthen typing when using verilog_blockt

### DIFF
--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -648,13 +648,25 @@ public:
   verilog_blockt():verilog_statementt(ID_block)
   {
   }
-  
-  inline irep_idt get_identifier() const
+
+  using statementst = std::vector<verilog_statementt>;
+
+  statementst &statements()
+  {
+    return (statementst &)operands();
+  }
+
+  const statementst &statements() const
+  {
+    return (const statementst &)operands();
+  }
+
+  irep_idt identifier() const
   {
     return get(ID_identifier);
   }
-  
-  inline bool is_named() const
+
+  bool is_named() const
   {
     return !get(ID_identifier).empty();
   }

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -857,8 +857,8 @@ void verilog_typecheckt::interface_block(
   
   if(is_named)
   {
-    irep_idt identifier=statement.get_identifier();
-  
+    irep_idt identifier = statement.identifier();
+
     // need to add to symbol table
     symbolt symbol;
 
@@ -892,9 +892,8 @@ void verilog_typecheckt::interface_block(
     
   // do block itself
 
-  forall_operands(it, statement)
-    interface_statement(
-      static_cast<const verilog_statementt &>(*it));
+  for(auto &block_statement : statement.statements())
+    interface_statement(block_statement);
 
   if(is_named)
     named_blocks.pop_back();

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -1570,8 +1570,8 @@ Function: verilog_synthesist::synth_block
 
 void verilog_synthesist::synth_block(const verilog_blockt &statement)
 {
-  forall_operands(it, statement)
-    synth_statement(static_cast<const verilog_statementt &>(*it));
+  for(auto &block_statement : statement.statements())
+    synth_statement(block_statement);
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -778,11 +778,11 @@ void verilog_typecheckt::convert_block(verilog_blockt &statement)
   bool is_named=statement.is_named();
   
   if(is_named)
-    enter_named_block(statement.get_identifier());
+    enter_named_block(statement.identifier());
 
-  Forall_operands(it, statement)
-    convert_statement(to_verilog_statement(*it));
-    
+  for(auto &block_statement : statement.statements())
+    convert_statement(block_statement);
+
   if(is_named)
     named_blocks.pop_back();
 }


### PR DESCRIPTION
This introduces a method for accessing the statements in the block.