### PR TITLE
Verilog: standard version now tracked in parse tree

### DIFF
--- a/src/verilog/scanner.l
+++ b/src/verilog/scanner.l
@@ -71,34 +71,34 @@ static void preprocessor()
                              TOK_NON_TYPE_IDENTIFIER; \
   }
 #define KEYWORD(s, x) \
-  { if(PARSER.mode >= verilog_standardt::s) \
+  { if(PARSER.parse_tree.standard >= verilog_standardt::s) \
       return x; \
     else \
       IDENTIFIER(yytext); \
   }
 #define SYSTEM_VERILOG_OPERATOR(token, text) \
-  { if(PARSER.mode >= verilog_standardt::SV2005) \
+  { if(PARSER.parse_tree.standard >= verilog_standardt::SV2005) \
       return token; \
     else \
       yyverilogerror(text " is a System Verilog operator"); \
   }
 #define VL2SMV_OR_SYSTEM_VERILOG_KEYWORD(x) \
-  { if(PARSER.mode >= verilog_standardt::SV2005 || \
-       PARSER.mode == verilog_standardt::V2005_SMV) \
+  { if(PARSER.parse_tree.standard >= verilog_standardt::SV2005 || \
+       PARSER.parse_tree.standard == verilog_standardt::V2005_SMV) \
       return x; \
     else \
       IDENTIFIER(yytext); \
   }
 #define VL2SMV_VERILOG_KEYWORD(x) \
-  { if(PARSER.mode == verilog_standardt::V2005_SMV) \
+  { if(PARSER.parse_tree.standard == verilog_standardt::V2005_SMV) \
       return x; \
     else \
       IDENTIFIER(yytext); \
   }
 #define VIS_OR_VL2SMV_OR_SYSTEM_VERILOG_KEYWORD(x) \
-  { if(PARSER.mode >= verilog_standardt::SV2005 || \
-       PARSER.mode == verilog_standardt::V2005_SMV || \
-       PARSER.mode == verilog_standardt::V2005_VIS) \
+  { if(PARSER.parse_tree.standard >= verilog_standardt::SV2005 || \
+       PARSER.parse_tree.standard == verilog_standardt::V2005_SMV || \
+       PARSER.parse_tree.standard == verilog_standardt::V2005_VIS) \
       return x; \
     else \
       IDENTIFIER(yytext); \

--- a/src/verilog/verilog_language.h
+++ b/src/verilog/verilog_language.h
@@ -87,8 +87,8 @@ public:
   }
   
   optionst options;
-  
-  verilog_languaget()
+
+  verilog_languaget() : parse_tree(verilog_standardt::NOT_SET)
   {
     options.set_option("flatten_hierarchy", true);
   }

--- a/src/verilog/verilog_parameterize_module.cpp
+++ b/src/verilog/verilog_parameterize_module.cpp
@@ -288,7 +288,8 @@ irep_idt verilog_typecheckt::parameterize_module(
 
   // recursive call
 
-  verilog_typecheckt verilog_typecheck(*new_symbol, symbol_table, get_message_handler());
+  verilog_typecheckt verilog_typecheck(
+    standard, *new_symbol, symbol_table, get_message_handler());
 
   if(verilog_typecheck.typecheck_main())
     throw 0;

--- a/src/verilog/verilog_parse_tree.h
+++ b/src/verilog/verilog_parse_tree.h
@@ -9,16 +9,24 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_VERILOG_PARSE_TREE_H
 #define CPROVER_VERILOG_PARSE_TREE_H
 
-#include <list>
-#include <set>
-
 #include <util/string_hash.h>
 
 #include "verilog_module.h"
+#include "verilog_standard.h"
+
+#include <list>
+#include <set>
 
 class verilog_parse_treet
 {
 public:
+  explicit verilog_parse_treet(verilog_standardt _standard)
+    : standard(_standard)
+  {
+  }
+
+  verilog_standardt standard;
+
   class verilog_typedeft
   {
   public:
@@ -93,6 +101,7 @@ public:
     parse_tree.items.swap(items);
     parse_tree.expr.swap(expr);
     parse_tree.module_map.swap(module_map);
+    std::swap(parse_tree.standard, standard);
   }
 
   void modules_provided(

--- a/src/verilog/verilog_parser.cpp
+++ b/src/verilog/verilog_parser.cpp
@@ -29,12 +29,12 @@ Function:
 
 \*******************************************************************/
 
-bool parse_verilog_file(const std::string &filename)
+bool parse_verilog_file(const std::string &filename, verilog_standardt standard)
 {
   std::ifstream in(widen_if_needed(filename));
   console_message_handlert console_message_handler;
 
-  verilog_parsert verilog_parser;
+  verilog_parsert verilog_parser(standard);
 
   verilog_parser.set_file(filename);
   verilog_parser.log.set_message_handler(console_message_handler);

--- a/src/verilog/verilog_parser.h
+++ b/src/verilog/verilog_parser.h
@@ -33,14 +33,12 @@ public:
   typedef enum { LANGUAGE, EXPRESSION, TYPE } grammart;
   grammart grammar;
 
-  verilog_standardt mode;
-
   virtual bool parse()
   {
     return yyverilogparse()!=0;
   }
 
-  verilog_parsert() : mode(verilog_standardt::V2005_VIS)
+  explicit verilog_parsert(verilog_standardt standard) : parse_tree(standard)
   {
     PRECONDITION(verilog_parser_ptr == nullptr);
     verilog_parser_ptr = this;
@@ -131,7 +129,7 @@ public:
   }
 };
 
-bool parse_verilog_file(const std::string &filename);
+bool parse_verilog_file(const std::string &filename, verilog_standardt);
 void verilog_scanner_init();
 
 #endif

--- a/src/verilog/verilog_standard.h
+++ b/src/verilog/verilog_standard.h
@@ -16,6 +16,7 @@ Author: Daniel Kroening, dkr@amazon.com
 // Verilog that the Cadence SMV model checker accepts.
 enum class verilog_standardt
 {
+  NOT_SET,
   V1995,
   V2001_NOCONFIG,
   V2001,

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -334,7 +334,8 @@ exprt verilog_synthesist::expand_function_call(const function_call_exprt &call)
     else
     {
       // Attempt to constant fold.
-      verilog_typecheck_exprt verilog_typecheck_expr(ns, get_message_handler());
+      verilog_typecheck_exprt verilog_typecheck_expr(
+        standard, ns, get_message_handler());
       auto result =
         verilog_typecheck_expr.elaborate_constant_system_function_call(call);
       if(!result.is_constant())
@@ -1404,7 +1405,7 @@ void verilog_synthesist::synth_module_instance(
 
   // make sure the module is synthesized already
   verilog_synthesis(
-    symbol_table, module_identifier, get_message_handler(), options);
+    symbol_table, module_identifier, standard, get_message_handler(), options);
 
   for(auto &instance : statement.instances())
     expand_module_instance(module_symbol, instance, trans);
@@ -3496,12 +3497,13 @@ Function: verilog_synthesis
 bool verilog_synthesis(
   symbol_table_baset &symbol_table,
   const irep_idt &module,
+  verilog_standardt standard,
   message_handlert &message_handler,
   const optionst &options)
 {
   const namespacet ns(symbol_table);
   verilog_synthesist verilog_synthesis(
-    ns, symbol_table, module, options, message_handler);
+    standard, ns, symbol_table, module, options, message_handler);
   return verilog_synthesis.typecheck_main();
 }
 
@@ -3520,6 +3522,7 @@ Function: verilog_synthesis
 bool verilog_synthesis(
   exprt &expr,
   const irep_idt &module_identifier,
+  verilog_standardt standard,
   message_handlert &message_handler,
   const namespacet &ns)
 {
@@ -3530,7 +3533,7 @@ bool verilog_synthesis(
     message_handler.get_message_count(messaget::M_ERROR);
 
   verilog_synthesist verilog_synthesis(
-    ns, symbol_table, module_identifier, options, message_handler);
+    standard, ns, symbol_table, module_identifier, options, message_handler);
 
   try
   {

--- a/src/verilog/verilog_synthesis.h
+++ b/src/verilog/verilog_synthesis.h
@@ -13,15 +13,19 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/options.h>
 #include <util/symbol_table_base.h>
 
+#include "verilog_standard.h"
+
 bool verilog_synthesis(
   symbol_table_baset &,
   const irep_idt &module,
+  verilog_standardt,
   message_handlert &,
   const optionst &);
 
 bool verilog_synthesis(
   exprt &,
   const irep_idt &module_identifier,
+  verilog_standardt,
   message_handlert &,
   const namespacet &);
 

--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -41,12 +41,13 @@ class verilog_synthesist:
 {
 public:
   verilog_synthesist(
+    verilog_standardt _standard,
     const namespacet &_ns,
     symbol_table_baset &_symbol_table,
     const irep_idt &_module,
     const optionst &_options,
     message_handlert &_message_handler)
-    : verilog_typecheck_baset(_ns, _message_handler),
+    : verilog_typecheck_baset(_standard, _ns, _message_handler),
       verilog_symbol_tablet(_symbol_table),
       options(_options),
       value_map(NULL),

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1746,7 +1746,10 @@ bool verilog_typecheck(
   }
 
   return verilog_typecheck(
-    symbol_table, it->second->verilog_module, message_handler);
+    symbol_table,
+    it->second->verilog_module,
+    parse_tree.standard,
+    message_handler);
 }
 
 /*******************************************************************\
@@ -1764,6 +1767,7 @@ Function: verilog_typecheck
 bool verilog_typecheck(
   symbol_table_baset &symbol_table,
   const verilog_modulet &verilog_module,
+  verilog_standardt standard,
   message_handlert &message_handler)
 {
   // create symbol
@@ -1793,6 +1797,7 @@ bool verilog_typecheck(
     return true;
   }
 
-  verilog_typecheckt verilog_typecheck(*new_symbol, symbol_table, message_handler);
+  verilog_typecheckt verilog_typecheck(
+    standard, *new_symbol, symbol_table, message_handler);
   return verilog_typecheck.typecheck_main();
 }

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -28,11 +28,13 @@ bool verilog_typecheck(
 bool verilog_typecheck(
   symbol_table_baset &,
   const verilog_modulet &verilog_module,
+  verilog_standardt,
   message_handlert &message_handler);
 
 bool verilog_typecheck(
   symbol_table_baset &,
   const std::string &module_identifier,
+  verilog_standardt,
   const exprt::operandst &parameters,
   message_handlert &message_handler);
 
@@ -54,10 +56,11 @@ class verilog_typecheckt:
 {
 public:
   verilog_typecheckt(
+    verilog_standardt _standard,
     symbolt &_module_symbol,
     symbol_table_baset &_symbol_table,
     message_handlert &_message_handler)
-    : verilog_typecheck_exprt(ns, _message_handler),
+    : verilog_typecheck_exprt(_standard, ns, _message_handler),
       verilog_symbol_tablet(_symbol_table),
       ns(_symbol_table),
       module_symbol(_module_symbol),

--- a/src/verilog/verilog_typecheck_base.h
+++ b/src/verilog/verilog_typecheck_base.h
@@ -9,9 +9,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_VERILOG_TYPECHEK_BASE_H
 #define CPROVER_VERILOG_TYPECHEK_BASE_H
 
+#include <util/mp_arith.h>
 #include <util/namespace.h>
 #include <util/typecheck.h>
-#include <util/mp_arith.h>
+
+#include "verilog_standard.h"
 
 irep_idt verilog_module_symbol(const irep_idt &base_name);
 irep_idt verilog_module_name(const irep_idt &identifier);
@@ -23,11 +25,13 @@ class verilog_typecheck_baset:public typecheckt
 {
 public:
   verilog_typecheck_baset(
+    verilog_standardt _standard,
     const namespacet &_ns,
-    message_handlert &_message_handler):
-    typecheckt(_message_handler),
-    ns(_ns),
-    mode(ID_Verilog)
+    message_handlert &_message_handler)
+    : typecheckt(_message_handler),
+      standard(_standard),
+      ns(_ns),
+      mode(ID_Verilog)
   { }
 
   // overloaded to use verilog syntax
@@ -36,6 +40,7 @@ public:
   std::string to_string(const exprt &expr);
 
 protected:
+  verilog_standardt standard;
   const namespacet &ns;
   const irep_idt mode;
 

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -2513,6 +2513,7 @@ Function: verilog_typecheck
 bool verilog_typecheck(
   exprt &expr,
   const std::string &module_identifier,
+  verilog_standardt standard,
   message_handlert &message_handler,
   const namespacet &ns)
 {
@@ -2520,7 +2521,7 @@ bool verilog_typecheck(
     message_handler.get_message_count(messaget::M_ERROR);
 
   verilog_typecheck_exprt verilog_typecheck_expr(
-    ns, module_identifier, message_handler);
+    standard, ns, module_identifier, message_handler);
 
   try
   {

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -25,16 +25,18 @@ class verilog_typecheck_exprt:public verilog_typecheck_baset
 {
 public:
   verilog_typecheck_exprt(
+    verilog_standardt _standard,
     const namespacet &_ns,
     message_handlert &_message_handler)
-    : verilog_typecheck_baset(_ns, _message_handler)
+    : verilog_typecheck_baset(_standard, _ns, _message_handler)
   { }
 
   verilog_typecheck_exprt(
+    verilog_standardt _standard,
     const namespacet &_ns,
     const std::string &_module_identifier,
     message_handlert &_message_handler)
-    : verilog_typecheck_baset(_ns, _message_handler),
+    : verilog_typecheck_baset(_standard, _ns, _message_handler),
       module_identifier(_module_identifier)
   { }
 
@@ -139,6 +141,7 @@ private:
 bool verilog_typecheck(
   exprt &,
   const std::string &module_identifier,
+  verilog_standardt,
   message_handlert &,
   const namespacet &);
 


### PR DESCRIPTION
This tracks the configured Verilog standard in the parse tree data structure, to support mixed-version models.