### PR TITLE
Fixup #529: add missing .desc file

### DIFF
--- a/regression/verilog/SVA/sequence3.desc
+++ b/regression/verilog/SVA/sequence3.desc
@@ -1,0 +1,12 @@
+CORE
+sequence3.sv
+--bound 20 --numbered-trace
+^\[main\.property\.1\] ##\[\*\] main\.x == 6: REFUTED$
+^Counterexample with 2 states:$
+^\[main\.property\.2\] ##\[\+\] main\.x == 0: REFUTED$
+^Counterexample with 7 states:$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--


### PR DESCRIPTION
This adds the `.desc` file that was forgotten in #529.