### PR TITLE
Verilog: add non-module declarations to parse tree

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -728,24 +728,30 @@ module_keyword:
 	;
 
 interface_declaration:
-          TOK_INTERFACE TOK_ENDINTERFACE
+          TOK_INTERFACE interface_identifier TOK_ENDINTERFACE
+		{
+		  PARSER.parse_tree.create_interface(stack_expr($2));
+	        }
         ;
 
 program_declaration:
-          TOK_PROGRAM TOK_ENDPROGRAM
+          TOK_PROGRAM program_identifier TOK_ENDPROGRAM
+		{
+		  PARSER.parse_tree.create_program(stack_expr($2));
+	        }
         ;
 
 class_declaration:
 	  TOK_CLASS class_identifier
-	  ';'
 		{
-		  $$ = $1;
 	          push_scope(stack_expr($2).id(), "::");
 	        }
+	  ';'
 	  class_item_brace
 	  TOK_ENDCLASS
 		{
 		  pop_scope();
+		  PARSER.parse_tree.create_class(stack_expr($2));
 	        }
 	;
 
@@ -754,7 +760,6 @@ package_declaration:
           lifetime_opt
           package_identifier ';'
 		{
-		  $$ = $1;
 	          push_scope(stack_expr($4).id(), "::");
 	        }
           timeunits_declaration_opt
@@ -762,6 +767,7 @@ package_declaration:
           TOK_ENDPACKAGE
 		{
 		  pop_scope();
+		  PARSER.parse_tree.create_package(stack_expr($4));
 	        }
         ;
 
@@ -2324,9 +2330,15 @@ constant_expression: expression;
 udp_declaration: attribute_instance_brace TOK_PRIMITIVE udp_identifier 
 	  '(' udp_port_list ')' ';' udp_port_declaration_brace
 	  udp_body TOK_ENDPRIMITIVE
+		{
+		  PARSER.parse_tree.create_primitive(stack_expr($3));
+	        }
 	| attribute_instance_brace TOK_PRIMITIVE udp_identifier 
 	  '(' udp_declaration_port_list ')' ';'
 	  udp_body TOK_ENDPRIMITIVE
+		{
+		  PARSER.parse_tree.create_primitive(stack_expr($3));
+	        }
 	;
 
 // System Verilog standard 1800-2017
@@ -3256,6 +3268,8 @@ net_identifier: identifier;
 package_identifier: TOK_NON_TYPE_IDENTIFIER;
 
 param_identifier: TOK_NON_TYPE_IDENTIFIER;
+
+program_identifier: TOK_NON_TYPE_IDENTIFIER;
 
 port_identifier: identifier;
 

