### PR TITLE
Verilog: fix always_comb synthesis

### DIFF
--- a/regression/verilog/synthesis/always_comb3.desc
+++ b/regression/verilog/synthesis/always_comb3.desc
@@ -1,0 +1,8 @@
+CORE
+always_comb3.sv
+--bound 1
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/synthesis/always_comb3.sv
+++ b/regression/verilog/synthesis/always_comb3.sv
@@ -1,0 +1,15 @@
+module main(input clk);
+  reg q;
+  
+  reg w;
+
+  // ff
+  always @(posedge clk)
+    q = !q;
+
+  always_comb
+    w = q;
+
+  p1: assert property (@(posedge clk) w == q);
+
+endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -3023,11 +3023,15 @@ exprt verilog_synthesist::current_value(
 
     if(
       construct == constructt::ALWAYS || construct == constructt::ALWAYS_FF ||
-      construct == constructt::ALWAYS_LATCH)
+      construct == constructt::ALWAYS_LATCH ||
+      construct == constructt::ALWAYS_COMB)
+    {
       return symbol_expr(symbol, CURRENT);
+    }
     else
     {
-      // make it some non-deterministic value
+      // Initial state computation, i.e., this is a value _before_ the
+      // initial state  -- make it non-deterministic
       exprt result=exprt(ID_nondet_symbol, symbol.type);
       result.set(ID_identifier, symbol.name);
       result.set("initial_value", true);


### PR DESCRIPTION
This fixes the synthesis of the RHS when using SystemVerilog's `always_comb`.