### PR TITLE
Verilog: introduce verilog_inst_baset

### DIFF
--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -388,25 +388,21 @@ to_verilog_local_parameter_decl(irept &irep)
   return static_cast<verilog_local_parameter_declt &>(irep);
 }
 
-class verilog_instt:public verilog_module_itemt
+class verilog_inst_baset : public verilog_module_itemt
 {
 public:
-  inline verilog_instt():verilog_module_itemt(ID_inst)
+  verilog_inst_baset(irep_idt id) : verilog_module_itemt(id)
   {
   }
 
-  inline irep_idt get_module() const { return get(ID_module); }
-  
-  inline void set_module(const irep_idt &module) { return set(ID_module, module); }
-  
-  inline exprt::operandst &parameter_assignments()
+  irep_idt get_module() const
   {
-    return static_cast<exprt &>(add(ID_parameter_assignments)).operands();
+    return get(ID_module);
   }
 
-  inline const exprt::operandst &parameter_assignments() const
+  void set_module(const irep_idt &module)
   {
-    return static_cast<const exprt &>(find(ID_parameter_assignments)).operands();
+    return set(ID_module, module);
   }
 
   class instancet : public exprt
@@ -452,6 +448,25 @@ protected:
   using exprt::operands;
 };
 
+class verilog_instt : public verilog_inst_baset
+{
+public:
+  inline verilog_instt() : verilog_inst_baset(ID_inst)
+  {
+  }
+
+  exprt::operandst &parameter_assignments()
+  {
+    return static_cast<exprt &>(add(ID_parameter_assignments)).operands();
+  }
+
+  const exprt::operandst &parameter_assignments() const
+  {
+    return static_cast<const exprt &>(find(ID_parameter_assignments))
+      .operands();
+  }
+};
+
 inline const verilog_instt &to_verilog_inst(const exprt &expr)
 {
   assert(expr.id()==ID_inst);
@@ -464,27 +479,11 @@ inline verilog_instt &to_verilog_inst(exprt &expr)
   return static_cast<verilog_instt &>(expr);
 }
 
