### PR TITLE
ebmc: KNOWNBUG test for a bounded sequence expression

### DIFF
--- a/regression/verilog/SVA/sequence1.desc
+++ b/regression/verilog/SVA/sequence1.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+sequence1.sv
+--bound 20 --numbered-trace
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The trace shown only has one state, but 10 are expected.

--- a/regression/verilog/SVA/sequence1.sv
+++ b/regression/verilog/SVA/sequence1.sv
@@ -1,0 +1,14 @@
+module main;
+
+  reg [31:0] x;
+  wire clk;
+
+  initial x=0;
+
+  always @(posedge clk)
+    x<=x+1;
+
+  // fails, and we want to see a trace 0...9
+  initial p0: assert property (##[0:9] x==100);
+
+endmodule


### PR DESCRIPTION
This adds a test that triggers a case where too few states are shown in the counterexample.