### PR TITLE
Verilog: double-backtick

### DIFF
--- a/regression/verilog/preprocessor/double_backtick1.desc
+++ b/regression/verilog/preprocessor/double_backtick1.desc
@@ -1,0 +1,12 @@
+CORE
+double_backtick1.sv
+--preprocess
+// Enable multi-line checking
+activate-multi-line-match
+`line 1 "double_backtick1.sv" 0
+
+foobar_else
+^EXIT=0$
+^SIGNAL=0$
+--
+^PREPROCESSING FAILED$

--- a/regression/verilog/preprocessor/double_backtick1.sv
+++ b/regression/verilog/preprocessor/double_backtick1.sv
@@ -1,0 +1,2 @@
+`define something foobar
+`something``_else

--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -342,8 +342,17 @@ Function: verilog_preprocessort::directive
 
 void verilog_preprocessort::directive()
 {
-  // we expect an identifier after the backtick
+  // After the backtick we expect:
+  // 1) an identifier
+  // 2) another backtick (double backtick)
   const auto directive_token = tokenizer().next_token();
+
+  // Double backtick?
+  if(directive_token == '`')
+  {
+    // these simply separate tokens -- do not emit anything
+    return;
+  }
 
   if(!directive_token.is_identifier())
     throw verilog_preprocessor_errort()


### PR DESCRIPTION
This adds the double-backtick to the Verilog preprocessor.