### PR TITLE
Verilog: collect port symbols during elaboration

### DIFF
--- a/regression/verilog/modules/ports3.v
+++ b/regression/verilog/modules/ports3.v
@@ -1,5 +1,8 @@
 module main(input [3:0] data);
 
+  // The type of the input port symbol 'data' must be
+  // available during constant elaboration.
+  localparam data_width = $bits(data);
   reg [$bits(data)-1:0] copy = data;
 
   always assert property1: $bits(copy) == 4;

--- a/regression/verilog/modules/ports6.desc
+++ b/regression/verilog/modules/ports6.desc
@@ -1,5 +1,5 @@
 CORE
-ports3.v
+ports6.v
 --bound 0
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/verilog/modules/ports6.v
+++ b/regression/verilog/modules/ports6.v
@@ -1,0 +1,7 @@
+// The type of the input port symbol 'data' must be
+// available during constant elaboration.
+module main(input [3:0] data1, input [$bits(data1)-1:0] data2);
+
+  always assert property1: $bits(data2) == 4;
+
+endmodule

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -87,6 +87,7 @@ protected:
   void collect_symbols(const verilog_statementt &);
   void
   collect_symbols(const typet &, const verilog_parameter_declt::declaratort &);
+  void collect_port_symbols(const verilog_declt &);
   std::vector<irep_idt> symbols_added;
 
   // instances


### PR DESCRIPTION
This moves the creation of the module port symbols from `verilog_interfaces` to `verilog_elaborate_constants`.  The benefit is that elaboration time constants may now depend on the type of module ports.