### PR TITLE
Verilog: introduce `sva_ranged_predicate_exprt`

### DIFF
--- a/src/trans-word-level/instantiate_word_level.cpp
+++ b/src/trans-word-level/instantiate_word_level.cpp
@@ -225,15 +225,14 @@ exprt wl_instantiatet::instantiate_rec(exprt expr, const mp_integer &t) const
   else if(expr.id() == ID_sva_eventually)
   {
     const auto &eventually_expr = to_sva_eventually_expr(expr);
-    const auto &range = eventually_expr.range();
     const auto &op = eventually_expr.op();
 
     mp_integer lower;
-    if(to_integer_non_constant(range.op0(), lower))
+    if(to_integer_non_constant(eventually_expr.lower(), lower))
       throw "failed to convert sva_eventually index";
 
     mp_integer upper;
-    if(to_integer_non_constant(range.op1(), upper))
+    if(to_integer_non_constant(eventually_expr.upper(), upper))
       throw "failed to convert sva_eventually index";
 
     // This is weak, and passes if any of the timeframes

--- a/src/trans-word-level/property.cpp
+++ b/src/trans-word-level/property.cpp
@@ -167,11 +167,14 @@ static void property_obligations_rec(
     auto &phi = property_expr.id() == ID_sva_ranged_always
                   ? to_sva_ranged_always_expr(property_expr).op()
                   : to_sva_s_always_expr(property_expr).op();
-    auto &range = property_expr.id() == ID_sva_ranged_always
-                    ? to_sva_ranged_always_expr(property_expr).range()
-                    : to_sva_s_always_expr(property_expr).range();
+    auto &lower = property_expr.id() == ID_sva_ranged_always
+                    ? to_sva_ranged_always_expr(property_expr).lower()
+                    : to_sva_s_always_expr(property_expr).lower();
+    auto &upper = property_expr.id() == ID_sva_ranged_always
+                    ? to_sva_ranged_always_expr(property_expr).upper()
+                    : to_sva_s_always_expr(property_expr).upper();
 
-    auto from_opt = numeric_cast<mp_integer>(range.op0());
+    auto from_opt = numeric_cast<mp_integer>(lower);
     if(!from_opt.has_value())
       throw ebmc_errort() << "failed to convert SVA always from index";
 
@@ -179,13 +182,13 @@ static void property_obligations_rec(
 
     mp_integer to;
 
-    if(range.op1().id() == ID_infinity)
+    if(upper.id() == ID_infinity)
     {
       to = no_timeframes - 1;
     }
     else
     {
-      auto to_opt = numeric_cast<mp_integer>(range.op1());
+      auto to_opt = numeric_cast<mp_integer>(upper);
       if(!to_opt.has_value())
         throw ebmc_errort() << "failed to convert SVA always to index";
       to = std::min(*to_opt, no_timeframes - 1);

--- a/src/verilog/expr2verilog_class.h
+++ b/src/verilog/expr2verilog_class.h
@@ -12,6 +12,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/bitvector_expr.h>
 #include <util/std_expr.h>
 
+class sva_ranged_predicate_exprt;
+
 class expr2verilogt
 {
 public:
@@ -82,15 +84,11 @@ public:
     const std::string &name,
     const exprt &src);
 
-  std::string convert_sva(
+  std::string convert_sva_ranged_predicate(
     const std::string &name,
-    const std::optional<exprt> &range,
-    const exprt &op);
+    const sva_ranged_predicate_exprt &);
 
-  std::string convert_sva(const std::string &name, const exprt &op)
-  {
-    return convert_sva(name, {}, op);
-  }
+  std::string convert_sva_unary(const std::string &name, const unary_exprt &);
 
   std::string
   convert_sva(const exprt &lhs, const std::string &name, const exprt &rhs);

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2062,16 +2062,16 @@ property_expr_proper:
         | "nexttime" property_expr          { init($$, "sva_nexttime"); mto($$, $2); }
         | "s_nexttime" property_expr        { init($$, "sva_s_nexttime"); mto($$, $2); }
         | "always" '[' cycle_delay_const_range_expression ']' property_expr %prec "always"
-		{ init($$, ID_sva_ranged_always); mto($$, $3); mto($$, $5); }
+		{ init($$, ID_sva_ranged_always); swapop($$, $3); mto($$, $5); }
         | "always" property_expr            { init($$, "sva_always"); mto($$, $2); }
         | "s_always" '[' constant_range ']' property_expr %prec "s_always"
-		{ init($$, ID_sva_s_always); mto($$, $3); mto($$, $5); }
+		{ init($$, ID_sva_s_always); swapop($$, $3); mto($$, $5); }
         | "s_eventually" property_expr
-		{ init($$, "sva_s_eventually"); mto($$, $2); }
+		{ init($$, ID_sva_s_eventually); mto($$, $2); }
         | "eventually" '[' constant_range ']' property_expr %prec "eventually"
-		{ init($$, "sva_eventually"); mto($$, $3); mto($$, $5); }
+		{ init($$, ID_sva_eventually); swapop($$, $3); mto($$, $5); }
         | "s_eventually" '[' cycle_delay_const_range_expression ']' property_expr %prec "s_eventually"
-		{ init($$, "sva_s_eventually"); mto($$, $5); }
+		{ init($$, ID_sva_s_eventually); swapop($$, $3); mto($$, $5); }
         | property_expr "until" property_expr        { init($$, "sva_until"); mto($$, $1); mto($$, $3); }
         | property_expr "until_with" property_expr   { init($$, "sva_until_with"); mto($$, $1); mto($$, $3); }
         | property_expr "s_until" property_expr      { init($$, "sva_s_until"); mto($$, $1); mto($$, $3); }

--- a/src/verilog/sva_expr.h
+++ b/src/verilog/sva_expr.h
@@ -58,54 +58,70 @@ static inline sva_s_nexttime_exprt &to_sva_s_nexttime_expr(exprt &expr)
   return static_cast<sva_s_nexttime_exprt &>(expr);
 }
 
-class sva_eventually_exprt : public binary_predicate_exprt
+class sva_ranged_predicate_exprt : public ternary_exprt
 {
 public:
-  explicit sva_eventually_exprt(exprt __range, exprt __op)
-    : binary_predicate_exprt(
-        std::move(__range),
-        ID_sva_eventually,
-        std::move(__op))
+  sva_ranged_predicate_exprt(
+    irep_idt __id,
+    exprt __lower,
+    exprt __upper,
+    exprt __op)
+    : ternary_exprt(
+        __id,
+        std::move(__lower),
+        std::move(__upper),
+        std::move(__op),
+        bool_typet())
   {
   }
 
-  // These come with a range, which is binary
-  const binary_exprt &range() const
+  const exprt &lower() const
   {
-    return static_cast<const binary_exprt &>(op0());
+    return op0();
   }
 
-  binary_exprt &range()
+  exprt &lower()
   {
-    return static_cast<binary_exprt &>(op0());
+    return op0();
+  }
+
+  const exprt &upper() const
+  {
+    return op1();
+  }
+
+  exprt &upper()
+  {
+    return op1();
   }
 
   const exprt &op() const
   {
-    return op1();
+    return op2();
   }
 
   exprt &op()
   {
-    return op1();
-  }
-
-  const exprt &lhs() const = delete;
-  exprt &lhs() = delete;
-  const exprt &rhs() const = delete;
-  exprt &rhs() = delete;
-
-  static void check(
-    const exprt &expr,
-    const validation_modet vm = validation_modet::INVARIANT)
-  {
-    binary_exprt::check(expr, vm);
-    binary_exprt::check(to_binary_expr(expr).op0(), vm);
+    return op2();
   }
 
 protected:
-  using binary_predicate_exprt::op0;
-  using binary_predicate_exprt::op1;
+  using ternary_exprt::op0;
+  using ternary_exprt::op1;
+  using ternary_exprt::op2;
+};
+
+class sva_eventually_exprt : public sva_ranged_predicate_exprt
+{
+public:
+  sva_eventually_exprt(exprt __lower, exprt __upper, exprt __op)
+    : sva_ranged_predicate_exprt(
+        ID_sva_eventually,
+        std::move(__lower),
+        std::move(__upper),
+        std::move(__op))
+  {
+  }
 };
 
 static inline const sva_eventually_exprt &
@@ -170,51 +186,17 @@ static inline sva_always_exprt &to_sva_always_expr(exprt &expr)
   return static_cast<sva_always_exprt &>(expr);
 }
 
-class sva_ranged_always_exprt : public binary_predicate_exprt
+class sva_ranged_always_exprt : public sva_ranged_predicate_exprt
 {
 public:
-  sva_ranged_always_exprt(binary_exprt range, exprt op)
-    : binary_predicate_exprt(std::move(range), ID_sva_always, std::move(op))
+  sva_ranged_always_exprt(exprt lower, exprt upper, exprt op)
+    : sva_ranged_predicate_exprt(
+        ID_sva_always,
+        std::move(lower),
+        std::move(upper),
+        std::move(op))
   {
   }
-
-  // These come with a range, which is binary
-  const binary_exprt &range() const
-  {
-    return static_cast<const binary_exprt &>(op0());
-  }
-
-  binary_exprt &range()
-  {
-    return static_cast<binary_exprt &>(op0());
-  }
-
-  const exprt &op() const
-  {
-    return op1();
-  }
-
-  exprt &op()
-  {
-    return op1();
-  }
-
-  const exprt &lhs() const = delete;
-  exprt &lhs() = delete;
-  const exprt &rhs() const = delete;
-  exprt &rhs() = delete;
-
-  static void check(
-    const exprt &expr,
-    const validation_modet vm = validation_modet::INVARIANT)
-  {
-    binary_exprt::check(expr, vm);
-    binary_exprt::check(to_binary_expr(expr).op0(), vm);
-  }
-
-protected:
-  using binary_predicate_exprt::op0;
-  using binary_predicate_exprt::op1;
 };
 
 static inline const sva_ranged_always_exprt &
@@ -232,51 +214,17 @@ static inline sva_ranged_always_exprt &to_sva_ranged_always_expr(exprt &expr)
   return static_cast<sva_ranged_always_exprt &>(expr);
 }
 
-class sva_s_always_exprt : public binary_predicate_exprt
+class sva_s_always_exprt : public sva_ranged_predicate_exprt
 {
 public:
-  sva_s_always_exprt(binary_exprt range, exprt op)
-    : binary_predicate_exprt(std::move(range), ID_sva_s_always, std::move(op))
+  sva_s_always_exprt(exprt lower, exprt upper, exprt op)
+    : sva_ranged_predicate_exprt(
+        ID_sva_s_always,
+        std::move(lower),
+        std::move(upper),
+        std::move(op))
   {
   }
-
-  // These come with a range, which is binary
-  const binary_exprt &range() const
-  {
-    return static_cast<const binary_exprt &>(op0());
-  }
-
-  binary_exprt &range()
-  {
-    return static_cast<binary_exprt &>(op0());
-  }
-
-  const exprt &op() const
-  {
-    return op1();
-  }
-
-  exprt &op()
-  {
-    return op1();
-  }
-
-  const exprt &lhs() const = delete;
-  exprt &lhs() = delete;
-  const exprt &rhs() const = delete;
-  exprt &rhs() = delete;
-
-  static void check(
-    const exprt &expr,
-    const validation_modet vm = validation_modet::INVARIANT)
-  {
-    binary_exprt::check(expr, vm);
-    binary_exprt::check(to_binary_expr(expr).op0(), vm);
-  }
-
-protected:
-  using binary_predicate_exprt::op0;
-  using binary_predicate_exprt::op1;
 };
 
 static inline const sva_s_always_exprt &to_sva_s_always_expr(const exprt &expr)

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -2231,39 +2231,6 @@ exprt verilog_typecheck_exprt::convert_binary_expr(binary_exprt expr)
 
     return std::move(expr);
   }
