### PR TITLE
EBMC: give error message when unsupported property is passed to IC3

### DIFF
--- a/regression/ebmc/ic3/not_supported1.desc
+++ b/regression/ebmc/ic3/not_supported1.desc
@@ -1,0 +1,7 @@
+CORE
+not_supported1.sv
+--ic3
+^\[main\.property\.p0\] always s_eventually main\.my_bit: FAILURE: property not supported by IC3 engine$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/ebmc/ic3/not_supported1.sv
+++ b/regression/ebmc/ic3/not_supported1.sv
@@ -1,0 +1,13 @@
+module main(input clk);
+
+  reg my_bit;
+
+  initial my_bit=0;
+
+  always @(posedge clk)
+    my_bit = !my_bit;
+
+  // expected to pass
+  p0: assert property (s_eventually my_bit);
+
+endmodule


### PR DESCRIPTION
The IC3 engine now reports an appropriate error message when given an unsupported property.