### PR TITLE
introduce ebmc_propertiest::exit_code

### DIFF
--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -228,10 +228,7 @@ int bdd_enginet::operator()()
 
     const namespacet ns(transition_system.symbol_table);
     report_results(cmdline, properties, ns, message.get_message_handler());
-
-    // We return '0' if all properties are proven,
-    // and '10' otherwise.
-    return properties.all_properties_proved() ? 0 : 10;
+    return properties.exit_code();
   }
   catch(const char *error_msg)
   {

--- a/src/ebmc/ebmc_base.cpp
+++ b/src/ebmc/ebmc_base.cpp
@@ -130,9 +130,7 @@ int ebmc_baset::finish_bit_level_bmc(const bmc_mapt &bmc_map, propt &solver)
     << std::chrono::duration<double>(sat_stop_time - sat_start_time).count()
     << messaget::eom;
 
-  // We return '0' if all properties are proved,
-  // and '10' otherwise.
-  return properties.all_properties_proved() ? 0 : 10;
+  return properties.exit_code();
 }
 
 /*******************************************************************\
@@ -541,10 +539,7 @@ int ebmc_baset::do_word_level_bmc()
       {
         const namespacet ns(transition_system.symbol_table);
         report_results(cmdline, properties, ns, message.get_message_handler());
-
-        // We return '0' if all properties are proved,
-        // and '10' otherwise.
-        result = properties.all_properties_proved() ? 0 : 10;
+        result = properties.exit_code();
       }
     }
   }

--- a/src/ebmc/ebmc_properties.cpp
+++ b/src/ebmc/ebmc_properties.cpp
@@ -192,3 +192,10 @@ ebmc_propertiest ebmc_propertiest::from_command_line(
     return properties;
   }
 }
+
+int ebmc_propertiest::exit_code() const
+{
+  // We return '0' if all properties are proved,
+  // and '10' otherwise.
+  return all_properties_proved() ? 0 : 10;
+}

--- a/src/ebmc/ebmc_properties.h
+++ b/src/ebmc/ebmc_properties.h
@@ -201,6 +201,9 @@ public:
   from_transition_system(const transition_systemt &, message_handlert &);
 
   bool select_property(const cmdlinet &, message_handlert &);
+
+  // command-line tool exit code, depending on property status
+  int exit_code() const;
 };
 
 #endif // CPROVER_EBMC_PROPERTIES_H

--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -159,10 +159,7 @@ int do_k_induction(
 
   const namespacet ns(transition_system.symbol_table);
   report_results(cmdline, properties, ns, message_handler);
-
-  // We return '0' if all properties are proved,
-  // and '10' otherwise.
-  return properties.all_properties_proved() ? 0 : 10;
+  return properties.exit_code();
 }
 
 /*******************************************************************\

--- a/src/ebmc/neural_liveness.cpp
+++ b/src/ebmc/neural_liveness.cpp
@@ -119,8 +119,7 @@ int neural_livenesst::operator()()
   // report outcomes
   const namespacet ns(transition_system.symbol_table);
   report_results(cmdline, properties, ns, message.get_message_handler());
-
-  return 0;
+  return properties.exit_code();
 }
 
 int neural_livenesst::show_traces()

--- a/src/ebmc/ranking_function.cpp
+++ b/src/ebmc/ranking_function.cpp
@@ -127,8 +127,7 @@ int do_ranking_function(
 
   const namespacet ns(transition_system.symbol_table);
   report_results(cmdline, properties, ns, message_handler);
-
-  return properties.all_properties_proved() ? 0 : 10;
+  return properties.exit_code();
 }
 
 std::pair<tvt, std::optional<trans_tracet>> is_ranking_function(

--- a/src/ic3/m1ain.cc
+++ b/src/ic3/m1ain.cc
@@ -135,7 +135,7 @@ int ic3_enginet::operator()()
     {
       namespacet ns(transition_system.symbol_table);
       report_results(cmdline, properties, ns, message.get_message_handler());
-      return 10;
+      return properties.exit_code();
     }
   }
   catch(const std::string &error_str)


### PR DESCRIPTION
This consolidates the logic for determining the tool exit code in one place, to achieve consistency.