### PR TITLE
function calls can be constants

### DIFF
--- a/regression/verilog/functioncall/functioncall_as_constant1.desc
+++ b/regression/verilog/functioncall/functioncall_as_constant1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 functioncall_as_constant1.v
 --module main --bound 0
 ^EXIT=0$

--- a/regression/verilog/functioncall/functioncall_as_constant1.v
+++ b/regression/verilog/functioncall/functioncall_as_constant1.v
@@ -1,6 +1,7 @@
 module main;
 
-  function [31:0] clog2(input [63:0] value);
+  function [31:0] clog2;
+  input [63:0] value;
   reg [63:0] tmp;
   begin
     tmp = value - 1;

--- a/src/verilog/verilog_elaborate_constants.cpp
+++ b/src/verilog/verilog_elaborate_constants.cpp
@@ -26,8 +26,8 @@ void verilog_typecheckt::collect_symbols(
   // If there's no type, parameters take the type of the
   // value. We signal this using the special type "derive_from_value".
 
-  auto symbol_type = type_with_subtypet(
-    ID_to_be_elaborated, type.is_nil() ? derive_from_value_typet() : type);
+  auto symbol_type =
+    to_be_elaborated_typet(type.is_nil() ? derive_from_value_typet() : type);
 
   symbolt symbol{full_identifier, symbol_type, mode};
 
@@ -108,9 +108,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
       auto full_identifier = hierarchical_identifier(base_name);
 
       symbolt symbol{
-        full_identifier,
-        type_with_subtypet(ID_to_be_elaborated, decl.type()),
-        mode};
+        full_identifier, to_be_elaborated_typet(decl.type()), mode};
 
       symbol.module = module_identifier;
       symbol.base_name = base_name;

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -202,6 +202,7 @@ Function: verilog_typecheckt::interface_function_or_task
 void verilog_typecheckt::interface_function_or_task(
   const verilog_declt &decl)
 {
+#if 0
   irep_idt decl_class=decl.get_class();
 
   // only add symbol for now
@@ -269,6 +270,7 @@ void verilog_typecheckt::interface_function_or_task(
   interface_statement(decl.body());
     
   function_or_task_name="";  
+#endif
 }
 
 /*******************************************************************\


### PR DESCRIPTION
Function calls with constant arguments can be elaboration time constants. This moves the creation of the function symbols into the constant elaboration phase to allow this.