### PR TITLE
netlists: move get_terminals into separate file

### DIFF
--- a/src/trans-netlist/Makefile
+++ b/src/trans-netlist/Makefile
@@ -1,8 +1,19 @@
-SRC = aig.cpp aig_prop.cpp bmc_map.cpp counterexample_netlist.cpp \
-      instantiate_netlist.cpp netlist.cpp trans_trace_netlist.cpp \
-      var_map.cpp unwind_netlist.cpp ldg.cpp compute_ct.cpp \
-      trans_trace.cpp trans_to_netlist.cpp \
-      map_aigs.cpp bv_varid.cpp
+SRC = aig.cpp \
+      aig_terminals.cpp \
+      aig_prop.cpp \
+      bmc_map.cpp \
+      counterexample_netlist.cpp \
+      instantiate_netlist.cpp \
+      netlist.cpp \
+      trans_trace_netlist.cpp \
+      var_map.cpp \
+      unwind_netlist.cpp \
+      ldg.cpp \
+      compute_ct.cpp \
+      trans_trace.cpp \
+      trans_to_netlist.cpp \
+      map_aigs.cpp \
+      bv_varid.cpp
 
 include ../config.inc
 include ../common

--- a/src/trans-netlist/aig.cpp
+++ b/src/trans-netlist/aig.cpp
@@ -20,43 +20,6 @@ std::string aigt::dot_label(nodest::size_type v) const {
   return "var(" + std::to_string(v) + ")";
 }
 
-void aigt::get_terminals(terminalst &terminals) const {
-  for (nodest::size_type n = 0; n < nodes.size(); n++)
-    get_terminals_rec(n, terminals);
-}
-
-const aigt::terminal_sett &
-aigt::get_terminals_rec(literalt::var_not n, terminalst &terminals) const {
-  terminalst::iterator it = terminals.find(n);
-
-  if (it != terminals.end())
-    return it->second; // already done
-
-  assert(n < nodes.size());
-  const aig_nodet &node = nodes[n];
-
-  terminal_sett &t = terminals[n];
-
-  if (node.is_and()) {
-    if (!node.a.is_constant()) {
-      const std::set<literalt::var_not> &ta =
-          get_terminals_rec(node.a.var_no(), terminals);
-      t.insert(ta.begin(), ta.end());
-    }
-
-    if (!node.b.is_constant()) {
-      const std::set<literalt::var_not> &tb =
-          get_terminals_rec(node.b.var_no(), terminals);
-      t.insert(tb.begin(), tb.end());
-    }
-  } else // this is a terminal
-  {
-    t.insert(n);
-  }
-
-  return t;
-}
-
 void aigt::print(std::ostream &out, literalt a) const {
   if (a == const_literal(false)) {
     out << "FALSE";

--- a/src/trans-netlist/aig.h
+++ b/src/trans-netlist/aig.h
@@ -48,13 +48,6 @@ public:
 
   void clear() { nodes.clear(); }
 
-  typedef std::set<literalt::var_not> terminal_sett;
-  typedef std::map<literalt::var_not, terminal_sett> terminalst;
-
-  // produces the support set
-  // should get re-written
-  void get_terminals(terminalst &terminals) const;
-
   const aig_nodet &get_node(literalt l) const { return nodes[l.var_no()]; }
 
   aig_nodet &get_node(literalt l) { return nodes[l.var_no()]; }
@@ -93,10 +86,6 @@ public:
 
   std::string label(nodest::size_type v) const;
   std::string dot_label(nodest::size_type v) const;
-
-protected:
-  const std::set<literalt::var_not> &
-  get_terminals_rec(literalt::var_not n, terminalst &terminals) const;
 };
 
 std::ostream &operator<<(std::ostream &, const aigt &);

--- a/src/trans-netlist/aig_terminals.cpp
+++ b/src/trans-netlist/aig_terminals.cpp
@@ -1,0 +1,59 @@
+/*******************************************************************\
+
+Module:
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#include "aig_terminals.h"
+
+const aig_terminal_sett &get_terminals_rec(
+  const aigt &aig,
+  literalt::var_not n,
+  aig_terminalst &terminals)
+{
+  PRECONDITION(n < aig.nodes.size());
+
+  auto it = terminals.find(n);
+
+  if(it != terminals.end())
+    return it->second; // already done
+
+  const aig_nodet &node = aig.nodes[n];
+
+  auto &t = terminals[n];
+
+  if(node.is_and())
+  {
+    if(!node.a.is_constant())
+    {
+      const std::set<literalt::var_not> &ta =
+        get_terminals_rec(aig, node.a.var_no(), terminals);
+      t.insert(ta.begin(), ta.end());
+    }
+
+    if(!node.b.is_constant())
+    {
+      const std::set<literalt::var_not> &tb =
+        get_terminals_rec(aig, node.b.var_no(), terminals);
+      t.insert(tb.begin(), tb.end());
+    }
+  }
+  else // this is a terminal
+  {
+    t.insert(n);
+  }
+
+  return t;
+}
+
+aig_terminalst terminals(const aigt &aig)
+{
+  aig_terminalst terminals;
+
+  for(aigt::nodest::size_type n = 0; n < aig.nodes.size(); n++)
+    get_terminals_rec(aig, n, terminals);
+
+  return terminals;
+}

--- a/src/trans-netlist/aig_terminals.h
+++ b/src/trans-netlist/aig_terminals.h
@@ -1,0 +1,23 @@
+/*******************************************************************\
+
+Module: AND-Inverter Graph Terminals
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+/// \file
+/// AND-Inverter Graph Terminals
+
+#ifndef CPROVER_TRANS_NETLIST_AIG_TERMINALS_H
+#define CPROVER_TRANS_NETLIST_AIG_TERMINALS_H
+
+#include "aig.h"
+
+typedef std::set<literalt::var_not> aig_terminal_sett;
+typedef std::map<literalt::var_not, aig_terminal_sett> aig_terminalst;
+
+// produces the support set of the given AIG
+aig_terminalst terminals(const aigt &);
+
+#endif // CPROVER_TRANS_NETLIST_AIG_TERMINALS_H

--- a/src/trans-netlist/ldg.cpp
+++ b/src/trans-netlist/ldg.cpp
@@ -6,10 +6,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-#include <iostream>
-#include <cassert>
-
 #include "ldg.h"
+
+#include "aig_terminals.h"
+
+#include <cassert>
+#include <iostream>
 
 /*******************************************************************\
 
@@ -73,9 +75,8 @@ void ldgt::compute(
       }
     }
   }
-  
-  aigt::terminalst terminals;
-  netlist.get_terminals(terminals);
+
+  auto terminals = ::terminals(netlist);
 
   for(latchest::const_iterator
       l_it=localization.begin();
@@ -84,7 +85,7 @@ void ldgt::compute(
   {
     unsigned v=*l_it;
     literalt next_state=nodes[v].next_state;
-    const aigt::terminal_sett &t=terminals[next_state.var_no()];
+    const auto &t = terminals[next_state.var_no()];
 
     for(std::set<unsigned>::const_iterator
         it=t.begin(); it!=t.end(); it++)


### PR DESCRIPTION
This extracts a rarely used method from aigt into a separate file.