### PR TITLE
Verilog: normalize `##[i:$]`

### DIFF
--- a/regression/verilog/SVA/sequence2.desc
+++ b/regression/verilog/SVA/sequence2.desc
@@ -1,0 +1,17 @@
+CORE
+sequence2.sv
+--bound 10 --numbered-trace
+^\[main\.property\.1] ##\[0:\$\] main\.x == 10: REFUTED$
+^Counterexample with 7 states:$
+^main\.x@0 = 0$
+^main\.x@1 = 1$
+^main\.x@2 = 2$
+^main\.x@3 = 3$
+^main\.x@4 = 4$
+^main\.x@5 = 5$
+^main\.x@6 = 5$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence2.sv
+++ b/regression/verilog/SVA/sequence2.sv
@@ -1,0 +1,15 @@
+module main;
+
+  reg [31:0] x;
+  wire clk;
+
+  initial x=0;
+
+  always @(posedge clk)
+    if(x != 5)
+      x<=x+1;
+
+  // fails once we see the lasso 0, 1, 2, 3, 4, 5, 5
+  initial p0: assert property (##[0:$] x==10);
+
+endmodule

--- a/src/verilog/sva_expr.h
+++ b/src/verilog/sva_expr.h
@@ -443,11 +443,21 @@ to_sva_non_overlapped_implication_expr(exprt &expr)
 class sva_cycle_delay_exprt : public ternary_exprt
 {
 public:
-  explicit sva_cycle_delay_exprt(exprt from, exprt to, exprt op)
+  sva_cycle_delay_exprt(exprt from, exprt to, exprt op)
     : ternary_exprt(
         ID_sva_cycle_delay,
         std::move(from),
         std::move(to),
+        std::move(op),
+        bool_typet())
+  {
+  }
+
+  sva_cycle_delay_exprt(exprt cycles, exprt op)
+    : ternary_exprt(
+        ID_sva_cycle_delay,
+        std::move(cycles),
+        nil_exprt{},
         std::move(op),
         bool_typet())
   {
@@ -473,6 +483,11 @@ public:
   exprt &to()
   {
     return op1();
+  }
+
+  bool is_unbounded() const
+  {
+    return to().id() == ID_infinity;
   }
 
   const exprt &op() const


### PR DESCRIPTION
This rewrites `##[i:$]` to LTL, enabling the back-end to generate counterexamples of the correct length.