### PR TITLE
verilog_typecheckt::elaborate now has module source parameter

### DIFF
--- a/src/verilog/verilog_elaborate_constants.cpp
+++ b/src/verilog/verilog_elaborate_constants.cpp
@@ -280,13 +280,9 @@ void verilog_typecheckt::add_symbol(symbolt symbol)
   symbols_added.push_back(result.first.name);
 }
 
-void verilog_typecheckt::elaborate()
+void verilog_typecheckt::elaborate(const verilog_module_sourcet &module_source)
 {
-  // First find the symbols in the module source.
-  auto &module_source =
-    to_verilog_module_source(module_symbol.type.find(ID_module_source));
-
-  // Then collect all constant identifiers into the symbol table,
+  // First collect all constant identifiers into the symbol table,
   // with type "to_be_elaborated".
   collect_symbols(module_source);
 

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1682,13 +1682,13 @@ void verilog_typecheckt::typecheck()
 {
   module_identifier = module_symbol.name;
 
+  const auto &module_source =
+    to_verilog_module_source(module_symbol.type.find(ID_module_source));
+
   // We first elaborate the named constants (parameters, enums).
   // Everything else (types of ports, generate constructs) may
   // depend on these.
-  elaborate();
-
-  const auto &module_source =
-    to_verilog_module_source(module_symbol.type.find(ID_module_source));
+  elaborate(module_source);
 
   // Create symbols for the functions, tasks, registers/variables and wires.
   module_interface(module_source);

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -77,7 +77,7 @@ protected:
   defparamst defparams;
 
   // Elaboration
-  void elaborate();
+  void elaborate(const verilog_module_sourcet &);
   void elaborate_rec(irep_idt) override;
   void add_symbol(symbolt);
   void collect_symbols(const typet &);


### PR DESCRIPTION
This improves the clarity of the interface.