### PR TITLE
README.md: update example to use SystemVerilog

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,9 @@ For full information see [cprover.org](http://www.cprover.org/ebmc/).
 Usage
 =====
 
-Let us assume we have the following Verilog code in `main.v`.
+Let us assume we have the following SystemVerilog code in `main.sv`.
 
-```main.v
-
+```main.sv
 module main(input clk, x, y);
 
   reg [1:0] cnt1;
@@ -36,15 +35,14 @@ module main(input clk, x, y);
       2'b1?: z=1;
     endcase
 
-  always assert p1: z==0;
+  p1: assert property (@(posedge clk) (z==0));
 
 endmodule
-
 ```
 
 Then we can run the EBMC verification as
 
-`$> ebmc main.v --module main --bound 3`
+`$> ebmc main.sv --module main --bound 3`
 
 setting the unwinding bound to `3` and running the verification of the module `main`.
 


### PR DESCRIPTION
This updates the example in `README.md` from Verilog to SystemVerilog.  In particular, a SystemVerilog assertion is used, instead of the nonstandard syntax extension to Verilog.