### PR TITLE
Verilog: split assert/assume module items and statements

### DIFF
--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -1579,10 +1579,11 @@ inline verilog_non_blocking_assignt &to_verilog_non_blocking_assign(exprt &expr)
   return static_cast<verilog_non_blocking_assignt &>(expr);
 }
 
-class verilog_assertt:public verilog_statementt
+/// Verilog concurrent assertions
+class verilog_assert_module_itemt : public verilog_module_itemt
 {
 public:
-  verilog_assertt():verilog_statementt(ID_assert)
+  verilog_assert_module_itemt() : verilog_module_itemt(ID_assert)
   {
     operands().resize(2);
   }
@@ -1596,26 +1597,39 @@ public:
   {
     return op0();
   }
+
+  const irep_idt &identifier() const
+  {
+    return get(ID_identifier);
+  }
+
+  void identifier(irep_idt __identifier)
+  {
+    set(ID_identifier, __identifier);
+  }
 };
 
-inline const verilog_assertt &to_verilog_assert(const exprt &expr)
+inline const verilog_assert_module_itemt &
+to_verilog_assert_module_item(const verilog_module_itemt &module_item)
 {
-  PRECONDITION(expr.id() == ID_assert);
-  binary_exprt::check(expr);
-  return static_cast<const verilog_assertt &>(expr);
+  PRECONDITION(module_item.id() == ID_assert);
+  binary_exprt::check(module_item);
+  return static_cast<const verilog_assert_module_itemt &>(module_item);
 }
 
-inline verilog_assertt &to_verilog_assert(exprt &expr)
+inline verilog_assert_module_itemt &
+to_verilog_assert_module_item(verilog_module_itemt &module_item)
 {
-  PRECONDITION(expr.id() == ID_assert);
-  binary_exprt::check(expr);
-  return static_cast<verilog_assertt &>(expr);
+  PRECONDITION(module_item.id() == ID_assert);
+  binary_exprt::check(module_item);
+  return static_cast<verilog_assert_module_itemt &>(module_item);
 }
 
-class verilog_assumet:public verilog_statementt
+/// Verilog concurrent assumptions
+class verilog_assume_module_itemt : public verilog_module_itemt
 {
 public:
-  verilog_assumet():verilog_statementt(ID_assume)
+  verilog_assume_module_itemt() : verilog_module_itemt(ID_assume)
   {
     operands().resize(2);
   }
@@ -1629,20 +1643,128 @@ public:
   {
     return op0();
   }
+
+  const irep_idt &identifier() const
+  {
+    return get(ID_identifier);
+  }
+
+  void identifier(irep_idt __identifier)
+  {
+    set(ID_identifier, __identifier);
+  }
 };
 
-inline const verilog_assumet &to_verilog_assume(const exprt &expr)
+inline const verilog_assume_module_itemt &
+to_verilog_assume_module_item(const verilog_module_itemt &module_item)
 {
-  PRECONDITION(expr.id() == ID_assume);
-  binary_exprt::check(expr);
-  return static_cast<const verilog_assumet &>(expr);
+  PRECONDITION(module_item.id() == ID_assume);
+  binary_exprt::check(module_item);
+  return static_cast<const verilog_assume_module_itemt &>(module_item);
 }
 