-class verilog_inst_builtint:public verilog_module_itemt
+class verilog_inst_builtint : public verilog_inst_baset
 {
 public:
-  inline verilog_inst_builtint():verilog_module_itemt(ID_inst_builtin)
+  inline verilog_inst_builtint() : verilog_inst_baset(ID_inst_builtin)
   {
-  }
-  
-  inline irep_idt get_module() const { return get(ID_module); }
-
-  using instancet = verilog_instt::instancet;
-
-  using instancest = std::vector<instancet>;
-
-  const instancest &instances() const
-  {
-    return (const instancest &)(operands());
-  }
-
-  instancest &instances()
-  {
-    return (instancest &)(operands());
   }
 };
 

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -637,18 +637,10 @@ Function: verilog_typecheckt::convert_inst
 \*******************************************************************/
 
 void verilog_typecheckt::interface_inst(
-  const verilog_module_itemt &inst_module_item)
+  const verilog_inst_baset &inst_module_item)
 {
-  if(inst_module_item.id() == ID_inst)
-  {
-    for(auto &instance : to_verilog_inst(inst_module_item).instances())
-      interface_inst(inst_module_item, instance);
-  }
-  else
-  {
-    for(auto &instance : to_verilog_inst_builtin(inst_module_item).instances())
-      interface_inst(inst_module_item, instance);
-  }
+  for(auto &instance : inst_module_item.instances())
+    interface_inst(inst_module_item, instance);
 }
 
 /*******************************************************************\
@@ -664,7 +656,7 @@ Function: verilog_typecheckt::interface_inst
 \*******************************************************************/
 
 void verilog_typecheckt::interface_inst(
-  const verilog_module_itemt &statement,
+  const verilog_inst_baset &statement,
   const verilog_instt::instancet &op)
 {
   bool primitive=statement.id()==ID_inst_builtin;
@@ -759,9 +751,10 @@ void verilog_typecheckt::interface_module_item(
   {
     // already done by elaborate_parameters
   }
-  else if(module_item.id()==ID_inst ||
-          module_item.id()==ID_inst_builtin)
-    interface_inst(module_item);
+  else if(module_item.id() == ID_inst)
+    interface_inst(to_verilog_inst(module_item));
+  else if(module_item.id() == ID_inst_builtin)
+    interface_inst(to_verilog_inst_builtin(module_item));
   else if(module_item.id()==ID_always)
     interface_statement(to_verilog_always(module_item).statement());
   else if(module_item.id()==ID_initial)

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -1086,10 +1086,8 @@ void verilog_synthesist::synth_module_instance_builtin(
 {
   const irep_idt &module=module_item.get_module();
 
-  forall_operands(it, module_item)
+  for(auto &instance : module_item.instances())
   {
-    const exprt &instance=*it;
-
     // check built-in ones
     if(module==ID_bufif0 ||
        module==ID_bufif1 ||
@@ -1097,8 +1095,8 @@ void verilog_synthesist::synth_module_instance_builtin(
        module==ID_notif1)
     {
       // add to general constraints
-    
-      exprt constraint=*it;
+
+      exprt constraint = instance;
       constraint.id("verilog-primitive-module");
       constraint.type()=bool_typet();
       constraint.set(ID_module, module);
@@ -1112,8 +1110,8 @@ void verilog_synthesist::synth_module_instance_builtin(
             module==ID_rpmos)
     {
       // add to general constraints
-    
-      exprt constraint=*it;
+
+      exprt constraint = instance;
       constraint.id("verilog-primitive-module");
       constraint.type()=bool_typet();
       constraint.set(ID_module, module);
@@ -1128,29 +1126,29 @@ void verilog_synthesist::synth_module_instance_builtin(
             module==ID_xor ||
             module==ID_xnor)
     {
-      assert(instance.operands().size()>=2);
+      assert(instance.connections().size() >= 2);
 
-      if(instance.operands().size()==2)
+      if(instance.connections().size() == 2)
       {
-        equal_exprt constraint{instance.operands()[0],
-                               instance.operands().back()};
+        equal_exprt constraint{
+          instance.connections()[0], instance.connections().back()};
         trans.invar().add_to_operands(std::move(constraint));
       }
       else
       {
-        for(unsigned i=1; i<=instance.operands().size()-2; i++)
+        for(unsigned i = 1; i <= instance.connections().size() - 2; i++)
         {
           exprt op(module, instance.type());
 
           if(i==1)
           {
-            op.add_to_operands(instance.operands()[i]);
-            op.add_to_operands(instance.operands()[i + 1]);
+            op.add_to_operands(instance.connections()[i]);
+            op.add_to_operands(instance.connections()[i + 1]);
           }
           else
           {
-            op.add_to_operands(instance.operands()[0]);
-            op.add_to_operands(instance.operands()[i + 1]);
+            op.add_to_operands(instance.connections()[0]);
+            op.add_to_operands(instance.connections()[i + 1]);
           }
 
           if(instance.type().id()!=ID_bool)
@@ -1162,7 +1160,7 @@ void verilog_synthesist::synth_module_instance_builtin(
         }
       }
 
-      /*assert(instance.operands().size()!=3);      
+      /*assert(instance.connections().size()!=3);      
       op.add_to_operands(std::move(instance.op1()), std::move(instance.op2()));
       
       if(instance.type().id()!=ID_bool)
@@ -1176,12 +1174,12 @@ void verilog_synthesist::synth_module_instance_builtin(
     }
     else if(module==ID_buf)
     {
-      assert(instance.operands().size()>=2);
+      assert(instance.connections().size() >= 2);
 
-      for(unsigned i=0; i<instance.operands().size()-1; i++)
+      for(unsigned i = 0; i < instance.connections().size() - 1; i++)
       {
-        equal_exprt constraint{instance.operands()[i],
-                               instance.operands().back()};
+        equal_exprt constraint{
+          instance.connections()[i], instance.connections().back()};
 
         assert(trans.operands().size()==3);
         trans.invar().add_to_operands(std::move(constraint));
@@ -1189,17 +1187,17 @@ void verilog_synthesist::synth_module_instance_builtin(
     }
     else if(module==ID_not)
     {
-      assert(instance.operands().size()>=2);
+      assert(instance.connections().size() >= 2);
 
-      for(unsigned i=0; i<instance.operands().size()-1; i++)
+      for(unsigned i = 0; i < instance.connections().size() - 1; i++)
       {
         exprt op(ID_not, instance.type());
-        op.add_to_operands(instance.operands()[i]);
+        op.add_to_operands(instance.connections()[i]);
 
         if(instance.type().id()!=ID_bool)
           op.id("bit"+op.id_string());
 
-        equal_exprt constraint{op, instance.operands().back()};
+        equal_exprt constraint{op, instance.connections().back()};
 
         assert(trans.operands().size()==3);
         trans.invar().add_to_operands(std::move(constraint));
@@ -1211,8 +1209,8 @@ void verilog_synthesist::synth_module_instance_builtin(
             module=="rtranif0")
     {
       // add to general constraints
-    
-      exprt constraint=*it;
+
+      exprt constraint = instance;
       constraint.id("verilog-primitive-module");
       constraint.type()=bool_typet();
       constraint.set(ID_module, module);
@@ -1224,8 +1222,8 @@ void verilog_synthesist::synth_module_instance_builtin(
             module=="rtran")
     {
       // add to general constraints
-    
-      exprt constraint=*it;
+
+      exprt constraint = instance;
       constraint.id("verilog-primitive-module");
       constraint.type()=bool_typet();
       constraint.set(ID_module, module);

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -641,10 +641,8 @@ void verilog_typecheckt::convert_inst_builtin(
 {
   const irep_idt &inst_module=inst.get_module();
 
-  Forall_operands(it, inst)
+  for(auto &instance : inst.instances())
   {
-    exprt &instance=*it;
-
     typecheck_builtin_port_connections(instance);
 
     // check built-in ones
@@ -669,7 +667,7 @@ void verilog_typecheckt::convert_inst_builtin(
             inst_module==ID_xor ||
             inst_module==ID_xnor)
     {
-      if(instance.operands().size()<2)
+      if(instance.connections().size() < 2)
       {
         error().source_location=instance.source_location();
         error() << "Primitive gate " << inst_module
@@ -680,7 +678,7 @@ void verilog_typecheckt::convert_inst_builtin(
     else if(inst_module==ID_buf ||
             inst_module==ID_not)
     {
-      if(instance.operands().size()<2)
+      if(instance.connections().size() < 2)
       {
         error().source_location=instance.source_location();
         error() << "Primitive gate " << inst_module

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -112,9 +112,9 @@ protected:
   void check_module_ports(const verilog_module_sourcet &);
   void interface_module_decl(const class verilog_declt &);
   void interface_function_or_task_decl(const class verilog_declt &);
-  void interface_inst(const verilog_module_itemt &);
+  void interface_inst(const verilog_inst_baset &);
   void interface_inst(
-    const verilog_module_itemt &,
+    const verilog_inst_baset &,
     const verilog_instt::instancet &op);
   void interface_module_item(const class verilog_module_itemt &);
   void interface_block(const class verilog_blockt &);


### PR DESCRIPTION
This improves the typing of `verilog_inst_builtint`.