### PR TITLE
Verilog: helper to merge declaration and declarator type

### DIFF
--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -25,8 +25,6 @@ void verilog_typecheckt::collect_port_symbols(const verilog_declt &decl)
   const irep_idt &base_name = declarator.base_name();
   const irep_idt &port_class = decl.get_class();
 
-  auto type = convert_type(decl.type());
-
   irep_idt identifier = hierarchical_identifier(base_name);
 
   if(port_class.empty())
@@ -36,18 +34,9 @@ void verilog_typecheckt::collect_port_symbols(const verilog_declt &decl)
   else
   {
     // add the symbol
-    typet final_type;
-    if(declarator.type().is_nil())
-      final_type = type;
-    else if(declarator.type().id() == ID_verilog_unpacked_array)
-      final_type = unpacked_array_type(declarator.type(), type);
-    else
-    {
-      throw errort().with_location(declarator.source_location())
-        << "unexpected type on declarator";
-    }
+    typet type = convert_type(declarator.merged_type(decl.type()));
 
-    symbolt new_symbol(identifier, final_type, mode);
+    symbolt new_symbol{identifier, type, mode};
 
     if(port_class == ID_input)
     {
@@ -208,8 +197,6 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
       symbol.module = module_identifier;
       symbol.value.make_nil();
 
-      auto type = convert_type(decl.type());
-
       if(decl_class == ID_input)
         symbol.is_input = true;
       else if(decl_class == ID_output)
@@ -232,16 +219,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
 
         symbol.base_name = declarator.base_name();
         symbol.location = declarator.source_location();
-
-        if(declarator.type().is_nil())
-          symbol.type = type;
-        else if(declarator.type().id() == ID_verilog_unpacked_array)
-          symbol.type = unpacked_array_type(declarator.type(), type);
-        else
-        {
-          throw errort().with_location(declarator.source_location())
-            << "unexpected type on declarator";
-        }
+        symbol.type = convert_type(declarator.merged_type(decl.type()));
 
         if(symbol.base_name.empty())
         {
@@ -293,8 +271,6 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
       symbol.module = module_identifier;
       symbol.value.make_nil();
 
-      auto type = convert_type(decl.type());
-
       symbol.is_state_var = true;
 
       if(decl_class == ID_input)
@@ -328,18 +304,8 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
             << "empty symbol name";
         }
 
-        if(declarator.type().is_nil())
-          symbol.type = type;
-        else if(declarator.type().id() == ID_verilog_unpacked_array)
-          symbol.type = unpacked_array_type(declarator.type(), type);
-        else
-        {
-          throw errort().with_location(declarator.source_location())
-            << "unexpected type on declarator";
-        }
-
+        symbol.type = convert_type(declarator.merged_type(decl.type()));
         symbol.name = hierarchical_identifier(symbol.base_name);
-
         symbol.pretty_name = strip_verilog_prefix(symbol.name);
 
         if(input || output)
@@ -411,24 +377,13 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
     symbol.module = module_identifier;
     symbol.value = nil_exprt();
 
-    auto type = convert_type(decl.type());
-
     for(auto &declarator : decl.declarators())
     {
       DATA_INVARIANT(declarator.id() == ID_declarator, "must have declarator");
 
       symbol.base_name = declarator.base_name();
       symbol.location = declarator.source_location();
-
-      if(declarator.type().is_nil())
-        symbol.type = type;
-      else if(declarator.type().id() == ID_verilog_unpacked_array)
-        symbol.type = unpacked_array_type(declarator.type(), type);
-      else
-      {
-        throw errort().with_location(symbol.location)
-          << "unexpected type on declarator";
-      }
+      symbol.type = convert_type(declarator.merged_type(decl.type()));
 
       if(symbol.base_name.empty())
       {
@@ -478,24 +433,13 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
     symbol.value = nil_exprt();
     symbol.is_state_var = true;
 
-    auto type = convert_type(decl.type());
-
     for(auto &declarator : decl.declarators())
     {
       DATA_INVARIANT(declarator.id() == ID_declarator, "must have declarator");
 
       symbol.base_name = declarator.base_name();
       symbol.location = declarator.source_location();
-
-      if(declarator.type().is_nil())
-        symbol.type = type;
-      else if(declarator.type().id() == ID_verilog_unpacked_array)
-        symbol.type = unpacked_array_type(declarator.type(), type);
-      else
-      {
-        throw errort().with_location(symbol.location)
-          << "unexpected type on declarator";
-      }
+      symbol.type = convert_type(declarator.merged_type(decl.type()));
 
       if(symbol.base_name.empty())
       {

--- a/src/verilog/verilog_expr.cpp
+++ b/src/verilog/verilog_expr.cpp
@@ -10,6 +10,20 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/prefix.h>
 
+typet verilog_declaratort::merged_type(const typet &declaration_type) const
+{
+  typet result = type();
+  typet *p = &result;
+
+  while(p->id() == ID_verilog_unpacked_array)
+    p = &to_type_with_subtype(*p).subtype();
+
+  DATA_INVARIANT(p->is_nil(), "merged_type only works on unpacked arrays");
+  *p = declaration_type;
+
+  return result;
+}
+
 bool function_call_exprt::is_system_function_call() const
 {
   return function().id() == ID_symbol &&

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -452,6 +452,10 @@ public:
     return symbol_exprt(identifier(), type())
       .with_source_location<symbol_exprt>(*this);
   }
+
+  // Helper to merge the declarator's unpacked array type
+  // with the declaration type.
+  typet merged_type(const typet &declaration_type) const;
 };
 
 using verilog_declaratorst = std::vector<verilog_declaratort>;

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -64,7 +64,7 @@ protected:
 
   typet convert_type(const typet &);
   typet convert_enum(const class verilog_enum_typet &);
-  array_typet unpacked_array_type(const typet &src, const typet &element_type);
+  array_typet convert_unpacked_array_type(const type_with_subtypet &);
 
   void convert_range(
     const exprt &range,


### PR DESCRIPTION
This removes the duplication of the code that merges the declarator type (an unpacked array type) with the type in the declaration by introducing a helper method.