### PR TITLE
Verilog: extend tests for module ports

### DIFF
--- a/regression/verilog/modules/input_and_wire.desc
+++ b/regression/verilog/modules/input_and_wire.desc
@@ -1,0 +1,7 @@
+CORE
+input_and_wire.v
+--module M1
+^no properties$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/verilog/modules/input_and_wire.v
+++ b/regression/verilog/modules/input_and_wire.v
@@ -1,13 +1,13 @@
 module M1(some_port);
-  output [31:0] some_port;
+  input [31:0] some_port;
   wire [31:0] some_port;
 endmodule
 
 module M2(some_port);
   // order flipped
+  input [31:0] some_port;
   wire [31:0] some_port;
-  output [31:0] some_port;
 endmodule
 
-module M3(output wire [31:0] some_port);
+module M3(input wire [31:0] some_port);
 endmodule


### PR DESCRIPTION
This adds tests for `input wire` ports, and for ANSI-style `output wire` ports.