### PR TITLE
trace length for disjunctive properties

### DIFF
--- a/regression/ebmc/traces/disjunction1.desc
+++ b/regression/ebmc/traces/disjunction1.desc
@@ -1,0 +1,12 @@
+CORE broken-smt-backend
+disjunction1.smv
+--bound 20 --numbered-trace
+^\[spec1\] G \(X FALSE \| X X FALSE\): REFUTED$
+^Counterexample with 3 states:$
+^i@0 = 0$
+^i@1 = 1$
+^i@2 = 2$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/ebmc/traces/disjunction1.smv
+++ b/regression/ebmc/traces/disjunction1.smv
@@ -1,0 +1,12 @@
+MODULE main
+
+VAR i: 0..20;
+
+ASSIGN init(i) := 0;
+       next(i) := case
+         i >= 10 : 10;
+         TRUE   : i + 1;
+       esac;
+
+-- we need to see a trace with three states
+LTLSPEC G ((X FALSE) | (X X FALSE))


### PR DESCRIPTION
Given a property a ∨ b with obligations at timeframe l and m, generate the obligation for the disjunction at timeframe max{l, m}.
