### PR TITLE
SMV netlist output now includes temporal logic properties

### DIFF
--- a/regression/ebmc/BDD/BDD_SVA1.desc
+++ b/regression/ebmc/BDD/BDD_SVA1.desc
@@ -6,7 +6,7 @@ BDD_SVA1.sv
 ^\[top\.property\.p0\] always top\.my_bit: PROVED$
 ^\[top\.property\.p1\] always top\.my_bit: PROVED$
 ^\[top\.property\.p2\] always \(top\.counter == 3 \|-> \(nexttime top\.counter == 4\)\): FAILURE: property not supported by BDD engine$
-^\[top\.property\.p3\] always \(top\.counter == 3 \|=> top\.counter == 4\): PROVED$
+^\[top\.property\.p3\] always \(top\.counter == 3 \|=> top\.counter == 4\): FAILURE: property not supported by BDD engine$
 ^\[top\.property\.p4\] always \(top\.counter == 3 \|=> \(nexttime top\.counter == 5\)\): FAILURE: property not supported by BDD engine$
 ^\[top\.property\.p5\] always s_eventually top\.counter == 8: PROVED$
 ^\[top\.property\.p6\] always \(top\.counter == 0 \|-> \(s_eventually top\.counter == 8\)\): FAILURE: property not supported by BDD engine$

--- a/src/temporal-logic/temporal_logic.cpp
+++ b/src/temporal-logic/temporal_logic.cpp
@@ -19,6 +19,7 @@ bool is_temporal_operator(const exprt &expr)
          expr.id() == ID_X || expr.id() == ID_sva_always ||
          expr.id() == ID_sva_always || expr.id() == ID_sva_ranged_always ||
          expr.id() == ID_sva_nexttime || expr.id() == ID_sva_s_nexttime ||
+         expr.id() == ID_sva_non_overlapped_implication ||
          expr.id() == ID_sva_until || expr.id() == ID_sva_s_until ||
          expr.id() == ID_sva_until_with || expr.id() == ID_sva_s_until_with ||
          expr.id() == ID_sva_eventually || expr.id() == ID_sva_s_eventually ||

--- a/src/trans-netlist/netlist.cpp
+++ b/src/trans-netlist/netlist.cpp
@@ -313,22 +313,50 @@ void netlistt::output_smv(std::ostream &out) const
   out << "-- Initial state" << '\n';
   out << '\n';
 
-  for(unsigned i=0; i<initial.size(); i++)
+  for(auto &initial_l : initial)
   {
-    out << "INIT ";
-    print_smv(out, initial[i]);
-    out << '\n';
+    if(!initial_l.is_true())
+    {
+      out << "INIT ";
+      print_smv(out, initial_l);
+      out << '\n';
+    }
   }
 
   out << '\n';
   out << "-- TRANS" << '\n';
   out << '\n';
 
-  for(unsigned i=0; i<transition.size(); i++)
+  for(auto &trans_l : transition)
   {
-    out << "TRANS ";
-    print_smv(out, transition[i]);
-    out << '\n';
+    if(!trans_l.is_true())
+    {
+      out << "TRANS ";
+      print_smv(out, trans_l);
+      out << '\n';
+    }
+  }
+
+  out << '\n';
+  out << "-- Properties" << '\n';
+  out << '\n';
+
+  for(auto &[id, property] : properties)
+  {
+    if(std::holds_alternative<Gpt>(property))
+    {
+      out << "-- " << id << '\n';
+      out << "LTLSPEC G ";
+      print_smv(out, std::get<Gpt>(property).p);
+      out << '\n';
+    }
+    else if(std::holds_alternative<GFpt>(property))
+    {
+      out << "-- " << id << '\n';
+      out << "LTLSPEC G F ";
+      print_smv(out, std::get<GFpt>(property).p);
+      out << '\n';
+    }
   }
 }
 

--- a/src/trans-netlist/netlist.h
+++ b/src/trans-netlist/netlist.h
@@ -9,10 +9,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_TRANS_NETLIST_H
 #define CPROVER_TRANS_NETLIST_H
 
-#include <iosfwd>
-
 #include "aig.h"
 #include "var_map.h"
+
+#include <iosfwd>
+#include <variant>
 
 class netlistt:public aig_plus_constraintst
 {
@@ -51,7 +52,23 @@ public:
   // these are implicit conjunctions
   bvt initial;
   bvt transition;
-  
+
+  struct Gpt
+  {
+    literalt p;
+  };
+
+  struct GFpt
+  {
+    literalt p;
+  };
+
+  using propertyt = std::variant<Gpt, GFpt>;
+
+  // map from property ID to property netlist nodes
+  using propertiest = std::map<irep_idt, propertyt>;
+  propertiest properties;
+
 protected:
   static std::string id2smv(const irep_idt &id);
   void print_smv(std::ostream &out, literalt l) const;


### PR DESCRIPTION
The conversion to netlist now includes the properties, which are then reproduced in the SMV output.