### PR TITLE
ebmc: generate a witness that a given candidate isn't a ranking function

### DIFF
--- a/regression/ebmc/ranking-function/counter2.fail.desc
+++ b/regression/ebmc/ranking-function/counter2.fail.desc
@@ -1,7 +1,9 @@
 CORE
 counter2.sv
---ranking-function counter
+--ranking-function counter --numbered-trace
 ^\[main\.property\.p0\] always s_eventually main.counter == 10: INCONCLUSIVE$
+^main\.counter@0 = .*$
+^main\.counter@1 = .*$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/src/ebmc/neural_liveness.cpp
+++ b/src/ebmc/neural_liveness.cpp
@@ -307,12 +307,14 @@ tvt neural_livenesst::verify(
     solver_factory,
     message.get_message_handler());
 
-  if(result.is_true())
+  property.witness_trace = std::move(result.second);
+
+  if(result.first.is_true())
     property.proved();
   else
     property.inconclusive();
 
-  return result;
+  return result.first;
 }
 
 int do_neural_liveness(

--- a/src/ebmc/ranking_function.h
+++ b/src/ebmc/ranking_function.h
@@ -18,6 +18,7 @@ Author: Daniel Kroening, dkr@amazon.com
 
 class exprt;
 class transition_systemt;
+class trans_tracet;
 
 int do_ranking_function(const cmdlinet &, message_handlert &);
 
@@ -26,7 +27,7 @@ exprt parse_ranking_function(
   const transition_systemt &,
   message_handlert &);
 
-tvt is_ranking_function(
+std::pair<tvt, std::optional<trans_tracet>> is_ranking_function(
   const transition_systemt &,
   const exprt &property,
   const exprt &ranking_function,


### PR DESCRIPTION
This records the satisfying assignment when checking a ranking function and outputs it as a two-step trace, to enable debugging the candidate ranking function.