### PR TITLE
Verilog: remove binary_to_hex

### DIFF
--- a/src/util/ebmc_util.h
+++ b/src/util/ebmc_util.h
@@ -57,44 +57,4 @@ inline void cnf_gate_and(cnft &cnf, literalt a, literalt b, literalt o) {
   cnf.lcnf(lits);
 }
 
-inline std::optional<std::pair<std::string, std::size_t>>
-b2h_conversion_specs(const exprt &expr)
-{
-  if (expr.id() == ID_constant) {
-    auto &constant_expr = to_constant_expr(expr);
-    const typet &type = constant_expr.type();
-    if (type.id() == ID_unsignedbv || type.id() == ID_signedbv) {
-      const std::size_t &width = to_bitvector_type(type).get_width();
-      const std::string value = id2string(constant_expr.get_value());
-      if (value.size() == width &&
-          std::all_of(value.begin(), value.end(),
-                      [](char c) { return (c == '0' || c == '1'); })) {
-        return std::make_pair(value, width);
-      }
-    }
-  }
-
-  return {};
-}
-
-inline void binary_to_hex_reinterpret(exprt &expr) {
-  auto conversion_specs = b2h_conversion_specs(expr);
-  if (conversion_specs.has_value()) {
-    expr.set(ID_value, integer2bvrep(string2integer(conversion_specs->first, 2),
-                                     conversion_specs->second));
-  }
-}
-
-inline exprt binary_to_hex(const exprt &expr) {
-  auto conversion_specs = b2h_conversion_specs(expr);
-  if (conversion_specs.has_value()) {
-    return constant_exprt{
-        integer2bvrep(string2integer(conversion_specs->first, 2),
-                      conversion_specs->second),
-        expr.type()};
-  }
-
-  return expr;
-}
-
 #endif // HW_CBMC_UTIL_EBMC_UTIL_H

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -1902,7 +1902,8 @@ exprt verilog_synthesist::case_comparison(
            new_pattern_value[i]=='x')
           new_pattern_value[i]='0';
 
-      constant_exprt new_pattern{new_pattern_value, new_type};
+      auto new_pattern =
+        from_integer(string2integer(new_pattern_value, 2), new_type);
 
       std::string new_mask_value=
         id2string(to_constant_expr(tmp).get_value());
@@ -1916,12 +1917,11 @@ exprt verilog_synthesist::case_comparison(
         else
           new_mask_value[i]='1';
 
-      constant_exprt new_mask{new_mask_value, new_type};
+      auto new_mask = from_integer(string2integer(new_mask_value, 2), new_type);
 
-      exprt bitand_expr =
-          bitand_exprt{new_case_operand, binary_to_hex(new_mask)};
+      exprt bitand_expr = bitand_exprt{new_case_operand, new_mask};
 
-      return equal_exprt{bitand_expr, binary_to_hex(new_pattern)};
+      return equal_exprt{bitand_expr, new_pattern};
     }
   }
 


### PR DESCRIPTION
This removes the last two uses of `binary_to_hex`.