### PR TITLE
SMV tests: use TRUE and FALSE

### DIFF
--- a/regression/ebmc/BDD/AF1.smv
+++ b/regression/ebmc/BDD/AF1.smv
@@ -2,10 +2,10 @@ MODULE main
 
 VAR some_var : boolean;
 
-INVAR some_var = 0
+INVAR some_var = FALSE
 
 -- should fail
-SPEC AF some_var = 1
+SPEC AF some_var = TRUE
 
 -- should pass
-SPEC AF some_var = 0
+SPEC AF some_var = FALSE

--- a/regression/ebmc/BDD/AF2.smv
+++ b/regression/ebmc/BDD/AF2.smv
@@ -2,10 +2,10 @@ MODULE main
 
 VAR some_var : boolean;
 
-ASSIGN next(some_var) := 0;
+ASSIGN next(some_var) := FALSE;
 
 -- should fail
-SPEC AF some_var = 1
+SPEC AF some_var = TRUE
 
 -- should pass
-SPEC AF some_var = 0
+SPEC AF some_var = FALSE

--- a/regression/ebmc/BDD/AG1.smv
+++ b/regression/ebmc/BDD/AG1.smv
@@ -2,10 +2,10 @@ MODULE main
 
 VAR some_var : boolean;
 
-INVAR some_var = 0
+INVAR some_var = FALSE
 
 -- should fail
-SPEC AG some_var = 1
+SPEC AG some_var = TRUE
 
 -- should pass
-SPEC AG some_var = 0
+SPEC AG some_var = FALSE

--- a/regression/ebmc/BDD/AG2.smv
+++ b/regression/ebmc/BDD/AG2.smv
@@ -2,10 +2,10 @@ MODULE main
 
 VAR some_var : boolean;
 
-ASSIGN next(some_var) := 0;
+ASSIGN next(some_var) := FALSE;
 
 -- should fail
-SPEC AG some_var = 1
+SPEC AG some_var = TRUE
 
 -- should fail
-SPEC AG some_var = 0
+SPEC AG some_var = FALSE

--- a/regression/ebmc/BDD/AU1.smv
+++ b/regression/ebmc/BDD/AU1.smv
@@ -6,7 +6,7 @@ VAR x : 0..10;
 ASSIGN init(x) := 1;
 ASSIGN next(x) := case
     x = 10 : 10;
-    1      : x + 1;
+    TRUE   : x + 1;
   esac;
 
 -- should fail, since x=0 is not reachable

--- a/regression/ebmc/BDD/AX1.smv
+++ b/regression/ebmc/BDD/AX1.smv
@@ -2,10 +2,10 @@ MODULE main
 
 VAR some_var : boolean;
 
-INVAR some_var = 0
+INVAR some_var = FALSE
 
 -- should fail
-SPEC AX some_var = 1
+SPEC AX some_var = TRUE
 
 -- should pass
-SPEC AX some_var = 0
+SPEC AX some_var = FALSE

--- a/regression/ebmc/BDD/BDD1.desc
+++ b/regression/ebmc/BDD/BDD1.desc
@@ -3,6 +3,6 @@ BDD1.smv
 --bdd
 ^EXIT=0$
 ^SIGNAL=0$
-^\[spec1\] AG \(!some_var = off\): PROVED$
+^\[spec1\] AG some_var != off: PROVED$
 --
 ^warning: ignoring

--- a/regression/ebmc/BDD/BDD1.smv
+++ b/regression/ebmc/BDD/BDD1.smv
@@ -7,9 +7,9 @@ ASSIGN next(some_var) :=
     some_var=red: green;
     some_var=green: yellow;
     some_var=yellow: red;
-    1: off;
+    TRUE: off;
   esac;
 
-INIT !some_var=off
+INIT some_var != off
 
-SPEC AG !some_var=off
+SPEC AG some_var != off

--- a/regression/ebmc/BDD/EF1.smv
+++ b/regression/ebmc/BDD/EF1.smv
@@ -2,10 +2,10 @@ MODULE main
 
 VAR some_var : boolean;
 
-INVAR some_var = 0
+INVAR some_var = FALSE
 
 -- should fail
-SPEC EF some_var = 1
+SPEC EF some_var = TRUE
 
 -- should pass
-SPEC EF some_var = 0
+SPEC EF some_var = FALSE

--- a/regression/ebmc/BDD/EF2.smv
+++ b/regression/ebmc/BDD/EF2.smv
@@ -2,10 +2,10 @@ MODULE main
 
 VAR some_var : boolean;
 
