### PR TITLE
Verilog: KNOWNBUG test for a wire with binary data type

### DIFF
--- a/regression/verilog/data-types/wire_must_be_fourvalued.desc
+++ b/regression/verilog/data-types/wire_must_be_fourvalued.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+wire_must_be_fourvalued.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Verilog wires must be four-valued.

--- a/regression/verilog/data-types/wire_must_be_fourvalued.sv
+++ b/regression/verilog/data-types/wire_must_be_fourvalued.sv
@@ -1,0 +1,4 @@
+module top;
+  // error: wires must have a four-valued data type
+  wire bit some_wire;
+endmodule


### PR DESCRIPTION
SystemVerilog requires wires to have four-valued data types.  We must error when given a binary data type.