### PR TITLE
Verilog: use `errort()` instead of `throw 0`

### DIFF
--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -433,10 +433,8 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
 
         if(osymbol.type.id() == ID_code)
         {
-          error().source_location = decl.source_location();
-          error() << "symbol `" << symbol.base_name << "' is already declared"
-                  << eom;
-          throw 0;
+          throw errort().with_location(decl.source_location())
+            << "symbol `" << symbol.base_name << "' is already declared";
         }
 
         // change of type?
@@ -895,9 +893,7 @@ void verilog_typecheckt::elaborate_symbol_rec(irep_idt identifier)
   }
   else if(symbol.type.id() == ID_elaborating)
   {
-    error().source_location = symbol.location;
-    error() << "cyclic dependency when elaborating " << symbol.display_name()
-            << eom;
-    throw 0;
+    throw errort().with_location(symbol.location)
+      << "cyclic dependency when elaborating " << symbol.display_name();
   }
 }

--- a/src/verilog/verilog_generate.cpp
+++ b/src/verilog/verilog_generate.cpp
@@ -135,9 +135,8 @@ void verilog_typecheckt::elaborate_generate_if(
   if(statement.operands().size()!=3 &&
      statement.operands().size()!=2)
   {
-    error().source_location = statement.source_location();
-    error() << "generate_if expects two or three operands" << eom;
-    throw 0;
+    throw errort().with_location(statement.source_location())
+      << "generate_if expects two or three operands";
   }
 
   mp_integer condition =
@@ -172,9 +171,8 @@ void verilog_typecheckt::elaborate_generate_assign(
 {
   if(statement.lhs().id() != ID_symbol)
   {
-    error().source_location = statement.lhs().source_location();
-    error() << "expected symbol on left hand side of assignment" << eom;
-    throw 0;
+    throw errort().with_location(statement.lhs().source_location())
+      << "expected symbol on left hand side of assignment";
   }
 
   const irep_idt &identifier = to_symbol_expr(statement.lhs()).get_identifier();
@@ -183,18 +181,16 @@ void verilog_typecheckt::elaborate_generate_assign(
   
   if(it==genvars.end())
   {
-    error().source_location = statement.lhs().source_location();
-    error() << "expected genvar on left hand side of assignment" << eom;
-    throw 0;
+    throw errort().with_location(statement.lhs().source_location())
+      << "expected genvar on left hand side of assignment";
   }
 
   mp_integer rhs = convert_integer_constant_expression(statement.rhs());
 
   if(rhs<0)
   {
-    error().source_location = statement.rhs().source_location();
-    error() << "must not assign negative value to genvar" << eom;
-    throw 0;
+    throw errort().with_location(statement.rhs().source_location())
+      << "must not assign negative value to genvar";
   }
   
   it->second=rhs;
@@ -222,9 +218,8 @@ exprt verilog_typecheckt::generate_for_loop_index(
   }
   else
   {
-    error().source_location = initialization_statement.source_location();
-    error() << "failed to determine generate loop index" << eom;
-    throw 0;
+    throw errort().with_location(initialization_statement.source_location())
+      << "failed to determine generate loop index";
   }
 }
 

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -121,10 +121,8 @@ void verilog_typecheckt::check_module_ports(
     if(symbol.is_input || symbol.is_output)
       if(port_names.find(symbol.base_name)==port_names.end())
       {
-        error().source_location=symbol.location;
-        error() << "port `" << symbol.base_name
-                << "' not in port list" << eom;
-        throw 0;
+        throw errort().with_location(symbol.location)
+          << "port `" << symbol.base_name << "' not in port list";
       }
   }
 }
@@ -190,11 +188,9 @@ void verilog_typecheckt::interface_inst(
 
   if(symbol_table.add(symbol))
   {
-    error().source_location = op.source_location();
-    error() << "duplicate definition of identifier `" 
-            << symbol.base_name << "' in module `"
-            << module_symbol.base_name << '\'' << eom;
-    throw 0;
+    throw errort().with_location(op.source_location())
+      << "duplicate definition of identifier `" << symbol.base_name
+      << "' in module `" << module_symbol.base_name << '\'';
   }
 }
 
@@ -316,8 +312,8 @@ void verilog_typecheckt::interface_statement(
   {
     if(statement.operands().size()!=2)
     {
-      error() << "event_guard expected to have two operands" << eom;
-      throw 0;
+      throw errort().with_location(statement.source_location())
+        << "event_guard expected to have two operands";
     }
 
     interface_statement(
@@ -327,8 +323,8 @@ void verilog_typecheckt::interface_statement(
   {
     if(statement.operands().size()!=2)
     {
-      error() << "delay expected to have two operands" << eom;
-      throw 0;
+      throw errort().with_location(statement.source_location())
+        << "delay expected to have two operands";
     }
 
     interface_statement(
@@ -382,11 +378,9 @@ void verilog_typecheckt::interface_block(
 
     if(symbol_table.add(symbol))
     {
-      error().source_location = statement.source_location();
-      error() << "duplicate definition of identifier `" 
-              << symbol.base_name << "' in module `"
-              << module_symbol.base_name << '\'' << eom;
-      throw 0;
+      throw errort().with_location(statement.source_location())
+        << "duplicate definition of identifier `" << symbol.base_name
+        << "' in module `" << module_symbol.base_name << '\'';
     }
 
     enter_named_block(base_name);

--- a/src/verilog/verilog_interpreter.cpp
+++ b/src/verilog/verilog_interpreter.cpp
@@ -34,9 +34,8 @@ void verilog_typecheckt::verilog_interpreter(
     exprt rhs = elaborate_constant_expression(assign.rhs());
     if(!rhs.is_constant())
     {
-      error().source_location=assign.rhs().source_location();
-      error() << "right-hand side of assignment is not constant" << eom;
-      throw 0;
+      throw errort().with_location(assign.rhs().source_location())
+        << "right-hand side of assignment is not constant";
     }
 
     if(assign.lhs().id()==ID_symbol)
@@ -76,9 +75,8 @@ void verilog_typecheckt::verilog_interpreter(
 
         if(to_integer_non_constant(cond, cond_i))
         {
-          error().source_location=verilog_for.source_location();
-          error() << "for condition is not constant: " << cond.pretty() << eom;
-          throw 0;
+          throw errort().with_location(verilog_for.source_location())
+            << "for condition is not constant: " << cond.pretty();
         }
 
         if(cond_i==0) break;
@@ -90,9 +88,7 @@ void verilog_typecheckt::verilog_interpreter(
   }
   else
   {
-    error().source_location=statement.source_location();
-    error() << "Don't know how to interpret statement `"
-            << statement.id() << '\'' << eom;
-    throw 0;
+    throw errort().with_location(statement.source_location())
+      << "Don't know how to interpret statement `" << statement.id() << '\'';
   }
 }

--- a/src/verilog/verilog_parameterize_module.cpp
+++ b/src/verilog/verilog_parameterize_module.cpp
@@ -129,9 +129,8 @@ std::list<exprt> verilog_typecheckt::get_parameter_values(
 
     if(p_it!=parameter_assignment.end())
     {
-      error().source_location = p_it->source_location();
-      error() << "too many parameter assignments" << eom;
-      throw 0;
+      throw errort().with_location(p_it->source_location())
+        << "too many parameter assignments";
     }
   }
   
@@ -218,12 +217,8 @@ irep_idt verilog_typecheckt::parameterize_module(
     symbol_table.symbols.find(module_identifier);
   
   if(it==symbol_table.symbols.end())
-  {
-    error().source_location=location;
-    error() << "module not found" << eom;
-    throw 0;
-  }
-  
+    throw errort().with_location(location) << "module not found";
+
   const symbolt &base_symbol=it->second;
 
   auto parameter_values = get_parameter_values(
@@ -249,10 +244,9 @@ irep_idt verilog_typecheckt::parameterize_module(
       mp_integer i;
       if(to_integer_non_constant(pv, i))
       {
-        error().source_location = pv.source_location();
-        error() << "parameter value expected to be constant, but got `"
-                << to_string(pv) << "'" << eom;
-        throw 0;
+        throw errort().with_location(pv.source_location())
+          << "parameter value expected to be constant, but got `"
+          << to_string(pv) << "'";
       }
       else
         suffix += integer2string(i);
@@ -288,10 +282,8 @@ irep_idt verilog_typecheckt::parameterize_module(
 
   if(symbol_table.move(symbol, new_symbol))
   {
-    error().source_location=location;
-    error() << "duplicate definition of parameterized module "
-            << symbol.base_name << eom;
-    throw 0;
+    throw errort().with_location(location)
+      << "duplicate definition of parameterized module " << symbol.base_name;
   }
 
   // recursive call

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1821,7 +1821,7 @@ bool verilog_typecheck(
     messaget message(message_handler);
     message.error() << "duplicate definition of module " 
                     << symbol.base_name << messaget::eom;
-    throw 0;
+    return true;
   }
 
   verilog_typecheckt verilog_typecheck(*new_symbol, symbol_table, message_handler);

--- a/src/verilog/verilog_typecheck_base.cpp
+++ b/src/verilog/verilog_typecheck_base.cpp
@@ -122,8 +122,8 @@ mp_integer verilog_typecheck_baset::array_size(const array_typet &type)
 
   if(!size_opt.has_value())
   {
-    error() << "failed to get array size of array type" << eom;
-    throw 0;
+    throw errort().with_location(type.source_location())
+      << "failed to get array size of array type";
   }
 
   return size_opt.value();
@@ -148,9 +148,8 @@ mp_integer verilog_typecheck_baset::array_offset(const array_typet &type)
   if(to_integer_non_constant(
        static_cast<const exprt &>(type.find(ID_offset)), offset))
   {
-    error() << "failed to get array offset of type `"
-            << type.id() << '\'' << eom;
-    throw 0;
+    throw errort().with_location(type.source_location())
+      << "failed to get array offset of type `" << type.id() << '\'';
   }
 
   return offset;
@@ -194,9 +193,8 @@ std::size_t verilog_typecheck_baset::get_width(const typet &type)
   else if(type.id() == ID_verilog_time)
     return 64;
 
-  error() << "type `" << type.id() << "' has unknown width"
-          << eom;
-  throw 0;
+  throw errort().with_location(type.source_location())
+    << "type `" << type.id() << "' has unknown width";
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_typecheck_type.cpp
+++ b/src/verilog/verilog_typecheck_type.cpp
@@ -182,8 +182,7 @@ typet verilog_typecheck_exprt::convert_type(const typet &src)
   }
   else
   {
-    error().source_location = source_location;
-    error() << "unexpected type: `" << src.id() << "'" << eom;
-    throw 0;
+    throw errort().with_location(source_location)
+      << "unexpected type: `" << src.id() << "'";
   }
 }


### PR DESCRIPTION
This replaces instances of `throw 0` by `errort()`.