### PR TITLE
Simplfy benchmark properties

### DIFF
--- a/examples/Benchmarks/check_ranking
+++ b/examples/Benchmarks/check_ranking
@@ -1,0 +1,137 @@
+#!/bin/sh
+
+set -e
+
+ebmc PWM_1.sv --ranking-function "2**10-cntR"
+ebmc PWM_2.sv --ranking-function "2**11-cntR"
+ebmc PWM_3.sv --ranking-function "2**12-cntR"
+ebmc PWM_4.sv --ranking-function "2**13-cntR"
+ebmc PWM_5.sv --ranking-function "2**14-cntR"
+ebmc PWM_6.sv --ranking-function "2**15-cntR"
+ebmc PWM_7.sv --ranking-function "2**16-cntR"
+ebmc PWM_8.sv --ranking-function "2**17-cntR"
+ebmc PWM_9.sv --ranking-function "2**18-cntR"
+
+ebmc delay_1.sv --ranking-function "750-cnt"
+ebmc delay_2.sv --ranking-function "1250-cnt"
+ebmc delay_3.sv --ranking-function "2500-cnt"
+ebmc delay_4.sv --ranking-function "5000-cnt"
+ebmc delay_5.sv --ranking-function "7500-cnt"
+ebmc delay_6.sv --ranking-function "10000-cnt"
+ebmc delay_7.sv --ranking-function "12500-cnt"
+ebmc delay_8.sv --ranking-function "15000-cnt"
+ebmc delay_9.sv --ranking-function "17500-cnt"
+ebmc delay_10.sv --ranking-function "20000-cnt"
+ebmc delay_11.sv --ranking-function "22500-cnt"
+ebmc delay_12.sv --ranking-function "25000-cnt"
+ebmc delay_13.sv --ranking-function "50000-cnt"
+ebmc delay_14.sv --ranking-function "100000-cnt"
+ebmc delay_15.sv --ranking-function "200000-cnt"
+ebmc delay_16.sv --ranking-function "400000-cnt"
+
+ebmc gray_1.sv --ranking-function "2**8-cnt"
+ebmc gray_2.sv --ranking-function "2**9-cnt"
+ebmc gray_3.sv --ranking-function "2**10-cnt"
+ebmc gray_4.sv --ranking-function "2**11-cnt"
+ebmc gray_5.sv --ranking-function "2**12-cnt"
+ebmc gray_6.sv --ranking-function "2**13-cnt"
+ebmc gray_7.sv --ranking-function "2**14-cnt"
+ebmc gray_8.sv --ranking-function "2**15-cnt"
+ebmc gray_9.sv --ranking-function "2**16-cnt"
+ebmc gray_10.sv --ranking-function "2**17-cnt"
+ebmc gray_11.sv --ranking-function "2**18-cnt"
+
+if false ; then
+ebmc i2c_1.sv --ranking-function "2**9-cnt"
+ebmc i2c_2.sv --ranking-function "2**10-cnt"
+ebmc i2c_3.sv --ranking-function "2**11-cnt"
+ebmc i2c_4.sv --ranking-function "2**12-cnt"
+ebmc i2c_5.sv --ranking-function "2**13-cnt"
+ebmc i2c_6.sv --ranking-function "2**14-cnt"
+ebmc i2c_7.sv --ranking-function "2**15-cnt"
+ebmc i2c_8.sv --ranking-function "2**16-cnt"
+ebmc i2c_9.sv --ranking-function "2**17-cnt"
+ebmc i2c_10.sv --ranking-function "2**18-cnt"
+ebmc i2c_11.sv --ranking-function "2**19-cnt"
+ebmc i2c_12.sv --ranking-function "2**10-cnt"
+ebmc i2c_13.sv --ranking-function "2**10-cnt"
+ebmc i2c_14.sv --ranking-function "2**10-cnt"
+ebmc i2c_15.sv --ranking-function "2**10-cnt"
+ebmc i2c_16.sv --ranking-function "2**10-cnt"
+ebmc i2c_17.sv --ranking-function "2**10-cnt"
+ebmc i2c_18.sv --ranking-function "2**10-cnt"
+ebmc i2c_19.sv --ranking-function "2**10-cnt"
+ebmc i2c_20.sv --ranking-function "2**19-cnt"
+fi
+
+ebmc lcd_1.sv --ranking-function "{3-state,500-cnt}"
+ebmc lcd_2.sv --ranking-function "{3-state,1000-cnt}"
+ebmc lcd_3.sv --ranking-function "{3-state,1500-cnt}"
+ebmc lcd_4.sv --ranking-function "{3-state,2500-cnt}"
+ebmc lcd_5.sv --ranking-function "{3-state,5000-cnt}"
+ebmc lcd_6.sv --ranking-function "{3-state,7500-cnt}"
+ebmc lcd_7.sv --ranking-function "{3-state,10000-cnt}"
+ebmc lcd_8.sv --ranking-function "{3-state,12500-cnt}"
+ebmc lcd_9.sv --ranking-function "{3-state,15000-cnt}"
+ebmc lcd_10.sv --ranking-function "{3-state,17500-cnt}"
+ebmc lcd_11.sv --ranking-function "{3-state,20000-cnt}"
+ebmc lcd_12.sv --ranking-function "{3-state,22500-cnt}"
+ebmc lcd_13.sv --ranking-function "{3-state,90000-cnt}"
+ebmc lcd_14.sv --ranking-function "{3-state,180000-cnt}"
+
+ebmc seven_seg_1.sv --ranking-function "250-cnt" --property SEVEN.property.p1
+ebmc seven_seg_2.sv --ranking-function "500-cnt" --property SEVEN.property.p1
+ebmc seven_seg_3.sv --ranking-function "750-cnt" --property SEVEN.property.p1
+ebmc seven_seg_4.sv --ranking-function "1000-cnt" --property SEVEN.property.p1
+ebmc seven_seg_5.sv --ranking-function "2500-cnt" --property SEVEN.property.p1
+ebmc seven_seg_6.sv --ranking-function "5000-cnt" --property SEVEN.property.p1
+ebmc seven_seg_7.sv --ranking-function "7500-cnt" --property SEVEN.property.p1
+ebmc seven_seg_8.sv --ranking-function "10000-cnt" --property SEVEN.property.p1
+ebmc seven_seg_9.sv --ranking-function "12500-cnt" --property SEVEN.property.p1
+ebmc seven_seg_10.sv --ranking-function "15000-cnt" --property SEVEN.property.p1
+ebmc seven_seg_11.sv --ranking-function "17500-cnt" --property SEVEN.property.p1
+ebmc seven_seg_12.sv --ranking-function "20000-cnt" --property SEVEN.property.p1
+ebmc seven_seg_16.sv --ranking-function "40000-cnt" --property SEVEN.property.p1
+ebmc seven_seg_17.sv --ranking-function "80000-cnt" --property SEVEN.property.p1
+ebmc seven_seg_18.sv --ranking-function "160000-cnt" --property SEVEN.property.p1
+
+ebmc thermocouple_1.sv --ranking-function "{2-state,2**5-cnt}"
+ebmc thermocouple_2.sv --ranking-function "{2-state,2**9-cnt}"
+ebmc thermocouple_3.sv --ranking-function "{2-state,2**10-cnt}"
+ebmc thermocouple_4.sv --ranking-function "{2-state,2**10-cnt}"
+ebmc thermocouple_5.sv --ranking-function "{2-state,2**11-cnt}"
+ebmc thermocouple_6.sv --ranking-function "{2-state,2**11-cnt}"
+ebmc thermocouple_7.sv --ranking-function "{2-state,2**12-cnt}"
+ebmc thermocouple_8.sv --ranking-function "{2-state,2**12-cnt}"
+ebmc thermocouple_9.sv --ranking-function "{2-state,2**13-cnt}"
+ebmc thermocouple_10.sv --ranking-function "{2-state,2**14-cnt}"
+ebmc thermocouple_11.sv --ranking-function "{2-state,2**14-cnt}"
+ebmc thermocouple_12.sv --ranking-function "{2-state,2**14-cnt}"
+ebmc thermocouple_13.sv --ranking-function "{2-state,2**15-cnt}"
+ebmc thermocouple_14.sv --ranking-function "{2-state,2**16-cnt}"
+ebmc thermocouple_15.sv --ranking-function "{2-state,2**17-cnt}"
+ebmc thermocouple_16.sv --ranking-function "{2-state,2**18-cnt}"
+ebmc thermocouple_17.sv --ranking-function "{2-state,2**19-cnt}"
+
+ebmc uart_transmit_1.sv --ranking-function "2**3-tx_cnt"
+ebmc uart_transmit_2.sv --ranking-function "2**4-tx_cnt"
+ebmc uart_transmit_3.sv --ranking-function "2**4-tx_cnt"
+ebmc uart_transmit_4.sv --ranking-function "2**4-tx_cnt"
+ebmc uart_transmit_5.sv --ranking-function "2**4-tx_cnt"
+ebmc uart_transmit_6.sv --ranking-function "2**4-tx_cnt"
+ebmc uart_transmit_7.sv --ranking-function "2**4-tx_cnt"
+ebmc uart_transmit_8.sv --ranking-function "2**4-tx_cnt"
+ebmc uart_transmit_9.sv --ranking-function "2**5-tx_cnt"
+ebmc uart_transmit_10.sv --ranking-function "2**5-tx_cnt"
+ebmc uart_transmit_11.sv --ranking-function "2**5-tx_cnt"
+ebmc uart_transmit_12.sv --ranking-function "2**6-tx_cnt"
+
+ebmc vga_1.sv --ranking-function "{2**5-v_cnt,2**7-h_cnt}"
+ebmc vga_2.sv --ranking-function "{2**6-v_cnt,2**8-h_cnt}"
+ebmc vga_3.sv --ranking-function "{2**6-v_cnt,2**8-h_cnt}"
+ebmc vga_4.sv --ranking-function "{2**7-v_cnt,2**9-h_cnt}"
+ebmc vga_5.sv --ranking-function "{2**8-v_cnt,2**9-h_cnt}"
+ebmc vga_6.sv --ranking-function "{2**8-v_cnt,2**9-h_cnt}"
+ebmc vga_7.sv --ranking-function "{2**8-v_cnt,2**10-h_cnt}"
+ebmc vga_8.sv --ranking-function "{2**9-v_cnt,2**10-h_cnt}"
+ebmc vga_9.sv --ranking-function "{2**9-v_cnt,2**11-h_cnt}"