-ASSIGN next(some_var) := 0;
+ASSIGN next(some_var) := FALSE;
 
 -- should fail
-SPEC EF some_var = 1
+SPEC EF some_var = TRUE
 
 -- should pass
-SPEC EF some_var = 0
+SPEC EF some_var = FALSE

--- a/regression/ebmc/BDD/EG1.smv
+++ b/regression/ebmc/BDD/EG1.smv
@@ -2,10 +2,10 @@ MODULE main
 
 VAR some_var : boolean;
 
-INVAR some_var = 0
+INVAR some_var = FALSE
 
 -- should fail
-SPEC EG some_var = 1
+SPEC EG some_var = TRUE
 
 -- should pass
-SPEC EG some_var = 0
+SPEC EG some_var = FALSE

--- a/regression/ebmc/BDD/EG2.smv
+++ b/regression/ebmc/BDD/EG2.smv
@@ -2,10 +2,10 @@ MODULE main
 
 VAR some_var : boolean;
 
-ASSIGN next(some_var) := 0;
+ASSIGN next(some_var) := FALSE;
 
 -- should fail
-SPEC EG some_var = 1
+SPEC EG some_var = TRUE
 
 -- should fail
-SPEC EG some_var = 0
+SPEC EG some_var = FALSE

--- a/regression/ebmc/BDD/EX1.smv
+++ b/regression/ebmc/BDD/EX1.smv
@@ -2,10 +2,10 @@ MODULE main
 
 VAR some_var : boolean;
 
-INVAR some_var = 0
+INVAR some_var = FALSE
 
 -- should fail
-SPEC EX some_var = 1
+SPEC EX some_var = TRUE
 
 -- should pass
-SPEC EX some_var = 0
+SPEC EX some_var = FALSE

--- a/regression/ebmc/BDD/EX2.smv
+++ b/regression/ebmc/BDD/EX2.smv
@@ -2,10 +2,10 @@ MODULE main
 
 VAR some_var : boolean;
 
-ASSIGN next(some_var) := 0;
+ASSIGN next(some_var) := FALSE;
 
 -- should fail
-SPEC EX some_var = 1
+SPEC EX some_var = TRUE
 
 -- should pass
-SPEC EX some_var = 0
+SPEC EX some_var = FALSE

--- a/regression/ebmc/BDD/just_p.smv
+++ b/regression/ebmc/BDD/just_p.smv
@@ -2,10 +2,10 @@ MODULE main
 
 VAR some_var : boolean;
 
-ASSIGN init(some_var) := 0;
+ASSIGN init(some_var) := FALSE;
 
 -- should fail
-SPEC some_var = 1
+SPEC some_var = TRUE
 
 -- should pass
-SPEC some_var = 0
+SPEC some_var = FALSE

--- a/regression/ebmc/range_type/range_type1.smv
+++ b/regression/ebmc/range_type/range_type1.smv
@@ -16,7 +16,7 @@ ASSIGN
       x=3 : 4;
       x=5 : 6;
       x=6 : 2;
-      1: 4;
+      TRUE: 4;
     esac;
 
 SPEC AG x!=4

--- a/regression/ebmc/range_type/range_type4.smv
+++ b/regression/ebmc/range_type/range_type4.smv
@@ -8,7 +8,7 @@ ASSIGN
   next(x) :=
     case
       ~(x=5): x+1;
-      1: 0;
+      TRUE: 0;
     esac;
 
 SPEC AG !(x=6)

--- a/regression/ebmc/range_type/range_type5.smv
+++ b/regression/ebmc/range_type/range_type5.smv
@@ -12,7 +12,7 @@ ASSIGN
   next(y) :=
     case
       x>=5: x;
-      1: 10;
+      TRUE: 10;
     esac;
 
 SPEC AG !(x=6)

--- a/regression/ebmc/smv/bdd_unsupported_property.smv
+++ b/regression/ebmc/smv/bdd_unsupported_property.smv
@@ -2,7 +2,7 @@ MODULE main
 
 VAR x : boolean;
 
-ASSIGN init(x) := 1;
+ASSIGN init(x) := TRUE;
 
-LTLSPEC !G x=0
-LTLSPEC G x=0
+LTLSPEC !G x=FALSE
+LTLSPEC G x=FALSE

--- a/regression/ebmc/smv/bmc_unsupported_property1.smv
+++ b/regression/ebmc/smv/bmc_unsupported_property1.smv
@@ -2,7 +2,7 @@ MODULE main
 
 VAR x : boolean;
 
