### PR TITLE
Verilog: use declaratort instead of symbol_exprt

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1165,6 +1165,7 @@ type_declaration:
 		  init($$, ID_decl);
 		  stack_expr($$).set(ID_class, ID_typedef);
 		  addswap($$, ID_type, $2);
+		  stack_expr($3).id(ID_declarator);
 		  mto($$, $3);
 		}
 	;
@@ -1186,7 +1187,8 @@ list_of_net_names:
 net_name: net_identifier packed_dimension_brace
           {
             $$=$1;
-            stack_expr($$).add(ID_type)=stack_expr($2);
+            stack_expr($$).id(ID_declarator);
+            addswap($$, ID_type, $2);
           }
 	;
 
@@ -1456,9 +1458,15 @@ delay_value:
 
 list_of_genvar_identifiers:
 	  genvar_identifier
-		{ init($$); mto($$, $1); } 
+		{ init($$);
+		  stack_expr($1).id(ID_declarator);
+		  mto($$, $1);
+		}
 	| list_of_genvar_identifiers ',' genvar_identifier
-		{ $$=$1;    mto($$, $3); }
+		{ $$=$1;
+		  stack_expr($3).id(ID_declarator);
+		  mto($$, $3);
+		}
 	;
 
 defparam_assignment:
@@ -1482,9 +1490,13 @@ list_of_variable_decl_assignments:
 
 list_of_variable_identifiers:
           variable_identifier
-		{ init($$); mto($$, $1); }
+		{ init($$);
+		  stack_expr($1).id(ID_declarator);
+		  mto($$, $1); }
 	| list_of_variable_identifiers ',' variable_identifier
-		{ $$=$1;    mto($$, $3); }
+		{ $$=$1;
+		  stack_expr($3).id(ID_declarator);
+		  mto($$, $3); }
         ;
 
 // This rule is more permissive that the grammar in the standard
@@ -1603,9 +1615,15 @@ automatic_opt:
 
 list_of_port_identifiers:
 	  port_identifier unpacked_dimension_brace
-		{ init($$); stack_expr($1).type().swap(stack_expr($2)); mto($$, $1); }
+		{ init($$);
+		  stack_expr($1).id(ID_declarator);
+		  addswap($1, ID_type, $2);
+		  mto($$, $1); }
 	| list_of_port_identifiers ',' port_identifier unpacked_dimension_brace
-		{ $$=$1;    stack_expr($3).type().swap(stack_expr($4)); mto($$, $3); }
+		{ $$=$1;
+		  stack_expr($3).id(ID_declarator);
+		  addswap($3, ID_type, $4);
+		  mto($$, $3); }
 	;
 
 range_opt:
@@ -1624,7 +1642,7 @@ net_decl_assignment: net_identifier '=' expression
 
 variable_decl_assignment:
 	  variable_identifier variable_dimension_brace
