### PR TITLE
Verilog: procedural assert/assume/cover are guarded

### DIFF
--- a/regression/verilog/SVA/immediate2.desc
+++ b/regression/verilog/SVA/immediate2.desc
@@ -1,0 +1,10 @@
+CORE broken-smt-backend
+immediate2.sv
+--bound 0
+^\[main\.property\.1\] always main\.index < 10: PROVED up to bound 0$
+^\[main\.property\.2\] always 0: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/immediate2.sv
+++ b/regression/verilog/SVA/immediate2.sv
@@ -1,0 +1,14 @@
+module main(input [31:0] index);
+
+  always @index begin
+    if(index >= 10)
+      assume(0);
+
+    // should pass
+    assert(index < 10);
+
+    // should fail
+    assert(0);
+  end
+
+endmodule

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -611,7 +611,10 @@ void verilog_typecheckt::collect_symbols(const verilog_lett &let)
 
 void verilog_typecheckt::collect_symbols(const verilog_statementt &statement)
 {
-  if(statement.id() == ID_verilog_immediate_assert)
+  if(
+    statement.id() == ID_verilog_immediate_assert ||
+    statement.id() == ID_verilog_immediate_assume ||
+    statement.id() == ID_verilog_immediate_cover)
   {
   }
   else if(

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -1845,6 +1845,7 @@ inline const verilog_assume_statementt &
 to_verilog_assume_statement(const verilog_statementt &statement)
 {
   PRECONDITION(
+    statement.id() == ID_verilog_immediate_assume ||
     statement.id() == ID_verilog_assume_property ||
     statement.id() == ID_verilog_smv_assume);
   binary_exprt::check(statement);
@@ -1855,6 +1856,7 @@ inline verilog_assume_statementt &
 to_verilog_assume_statement(verilog_statementt &statement)
 {
   PRECONDITION(
+    statement.id() == ID_verilog_immediate_assume ||
     statement.id() == ID_verilog_assume_property ||
     statement.id() == ID_verilog_smv_assume);
   binary_exprt::check(statement);

--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -19,7 +19,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "verilog_symbol_table.h"
 #include "verilog_typecheck_base.h"
 
-#include <cassert>
 #include <map>
 #include <set>
 #include <unordered_set>
@@ -166,22 +165,33 @@ protected:
       current.changed.clear();
       final.changed.clear();
     }
+
+    // current guard
+    exprt::operandst guard;
+
+    exprt guarded_expr(exprt) const;
   };
    
   exprt current_value(
     const value_mapt::mapt &map,
     const symbolt &symbol,
     bool use_previous_assignments);
-  
+
+  exprt guarded_expr(exprt expr) const
+  {
+    PRECONDITION(value_map != NULL);
+    return value_map->guarded_expr(expr);
+  }
+
   inline exprt current_value(const symbolt &symbol)
   {
-    assert(value_map!=NULL);
+    PRECONDITION(value_map != NULL);
     return current_value(value_map->current, symbol, false);
   }
 
   inline exprt final_value(const symbolt &symbol)
   {
-    assert(value_map!=NULL);
+    PRECONDITION(value_map != NULL);
     return current_value(value_map->final, symbol, true);
   }
 

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1443,6 +1443,7 @@ void verilog_typecheckt::convert_statement(
     convert_assert_cover(to_verilog_assert_assume_cover_statement(statement));
   }
   else if(
+    statement.id() == ID_verilog_immediate_assume ||
     statement.id() == ID_verilog_assume_property ||
     statement.id() == ID_verilog_smv_assume)
   {


### PR DESCRIPTION
This fixes the bug that procedural `assert`/`assume`/`cover` statements do not consider the execution guard.