--- a/examples/Benchmarks/delay_1.sv
+++ b/examples/Benchmarks/delay_1.sv
@@ -7,6 +7,6 @@ module DELAY #(localparam N = 750, localparam CBITS = 10) (input clk, input rst,
       cnt = 0; end
     else sig = 0;
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1) ;
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/delay_10.sv
+++ b/examples/Benchmarks/delay_10.sv
@@ -7,6 +7,6 @@ module DELAY #(localparam N = 20000, localparam CBITS = 15) (input clk, input rs
       cnt = 0; end
     else sig = 0;
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/delay_11.sv
+++ b/examples/Benchmarks/delay_11.sv
@@ -7,6 +7,6 @@ module DELAY #(localparam N = 22500, localparam CBITS = 15) (input clk, input rs
       cnt = 0; end
     else sig = 0;
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/delay_12.sv
+++ b/examples/Benchmarks/delay_12.sv
@@ -7,6 +7,6 @@ module DELAY #(localparam N = 25000, localparam CBITS = 15) (input clk, input rs
       cnt = 0; end
     else sig = 0;
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/delay_13.sv
+++ b/examples/Benchmarks/delay_13.sv
@@ -7,6 +7,6 @@ module DELAY #(localparam N = 50000, localparam CBITS = 16) (input clk, input rs
       cnt = 0; end
     else sig = 0;
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/delay_14.sv
+++ b/examples/Benchmarks/delay_14.sv
@@ -7,6 +7,6 @@ module DELAY #(localparam N = 100000, localparam CBITS = 17) (input clk, input r
       cnt = 0; end
     else sig = 0;
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/delay_15.sv
+++ b/examples/Benchmarks/delay_15.sv
@@ -7,6 +7,6 @@ module DELAY #(localparam N = 200000, localparam CBITS = 18) (input clk, input r
       cnt = 0; end
     else sig = 0;
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/delay_16.sv
+++ b/examples/Benchmarks/delay_16.sv
@@ -7,6 +7,6 @@ module DELAY #(localparam N = 400000, localparam CBITS = 19) (input clk, input r
       cnt = 0; end
     else sig = 0;
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/delay_2.sv
+++ b/examples/Benchmarks/delay_2.sv
@@ -7,6 +7,6 @@ module DELAY #(localparam N = 1250, localparam CBITS = 11) (input clk, input rst
       cnt = 0; end
     else sig = 0;
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/delay_3.sv
+++ b/examples/Benchmarks/delay_3.sv
@@ -7,6 +7,6 @@ module DELAY #(localparam N = 2500, localparam CBITS = 12) (input clk, input rst
       cnt = 0; end
     else sig = 0;
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/delay_4.sv
+++ b/examples/Benchmarks/delay_4.sv
@@ -7,6 +7,6 @@ module DELAY #(localparam N = 5000, localparam CBITS = 13) (input clk, input rst
       cnt = 0; end
     else sig = 0;
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/delay_5.sv
+++ b/examples/Benchmarks/delay_5.sv
@@ -7,6 +7,6 @@ module DELAY #(localparam N = 7500, localparam CBITS = 13) (input clk, input rst
       cnt = 0; end
     else sig = 0;
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/delay_6.sv
+++ b/examples/Benchmarks/delay_6.sv
@@ -7,6 +7,6 @@ module DELAY #(localparam N = 10000, localparam CBITS = 14) (input clk, input rs
       cnt = 0; end
     else sig = 0;
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/delay_7.sv
+++ b/examples/Benchmarks/delay_7.sv
@@ -7,6 +7,6 @@ module DELAY #(localparam N = 12500, localparam CBITS = 14) (input clk, input rs
       cnt = 0; end
     else sig = 0;
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/delay_8.sv
+++ b/examples/Benchmarks/delay_8.sv
@@ -7,6 +7,6 @@ module DELAY #(localparam N = 15000, localparam CBITS = 14) (input clk, input rs
       cnt = 0; end
     else sig = 0;
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/delay_9.sv
+++ b/examples/Benchmarks/delay_9.sv
@@ -7,6 +7,6 @@ module DELAY #(localparam N = 17500, localparam CBITS = 15) (input clk, input rs
       cnt = 0; end
     else sig = 0;
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/gray_1.sv
+++ b/examples/Benchmarks/gray_1.sv
@@ -13,6 +13,6 @@ module GRAY #(localparam CBITS = 8) (input clk, input rst, output reg [CBITS-1:0
         sig = 0;
     end
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/gray_10.sv
+++ b/examples/Benchmarks/gray_10.sv
@@ -13,6 +13,6 @@ module GRAY #(localparam CBITS = 17) (input clk, input rst, output reg [CBITS-1:
         sig = 0;
     end
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/gray_11.sv
+++ b/examples/Benchmarks/gray_11.sv
@@ -13,6 +13,6 @@ module GRAY #(localparam CBITS = 18) (input clk, input rst, output reg [CBITS-1:
         sig = 0;
     end
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/gray_2.sv
+++ b/examples/Benchmarks/gray_2.sv
@@ -13,6 +13,6 @@ module GRAY #(localparam CBITS = 9) (input clk, input rst, output reg [CBITS-1:0
         sig = 0;
     end
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/gray_3.sv
+++ b/examples/Benchmarks/gray_3.sv
@@ -13,6 +13,6 @@ module GRAY #(localparam CBITS = 10) (input clk, input rst, output reg [CBITS-1:
         sig = 0;
     end
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/gray_4.sv
+++ b/examples/Benchmarks/gray_4.sv
@@ -13,6 +13,6 @@ module GRAY #(localparam CBITS = 11) (input clk, input rst, output reg [CBITS-1:
         sig = 0;
     end
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/gray_5.sv
+++ b/examples/Benchmarks/gray_5.sv
@@ -13,6 +13,6 @@ module GRAY #(localparam CBITS = 12) (input clk, input rst, output reg [CBITS-1:
         sig = 0;
     end
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/gray_6.sv
+++ b/examples/Benchmarks/gray_6.sv
@@ -13,6 +13,6 @@ module GRAY #(localparam CBITS = 13) (input clk, input rst, output reg [CBITS-1:
         sig = 0;
     end
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/gray_7.sv
+++ b/examples/Benchmarks/gray_7.sv
@@ -13,6 +13,6 @@ module GRAY #(localparam CBITS = 14) (input clk, input rst, output reg [CBITS-1:
         sig = 0;
     end
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/gray_8.sv
+++ b/examples/Benchmarks/gray_8.sv
@@ -13,6 +13,6 @@ module GRAY #(localparam CBITS = 15) (input clk, input rst, output reg [CBITS-1:
         sig = 0;
     end
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/gray_9.sv
+++ b/examples/Benchmarks/gray_9.sv
@@ -13,6 +13,6 @@ module GRAY #(localparam CBITS = 16) (input clk, input rst, output reg [CBITS-1:
         sig = 0;
     end
   end
