### PR TITLE
fixup! SMV frontend: strip main:: from property pretty names

### DIFF
--- a/regression/ebmc/smv/module1.desc
+++ b/regression/ebmc/smv/module1.desc
@@ -3,6 +3,6 @@ module1.smv
 --bound 10
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main::spec1\] AG subA.flag & AG subB.flag: PROVED up to bound 10$
+^\[spec1\] AG subA.flag & AG subB.flag: PROVED up to bound 10$
 --
 ^warning: ignoring


### PR DESCRIPTION
Fixes a test that was newly introduced in 53367541f with fde07ab being done (and now merged) independently.