### PR TITLE
ebmc: reporting when unsupported property is given

### DIFF
--- a/regression/ebmc/smv/bdd_unsupported_property.desc
+++ b/regression/ebmc/smv/bdd_unsupported_property.desc
@@ -1,0 +1,9 @@
+CORE
+bdd_unsupported_property.smv
+--bdd
+^EXIT=10$
+^SIGNAL=0$
+^\[main::spec1\] !G main::var::x = FALSE: FAILURE: property not supported by BDD engine$
+^\[main::spec2\] G main::var::x = FALSE: REFUTED$
+--
+^warning: ignoring

--- a/regression/ebmc/smv/bdd_unsupported_property.smv
+++ b/regression/ebmc/smv/bdd_unsupported_property.smv
@@ -1,0 +1,8 @@
+MODULE main
+
+VAR x : boolean;
+
+ASSIGN init(x) := 1;
+
+LTLSPEC !G x=0
+LTLSPEC G x=0

--- a/regression/ebmc/smv/bmc_unsupported_property1.desc
+++ b/regression/ebmc/smv/bmc_unsupported_property1.desc
@@ -1,0 +1,9 @@
+CORE
+bmc_unsupported_property1.smv
+
+^EXIT=10$
+^SIGNAL=0$
+^\[main::spec1\] !G main::var::x = FALSE: FAILURE: property not supported by BMC engine$
+^\[main::spec2\] G main::var::x = FALSE: REFUTED$
+--
+^warning: ignoring

--- a/regression/ebmc/smv/bmc_unsupported_property1.smv
+++ b/regression/ebmc/smv/bmc_unsupported_property1.smv
@@ -1,0 +1,8 @@
+MODULE main
+
+VAR x : boolean;
+
+ASSIGN init(x) := 1;
+
+LTLSPEC !G x=0
+LTLSPEC G x=0

--- a/regression/ebmc/smv/bmc_unsupported_property2.desc
+++ b/regression/ebmc/smv/bmc_unsupported_property2.desc
@@ -1,0 +1,9 @@
+CORE
+bmc_unsupported_property2.smv
+
+^EXIT=10$
+^SIGNAL=0$
+^\[main::spec1\] !G main::var::x = FALSE: FAILURE: property not supported by BMC engine$
+^\[main::spec2\] G main::var::x = TRUE: PROVED up to bound 1$
+--
+^warning: ignoring

--- a/regression/ebmc/smv/bmc_unsupported_property2.smv
+++ b/regression/ebmc/smv/bmc_unsupported_property2.smv
@@ -1,0 +1,9 @@
+MODULE main
+
+VAR x : boolean;
+
+ASSIGN init(x) := 1;
+ASSIGN next(x) := x;
+
+LTLSPEC !G x=0 -- unsupported
+LTLSPEC G x=1 -- should pass

--- a/src/ebmc/bmc.cpp
+++ b/src/ebmc/bmc.cpp
@@ -46,6 +46,13 @@ void bmc(
     if(property.is_disabled() || property.is_failure())
       continue;
 
+    // Is it supported by the BMC engine?
+    if(!bmc_supports_property(property.expr))
+    {
+      property.failure("property not supported by BMC engine");
+      continue;
+    }
+
     ::property(
       property.expr,
       property.timeframe_handles,

--- a/src/trans-word-level/property.h
+++ b/src/trans-word-level/property.h
@@ -23,6 +23,9 @@ void property(
   std::size_t no_timeframes,
   const namespacet &);
 
+/// Is the given property supported by word-level unwinding?
+bool bmc_supports_property(const exprt &);
+
 /// Adds a constraint that can be used to determine whether the
 /// given state has already been seen earlier in the trace.
 void lasso_constraints(


### PR DESCRIPTION
This changes the behavior when an unsupported property is given to the BMC engine.  Instead of exiting, this is now reported in the property list. Supported properties are still checked.