-  p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually sig == 1))) ;
+  p1: assert property (@(posedge clk) s_eventually rst || sig == 1);
   // F G (rst = F) -> G F (sig = T)
 endmodule

--- a/examples/Benchmarks/i2c_1.sv
+++ b/examples/Benchmarks/i2c_1.sv
@@ -33,7 +33,8 @@ module i2cStrech #(localparam divider = 125, localparam CBITS = 9) (input clk, i
 			data_clk = 0;
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually (rst == 1 or scl_not_ena == 1)) or (always s_eventually stretch == 1))) ;
+
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || scl_not_ena == 1 || stretch == 1);
 	//F G (rst = F & scl_not_ena = F) -> G F (stretch = T)
 
 endmodule

--- a/examples/Benchmarks/i2c_10.sv
+++ b/examples/Benchmarks/i2c_10.sv
@@ -33,6 +33,6 @@ module i2cStrech #(localparam divider = 4000, localparam CBITS = 14) (input clk,
 			data_clk = 0;
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually (rst == 1 or scl_not_ena == 1)) or (always s_eventually stretch == 1))) ;
+	p1: assert property  (@(posedge clk) s_eventually (rst == 1 || scl_not_ena == 1 || stretch == 1))) ;
 	//F G (rst = F & scl_not_ena = F) -> G F (stretch = T)
 endmodule

