### PR TITLE
Verilog: move translation of part select expressions into synthesis phase

### DIFF
--- a/regression/verilog/synthesis/part_select1.desc
+++ b/regression/verilog/synthesis/part_select1.desc
@@ -1,0 +1,7 @@
+CORE
+part_select1.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/synthesis/part_select1.sv
+++ b/regression/verilog/synthesis/part_select1.sv
@@ -1,0 +1,15 @@
+module main;
+
+  reg [31:0] t;
+
+  always @(*) begin
+    t = 0;
+
+    // out of bounds accesses are ignored
+    t[0:-1] = 'b10;
+
+    // should pass
+    assert(t == 1);
+  end
+
+endmodule

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -681,14 +681,17 @@ void verilog_typecheckt::check_lhs(
 
     check_lhs(to_extractbit_expr(lhs).src(), vassign);
   }
-  else if(lhs.id()==ID_extractbits)
+  else if(lhs.id() == ID_verilog_non_indexed_part_select)
   {
-    if(lhs.operands().size()!=3)
-    {
-      throw errort() << "extractbits takes three operands";
-    }
-
-    check_lhs(to_extractbits_expr(lhs).src(), vassign);
+    auto &part_select = to_verilog_non_indexed_part_select_expr(lhs);
+    check_lhs(part_select.src(), vassign);
+  }
+  else if(
+    lhs.id() == ID_verilog_indexed_part_select_plus ||
+    lhs.id() == ID_verilog_indexed_part_select_minus)
+  {
+    auto &part_select = to_verilog_indexed_part_select_plus_or_minus_expr(lhs);
+    check_lhs(part_select.src(), vassign);
   }
   else if(lhs.id()==ID_concatenation)
   {


### PR DESCRIPTION
The Verilog frontend translates Verilog part select expressions into extractbits expressions.  This is moved from the typechecker to the synthesis phase.
