### PR TITLE
Tests: enable exit-code requirement and output on failure

### DIFF
--- a/regression/ebmc/Makefile
+++ b/regression/ebmc/Makefile
@@ -3,7 +3,7 @@ default: test
 TEST_PL = ../../lib/cbmc/regression/test.pl
 
 test:
-	@$(TEST_PL) -c ../../../src/ebmc/ebmc
+	@$(TEST_PL) -e -p -c ../../../src/ebmc/ebmc
 
 test-z3:
 	@$(TEST_PL) -e -p -c "../../../src/ebmc/ebmc --z3" -X broken-smt-backend

--- a/regression/hw-cbmc/Makefile
+++ b/regression/hw-cbmc/Makefile
@@ -1,10 +1,10 @@
 default: tests.log
 
 test:
-	@../test.pl -c ../../../src/hw-cbmc/hw-cbmc
+	@../test.pl -e -p -c ../../../src/hw-cbmc/hw-cbmc
 
-tests.log: ../test.pl
-	@../test.pl -c ../../../src/hw-cbmc/hw-cbmc
+tests.log:
+	@../test.pl -e -p -c ../../../src/hw-cbmc/hw-cbmc
 
 show:
 	@for dir in *; do \

--- a/regression/verilog/Makefile
+++ b/regression/verilog/Makefile
@@ -3,7 +3,7 @@ default: test
 TEST_PL = ../../lib/cbmc/regression/test.pl
 
 test:
-	@$(TEST_PL) -c ../../../src/ebmc/ebmc
+	@$(TEST_PL) -e -p -c ../../../src/ebmc/ebmc
 
 test-z3:
 	@$(TEST_PL) -e -p -c "../../../src/ebmc/ebmc --z3" -X broken-smt-backend

--- a/regression/vhdl/Makefile
+++ b/regression/vhdl/Makefile
@@ -1,10 +1,10 @@
 default: tests.log
 
 test:
-	@../test.pl -c ../../../src/ebmc/ebmc
+	@../test.pl -e -p -c ../../../src/ebmc/ebmc
 
-tests.log: ../test.pl ../../../src/ebmc/ebmc
-	@../test.pl
+tests.log:
+	@../test.pl -e -p -c ../../../src/ebmc/ebmc
 
 show:
 	@for dir in *; do \


### PR DESCRIPTION
To better understand CI failures, `-p` results in all output of failing tests to be printed. While at it, also enable exit-code requirements (`-e`) to make sure all test specifications include those.