--- a/examples/Benchmarks/i2c_2.sv
+++ b/examples/Benchmarks/i2c_2.sv
@@ -33,6 +33,6 @@ module i2cStrech #(localparam divider = 250, localparam CBITS = 10) (input clk, 
 			data_clk = 0;
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually (rst == 1 or scl_not_ena == 1)) or (always s_eventually stretch == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually (rst == 1 || scl_not_ena == 1 || stretch == 1))) ;
 	//F G (rst = F & scl_not_ena = F) -> G F (stretch = T)
 endmodule

--- a/examples/Benchmarks/lcd_1.sv
+++ b/examples/Benchmarks/lcd_1.sv
@@ -94,10 +94,7 @@ module LCD #(localparam clk_freq = 1, localparam CBITS = 9) (input clk, input [6
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually lcd_enable == 0 ) or (always s_eventually state == 2))) ;
+
+	p1: assert property (@(posedge clk) s_eventually lcd_enable == 0 || state == 2);
 	//F G (lcd_enable = T) -> G F (state[1] = T & state[0] = F)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/lcd_10.sv
+++ b/examples/Benchmarks/lcd_10.sv
@@ -94,10 +94,6 @@ module LCD #(localparam clk_freq = 35, localparam CBITS = 15) (input clk, input 
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually lcd_enable == 0 ) or (always s_eventually state == 2))) ;
+	p1: assert property (@(posedge clk) s_eventually lcd_enable == 0 || state == 2);
 	//F G (lcd_enable = T) -> G F (state[1] = T & state[0] = F)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/lcd_11.sv
+++ b/examples/Benchmarks/lcd_11.sv
@@ -94,10 +94,6 @@ module LCD #(localparam clk_freq = 40, localparam CBITS = 15) (input clk, input 
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually lcd_enable == 0 ) or (always s_eventually state == 2))) ;
+	p1: assert property (@(posedge clk) s_eventually lcd_enable == 0 || state == 2);
 	//F G (lcd_enable = T) -> G F (state[1] = T & state[0] = F)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/lcd_12.sv
+++ b/examples/Benchmarks/lcd_12.sv
@@ -94,10 +94,6 @@ module LCD #(localparam clk_freq = 45, localparam CBITS = 15) (input clk, input 
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually lcd_enable == 0 ) or (always s_eventually state == 2))) ;
+	p1: assert property (@(posedge clk) s_eventually lcd_enable == 0 || state == 2);
 	//F G (lcd_enable = T) -> G F (state[1] = T & state[0] = F)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/lcd_13.sv
+++ b/examples/Benchmarks/lcd_13.sv
@@ -94,7 +94,7 @@ module LCD #(localparam clk_freq = 180, localparam CBITS = 17) (input clk, input
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually lcd_enable == 0 ) or (always s_eventually state == 2))) ;
+	p1: assert property  (@(posedge clk) s_eventually lcd_enable == 0 || state == 2);
 	//F G (lcd_enable = T) -> G F (state[1] = T & state[0] = F)
 endmodule
 

--- a/examples/Benchmarks/lcd_14.sv
+++ b/examples/Benchmarks/lcd_14.sv
@@ -94,7 +94,7 @@ module LCD #(localparam clk_freq = 360, localparam CBITS = 18) (input clk, input
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually lcd_enable == 0 ) or (always s_eventually state == 2))) ;
+	p1: assert property  (@(posedge clk) s_eventually lcd_enable == 0 || state == 2);
 	//F G (lcd_enable = T) -> G F (state[1] = T & state[0] = F)
 endmodule
 

