### PR TITLE
Verilog: const variable declarations

### DIFF
--- a/regression/verilog/const/const1.desc
+++ b/regression/verilog/const/const1.desc
@@ -1,0 +1,8 @@
+CORE
+const1.sv
+
+^no properties$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/const/const1.sv
+++ b/regression/verilog/const/const1.sv
@@ -1,0 +1,5 @@
+module main;
+  const bit my_true2 = 1;
+  const var my_true3 = 1;
+  const logic my_true4 = 1;
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1110,18 +1110,23 @@ part_select:
 // TOK_VAR is optional, but footnote 10 in IEEE 1800-2017 requires it
 // when the data_type is omitted. We split the rule in the standard into two.
 data_declaration:
-	  TOK_VAR lifetime_opt data_type_or_implicit list_of_variable_decl_assignments ';'
+	  const_opt TOK_VAR lifetime_opt data_type_or_implicit list_of_variable_decl_assignments ';'
 	  	{ init($$, ID_decl);
 		  stack_expr($$).set(ID_class, ID_var);
-		  addswap($$, ID_type, $3);
-		  swapop($$, $4); }
-	| lifetime_opt data_type list_of_variable_decl_assignments ';'
+		  addswap($$, ID_type, $4);
+		  swapop($$, $5); }
+	| const_opt lifetime_opt data_type list_of_variable_decl_assignments ';'
 		{ init($$, ID_decl);
 		  stack_expr($$).set(ID_class, ID_reg);
-		  addswap($$, ID_type, $2);
-		  swapop($$, $3); }
+		  addswap($$, ID_type, $3);
+		  swapop($$, $4); }
 	| type_declaration
 	| package_import_declaration
+	;
+
+const_opt:
+	  /* Optional */
+	| TOK_CONST
 	;
 
 package_import_declaration_brace:


### PR DESCRIPTION
This adds the grammar rules for `const` variable declarations.