### PR TITLE
Verilog: parse tree now stores package_items

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -591,6 +591,7 @@ description:
  	| program_declaration
  	| package_declaration
 	| attribute_instance_brace package_item
+		{ PARSER.parse_tree.create_package_item(stack_expr($2)); }
  	| attribute_instance_brace bind_directive
  	| config_declaration
         ;

--- a/src/verilog/verilog_parse_tree.cpp
+++ b/src/verilog/verilog_parse_tree.cpp
@@ -29,10 +29,8 @@ void verilog_parse_treet::create_module(
   exprt &ports,
   exprt &module_items)
 {
-  items.push_back(itemt());
+  items.push_back(itemt(itemt::MODULE));
   itemt &item=items.back();
-  
-  item.type=itemt::MODULE;
 
   verilog_modulet &new_module=item.verilog_module;
 
@@ -135,9 +133,10 @@ void verilog_parse_treet::itemt::show(std::ostream &out) const
   case itemt::MODULE:
     verilog_module.show(out);
     break;
-    
-  case itemt::TYPEDEF:
-    verilog_typedef.show(out);
+
+  case itemt::PACKAGE_ITEM:
+    out << "Package item:\n";
+    out << verilog_package_item.pretty() << '\n';
     break;
     
   default:

--- a/src/verilog/verilog_parse_tree.h
+++ b/src/verilog/verilog_parse_tree.h
@@ -27,37 +27,32 @@ public:
 
   verilog_standardt standard;
 
-  class verilog_typedeft
-  {
-  public:
-    typet symbol;
-    typet type;
-    
-    void show(std::ostream &out) const
-    {
-      out << "Typedef:\n";
-      out << "\n";
-    }
-  };
-
   struct itemt
   {
   public:
-    typedef enum { MODULE, TYPEDEF } item_typet;
+    typedef enum
+    {
+      MODULE,
+      PACKAGE_ITEM
+    } item_typet;
     item_typet type;
-    
+
+    explicit itemt(item_typet __type) : type(__type)
+    {
+    }
+
     verilog_modulet verilog_module;
-    
-    verilog_typedeft verilog_typedef;
-    
+
+    exprt verilog_package_item;
+
     bool is_module() const
     {
       return type==MODULE;
     }
 
-    bool is_typedef() const
+    bool is_package_item() const
     {
-      return type==TYPEDEF;
+      return type == PACKAGE_ITEM;
     }
     
     void show(std::ostream &out) const;
@@ -88,12 +83,10 @@ public:
     exprt &ports,
     exprt &statements);
 
-  void create_typedef(irept &declaration)
+  void create_package_item(exprt package_item)
   {
-    items.push_back(itemt());
-    items.back().type=itemt::TYPEDEF;
-    items.back().verilog_typedef.symbol.swap(declaration.get_sub()[0]);
-    items.back().verilog_typedef.type.swap(declaration.add(ID_type));
+    items.push_back(itemt(itemt::PACKAGE_ITEM));
+    items.back().verilog_package_item = std::move(package_item);
   }
   
   void swap(verilog_parse_treet &parse_tree)


### PR DESCRIPTION
SystemVerilog allows any `package_item` at the top level of the file.  This extends the parse tree to store these, generalising from typedefs, which are package_items.