### PR TITLE
Verilog: localparam parameter ports

### DIFF
--- a/regression/verilog/modules/parameter_ports3.desc
+++ b/regression/verilog/modules/parameter_ports3.desc
@@ -1,0 +1,7 @@
+CORE
+parameter_ports3.v
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+The type of the parameter needs to be processed.

--- a/regression/verilog/modules/parameter_ports3.v
+++ b/regression/verilog/modules/parameter_ports3.v
@@ -1,0 +1,11 @@
+module sub #(parameter p = 1, localparam derived = p+1)();
+
+  always assert p1: derived == 124;
+
+endmodule
+
+module main;
+
+  sub #(123) submodule();
+
+endmodule // main

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1537,6 +1537,8 @@ list_of_variable_identifiers:
 parameter_port_declaration:
           TOK_PARAMETER data_type_or_implicit param_assignment
 		{ $$ = $3; }
+	| TOK_LOCALPARAM data_type_or_implicit param_assignment
+		{ $$ = $3; }
 	| data_type param_assignment
 		{ $$ = $2; }
 	| param_assignment


### PR DESCRIPTION
This adds support for `localparam` parameter ports.