### PR TITLE
Verilog: KNOWNBUG test for continuous assignments to variables

### DIFF
--- a/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog.desc
+++ b/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog.desc
@@ -1,5 +1,5 @@
 CORE
-continuous_assignment_to_variable.v
+continuous_assignment_to_variable_systemverilog.sv
 --bound 0
 ^\[main\.property\.p1\] always main\.some_reg == main\.i: PROVED up to bound 0$
 ^EXIT=0$

--- a/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog.sv
+++ b/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog.sv
@@ -1,0 +1,11 @@
+module main(input i);
+
+  reg some_reg;
+
+  // continuous assignments to variables are allowed in SystemVerilog
+  assign some_reg = i;
+
+  // should pass
+  p1: assert property (some_reg == i);
+
+endmodule

--- a/regression/verilog/synthesis/continuous_assignment_to_variable_verilog.desc
+++ b/regression/verilog/synthesis/continuous_assignment_to_variable_verilog.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+continuous_assignment_to_variable_verilog.v
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This should error.

--- a/regression/verilog/synthesis/continuous_assignment_to_variable_verilog.v
+++ b/regression/verilog/synthesis/continuous_assignment_to_variable_verilog.v
@@ -2,9 +2,7 @@ module main(input i);
 
   reg some_reg;
 
+  // continuous assignment to variables are not allowed in Verilog
   assign some_reg = i;
-
-  // should pass
-  always assert p1: some_reg == i;
 
 endmodule


### PR DESCRIPTION
Continous assignments to variables are allowed in SystemVerilog, but not Verilog.