### PR TITLE
Verilog: parameter_value_assignment is optional

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2212,18 +2212,24 @@ name_of_gate_instance: TOK_NON_TYPE_IDENTIFIER;
 // A.4.1.1 Module instantiation
 
 module_instantiation:
-	  module_identifier param_value_assign_opt module_instance_brace ';'
+	  module_identifier parameter_value_assignment_opt module_instance_brace ';'
 		{ init($$, ID_inst);
                   addswap($$, ID_module, $1);
 		  addswap($$, ID_parameter_assignments, $2);
                   swapop($$, $3); }
 	;
 
-param_value_assign_opt:
+parameter_value_assignment_opt:
 	  /* Optional */
 		{ make_nil($$); }
-	| '#' '(' list_of_parameter_assignments ')'
+	| '#' '(' list_of_parameter_assignments_opt ')'
 		{ $$ = $3; }
+	;
+
+list_of_parameter_assignments_opt:
+	  /* Optional */
+		{ make_nil($$); }
+	| list_of_parameter_assignments
 	;
 
 list_of_parameter_assignments:


### PR DESCRIPTION
This renames the rule to match SystemVerilog 1800-2017, and makes it optional, as in the standard.