-  else if(
-    expr.id() == ID_sva_eventually || expr.id() == ID_sva_ranged_always ||
-    expr.id() == ID_sva_s_always)
-  {
-    auto &range = to_binary_expr(expr.op0());
-
-    auto lower = convert_integer_constant_expression(range.op0());
-
-    range.op0() =
-      from_integer(lower, natural_typet()).with_source_location(range.op0());
-
-    if(range.op1().id() == ID_infinity)
-    {
-    }
-    else
-    {
-      auto upper = convert_integer_constant_expression(range.op1());
-      if(lower > upper)
-      {
-        throw errort().with_location(expr.source_location())
-          << "range must be lower <= upper";
-      }
-
-      range.op1() =
-        from_integer(upper, natural_typet()).with_source_location(range.op1());
-    }
-
-    convert_expr(expr.op1());
-    make_boolean(expr.op1());
-    expr.type() = bool_typet();
-
-    return std::move(expr);
-  }
   else if(expr.id()==ID_hierarchical_identifier)
   {
     return convert_hierarchical_identifier(
@@ -2519,6 +2486,37 @@ exprt verilog_typecheck_exprt::convert_trinary_expr(ternary_exprt expr)
     if(expr.op1().is_not_nil()) convert_expr(expr.op1());
     convert_expr(expr.op2());
     make_boolean(expr.op2());
+    return std::move(expr);
+  }
+  else if(
+    expr.id() == ID_sva_eventually || expr.id() == ID_sva_ranged_always ||
+    expr.id() == ID_sva_s_always)
+  {
+    auto lower = convert_integer_constant_expression(expr.op0());
+
+    expr.op0() =
+      from_integer(lower, natural_typet()).with_source_location(expr.op0());
+
+    if(expr.op1().id() == ID_infinity)
+    {
+    }
+    else
+    {
+      auto upper = convert_integer_constant_expression(expr.op1());
+      if(lower > upper)
+      {
+        throw errort().with_location(expr.source_location())
+          << "range must be lower <= upper";
+      }
+
+      expr.op1() =
+        from_integer(upper, natural_typet()).with_source_location(expr.op1());
+    }
+
+    convert_expr(expr.op2());
+    make_boolean(expr.op2());
+    expr.type() = bool_typet();
+
     return std::move(expr);
   }
   else


### PR DESCRIPTION
This consolidates replicated code from the SVA predicates that have a range into a common base class.