### PR TITLE
BDD engine: KNOWNBUG for G F properties

### DIFF
--- a/regression/ebmc/BDD/GF1.desc
+++ b/regression/ebmc/BDD/GF1.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+GF1.smv
+--bdd
+^\[main::spec1\] G F some_var: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Wrong result by BDD engine.

--- a/regression/ebmc/BDD/GF1.smv
+++ b/regression/ebmc/BDD/GF1.smv
@@ -1,0 +1,6 @@
+MODULE main
+
+VAR some_var : boolean;
+
+-- should fail
+LTLSPEC G F some_var


### PR DESCRIPTION
Minimal example for a bug in the BDD engine when doing `G` `F` properties.