### PR TITLE
Verilog: clean-up identifier vs. base_name

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2216,7 +2216,7 @@ generate_block:
 	| TOK_BEGIN TOK_COLON generate_block_identifier generate_item_brace TOK_END
 		{ init($$, ID_generate_block);
 		  swapop($$, $4);
-		  stack_expr($$).set(ID_identifier, stack_expr($3).id()); }
+		  stack_expr($$).set(ID_base_name, stack_expr($3).id()); }
 	;
 
 generate_item:
@@ -2640,7 +2640,7 @@ seq_block:
           TOK_END
                 { init($$, ID_block);
                   swapop($$, $5);
-                  addswap($$, ID_identifier, $3);
+                  addswap($$, ID_base_name, $3);
                   pop_scope();
                 }
 	;
@@ -2868,7 +2868,7 @@ par_block:
           statement_or_null_brace TOK_JOIN
                 { init($$, ID_block);
                   swapop($$, $4);
-                  addswap($$, ID_identifier, $3); }
+                  addswap($$, ID_base_name, $3); }
 
 	;
 

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -22,7 +22,7 @@ void verilog_typecheckt::collect_port_symbols(const verilog_declt &decl)
 
   const auto &declarator = decl.declarators().front();
 
-  const irep_idt &base_name = declarator.identifier();
+  const irep_idt &base_name = declarator.base_name();
   const irep_idt &port_class = decl.get_class();
   auto type = convert_type(decl.type());
   irep_idt identifier = hierarchical_identifier(base_name);
@@ -69,10 +69,9 @@ void verilog_typecheckt::collect_symbols(
   const verilog_parameter_declt::declaratort &declarator)
 {
   // A localparam or parameter declarator.
-  auto base_name = declarator.identifier();
+  auto base_name = declarator.base_name();
 
-  auto full_identifier =
-    id2string(module_identifier) + "." + id2string(base_name);
+  auto full_identifier = hierarchical_identifier(base_name);
 
   // If there's no type, parameters take the type of the
   // value. We signal this using the special type "derive_from_value".
@@ -118,9 +117,11 @@ void verilog_typecheckt::collect_symbols(const typet &type)
 
       exprt value = typecast_exprt(initializer, base_type);
 
-      symbolt enum_name_symbol(enum_name.identifier(), base_type, mode);
+      const auto base_name = enum_name.base_name();
+      const auto identifier = hierarchical_identifier(base_name);
+      symbolt enum_name_symbol(identifier, base_type, mode);
       enum_name_symbol.module = module_identifier;
-      enum_name_symbol.base_name = enum_name.base_name();
+      enum_name_symbol.base_name = base_name;
       enum_name_symbol.value = std::move(value);
       enum_name_symbol.is_macro = true;
       enum_name_symbol.is_file_local = true;
@@ -199,7 +200,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
     {
       DATA_INVARIANT(declarator.id() == ID_declarator, "must have declarator");
 
-      symbol.base_name = declarator.identifier();
+      symbol.base_name = declarator.base_name();
       symbol.location = declarator.source_location();
 
       if(declarator.type().is_nil())
@@ -288,7 +289,7 @@ void verilog_typecheckt::collect_symbols(const verilog_statementt &statement)
     auto &block_statement = to_verilog_block(statement);
 
     if(block_statement.is_named())
-      enter_named_block(block_statement.identifier());
+      enter_named_block(block_statement.base_name());
 
     for(auto &block_statement : to_verilog_block(statement).operands())
       collect_symbols(to_verilog_statement(block_statement));

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -217,22 +217,27 @@ public:
   }
 
   verilog_generate_blockt(
-    irep_idt _identifier,
+    irep_idt _base_name,
     verilog_module_exprt::module_itemst _module_items)
     : verilog_module_itemt(ID_generate_block)
   {
-    set(ID_identifier, _identifier);
+    set(ID_base_name, _base_name);
     module_items() = std::move(_module_items);
   }
 
-  const irep_idt &identifier() const
+  const irep_idt &base_name() const
   {
-    return get(ID_identifier);
+    return get(ID_base_name);
+  }
+
+  void base_name(irep_idt __base_name)
+  {
+    return set(ID_base_name, __base_name);
   }
 
   bool is_named() const
   {
-    return !identifier().empty();
+    return !base_name().empty();
   }
 
   const verilog_module_exprt::module_itemst &module_items() const
@@ -740,14 +745,14 @@ public:
     return (const statementst &)operands();
   }
 
