### PR TITLE
Verilog: move concurrent_assertion_statement

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2652,7 +2652,6 @@ statement_item:
           blocking_assignment ';' { $$ = $1; }
 	| nonblocking_assignment ';' { $$ = $1; }
 	| case_statement
-	| concurrent_assertion_statement
 	| conditional_statement
 	| inc_or_dec_expression ';'
 	| subroutine_call_statement
@@ -2822,7 +2821,9 @@ statement_brace:
 // A.6.10 Assertion statements
 
 procedural_assertion_statement:
-	  immediate_assertion_statement
+	  concurrent_assertion_statement
+	| immediate_assertion_statement
+        /* | checker_instantiation */
 	;
 
 immediate_assertion_statement:


### PR DESCRIPTION
This moves the `concurrent_assertion_statement` rule from `statement_item` to `procedural_assertion_statement`, as in 1800-2017.