### PR TITLE
Verilog: fix scope created for functions

### DIFF
--- a/regression/verilog/typedef/typedef2.sv
+++ b/regression/verilog/typedef/typedef2.sv
@@ -5,12 +5,27 @@ module main();
 
   // as 'module_item'
   typedef bit my_type2;
+  my_type2 my_type2_var;
 
   function some_function;
     // as 'block_item'
     typedef bit my_type3;
     begin
+      my_type3 my_type3_var;
     end
   endfunction
+
+  task some_task;
+    // as 'block_item'
+    typedef bit my_type4;
+    begin
+      my_type4 my_type4_var;
+    end
+  endtask
+
+  always @my_type2_var begin : named_block
+    typedef bit my_type5;
+    my_type5 my_type5_var;
+  end
 
 endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1706,7 +1706,7 @@ function_declaration:
 	  TOK_FUNCTION
 	  automatic_opt signing_opt range_or_type_opt
 	  function_identifier
-		{ push_scope(stack_expr($1).get(ID_identifier), "."); }
+		{ push_scope(stack_expr($5).get(ID_identifier), "."); }
 	  list_of_ports_opt ';'
           function_item_declaration_brace statement
           TOK_ENDFUNCTION


### PR DESCRIPTION
This fixes the name of the scope created for functions.