--- a/examples/Benchmarks/lcd_2.sv
+++ b/examples/Benchmarks/lcd_2.sv
@@ -94,10 +94,6 @@ module LCD #(localparam clk_freq = 2, localparam CBITS = 10) (input clk, input [
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually lcd_enable == 0 ) or (always s_eventually state == 2))) ;
+	p1: assert property (@(posedge clk) s_eventually lcd_enable == 0 || state == 2);
 	//F G (lcd_enable = T) -> G F (state[1] = T & state[0] = F)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/lcd_3.sv
+++ b/examples/Benchmarks/lcd_3.sv
@@ -94,7 +94,7 @@ module LCD #(localparam clk_freq = 3, localparam CBITS = 11) (input clk, input [
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually lcd_enable == 0 ) or (always s_eventually state == 2))) ;
+	p1: assert property (@(posedge clk) s_eventually lcd_enable == 0 || state == 2);
 	//F G (lcd_enable = T) -> G F (state[1] = T & state[0] = F)
 endmodule
 

--- a/examples/Benchmarks/lcd_4.sv
+++ b/examples/Benchmarks/lcd_4.sv
@@ -94,10 +94,6 @@ module LCD #(localparam clk_freq = 5, localparam CBITS = 12) (input clk, input [
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually lcd_enable == 0 ) or (always s_eventually state == 2))) ;
+	p1: assert property (@(posedge clk) s_eventually lcd_enable == 0 || state == 2);
 	//F G (lcd_enable = T) -> G F (state[1] = T & state[0] = F)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/lcd_5.sv
+++ b/examples/Benchmarks/lcd_5.sv
@@ -94,7 +94,7 @@ module LCD #(localparam clk_freq = 10, localparam CBITS = 13) (input clk, input 
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually lcd_enable == 0 ) or (always s_eventually state == 2))) ;
+	p1: assert property (@(posedge clk) s_eventually lcd_enable == 0 || state == 2) ;
 	//F G (lcd_enable = T) -> G F (state[1] = T & state[0] = F)
 endmodule
 

--- a/examples/Benchmarks/lcd_6.sv
+++ b/examples/Benchmarks/lcd_6.sv
@@ -94,10 +94,6 @@ module LCD #(localparam clk_freq = 15, localparam CBITS = 13) (input clk, input 
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually lcd_enable == 0 ) or (always s_eventually state == 2))) ;
+	p1: assert property  (@(posedge clk) s_eventually lcd_enable == 0 || state == 2);
 	//F G (lcd_enable = T) -> G F (state[1] = T & state[0] = F)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/lcd_7.sv
+++ b/examples/Benchmarks/lcd_7.sv
@@ -94,10 +94,6 @@ module LCD #(localparam clk_freq = 20, localparam CBITS = 14) (input clk, input 
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually lcd_enable == 0 ) or (always s_eventually state == 2))) ;
+	p1: assert property (@(posedge clk) s_eventually lcd_enable == 0 || state == 2);
 	//F G (lcd_enable = T) -> G F (state[1] = T & state[0] = F)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/lcd_8.sv
+++ b/examples/Benchmarks/lcd_8.sv
@@ -94,10 +94,6 @@ module LCD #(localparam clk_freq = 25, localparam CBITS = 14) (input clk, input 
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually lcd_enable == 0 ) or (always s_eventually state == 2))) ;
+	p1: assert property (@(posedge clk) s_eventually lcd_enable == 0 || state == 2);
 	//F G (lcd_enable = T) -> G F (state[1] = T & state[0] = F)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/lcd_9.sv
+++ b/examples/Benchmarks/lcd_9.sv
@@ -94,10 +94,6 @@ module LCD #(localparam clk_freq = 30, localparam CBITS = 14) (input clk, input 
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually lcd_enable == 0 ) or (always s_eventually state == 2))) ;
+	p1: assert property (@(posedge clk) s_eventually lcd_enable == 0 || state == 2);
 	//F G (lcd_enable = T) -> G F (state[1] = T & state[0] = F)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/seven_seg_1.sv
+++ b/examples/Benchmarks/seven_seg_1.sv
@@ -22,12 +22,8 @@ module SEVEN #(localparam freq = 250, localparam CBITS = 8) (input clk, input rs
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 1)));
-	p2: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 1);
+	p2: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 0);
 	//F G (rst = FALSE) -> G F (digit_select = TRUE)
 	//F G (rst = FALSE) -> G F (digit_select = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/seven_seg_10.sv
+++ b/examples/Benchmarks/seven_seg_10.sv
@@ -22,12 +22,8 @@ module SEVEN #(localparam freq = 15000, localparam CBITS = 14) (input clk, input
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 1)));
-	p2: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 1);
+	p2: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 0);
 	//F G (rst = FALSE) -> G F (digit_select = TRUE)
 	//F G (rst = FALSE) -> G F (digit_select = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/seven_seg_11.sv
+++ b/examples/Benchmarks/seven_seg_11.sv
@@ -22,12 +22,8 @@ module SEVEN #(localparam freq = 17500, localparam CBITS = 15) (input clk, input
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 1)));
-	p2: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 0)));
+	p1: assert property  (@(posedge clk) s_eventually rst == 1 || digit_select == 1);
+	p2: assert property  (@(posedge clk) s_eventually rst == 1 || digit_select == 0);
 	//F G (rst = FALSE) -> G F (digit_select = TRUE)
 	//F G (rst = FALSE) -> G F (digit_select = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/seven_seg_12.sv
