### PR TITLE
Verilog: `get_width` now returns `mp_integer`

### DIFF
--- a/src/verilog/verilog_typecheck_base.cpp
+++ b/src/verilog/verilog_typecheck_base.cpp
@@ -167,7 +167,7 @@ Function: verilog_typecheck_baset::get_width
 
 \*******************************************************************/
 
-std::size_t verilog_typecheck_baset::get_width(const typet &type)
+mp_integer verilog_typecheck_baset::get_width(const typet &type)
 {
   if(type.id()==ID_bool)
     return 1;
@@ -188,7 +188,7 @@ std::size_t verilog_typecheck_baset::get_width(const typet &type)
     mp_integer sum = 0;
     for(auto &component : to_struct_type(type).components())
       sum += get_width(component.type());
-    return sum.to_ulong();
+    return sum;
   }
 
   if(type.id() == ID_verilog_shortint)

--- a/src/verilog/verilog_typecheck_base.h
+++ b/src/verilog/verilog_typecheck_base.h
@@ -38,9 +38,12 @@ public:
 protected:
   const namespacet &ns;
   const irep_idt mode;
-  
-  std::size_t get_width(const exprt &expr) { return get_width(expr.type()); }
-  std::size_t get_width(const typet &type);
+
+  mp_integer get_width(const exprt &expr)
+  {
+    return get_width(expr.type());
+  }
+  mp_integer get_width(const typet &type);
   mp_integer array_size(const array_typet &);
   mp_integer array_offset(const array_typet &);
   typet index_type(const array_typet &);

--- a/src/verilog/verilog_types.h
+++ b/src/verilog/verilog_types.h
@@ -65,7 +65,8 @@ public:
   {
   }
 
-  explicit inline verilog_signedbv_typet(unsigned width):bitvector_typet(ID_verilog_signedbv, width)
+  explicit inline verilog_signedbv_typet(std::size_t width)
+    : bitvector_typet(ID_verilog_signedbv, width)
   {
   }
 };
@@ -102,7 +103,8 @@ public:
   {
   }
 
-  explicit inline verilog_unsignedbv_typet(unsigned width):bitvector_typet(ID_verilog_unsignedbv, width)
+  explicit inline verilog_unsignedbv_typet(std::size_t width)
+    : bitvector_typet(ID_verilog_unsignedbv, width)
   {
   }
 };


### PR DESCRIPTION
This avoids checking for overflows when adding up widths.