### PR TITLE
Fix ebmc release workflow

### DIFF
--- a/.github/workflows/ebmc-release.yaml
+++ b/.github/workflows/ebmc-release.yaml
@@ -194,7 +194,7 @@ jobs:
           echo Building ebmc-${VERSION}-1.x86_64.rpm
           (cd ~/rpmbuild/SPECS ; rpmbuild -v -bb ebmc.spec )
           rpm_package_name=ebmc-${VERSION}-1.x86_64.rpm
-          echo "rpm_package_path=$HOME/rpmbuild/SPECS/$rpm_package_name" >> $GITHUB_OUTPUT
+          echo "rpm_package_path=$HOME/rpmbuild/RPMS/x86_64/$rpm_package_name" >> $GITHUB_OUTPUT
           echo "rpm_package_name=centos8-$rpm_package_name" >> $GITHUB_OUTPUT
       - name: Upload binary packages
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Another attempt at fixing the path name of the CentOS 8 rpm.