-		{ $$ = $1; stack_expr($$).type().swap(stack_expr($2)); }
+		{ $$ = $1; stack_expr($$).id(ID_declarator); addswap($$, ID_type, $2); }
 	| variable_identifier variable_dimension_brace '=' expression
 		{ $$ = $1; stack_expr($$).id(ID_declarator);
 		  addswap($$, ID_type, $2);

--- a/src/verilog/verilog_elaborate_constants.cpp
+++ b/src/verilog/verilog_elaborate_constants.cpp
@@ -143,17 +143,11 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
   // Typedef?
   if(decl_class == ID_typedef)
   {
-    for(auto &declarator : decl.operands())
+    for(auto &declarator : decl.declarators())
     {
-      auto symbol_expr = [](const exprt &declarator) -> const symbol_exprt & {
-        if(declarator.id() == ID_symbol)
-          return to_symbol_expr(declarator);
-        else
-          DATA_INVARIANT(false, "failed to find symbol in declarator");
-      }(declarator);
+      DATA_INVARIANT(declarator.id() == ID_declarator, "must have declarator");
 
-      auto base_name = symbol_expr.get_identifier();
-
+      auto base_name = declarator.base_name();
       auto full_identifier = hierarchical_identifier(base_name);
 
       symbolt symbol{
@@ -203,25 +197,19 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
 
     for(auto &declarator : decl.declarators())
     {
-      if(declarator.id() == ID_symbol)
-      {
-        symbol.base_name = declarator.identifier();
-        symbol.location = declarator.source_location();
+      DATA_INVARIANT(declarator.id() == ID_declarator, "must have declarator");
 
-        if(declarator.type().is_nil())
-          symbol.type = type;
-        else if(declarator.type().id() == ID_array)
-          symbol.type = array_type(declarator.type(), type);
-        else
-        {
-          throw errort().with_location(declarator.source_location())
-            << "unexpected type on declarator";
-        }
-      }
+      symbol.base_name = declarator.identifier();
+      symbol.location = declarator.source_location();
+
+      if(declarator.type().is_nil())
+        symbol.type = type;
+      else if(declarator.type().id() == ID_array)
+        symbol.type = array_type(declarator.type(), type);
       else
       {
         throw errort().with_location(declarator.source_location())
-          << "unexpected declaration: " << declarator.id();
+          << "unexpected type on declarator";
       }
 
       if(symbol.base_name.empty())

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -328,6 +328,11 @@ public:
       return static_cast<exprt &>(add(ID_value));
     }
 
+    bool has_value() const
+    {
+      return find(ID_value).is_not_nil();
+    }
+
     // helper to generate a symbol expression
     symbol_exprt symbol_expr() const
     {

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -310,28 +310,17 @@ void verilog_typecheckt::interface_function_or_task_decl(const verilog_declt &de
 
   for(auto &declarator : decl.declarators())
   {
-    if(declarator.id() == ID_symbol)
+    DATA_INVARIANT(declarator.id() == ID_declarator, "must have declarator");
+
+    symbol.base_name = declarator.base_name();
+
+    if(symbol.base_name.empty())
     {
-      symbol.base_name = declarator.identifier();
-      symbol.type=type;
-    }
-    else if(declarator.id() == ID_array)
-    {
-      symbol.base_name = declarator.identifier();
-      symbol.type = array_type(declarator, type);
-    }
-    else
-    {
-      throw errort().with_location(declarator.source_location())
-        << "unexpected declaration: " << declarator.id();
+      throw errort().with_location(decl.source_location())
+        << "empty symbol name";
     }
 
-    if(symbol.base_name=="")
-    {
-      error().source_location = decl.source_location();
-      error() << "empty symbol name" << eom;
-      throw 0;
-    }
+    symbol.type = type;
 
     symbol.name = hierarchical_identifier(symbol.base_name);
 
@@ -451,32 +440,20 @@ void verilog_typecheckt::interface_module_decl(
 
   for(auto &declarator : decl.declarators())
   {
-    if(declarator.id() == ID_symbol)
-    {
-      symbol.base_name = declarator.identifier();
-      symbol.location = declarator.source_location();
+    DATA_INVARIANT(declarator.id() == ID_declarator, "must have declarator");
 
-      if(declarator.type().is_nil())
-        symbol.type=type;
-      else if(declarator.type().id() == ID_array)
-        symbol.type = array_type(declarator.type(), type);
-      else
-      {
-        error().source_location = symbol.location;
-        error() << "unexpected type on declarator" << eom;
-        throw 0;
-      }
-    }
-    else if(declarator.id() == ID_declarator)
-    {
-      symbol.base_name = declarator.base_name();
-      symbol.location = declarator.source_location();
+    symbol.base_name = declarator.base_name();
+    symbol.location = declarator.source_location();
+
+    if(declarator.type().is_nil())
       symbol.type=type;
-    }
+    else if(declarator.type().id() == ID_array)
+      symbol.type = array_type(declarator.type(), type);
     else
     {
-      throw errort().with_location(declarator.source_location())
-        << "unexpected declaration: " << declarator.id();
+      error().source_location = symbol.location;
+      error() << "unexpected type on declarator" << eom;
+      throw 0;
     }
 
     if(symbol.base_name.empty())


### PR DESCRIPTION
This replaces the use of `symbol_exprt` as a declarator in all declarations by the dedicated type `declaratort`.