-ASSIGN init(x) := 1;
+ASSIGN init(x) := TRUE;
 
-SPEC EG x=0
-LTLSPEC G x=0
+SPEC EG x=FALSE
+LTLSPEC G x=FALSE

--- a/regression/ebmc/smv/bmc_unsupported_property2.smv
+++ b/regression/ebmc/smv/bmc_unsupported_property2.smv
@@ -2,8 +2,8 @@ MODULE main
 
 VAR x : boolean;
 
-ASSIGN init(x) := 1;
+ASSIGN init(x) := TRUE;
 ASSIGN next(x) := x;
 
-SPEC EG x=0 -- unsupported
-LTLSPEC G x=1 -- should pass
+SPEC EG x=FALSE -- unsupported
+LTLSPEC G x=TRUE -- should pass

--- a/regression/ebmc/smv/bmc_unsupported_property3.smv
+++ b/regression/ebmc/smv/bmc_unsupported_property3.smv
@@ -2,7 +2,7 @@ MODULE main
 
 VAR x : boolean;
 
-ASSIGN init(x) := 1;
+ASSIGN init(x) := TRUE;
 
-LTLSPEC !G x=0
-LTLSPEC G x=0
+LTLSPEC !G x=FALSE
+LTLSPEC G x=FALSE

--- a/regression/ebmc/smv/initial1.smv
+++ b/regression/ebmc/smv/initial1.smv
@@ -3,10 +3,10 @@ MODULE main
 VAR tmp1: boolean;
 VAR tmp2: boolean;
 
-ASSIGN init(tmp1):=1;
+ASSIGN init(tmp1):=TRUE;
 
 -- should pass
-SPEC tmp1 = 1;
+SPEC tmp1 = TRUE;
 
 -- should fail
-SPEC tmp2 = 1;
+SPEC tmp2 = TRUE;

--- a/regression/ebmc/smv/module1.smv
+++ b/regression/ebmc/smv/module1.smv
@@ -9,5 +9,5 @@ MODULE my-module
 
 VAR flag : boolean;
 
-ASSIGN init(flag) := 1;
-ASSIGN next(flag) := 1;
+ASSIGN init(flag) := TRUE;
+ASSIGN next(flag) := TRUE;

--- a/regression/ebmc/smv/smv2.smv
+++ b/regression/ebmc/smv/smv2.smv
@@ -4,7 +4,7 @@ VAR z: boolean;
 VAR y: boolean;
 
 ASSIGN init(z):=_tt;
-ASSIGN init(y):=0;
+ASSIGN init(y):=FALSE;
 ASSIGN next(z):=m;
 ASSIGN next(y):=y;
 

--- a/regression/ebmc/smv/smv3.smv
+++ b/regression/ebmc/smv/smv3.smv
@@ -2,6 +2,6 @@ MODULE main
 
 DEFINE xx:=yy;
 
-DEFINE yy:=1;
+DEFINE yy:=TRUE;
 
 SPEC AG xx

--- a/regression/ebmc/smv/smv_ltlspec1.smv
+++ b/regression/ebmc/smv/smv_ltlspec1.smv
@@ -8,7 +8,7 @@ ASSIGN
   next(x) :=
     case
       x=3 : 3;
-      1   : x+1;
+      TRUE: x+1;
     esac;
 
 LTLSPEC G x!=0

--- a/regression/ebmc/smv/smv_ltlspec2.smv
+++ b/regression/ebmc/smv/smv_ltlspec2.smv
@@ -8,7 +8,7 @@ ASSIGN
   next(x) :=
     case
       x=3 : 3;
-      1   : x+1;
+      TRUE: x+1;
     esac;
 
 LTLSPEC G F x=3

--- a/regression/ebmc/smv/smv_ltlspec3.smv
+++ b/regression/ebmc/smv/smv_ltlspec3.smv
@@ -3,8 +3,8 @@ MODULE main
 VAR x : boolean;
 
 ASSIGN
-  init(x) := 0;
+  init(x) := FALSE;
   next(x) := x;
 
 -- we want to see a trace with three states
-LTLSPEC X X x=1
+LTLSPEC X X x=TRUE


### PR DESCRIPTION
Since version 2.5.1, NuSMV no longer performs an implicit conversion from integers to booleans.  This replaces `1` by `TRUE` and `0` by `FALSE` to enable NuSMV to read our tests.