+++ b/examples/Benchmarks/seven_seg_12.sv
@@ -22,12 +22,8 @@ module SEVEN #(localparam freq = 20000, localparam CBITS = 15) (input clk, input
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 1)));
-	p2: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 1);
+	p2: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 0);
 	//F G (rst = FALSE) -> G F (digit_select = TRUE)
 	//F G (rst = FALSE) -> G F (digit_select = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/seven_seg_16.sv
+++ b/examples/Benchmarks/seven_seg_16.sv
@@ -22,12 +22,8 @@ module SEVEN #(localparam freq = 40000, localparam CBITS = 16) (input clk, input
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 1)));
-	p2: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 1);
+	p2: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 0);
 	//F G (rst = FALSE) -> G F (digit_select = TRUE)
 	//F G (rst = FALSE) -> G F (digit_select = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/seven_seg_17.sv
+++ b/examples/Benchmarks/seven_seg_17.sv
@@ -22,12 +22,8 @@ module SEVEN #(localparam freq = 80000, localparam CBITS = 17) (input clk, input
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 1)));
-	p2: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst || digit_select == 1);
+	p2: assert property (@(posedge clk) s_eventually rst || digit_select == 0);
 	//F G (rst = FALSE) -> G F (digit_select = TRUE)
 	//F G (rst = FALSE) -> G F (digit_select = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/seven_seg_18.sv
+++ b/examples/Benchmarks/seven_seg_18.sv
@@ -22,12 +22,8 @@ module SEVEN #(localparam freq = 160000, localparam CBITS = 18) (input clk, inpu
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 1)));
-	p2: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst || digit_select == 1);
+	p2: assert property (@(posedge clk) s_eventually rst || digit_select == 0);
 	//F G (rst = FALSE) -> G F (digit_select = TRUE)
 	//F G (rst = FALSE) -> G F (digit_select = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/seven_seg_2.sv
+++ b/examples/Benchmarks/seven_seg_2.sv
@@ -22,12 +22,8 @@ module SEVEN #(localparam freq = 500, localparam CBITS = 9) (input clk, input rs
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 1)));
-	p2: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 1);
+	p2: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 0);
 	//F G (rst = FALSE) -> G F (digit_select = TRUE)
 	//F G (rst = FALSE) -> G F (digit_select = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/seven_seg_3.sv
+++ b/examples/Benchmarks/seven_seg_3.sv
@@ -22,12 +22,8 @@ module SEVEN #(localparam freq = 750, localparam CBITS = 10) (input clk, input r
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 1)));
-	p2: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 1);
+	p2: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 0);
 	//F G (rst = FALSE) -> G F (digit_select = TRUE)
 	//F G (rst = FALSE) -> G F (digit_select = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/seven_seg_4.sv
+++ b/examples/Benchmarks/seven_seg_4.sv
@@ -22,12 +22,8 @@ module SEVEN #(localparam freq = 1000, localparam CBITS = 10) (input clk, input 
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 1)));
-	p2: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 1);
+	p2: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 0);
 	//F G (rst = FALSE) -> G F (digit_select = TRUE)
 	//F G (rst = FALSE) -> G F (digit_select = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/seven_seg_5.sv
+++ b/examples/Benchmarks/seven_seg_5.sv
@@ -22,12 +22,8 @@ module SEVEN #(localparam freq = 2500, localparam CBITS = 12) (input clk, input 
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 1)));
-	p2: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 1);
+	p2: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 0);
 	//F G (rst = FALSE) -> G F (digit_select = TRUE)
 	//F G (rst = FALSE) -> G F (digit_select = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/seven_seg_6.sv
+++ b/examples/Benchmarks/seven_seg_6.sv
@@ -22,12 +22,8 @@ module SEVEN #(localparam freq = 5000, localparam CBITS = 13) (input clk, input 
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 1)));
-	p2: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 1);
+	p2: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 0);
 	//F G (rst = FALSE) -> G F (digit_select = TRUE)
 	//F G (rst = FALSE) -> G F (digit_select = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/seven_seg_7.sv
+++ b/examples/Benchmarks/seven_seg_7.sv
@@ -22,12 +22,8 @@ module SEVEN #(localparam freq = 7500, localparam CBITS = 13) (input clk, input 
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 1)));
-	p2: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 1);
+	p2: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 0);
 	//F G (rst = FALSE) -> G F (digit_select = TRUE)
 	//F G (rst = FALSE) -> G F (digit_select = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/seven_seg_8.sv
+++ b/examples/Benchmarks/seven_seg_8.sv
@@ -22,12 +22,8 @@ module SEVEN #(localparam freq = 10000, localparam CBITS = 14) (input clk, input
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 1)));
-	p2: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 1);
+	p2: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 0);
 	//F G (rst = FALSE) -> G F (digit_select = TRUE)
 	//F G (rst = FALSE) -> G F (digit_select = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/seven_seg_9.sv
+++ b/examples/Benchmarks/seven_seg_9.sv
@@ -22,12 +22,8 @@ module SEVEN #(localparam freq = 12500, localparam CBITS = 14) (input clk, input
 			end
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 1)));
-	p2: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually digit_select == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 1);
+	p2: assert property (@(posedge clk) s_eventually rst == 1 || digit_select == 0);
 	//F G (rst = FALSE) -> G F (digit_select = TRUE)
 	//F G (rst = FALSE) -> G F (digit_select = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/thermocouple_1.sv
