### PR TITLE
Verilog: KNOWNBUG test for global-scoped typedefs

### DIFF
--- a/regression/verilog/typedef/global_typedef.desc
+++ b/regression/verilog/typedef/global_typedef.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+global_typedef.sv
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Global typedefs must be added to the symbol table.

--- a/regression/verilog/typedef/global_typedef.sv
+++ b/regression/verilog/typedef/global_typedef.sv
@@ -1,0 +1,24 @@
+// The VIS model checker accepts global-scoped typedefs as an extension of
+// Verilog. These are at the top-level scope, which is not permitted by
+// SystemVerilog.  It is not clear whether these are file-local or not.
+
+typedef bit [31:0] some_word_type;
+
+module sub(data_in, data_out);
+  input some_word_type data_in;
+  output some_word_type data_out;
+
+  // just echo it back
+  always @data_in data_out = data_in;
+
+endmodule
+
+module main;
+
+   wire some_word_type data_in, data_out;
+
+   sub s(data_in, data_out);
+
+   p0: assert property (data_in == data_out);
+
+endmodule


### PR DESCRIPTION
These are an extension used by the VIS model checker, and are not supported by SystemVerilog.