### PR TITLE
SystemVerilog: no parentheses for clocking_event property_expr

### DIFF
--- a/regression/verilog/SVA/system_verilog_assertion2.sv
+++ b/regression/verilog/SVA/system_verilog_assertion2.sv
@@ -7,8 +7,6 @@ module main();
   
   always @(posedge clk) x<=x+1;
 
-  my_label: assert property (x!=10);
-
-  //assert property (@(posedge clk) x!=10);
+  my_label: assert property (@(posedge clk) x!=10);
 
 endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -525,6 +525,7 @@ int yyverilogerror(const char *error)
 // whereas the table gives them in decreasing order.
 // The precendence of the assertion operators is lower than
 // those in Table 11-2.
+%nonassoc "property_expr_event_control" // @(...) property_expr
 %nonassoc "always" "s_always" "eventually" "s_eventually"
 %nonassoc "accept_on" "reject_on"
 %nonassoc "sync_accept_on" "sync_reject_on"
@@ -2002,7 +2003,7 @@ property_expr_proper:
         | "reject_on" '(' expression_or_dist ')'      { init($$, "sva_reject_on"); mto($$, $3); }
         | "sync_accept_on" '(' expression_or_dist ')' { init($$, "sva_sync_accept_on"); mto($$, $3); }
         | "sync_reject_on" '(' expression_or_dist ')' { init($$, "sva_sync_reject_on"); mto($$, $3); }
-        | event_control '(' property_expr ')' { $$=$3; }
+        | event_control property_expr { $$=$2; } %prec "property_expr_event_control"
         ;
 
 sequence_expr:


### PR DESCRIPTION
SystemVerilog does not require parentheses around the `property_expr` when preceding that with a `clocking_event`.

The `clocking_event` is believed to bind more weakly than any of the `property_expr` operators.