### PR TITLE
Verilog: fix for file in subdirectory with local include

### DIFF
--- a/regression/verilog/preprocessor/in_subdir.desc
+++ b/regression/verilog/preprocessor/in_subdir.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+subdir/in_subdir.v
+--preprocess
+^EXIT=0$
+^SIGNAL=0$
+--
+include file in subdirectory not found

--- a/regression/verilog/preprocessor/in_subdir.desc
+++ b/regression/verilog/preprocessor/in_subdir.desc
@@ -1,7 +1,7 @@
-KNOWNBUG
+CORE
 subdir/in_subdir.v
 --preprocess
+`line 1 "subdir/include_file\.vh" 1
 ^EXIT=0$
 ^SIGNAL=0$
 --
-include file in subdirectory not found

--- a/regression/verilog/preprocessor/include2.desc
+++ b/regression/verilog/preprocessor/include2.desc
@@ -4,7 +4,7 @@ include2.v
 // Enable multi-line checking
 activate-multi-line-match
 `line 1 "include2\.v" 0
-`line 1 "include_file\.vh" 1
+`line 1 "subdir/include_file\.vh" 1
 
 `line 2 "include2\.v" 2
 ^EXIT=0$

--- a/regression/verilog/preprocessor/subdir/in_subdir.v
+++ b/regression/verilog/preprocessor/subdir/in_subdir.v
@@ -1,0 +1,1 @@
+`include "include_file.vh"

--- a/src/verilog/verilog_preprocessor.h
+++ b/src/verilog/verilog_preprocessor.h
@@ -44,8 +44,10 @@ protected:
   definest defines;
 
   void directive();
-  std::string
-  find_include_file(const std::string &filename, bool include_paths_only);
+  std::string find_include_file(
+    const std::string &including_file,
+    const std::string &given_filename,
+    bool include_paths_only);
   definet::parameterst parse_define_parameters();
 
   using define_argumentst = std::map<std::string, std::vector<tokent>>;


### PR DESCRIPTION
This adds a KNOWNBUG test for the case where a Verilog file is in a subdirectory and a local include is in the same subdirectory.