+++ b/examples/Benchmarks/thermocouple_1.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 10, localparam CBITS = 5) (input clk
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/thermocouple_10.sv
+++ b/examples/Benchmarks/thermocouple_10.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 3000, localparam CBITS = 14) (input 
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/thermocouple_11.sv
+++ b/examples/Benchmarks/thermocouple_11.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 4000, localparam CBITS = 14) (input 
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/thermocouple_12.sv
+++ b/examples/Benchmarks/thermocouple_12.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 5000, localparam CBITS = 14) (input 
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/thermocouple_13.sv
+++ b/examples/Benchmarks/thermocouple_13.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 6000, localparam CBITS = 15) (input 
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/thermocouple_14.sv
+++ b/examples/Benchmarks/thermocouple_14.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 12000, localparam CBITS = 16) (input
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/thermocouple_15.sv
+++ b/examples/Benchmarks/thermocouple_15.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 24000, localparam CBITS = 17) (input
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/thermocouple_16.sv
+++ b/examples/Benchmarks/thermocouple_16.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 48000, localparam CBITS = 18) (input
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/thermocouple_17.sv
+++ b/examples/Benchmarks/thermocouple_17.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 96000, localparam CBITS = 19) (input
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/thermocouple_2.sv
+++ b/examples/Benchmarks/thermocouple_2.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 100, localparam CBITS = 9) (input cl
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/thermocouple_3.sv
+++ b/examples/Benchmarks/thermocouple_3.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 200, localparam CBITS = 10) (input c
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/thermocouple_4.sv
+++ b/examples/Benchmarks/thermocouple_4.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 300, localparam CBITS = 10) (input c
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/thermocouple_5.sv
+++ b/examples/Benchmarks/thermocouple_5.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 400, localparam CBITS = 11) (input c
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/thermocouple_6.sv
+++ b/examples/Benchmarks/thermocouple_6.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 600, localparam CBITS = 11) (input c
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/thermocouple_7.sv
+++ b/examples/Benchmarks/thermocouple_7.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 800, localparam CBITS = 12) (input c
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/thermocouple_8.sv
+++ b/examples/Benchmarks/thermocouple_8.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 1000, localparam CBITS = 12) (input 
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/thermocouple_9.sv
+++ b/examples/Benchmarks/thermocouple_9.sv
@@ -41,6 +41,6 @@ module Thermocouple #(localparam clk_freq = 2000, localparam CBITS = 13) (input 
 		else
 			state = 1;
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1 ) or (always s_eventually state == 1))) ;
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || state == 1);
 	//F G (rst = F) -> G F (state[1] = F & state[0] = T)
 endmodule

--- a/examples/Benchmarks/uart_transmit_1.sv
+++ b/examples/Benchmarks/uart_transmit_1.sv
@@ -33,10 +33,6 @@ module UART_T #(localparam d_width = 4, localparam c_width = 3) (input clk, inpu
 		end
 		tx = tx_buffer[0];
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually tx_state == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 ||  tx_state == 0);
   	// F G (rst = FALSE) -> G F (tx_state = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/uart_transmit_10.sv
+++ b/examples/Benchmarks/uart_transmit_10.sv
@@ -33,10 +33,6 @@ module UART_T #(localparam d_width = 15, localparam c_width = 5) (input clk, inp
 		end
 		tx = tx_buffer[0];
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually tx_state == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || tx_state == 0);
   	// F G (rst = FALSE) -> G F (tx_state = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/uart_transmit_11.sv
+++ b/examples/Benchmarks/uart_transmit_11.sv
@@ -33,10 +33,6 @@ module UART_T #(localparam d_width = 16, localparam c_width = 5) (input clk, inp
 		end
 		tx = tx_buffer[0];
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually tx_state == 0)));
+	p1: assert property (@(posedge clk)  s_eventually rst == 1 || tx_state == 0);
   	// F G (rst = FALSE) -> G F (tx_state = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/uart_transmit_12.sv
+++ b/examples/Benchmarks/uart_transmit_12.sv
@@ -33,10 +33,6 @@ module UART_T #(localparam d_width = 28, localparam c_width = 6) (input clk, inp
 		end
 		tx = tx_buffer[0];
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually tx_state == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || tx_state == 0);
   	// F G (rst = FALSE) -> G F (tx_state = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/uart_transmit_2.sv
+++ b/examples/Benchmarks/uart_transmit_2.sv
@@ -33,10 +33,6 @@ module UART_T #(localparam d_width = 6, localparam c_width = 4) (input clk, inpu
 		end
 		tx = tx_buffer[0];
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually tx_state == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 ||  tx_state == 0);
   	// F G (rst = FALSE) -> G F (tx_state = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/uart_transmit_3.sv
+++ b/examples/Benchmarks/uart_transmit_3.sv
@@ -33,10 +33,6 @@ module UART_T #(localparam d_width = 8, localparam c_width = 4) (input clk, inpu
 		end
 		tx = tx_buffer[0];
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually tx_state == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || tx_state == 0);
   	// F G (rst = FALSE) -> G F (tx_state = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/uart_transmit_4.sv
+++ b/examples/Benchmarks/uart_transmit_4.sv
@@ -33,10 +33,6 @@ module UART_T #(localparam d_width = 9, localparam c_width = 4) (input clk, inpu
 		end
 		tx = tx_buffer[0];
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually tx_state == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || tx_state == 0);
   	// F G (rst = FALSE) -> G F (tx_state = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/uart_transmit_5.sv
+++ b/examples/Benchmarks/uart_transmit_5.sv
@@ -33,10 +33,6 @@ module UART_T #(localparam d_width = 10, localparam c_width = 4) (input clk, inp
 		end
 		tx = tx_buffer[0];
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually tx_state == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || tx_state == 0);
   	// F G (rst = FALSE) -> G F (tx_state = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/uart_transmit_6.sv
