### PR TITLE
Verilog: replace equality by declarator class

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1619,17 +1619,16 @@ range:	part_select;
 // A.2.4 Declaration assignments
 
 net_decl_assignment: net_identifier '=' expression
-		{ init($$, ID_equal); mto($$, $1); mto($$, $3); }
+		{ $$ = $1; stack_expr($$).id(ID_declarator); addswap($$, ID_value, $3); }
 	;
 
 variable_decl_assignment:
 	  variable_identifier variable_dimension_brace
 		{ $$ = $1; stack_expr($$).type().swap(stack_expr($2)); }
 	| variable_identifier variable_dimension_brace '=' expression
-		{ init($$, ID_equal);
-		  stack_expr($1).type().swap(stack_expr($2));
-		  mto($$, $1);
-		  mto($$, $4); }
+		{ $$ = $1; stack_expr($$).id(ID_declarator);
+		  addswap($$, ID_type, $2);
+		  addswap($$, ID_value, $4); }
 	;
 
 // System Verilog standard 1800-2017

--- a/src/verilog/verilog_elaborate_constants.cpp
+++ b/src/verilog/verilog_elaborate_constants.cpp
@@ -148,10 +148,6 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
       auto symbol_expr = [](const exprt &declarator) -> const symbol_exprt & {
         if(declarator.id() == ID_symbol)
           return to_symbol_expr(declarator);
-        else if(
-          declarator.id() == ID_equal &&
-          to_equal_expr(declarator).lhs().id() == ID_symbol)
-          return to_symbol_expr(to_equal_expr(declarator).lhs());
         else
           DATA_INVARIANT(false, "failed to find symbol in declarator");
       }(declarator);
@@ -221,27 +217,6 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
           throw errort().with_location(declarator.source_location())
             << "unexpected type on declarator";
         }
-      }
-      else if(declarator.id() == ID_equal)
-      {
-        if(declarator.operands().size() != 2)
-        {
-          throw errort().with_location(declarator.source_location())
-            << "expected two operands in declarator assignment";
-        }
-
-        if(to_binary_expr(declarator).op0().id() != ID_symbol)
-        {
-          throw errort().with_location(declarator.source_location())
-            << "expected symbol on left hand side of assignment"
-               " but got `"
-            << to_string(to_binary_expr(declarator).op0()) << '\'';
-        }
-
-        symbol.base_name =
-          to_symbol_expr(to_binary_expr(declarator).op0()).get_identifier();
-        symbol.location = to_binary_expr(declarator).op0().source_location();
-        symbol.type = type;
       }
       else
       {

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -308,6 +308,11 @@ public:
       return get(ID_identifier);
     }
 
+    void identifier(irep_idt _identifier)
+    {
+      set(ID_identifier, _identifier);
+    }
+
     const irep_idt &base_name() const
     {
       return get(ID_identifier);
@@ -321,6 +326,13 @@ public:
     exprt &value()
     {
       return static_cast<exprt &>(add(ID_value));
+    }
+
+    // helper to generate a symbol expression
+    symbol_exprt symbol_expr() const
+    {
+      return symbol_exprt(identifier(), type())
+        .with_source_location<symbol_exprt>(*this);
     }
   };
 
@@ -1224,7 +1236,7 @@ inline verilog_forcet &to_verilog_force(exprt &expr)
 class verilog_continuous_assignt:public verilog_module_itemt
 {
 public:
-  explicit verilog_continuous_assignt(exprt assignment)
+  explicit verilog_continuous_assignt(equal_exprt assignment)
     : verilog_module_itemt(ID_continuous_assign)
   {
     add_to_operands(std::move(assignment));

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -315,26 +315,6 @@ void verilog_typecheckt::interface_function_or_task_decl(const verilog_declt &de
       symbol.base_name = declarator.identifier();
       symbol.type=type;
     }
-    else if(declarator.id() == ID_equal)
-    {
-      if(declarator.operands().size() != 2)
-      {
-        error() << "expected two operands in assignment" << eom;
-        throw 0;
-      }
-
-      if(to_equal_expr(declarator).lhs().id() != ID_symbol)
-      {
-        throw errort().with_location(declarator.source_location())
-          << "expected symbol on left hand side of assignment"
-             " but got `"
-          << to_string(to_equal_expr(declarator).lhs()) << '\'';
-      }
-
-      symbol.base_name =
-        to_symbol_expr(to_equal_expr(declarator).lhs()).get_identifier();
-      symbol.type=type;
-    }
     else if(declarator.id() == ID_array)
     {
       symbol.base_name = declarator.identifier();
@@ -487,24 +467,10 @@ void verilog_typecheckt::interface_module_decl(
         throw 0;
       }
     }
-    else if(declarator.id() == ID_equal)
+    else if(declarator.id() == ID_declarator)
     {
-      if(declarator.operands().size() != 2)
-      {
-        error() << "expected two operands in assignment" << eom;
-        throw 0;
-      }
-
-      if(to_binary_expr(declarator).op0().id() != ID_symbol)
-      {
-        throw errort().with_location(declarator.source_location())
-          << "expected symbol on left hand side of assignment"
-             " but got `"
-          << to_string(to_binary_expr(declarator).op0()) << '\'';
-      }
-
-      symbol.base_name = to_binary_expr(declarator).op0().get(ID_identifier);
-      symbol.location = to_binary_expr(declarator).op0().source_location();
+      symbol.base_name = declarator.base_name();
+      symbol.location = declarator.source_location();
       symbol.type=type;
     }
     else


### PR DESCRIPTION
This replaces the use of an equality expression for declarators with initializers by the declarator class.