### PR TITLE
Verilog: zero-count replication

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -49,6 +49,8 @@ jobs:
         run: make -C regression/ebmc test-z3
       - name: Run the verilog tests
         run: make -C regression/verilog test
+      - name: Run the verilog tests with Z3
+        run: make -C regression/verilog test-z3
       - name: Print ccache stats
         run: ccache -s
 
@@ -100,6 +102,8 @@ jobs:
         run: make -C regression/ebmc test-z3
       - name: Run the verilog tests
         run: make -C regression/verilog test
+      - name: Run the verilog tests with Z3
+        run: make -C regression/verilog test-z3
       - name: Print ccache stats
         run: ccache -s
 

--- a/regression/verilog/Makefile
+++ b/regression/verilog/Makefile
@@ -1,4 +1,9 @@
 default: test
 
+TEST_PL = ../../lib/cbmc/regression/test.pl
+
 test:
-	@../../lib/cbmc/regression/test.pl -c ../../../src/ebmc/ebmc
+	@$(TEST_PL) -c ../../../src/ebmc/ebmc
+
+test-z3:
+	@$(TEST_PL) -e -p -c "../../../src/ebmc/ebmc --z3" -X broken-smt-backend

--- a/regression/verilog/assignment-to-concatenation/test.desc
+++ b/regression/verilog/assignment-to-concatenation/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.v
 --bound 1
 ^EXIT=0$

--- a/regression/verilog/assignment-to-range1/test.desc
+++ b/regression/verilog/assignment-to-range1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.v
 --bound 1
 ^EXIT=0$

--- a/regression/verilog/bit-extract/bit-extract1.desc
+++ b/regression/verilog/bit-extract/bit-extract1.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 bit-extract1.v
 --bound 1
 ^EXIT=0$

--- a/regression/verilog/bit-extract/bit-extract2.desc
+++ b/regression/verilog/bit-extract/bit-extract2.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 bit-extract2.v
 --module main --bound 1 --trace
 ^EXIT=10$

--- a/regression/verilog/case/case3.desc
+++ b/regression/verilog/case/case3.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 case3.v
 --module main --bound 3 --trace
 ^EXIT=10$

--- a/regression/verilog/case/case4.desc
+++ b/regression/verilog/case/case4.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 case4.v
 --module main --bound 1
 ^EXIT=0$

--- a/regression/verilog/functioncall/functioncall3.desc
+++ b/regression/verilog/functioncall/functioncall3.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 functioncall3.v
 --module main --bound 0
 ^EXIT=0$

--- a/regression/verilog/generate/generate-for2.desc
+++ b/regression/verilog/generate/generate-for2.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 generate-for2.v
 --bound 0
 ^EXIT=0$

--- a/regression/verilog/generate/generate-reg1.desc
+++ b/regression/verilog/generate/generate-reg1.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 generate-reg1.v
 --module main --bound 0
 ^EXIT=0$

--- a/regression/verilog/generate1/test.desc
+++ b/regression/verilog/generate1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.v
 --module main --bound 1
 ^EXIT=0$

--- a/regression/verilog/indexed-part-select1/test.desc
+++ b/regression/verilog/indexed-part-select1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.sv
 --bound 1
 ^EXIT=0$

--- a/regression/verilog/modules/ports2.desc
+++ b/regression/verilog/modules/ports2.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 ports2.v
 --module main --bound 1
 ^EXIT=0$

--- a/regression/verilog/multiple_assign1/test.desc
+++ b/regression/verilog/multiple_assign1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.v
 --module main --bound 1
 ^EXIT=0$

--- a/regression/verilog/nondet1/test.desc
+++ b/regression/verilog/nondet1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.v
 --module main --bound 3 --trace
 ^EXIT=10$

--- a/regression/verilog/replication/replication1.desc
+++ b/regression/verilog/replication/replication1.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
-main.v
---bound 1
+replication1.v
+--bound 0
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/replication/replication1.v
+++ b/regression/verilog/replication/replication1.v
@@ -13,8 +13,12 @@ module main(in);
   always assert property2:
     {{ 1 { in }}, in } == { in, in };
 
-  // replication of something boolean
+  // 0-replication
   always assert property3:
+    {{ 0 { in }}, in } == { in };
+
+  // replication of something boolean
+  always assert property4:
     {{ 1 { 1'b0 }}, in } == in;
 
 endmodule

--- a/regression/verilog/replication1/test.desc
+++ b/regression/verilog/replication1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.v
 --bound 1
 ^EXIT=0$

--- a/regression/verilog/system_verilog_assertion/system_verilog_assertion3.desc
+++ b/regression/verilog/system_verilog_assertion/system_verilog_assertion3.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 system_verilog_assertion3.sv
 --module main --bound 1
 ^EXIT=0$

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1911,7 +1911,7 @@ exprt verilog_typecheck_exprt::convert_replication_expr(replication_exprt expr)
   if(op1.type().id()==ID_bool)
     op1 = typecast_exprt{op1, unsignedbv_typet{1}};
 
-  unsigned width=get_width(expr.op1().type());
+  auto width = get_width(expr.op1().type());
 
   mp_integer op0 = convert_integer_constant_expression(expr.op0());
 
@@ -1921,12 +1921,8 @@ exprt verilog_typecheck_exprt::convert_replication_expr(replication_exprt expr)
       << "number of replications must not be negative";
   }
 
-  if(op0==0)
-  {
-    // ruled out by IEEE 1364-2001
-    throw errort().with_location(expr.source_location())
-      << "number of replications must not be zero";
-  }
+  // IEEE 1800-2017 explicitly allows replication with
+  // count zero.
 
   {
     expr.op0()=from_integer(op0, natural_typet());


### PR DESCRIPTION
The SystemVerilog 1800-2017 standard explicitly allows replications with count zero.