+++ b/examples/Benchmarks/uart_transmit_6.sv
@@ -33,10 +33,6 @@ module UART_T #(localparam d_width = 11, localparam c_width = 4) (input clk, inp
 		end
 		tx = tx_buffer[0];
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually tx_state == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || tx_state == 0);
   	// F G (rst = FALSE) -> G F (tx_state = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/uart_transmit_7.sv
+++ b/examples/Benchmarks/uart_transmit_7.sv
@@ -33,10 +33,6 @@ module UART_T #(localparam d_width = 12, localparam c_width = 4) (input clk, inp
 		end
 		tx = tx_buffer[0];
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually tx_state == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || tx_state == 0);
   	// F G (rst = FALSE) -> G F (tx_state = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/uart_transmit_8.sv
+++ b/examples/Benchmarks/uart_transmit_8.sv
@@ -33,10 +33,6 @@ module UART_T #(localparam d_width = 13, localparam c_width = 5) (input clk, inp
 		end
 		tx = tx_buffer[0];
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually tx_state == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || tx_state == 0);
   	// F G (rst = FALSE) -> G F (tx_state = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/uart_transmit_9.sv
+++ b/examples/Benchmarks/uart_transmit_9.sv
@@ -33,10 +33,6 @@ module UART_T #(localparam d_width = 14, localparam c_width = 5) (input clk, inp
 		end
 		tx = tx_buffer[0];
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually tx_state == 0)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || tx_state == 0);
   	// F G (rst = FALSE) -> G F (tx_state = FALSE)
 endmodule
-
-
-
-

--- a/examples/Benchmarks/vga_1.sv
+++ b/examples/Benchmarks/vga_1.sv
@@ -61,7 +61,7 @@ module VGA #(localparam  size = 1, localparam h_bits = 7, localparam v_bits = 5)
 				disp_ena = 0;
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually disp_ena == 1)));
+	p1: assert property  (@(posedge clk) s_eventually rst == 1 || disp_ena == 1);
   	// F G !rst -> G F disp_ena
 endmodule
 

--- a/examples/Benchmarks/vga_2.sv
+++ b/examples/Benchmarks/vga_2.sv
@@ -61,7 +61,7 @@ module VGA #(localparam  size = 2, localparam h_bits = 8, localparam v_bits = 6)
 				disp_ena = 0;
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually disp_ena == 1)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || disp_ena == 1);
   	// F G !rst -> G F disp_ena
 endmodule
 

--- a/examples/Benchmarks/vga_3.sv
+++ b/examples/Benchmarks/vga_3.sv
@@ -61,7 +61,7 @@ module VGA #(localparam  size = 3, localparam h_bits = 8, localparam v_bits = 7)
 				disp_ena = 0;
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually disp_ena == 1)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || disp_ena == 1);
   	// F G !rst -> G F disp_ena
 endmodule
 

--- a/examples/Benchmarks/vga_4.sv
+++ b/examples/Benchmarks/vga_4.sv
@@ -61,7 +61,6 @@ module VGA #(localparam  size = 4, localparam h_bits = 9, localparam v_bits = 7)
 				disp_ena = 0;
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually disp_ena == 1)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || disp_ena == 1);
   	// F G !rst -> G F disp_ena
 endmodule
-

--- a/examples/Benchmarks/vga_5.sv
+++ b/examples/Benchmarks/vga_5.sv
@@ -61,7 +61,6 @@ module VGA #(localparam  size = 5, localparam h_bits = 9, localparam v_bits = 8)
 				disp_ena = 0;
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually disp_ena == 1)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || disp_ena == 1);
   	// F G !rst -> G F disp_ena
 endmodule
-

--- a/examples/Benchmarks/vga_6.sv
+++ b/examples/Benchmarks/vga_6.sv
@@ -61,7 +61,6 @@ module VGA #(localparam  size = 6, localparam h_bits = 9, localparam v_bits = 8)
 				disp_ena = 0;
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually disp_ena == 1)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || disp_ena == 1);
   	// F G !rst -> G F disp_ena
 endmodule
-

--- a/examples/Benchmarks/vga_7.sv
+++ b/examples/Benchmarks/vga_7.sv
@@ -61,7 +61,6 @@ module VGA #(localparam  size = 8, localparam h_bits = 10, localparam v_bits = 8
 				disp_ena = 0;
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually disp_ena == 1)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || disp_ena == 1);
   	// F G !rst -> G F disp_ena
 endmodule
-

--- a/examples/Benchmarks/vga_8.sv
+++ b/examples/Benchmarks/vga_8.sv
@@ -61,7 +61,6 @@ module VGA #(localparam  size = 10, localparam h_bits = 10, localparam v_bits = 
 				disp_ena = 0;
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually disp_ena == 1)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || disp_ena == 1);
   	// F G !rst -> G F disp_ena
 endmodule
-

--- a/examples/Benchmarks/vga_9.sv
+++ b/examples/Benchmarks/vga_9.sv
@@ -61,7 +61,7 @@ module VGA #(localparam  size = 16, localparam h_bits = 11, localparam v_bits = 
 				disp_ena = 0;
 		end
 	end
-	p1: assert property  (@(posedge clk) ((always s_eventually rst == 1) or (always s_eventually disp_ena == 1)));
+	p1: assert property (@(posedge clk) s_eventually rst == 1 || disp_ena == 1);
   	// F G !rst -> G F disp_ena
 endmodule
 


### PR DESCRIPTION
1) This removes the redundant SVA always operator.

2) This adds a script for checking a ranking function on the benchmarks.