### PR TITLE
Verilog: consolidate code that computes width of given type

### DIFF
--- a/src/verilog/verilog_typecheck_base.h
+++ b/src/verilog/verilog_typecheck_base.h
@@ -44,14 +44,16 @@ protected:
   const namespacet &ns;
   const irep_idt mode;
 
-  mp_integer get_width(const exprt &expr)
+  static mp_integer get_width(const exprt &expr)
   {
     return get_width(expr.type());
   }
-  mp_integer get_width(const typet &type);
-  mp_integer array_size(const array_typet &);
-  mp_integer array_offset(const array_typet &);
-  typet index_type(const array_typet &);
+
+  static mp_integer get_width(const typet &);
+  static std::optional<mp_integer> get_width_opt(const typet &);
+  static mp_integer array_size(const array_typet &);
+  static mp_integer array_offset(const array_typet &);
+  static typet index_type(const array_typet &);
 };
 
 #endif

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -434,7 +434,7 @@ Function: verilog_typecheck_exprt::bits
 
 exprt verilog_typecheck_exprt::bits(const exprt &expr)
 {
-  auto width_opt = bits_rec(expr.type());
+  auto width_opt = get_width_opt(expr.type());
 
   if(!width_opt.has_value())
   {
@@ -443,57 +443,6 @@ exprt verilog_typecheck_exprt::bits(const exprt &expr)
   }
 
   return from_integer(width_opt.value(), integer_typet());
-}
-
-/*******************************************************************\
-
-Function: verilog_typecheck_exprt::bits_rec
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-std::optional<mp_integer>
-verilog_typecheck_exprt::bits_rec(const typet &type) const
-{
-  if(type.id() == ID_bool)
-    return 1;
-  else if(type.id() == ID_unsignedbv)
-    return to_unsignedbv_type(type).get_width();
-  else if(type.id() == ID_signedbv)
-    return to_signedbv_type(type).get_width();
-  else if(type.id() == ID_integer)
-    return 32;
-  else if(type.id() == ID_array)
-  {
-    auto &array_type = to_array_type(type);
-    auto size_int =
-      numeric_cast_v<mp_integer>(to_constant_expr(array_type.size()));
-    auto element_bits_opt = bits_rec(array_type.element_type());
-    if(element_bits_opt.has_value())
-      return element_bits_opt.value() * size_int;
-    else
-      return {};
-  }
-  else if(type.id() == ID_struct)
-  {
-    auto &struct_type = to_struct_type(type);
-    mp_integer sum = 0;
-    for(auto &component : struct_type.components())
-    {
-      auto component_bits_opt = bits_rec(component.type());
-      if(!component_bits_opt.has_value())
-        return component_bits_opt.value();
-      sum += component_bits_opt.value();
-    }
-    return sum;
-  }
-  else
-    return {};
 }
 
 /*******************************************************************\


### PR DESCRIPTION
This replaces `verilog_typecheck_exprt::bits_rec` by an invocation to `verilog_typecheck_baset::get_width_opt`.