### PR TITLE
Verilog: clarify method signatures

### DIFF
--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -35,7 +35,7 @@ void verilog_typecheckt::module_interface(
     interface_module_item(module_item);
 
   // Check the typing of the ports
-  check_module_ports(module_source);
+  check_module_ports(module_source.ports());
 }
 
 /*******************************************************************\
@@ -51,10 +51,8 @@ Function: verilog_typecheckt::check_module_ports
 \*******************************************************************/
 
 void verilog_typecheckt::check_module_ports(
-  const verilog_module_sourcet &module_source)
+  const verilog_module_sourcet::port_listt &module_ports)
 {
-  const auto &module_ports = module_source.ports();
-
   auto &ports = module_symbol.type.add(ID_ports).get_sub();
   ports.resize(module_ports.size());
   std::map<irep_idt, unsigned> port_names;

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1604,9 +1604,6 @@ void verilog_typecheckt::convert_statements(
   // typecheck the new module items
   for(auto &item : verilog_module_expr.module_items())
     convert_module_item(item);
-
-  // store the module expression in module_symbol.value
-  module_symbol.value = std::move(verilog_module_expr);
 }
 
 /*******************************************************************\
@@ -1674,8 +1671,11 @@ void verilog_typecheckt::typecheck()
 
   auto verilog_module_expr = elaborate_generate_constructs(module_source);
 
-  // Now typecheck the statements.
+  // Now typecheck the generated statements.
   convert_statements(verilog_module_expr);
+
+  // store the module expression in module_symbol.value
+  module_symbol.value = std::move(verilog_module_expr);
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -111,7 +111,7 @@ protected:
 
   // interfaces
   void module_interface(const verilog_module_sourcet &);
-  void check_module_ports(const verilog_module_sourcet &);
+  void check_module_ports(const verilog_module_sourcet::port_listt &);
   void interface_module_decl(const class verilog_declt &);
   void interface_function_or_task_decl(const class verilog_declt &);
   void interface_inst(const verilog_inst_baset &);


### PR DESCRIPTION
To clarify the side effect of the `typecheck()` method, the value of the module symbol is now set there.