### PR TITLE
Verilog: add test for module with undeclared port

### DIFF
--- a/regression/verilog/modules/port_not_declared.desc
+++ b/regression/verilog/modules/port_not_declared.desc
@@ -1,0 +1,7 @@
+CORE
+port_not_declared.v
+
+^file .* line 1: port `some_port' not declared$
+^EXIT=2$
+^SIGNAL=0$
+--

--- a/regression/verilog/modules/port_not_declared.v
+++ b/regression/verilog/modules/port_not_declared.v
@@ -1,0 +1,5 @@
+module my_module(some_port);
+
+  // some_port is not declared as input or output
+
+endmodule


### PR DESCRIPTION
This adds a test to check error handling in case of a malformed port declaration.