### PR TITLE
Verilog: allow whitespace between macro and arguments

### DIFF
--- a/regression/verilog/preprocessor/define1.desc
+++ b/regression/verilog/preprocessor/define1.desc
@@ -13,6 +13,7 @@ value
 
 x-y-z
 x-y-value
+moo-foo-bar
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/preprocessor/define1.v
+++ b/regression/verilog/preprocessor/define1.v
@@ -7,3 +7,6 @@
 `define with_parameter(a, b, c) a-b-c
 `with_parameter(x, y, z)
 `with_parameter(x, y, `with_value)
+`with_parameter (moo, foo, bar)
+`define no_parameter (1+2)
+`no_parameter

--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -277,6 +277,9 @@ auto verilog_preprocessort::parse_define_arguments(const definet &define)
   if(define.parameters.empty())
     return {};
 
+  // skip whitespace
+  tokenizer().skip_ws();
+
   if(tokenizer().next_token() != '(')
     throw verilog_preprocessor_errort() << "expecting define arguments";
 
@@ -362,11 +365,10 @@ void verilog_preprocessort::directive()
     auto &identifier = identifier_token.text;
     auto &define = defines[identifier];
 
-    // skip whitespace
-    tokenizer().skip_ws();
-
     // Is there a parameter list?
     // These have been introduced in Verilog 2001.
+    // 1800-2017: "The left parenthesis shall follow the text macro name
+    // immediately, with no space in between."
     if(tokenizer().peek() == '(')
       define.parameters = parse_define_parameters();
 


### PR DESCRIPTION
Verilog allows whitespace between the macro identifier and the parentheses.