-inline verilog_assumet &to_verilog_assume(exprt &expr)
+inline verilog_assume_module_itemt &
+to_verilog_assume_module_item(verilog_module_itemt &module_item)
 {
-  PRECONDITION(expr.id() == ID_assume);
-  binary_exprt::check(expr);
-  return static_cast<verilog_assumet &>(expr);
+  PRECONDITION(module_item.id() == ID_assume);
+  binary_exprt::check(module_item);
+  return static_cast<verilog_assume_module_itemt &>(module_item);
+}
+
+// Intermediate assertion statements, and SMV-style assertions.
+class verilog_assert_statementt : public verilog_statementt
+{
+public:
+  verilog_assert_statementt() : verilog_statementt(ID_assert)
+  {
+    operands().resize(2);
+  }
+
+  inline exprt &condition()
+  {
+    return op0();
+  }
+
+  inline const exprt &condition() const
+  {
+    return op0();
+  }
+
+  // The Verilog intermediate assertion does not have an identifier,
+  // but the SMV-style ones do.
+  const irep_idt &identifier() const
+  {
+    return get(ID_identifier);
+  }
+
+  void identifier(irep_idt _identifier)
+  {
+    set(ID_identifier, _identifier);
+  }
+};
+
+inline const verilog_assert_statementt &
+to_verilog_assert_statement(const verilog_statementt &statement)
+{
+  PRECONDITION(statement.id() == ID_assert);
+  binary_exprt::check(statement);
+  return static_cast<const verilog_assert_statementt &>(statement);
+}
+
+inline verilog_assert_statementt &
+to_verilog_assert_statement(verilog_statementt &statement)
+{
+  PRECONDITION(statement.id() == ID_assert);
+  binary_exprt::check(statement);
+  return static_cast<verilog_assert_statementt &>(statement);
+}
+
+// Intermediate assumption statements, and SMV-style assumptions.
+class verilog_assume_statementt : public verilog_statementt
+{
+public:
+  verilog_assume_statementt() : verilog_statementt(ID_assume)
+  {
+    operands().resize(2);
+  }
+
+  inline exprt &condition()
+  {
+    return op0();
+  }
+
+  inline const exprt &condition() const
+  {
+    return op0();
+  }
+
+  // The Verilog intermediate assumption does not have an identifier,
+  // but the SMV-style ones do.
+  const irep_idt &identifier() const
+  {
+    return get(ID_identifier);
+  }
+
+  void identifier(irep_idt _identifier)
+  {
+    set(ID_identifier, _identifier);
+  }
+};
+
+inline const verilog_assume_statementt &
+to_verilog_assume_statement(const verilog_statementt &statement)
+{
+  PRECONDITION(statement.id() == ID_assume);
+  binary_exprt::check(statement);
+  return static_cast<const verilog_assume_statementt &>(statement);
+}
+
+inline verilog_assume_statementt &
+to_verilog_assume_statement(verilog_statementt &statement)
+{
+  PRECONDITION(statement.id() == ID_assume);
+  binary_exprt::check(statement);
+  return static_cast<verilog_assume_statementt &>(statement);
 }
 
 class verilog_module_sourcet : public irept

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -1751,14 +1751,8 @@ Function: verilog_synthesist::synth_assert
 \*******************************************************************/
 
 void verilog_synthesist::synth_assert(
-  const verilog_assertt &statement)
+  const verilog_assert_statementt &statement)
 {
-  if(statement.operands().size()!=2)
-  {
-    throw errort().with_location(statement.source_location())
-      << "assert statement expected to have two operands";
-  }
-
   const irep_idt &identifier=statement.get(ID_identifier);
   symbolt &symbol=symbol_table_lookup(identifier);
   
@@ -1807,14 +1801,8 @@ Function: verilog_synthesist::synth_assume
 \*******************************************************************/
 
 void verilog_synthesist::synth_assume(
-  const verilog_assumet &statement)
+  const verilog_assume_statementt &statement)
 {
-  if(statement.operands().size()!=2)
-  {
-    throw errort().with_location(statement.source_location())
-      << "assume statement expected to have two operands";
-  }
-  
   construct=constructt::OTHER;
 
   auto condition = synth_expr(statement.condition(), symbol_statet::CURRENT);
@@ -2537,9 +2525,9 @@ void verilog_synthesist::synth_statement(
       << "synthesis of procedural continuous assignment not supported";
   }
   else if(statement.id()==ID_assert)
-    synth_assert(to_verilog_assert(statement));
+    synth_assert(to_verilog_assert_statement(statement));
   else if(statement.id()==ID_assume)
-    synth_assume(to_verilog_assume(statement));
+    synth_assume(to_verilog_assume_statement(statement));
   else if(statement.id()==ID_non_blocking_assign)
     synth_assign(statement, false);
   else if(statement.id()==ID_force)

--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -239,8 +239,8 @@ protected:
   void synth_repeat(const verilog_repeatt &);
   void synth_function_call_or_task_enable(const verilog_function_callt &);
   void synth_assign(const exprt &, bool blocking);
-  void synth_assert(const verilog_assertt &);
-  void synth_assume(const verilog_assumet &);
+  void synth_assert(const verilog_assert_statementt &);
+  void synth_assume(const verilog_assume_statementt &);
   void synth_prepostincdec(const verilog_statementt &);
   void synth_assignments(transt &);
 

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -150,7 +150,9 @@ protected:
   void convert_procedural_continuous_assign(
     class verilog_procedural_continuous_assignt &);
   void convert_prepostincdec(class verilog_statementt &);
-  
+  void convert_assert(verilog_assert_statementt &);
+  void convert_assume(verilog_assume_statementt &);
+
   // module items
   void convert_decl(class verilog_declt &);
   void convert_function_or_task(class verilog_declt &);
@@ -159,8 +161,8 @@ protected:
   void convert_always(class verilog_alwayst &);
   void convert_initial(class verilog_initialt &);
   void convert_continuous_assign(class verilog_continuous_assignt &);
-  void convert_assert(exprt &statement);
-  void convert_assume(exprt &statement);
+  void convert_assert(verilog_assert_module_itemt &);
+  void convert_assume(verilog_assume_module_itemt &);
   void check_lhs(const exprt &lhs, vassignt vassign);
   void convert_assignments(exprt &trans);
   void convert_module_item(class verilog_module_itemt &);


### PR DESCRIPTION
SystemVerilog assertions and assumptions can be module items (called concurrent assertions/assumptions) or statements.  While the syntax for the two variants is similar, there are differences.  This commit splits the ireps for the two variants.