### PR TITLE
fix typo in release workflow

### DIFF
--- a/.github/workflows/ebmc-release.yaml
+++ b/.github/workflows/ebmc-release.yaml
@@ -13,22 +13,20 @@ jobs:
       version: ${{ steps.split-version.outputs._1 }}
     steps:
       - uses: jungwinter/split@v2
-        id: split
+        id: split-ref
         with:
           msg: ${{ github.ref }}
-          seperator: '/'
+          separator: '/'
       - uses: jungwinter/split@v2
         id: split-version
         with:
-          msg: ${{ steps.split.outputs._2 }}
-          seperator: '-'
+          msg: ${{ steps.split-ref.outputs._2 }}
+          separator: '-'
   perform-release:
     name: Perform Release
     runs-on: ubuntu-20.04
     needs: get-version-information
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
       - name: Create release
         uses: actions/create-release@v1
         env:


### PR DESCRIPTION
This fixes a typo ('seperator' -> 'separator') copied from the CBMC repo.