-  irep_idt identifier() const
+  irep_idt base_name() const
   {
-    return get(ID_identifier);
+    return get(ID_base_name);
   }
 
   bool is_named() const
   {
-    return !get(ID_identifier).empty();
+    return !get(ID_base_name).empty();
   }
 };
 

--- a/src/verilog/verilog_generate.cpp
+++ b/src/verilog/verilog_generate.cpp
@@ -72,14 +72,14 @@ void verilog_typecheckt::elaborate_generate_block(
   bool is_named = generate_block.is_named();
 
   if(is_named)
-    enter_named_block(generate_block.identifier());
+    enter_named_block(generate_block.base_name());
 
   module_itemst new_module_items;
 
   for(auto &item : generate_block.module_items())
     elaborate_generate_item(item, new_module_items);
 
-  auto identifier = generate_block.identifier();
+  auto identifier = generate_block.base_name();
   auto block = verilog_generate_blockt(identifier, std::move(new_module_items));
   block.add_source_location() = generate_block.source_location();
 
@@ -373,11 +373,12 @@ void verilog_typecheckt::elaborate_generate_for(
     auto copy_of_body = for_statement.body();
     if(copy_of_body.id() == ID_generate_block)
     {
+      auto &generate_block = to_verilog_generate_block(copy_of_body);
       const mp_integer loop_index_int =
         convert_integer_constant_expression(loop_index);
-      auto new_identifier = id2string(copy_of_body.get(ID_identifier)) + '[' +
-                            integer2string(loop_index_int) + ']';
-      copy_of_body.set(ID_identifier, new_identifier);
+      auto new_base_name = id2string(generate_block.base_name()) + '[' +
+                           integer2string(loop_index_int) + ']';
+      generate_block.base_name(new_base_name);
     }
 
     elaborate_generate_item(copy_of_body, dest);

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -592,8 +592,8 @@ void verilog_typecheckt::interface_generate_block(
 
   if(is_named)
   {
-    irep_idt identifier = generate_block.identifier();
-    enter_named_block(identifier);
+    irep_idt base_name = generate_block.base_name();
+    enter_named_block(base_name);
   }
 
   for(auto &item : generate_block.module_items())
@@ -729,13 +729,13 @@ void verilog_typecheckt::interface_block(
   
   if(is_named)
   {
-    irep_idt identifier = statement.identifier();
+    const irep_idt base_name = statement.base_name();
 
     // need to add to symbol table
     symbolt symbol;
 
     symbol.mode=mode;
-    symbol.base_name=identifier;
+    symbol.base_name = base_name;
     symbol.type=typet(ID_named_block);
     symbol.module=module_identifier;
     symbol.name = hierarchical_identifier(symbol.base_name);
@@ -749,9 +749,9 @@ void verilog_typecheckt::interface_block(
               << symbol.base_name << "' in module `"
               << module_symbol.base_name << '\'' << eom;
       throw 0;
-    }    
+    }
 
-    enter_named_block(identifier);
+    enter_named_block(base_name);
   }
 
   // do decl

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -734,7 +734,7 @@ void verilog_typecheckt::convert_block(verilog_blockt &statement)
   bool is_named=statement.is_named();
   
   if(is_named)
-    enter_named_block(statement.identifier());
+    enter_named_block(statement.base_name());
 
   for(auto &block_statement : statement.statements())
     convert_statement(block_statement);
@@ -1537,7 +1537,7 @@ void verilog_typecheckt::convert_module_item(
     bool is_named = generate_block.is_named();
 
     if(is_named)
-      enter_named_block(generate_block.identifier());
+      enter_named_block(generate_block.base_name());
 
     for(auto &sub_module_item : generate_block.module_items())
       convert_module_item(sub_module_item);


### PR DESCRIPTION
Clean up terminology: identifier (with scope) vs. base name (no scope)