### PR TITLE
fixup for #432

### DIFF
--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1592,7 +1592,6 @@ void verilog_typecheck_exprt::implicit_typecast(
       return;
     }
   }
-#if 0
   else if(src_type.id() == ID_natural)
   {
     if(dest_type.id()==ID_integer)
@@ -1601,7 +1600,6 @@ void verilog_typecheck_exprt::implicit_typecast(
       return;
     }
   }
-#endif
   else if(
     src_type.id() == ID_bool || src_type.id() == ID_unsignedbv ||
     src_type.id() == ID_signedbv || src_type.id() == ID_verilog_unsignedbv ||


### PR DESCRIPTION
This restores code accidentally commented out in
4b56ef0ed71fba918d0db55f69dab80df8f268f7.