### PR TITLE
property instantiation now returns largest timeframe used

### DIFF
--- a/regression/verilog/SVA/sequence1.desc
+++ b/regression/verilog/SVA/sequence1.desc
@@ -1,9 +1,12 @@
-KNOWNBUG
+CORE
 sequence1.sv
 --bound 20 --numbered-trace
+^\[main\.property\.1\] ##\[0:9\] main\.x == 100: REFUTED$
+^Counterexample with 10 states:$
+^main\.x@0 = 0$
+^main\.x@9 = 9$
 ^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-The trace shown only has one state, but 10 are expected.

--- a/src/trans-word-level/instantiate_word_level.h
+++ b/src/trans-word-level/instantiate_word_level.h
@@ -20,6 +20,12 @@ exprt instantiate(
   const mp_integer &no_timeframes,
   const namespacet &);
 
+std::pair<mp_integer, exprt> instantiate_property(
+  const exprt &,
+  const mp_integer &current,
+  const mp_integer &no_timeframes,
+  const namespacet &);
+
 std::string
 timeframe_identifier(const mp_integer &timeframe, const irep_idt &identifier);
 


### PR DESCRIPTION
The word-level property instantiation now returns the largest timeframe used, in addition to the instantiated property.

This enables making the counterexample have the right length.