### PR TITLE
ebmc: error when BDD engine is given unsupported property

### DIFF
--- a/regression/ebmc/BDD/BDD_SVA1.desc
+++ b/regression/ebmc/BDD/BDD_SVA1.desc
@@ -5,12 +5,12 @@ BDD_SVA1.sv
 ^SIGNAL=0$
 ^\[top\.property\.p0\] always top\.my_bit: PROVED$
 ^\[top\.property\.p1\] always top\.my_bit: PROVED$
-^\[top\.property\.p2\] always \(top\.counter == 3 \|-> \(nexttime top\.counter == 4\)\): UNKNOWN$
+^\[top\.property\.p2\] always \(top\.counter == 3 \|-> \(nexttime top\.counter == 4\)\): FAILURE: property not supported by BDD engine$
 ^\[top\.property\.p3\] always \(top\.counter == 3 \|=> top\.counter == 4\): PROVED$
-^\[top\.property\.p4\] always \(top\.counter == 3 \|=> \(nexttime top\.counter == 5\)\): UNKNOWN$
+^\[top\.property\.p4\] always \(top\.counter == 3 \|=> \(nexttime top\.counter == 5\)\): FAILURE: property not supported by BDD engine$
 ^\[top\.property\.p5\] always eventually top\.counter == 8: PROVED$
-^\[top\.property\.p6\] always \(top\.counter == 0 \|-> \(eventually top\.counter == 8\)\): UNKNOWN$
-^\[top\.property\.p7\] always \(top\.counter == 0 \|-> \(top\.counter <= 5 until top\.counter == 6\)\): UNKNOWN$
-^\[top\.property\.p8\] always \(top\.counter == 0 \|-> \(top\.counter <= 5 until_with top\.counter == 5\)\): UNKNOWN$
+^\[top\.property\.p6\] always \(top\.counter == 0 \|-> \(eventually top\.counter == 8\)\): FAILURE: property not supported by BDD engine$
+^\[top\.property\.p7\] always \(top\.counter == 0 \|-> \(top\.counter <= 5 until top\.counter == 6\)\): FAILURE: property not supported by BDD engine$
+^\[top\.property\.p8\] always \(top\.counter == 0 \|-> \(top\.counter <= 5 until_with top\.counter == 5\)\): FAILURE: property not supported by BDD engine$
 --
 ^warning: ignoring

--- a/regression/ebmc/k-induction/k-induction-unsupported1.desc
+++ b/regression/ebmc/k-induction/k-induction-unsupported1.desc
@@ -3,6 +3,6 @@ k-induction-unsupported1.sv
 --module main --k-induction
 ^EXIT=6$
 ^SIGNAL=0$
-^file k-induction-unsupported1\.sv line 14: error: k-induction does not support liveness properties$
+^error: there is no property suitable for k-induction$
 --
 ^warning: ignoring

--- a/regression/ebmc/k-induction/k-induction-unsupported2.desc
+++ b/regression/ebmc/k-induction/k-induction-unsupported2.desc
@@ -1,0 +1,9 @@
+CORE
+k-induction-unsupported2.sv
+--module main --k-induction
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.property\.p0\] always eventually main\.x == 10: FAILURE: property unsupported by k-induction$
+^\[main\.property\.p1\] always main\.x <= 10: PROVED$
+--
+^warning: ignoring

--- a/regression/ebmc/k-induction/k-induction-unsupported2.sv
+++ b/regression/ebmc/k-induction/k-induction-unsupported2.sv
@@ -1,0 +1,17 @@
+module main(input clk);
+
+  reg [31:0] x;
+  
+  initial x=1;
+  
+  always @(posedge clk)
+    if(x<10)
+      x<=x+1;
+
+  // true, but not supported by k-induction
+  p0: assert property (eventually x == 10);
+
+  // true and supported by k-induction
+  p1: assert property (x<=10);
+
+endmodule

--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -449,6 +449,8 @@ void bdd_enginet::check_property(propertyt &property)
   {
     just_p(property);
   }
+  else
+    property.failure("property not supported by BDD engine");
 }
 
 /*******************************************************************\

--- a/src/ebmc/bmc.cpp
+++ b/src/ebmc/bmc.cpp
@@ -43,7 +43,7 @@ void bmc(
 
   for(auto &property : properties.properties)
   {
-    if(property.is_disabled())
+    if(property.is_disabled() || property.is_failure())
       continue;
 
     ::property(
@@ -86,7 +86,7 @@ void bmc(
 
     for(auto &property : properties.properties)
     {
-      if(property.is_disabled())
+      if(property.is_disabled() || property.is_failure())
         continue;
 
       message.status() << "Checking " << property.name << messaget::eom;

--- a/src/ebmc/ebmc_properties.cpp
+++ b/src/ebmc/ebmc_properties.cpp
@@ -29,7 +29,8 @@ std::string ebmc_propertiest::propertyt::status_as_string() const
   case statust::INCONCLUSIVE:
     return "INCONCLUSIVE";
   case statust::FAILURE:
-    return "FAILURE";
+    return failure_reason.has_value() ? "FAILURE: " + failure_reason.value()
+                                      : "FAILURE";
   case statust::DROPPED:
     return "DROPPED";
   case statust::DISABLED:

--- a/src/ebmc/ebmc_properties.h
+++ b/src/ebmc/ebmc_properties.h
@@ -48,6 +48,7 @@ public:
 
     std::size_t bound = 0;
     std::optional<trans_tracet> counterexample;
+    std::optional<std::string> failure_reason;
 
     bool has_counterexample() const
     {
@@ -125,9 +126,10 @@ public:
       status = statust::DROPPED;
     }
 
-    void failure()
+    void failure(const std::optional<std::string> &reason = {})
     {
       status = statust::FAILURE;
+      failure_reason = reason;
     }
 
     void inconclusive()


### PR DESCRIPTION
Instead of reporting an unhelpful `UNKNOWN`, the user is now told explicitly
that the property is not supported.