### PR TITLE
Introduce `verilog_inst_baset::named_port_connectiont`

### DIFF
--- a/regression/verilog/modules/inout_and_variable.desc
+++ b/regression/verilog/modules/inout_and_variable.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+inout_and_variable.v
+
+^file .* line 4: symbol `some_var' is declared both as input and as register$
+^EXIT=2$
+^SIGNAL=0$
+--
+--
+The use of a variable with an inout port should be rejected.

--- a/regression/verilog/modules/inout_and_variable.v
+++ b/regression/verilog/modules/inout_and_variable.v
@@ -1,0 +1,12 @@
+module sub(inout some_port);
+
+endmodule
+
+module main;
+  // 1800-2017 6.5
+  // "Variables cannot be connected to either side of an inout port"
+  reg my_var;
+
+  sub sub(my_var);
+
+endmodule

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -573,6 +573,39 @@ public:
     return set(ID_module, module);
   }
 
+  class named_port_connectiont : public binary_exprt
+  {
+  public:
+    named_port_connectiont(exprt _port, exprt _value)
+      : binary_exprt(
+          std::move(_port),
+          ID_named_port_connection,
+          std::move(_value),
+          typet{})
+    {
+    }
+
+    const exprt &port() const
+    {
+      return op0();
+    }
+
+    exprt &port()
+    {
+      return op0();
+    }
+
+    const exprt &value() const
+    {
+      return op1();
+    }
+
+    exprt &value()
+    {
+      return op1();
+    }
+  };
+
   class instancet : public exprt
   {
   public:
@@ -620,6 +653,22 @@ public:
 protected:
   using exprt::operands;
 };
+
+inline const verilog_inst_baset::named_port_connectiont &
+to_verilog_named_port_connection(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_named_port_connection);
+  verilog_inst_baset::named_port_connectiont::check(expr);
+  return static_cast<const verilog_inst_baset::named_port_connectiont &>(expr);
+}
+
+inline verilog_inst_baset::named_port_connectiont &
+to_verilog_named_port_connection(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_named_port_connection);
+  verilog_inst_baset::named_port_connectiont::check(expr);
+  return static_cast<verilog_inst_baset::named_port_connectiont &>(expr);
+}
 
 class verilog_instt : public verilog_inst_baset
 {

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -596,6 +596,11 @@ public:
       return operands();
     }
 
+    exprt::operandst &connections()
+    {
+      return operands();
+    }
+
   protected:
     using exprt::operands;
   };

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -121,24 +121,24 @@ void verilog_typecheckt::typecheck_port_connections(
 
     for(auto &connection : inst.connections())
     {
-      if(
-        connection.id() != ID_named_port_connection ||
-        connection.operands().size() != 2)
+      if(connection.id() != ID_named_port_connection)
       {
         throw errort().with_location(inst.source_location())
           << "expected a named port connection";
       }
 
-      exprt &op = to_binary_expr(connection).op1();
-      const irep_idt &name =
-        to_binary_expr(connection).op0().get(ID_identifier);
+      auto &named_port_connection =
+        to_verilog_named_port_connection(connection);
+
+      exprt &value = named_port_connection.value();
+      const irep_idt &name = named_port_connection.port().get(ID_identifier);
 
       bool found=false;
 
       std::string identifier=
         id2string(symbol.module)+"."+id2string(name);
 
-      to_binary_expr(connection).op0().set(ID_identifier, identifier);
+      named_port_connection.port().set(ID_identifier, identifier);
 
       if(assigned_ports.find(name)!=
          assigned_ports.end())
@@ -153,8 +153,8 @@ void verilog_typecheckt::typecheck_port_connections(
         {
           auto &p_expr = static_cast<const exprt &>(port);
           found=true;
-          typecheck_port_connection(op, p_expr);
-          to_binary_expr(connection).op0().type() = p_expr.type();
+          typecheck_port_connection(value, p_expr);
+          named_port_connection.port().type() = p_expr.type();
           break;
         }
       }

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -177,15 +177,15 @@ protected:
 
   void instantiate_port_connections(
     const std::string &instance,
-    const exprt &inst,
+    const verilog_inst_baset::instancet &,
     const symbolt &symbol,
     exprt &trans);
 
   void typecheck_port_connections(
-    exprt &inst,
+    verilog_inst_baset::instancet &,
     const symbolt &symbol);
 
-  void typecheck_builtin_port_connections(exprt &inst);
+  void typecheck_builtin_port_connections(verilog_inst_baset::instancet &);
 
   void typecheck_port_connection(
     exprt &op,


### PR DESCRIPTION
This class documents an existing expression type in the Verilog frontend.