--- a/src/verilog/verilog_parse_tree.cpp
+++ b/src/verilog/verilog_parse_tree.cpp
@@ -11,6 +11,44 @@ Author: Daniel Kroening, kroening@kroening.com
 
 /*******************************************************************\
 
+Function: verilog_parse_treet::create_class
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void verilog_parse_treet::create_class(exprt &name)
+{
+  items.emplace_back(itemt::CLASS);
+  itemt &item = items.back();
+  item.source_location = name.source_location();
+}
+
+/*******************************************************************\
+
+Function: verilog_parse_treet::create_interface
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void verilog_parse_treet::create_interface(exprt &name)
+{
+  items.emplace_back(itemt::INTERFACE);
+  itemt &item = items.back();
+  item.source_location = name.source_location();
+}
+
+/*******************************************************************\
+
 Function: verilog_parse_treet::create_module
 
   Inputs:
@@ -29,10 +67,8 @@ void verilog_parse_treet::create_module(
   exprt &ports,
   exprt &module_items)
 {
-  items.push_back(itemt());
+  items.emplace_back(itemt::MODULE);
   itemt &item=items.back();
-  
-  item.type=itemt::MODULE;
 
   verilog_modulet &new_module=item.verilog_module;
 
@@ -48,6 +84,63 @@ void verilog_parse_treet::create_module(
 
   // add to module map  
   module_map[new_module.name]=--items.end();
+}
+
+/*******************************************************************\
+
+Function: verilog_parse_treet::create_package
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void verilog_parse_treet::create_package(exprt &name)
+{
+  items.emplace_back(itemt::PACKAGE);
+  itemt &item = items.back();
+  item.source_location = name.source_location();
+}
+
+/*******************************************************************\
+
+Function: verilog_parse_treet::create_primitive
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void verilog_parse_treet::create_primitive(exprt &name)
+{
+  items.emplace_back(itemt::PRIMITIVE);
+  itemt &item = items.back();
+  item.source_location = name.source_location();
+}
+
+/*******************************************************************\
+
+Function: verilog_parse_treet::create_program
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void verilog_parse_treet::create_program(exprt &name)
+{
+  items.emplace_back(itemt::PROGRAM);
+  itemt &item = items.back();
+  item.source_location = name.source_location();
 }
 
 /*******************************************************************\
@@ -132,10 +225,30 @@ void verilog_parse_treet::itemt::show(std::ostream &out) const
 {
   switch(type)
   {
+  case itemt::CLASS:
+    out << "CLASS " << source_location << "\n";
+    break;
+
+  case itemt::INTERFACE:
+    out << "INTERFACE " << source_location << "\n";
+    break;
+
   case itemt::MODULE:
     verilog_module.show(out);
     break;
-    
+
+  case itemt::PACKAGE:
+    out << "PACKAGE " << source_location << "\n";
+    break;
+
+  case itemt::PRIMITIVE:
+    out << "PRIMITIVE " << source_location << "\n";
+    break;
+
+  case itemt::PROGRAM:
+    out << "PROGRAM " << source_location << "\n";
+    break;
+
   case itemt::TYPEDEF:
     verilog_typedef.show(out);
     break;

--- a/src/verilog/verilog_parse_tree.h
+++ b/src/verilog/verilog_parse_tree.h
@@ -35,24 +35,64 @@ public:
   struct itemt
   {
   public:
-    typedef enum { MODULE, TYPEDEF } item_typet;
+    typedef enum
+    {
+      CLASS,
+      INTERFACE,
+      MODULE,
+      PACKAGE,
+      PRIMITIVE,
+      PROGRAM,
+      TYPEDEF
+    } item_typet;
     item_typet type;
-    
+
+    explicit itemt(item_typet __type) : type(__type)
+    {
+    }
+
     verilog_modulet verilog_module;
     
     verilog_typedeft verilog_typedef;
-    
+
+    source_locationt source_location;
+
+    bool is_class() const
+    {
+      return type == CLASS;
+    }
+
+    bool is_interface() const
+    {
+      return type == INTERFACE;
+    }
+
     bool is_module() const
     {
       return type==MODULE;
+    }
+
+    bool is_package() const
+    {
+      return type == PACKAGE;
+    }
+
+    bool is_primitive() const
+    {
+      return type == PRIMITIVE;
+    }
+
+    bool is_program() const
+    {
+      return type == PROGRAM;
     }
 
     bool is_typedef() const
     {
       return type==TYPEDEF;
     }
-    
-    void show(std::ostream &out) const;
+
+    void show(std::ostream &) const;
   };
   
   typedef std::list<itemt> itemst;
@@ -72,6 +112,10 @@ public:
     return module_map.count(name)!=0;
   }
 
+  void create_class(exprt &name);
+
+  void create_interface(exprt &name);
+
   void create_module(
     irept &attributes,
     irept &module_keyword,
@@ -80,10 +124,15 @@ public:
     exprt &ports,
     exprt &statements);
 
+  void create_package(exprt &name);
+
+  void create_primitive(exprt &name);
+
+  void create_program(exprt &name);
+
   void create_typedef(irept &declaration)
   {
-    items.push_back(itemt());
-    items.back().type=itemt::TYPEDEF;
+    items.emplace_back(itemt::TYPEDEF);
     items.back().verilog_typedef.symbol.swap(declaration.get_sub()[0]);
     items.back().verilog_typedef.type.swap(declaration.add(ID_type));
   }


### PR DESCRIPTION
Verilog UDP declarations are now added to the parse tree.

SystemVerilog introduces classes, interfaces, packages and programs, which are now added to the parse tree.