### PR TITLE
replace `assert(...)`

### DIFF
--- a/src/trans-netlist/aig_prop.h
+++ b/src/trans-netlist/aig_prop.h
@@ -9,10 +9,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_TRANS_NETLIST_AIG_PROP_H
 #define CPROVER_TRANS_NETLIST_AIG_PROP_H
 
-#include <cassert>
+#include <util/invariant.h>
+#include <util/threeval.h>
 
 #include <solvers/prop/prop.h>
-#include <util/threeval.h>
 
 #include "aig.h"
 
@@ -28,7 +28,10 @@ public:
   literalt lor(literalt a, literalt b) override;
   literalt land(const bvt &bv) override;
   literalt lor(const bvt &bv) override;
-  void lcnf(const bvt &clause) override { assert(false); }
+  void lcnf(const bvt &clause) override
+  {
+    PRECONDITION(false);
+  }
   literalt lxor(literalt a, literalt b) override;
   literalt lxor(const bvt &bv) override;
   literalt lnand(literalt a, literalt b) override;
@@ -38,7 +41,10 @@ public:
   literalt lselect(literalt a, literalt b, literalt c) override; // a?b:c
   void set_equal(literalt a, literalt b) override;
 
-  void l_set_to(literalt a, bool value) override { assert(false); }
+  void l_set_to(literalt a, bool value) override
+  {
+    PRECONDITION(false);
+  }
 
   literalt new_variable() override { return dest.new_node(); }
 
@@ -49,12 +55,12 @@ public:
   }
 
   tvt l_get(literalt a) const override {
-    assert(0);
+    PRECONDITION(false);
     return tvt::unknown();
   }
 
   resultt prop_solve() {
-    assert(0);
+    PRECONDITION(false);
     return resultt::P_ERROR;
   }
 

--- a/src/trans-netlist/trans_to_netlist.cpp
+++ b/src/trans-netlist/trans_to_netlist.cpp
@@ -532,7 +532,7 @@ void convert_trans_to_netlistt::convert_lhs_rec(
   std::size_t from, std::size_t to,
   propt &prop)
 {
-  assert(from<=to);
+  PRECONDITION(from <= to);
 
   if(expr.id()==ID_symbol)
   { 
@@ -629,11 +629,11 @@ literalt convert_trans_to_netlistt::convert_rhs(
     instantiate_convert(
       prop, dest.var_map, rhs_entry.expr, ns,
       get_message_handler(), rhs_entry.bv);
-      
-    assert(rhs_entry.bv.size()==rhs_entry.width);
+
+    DATA_INVARIANT(rhs_entry.bv.size() == rhs_entry.width, "bit-width match");
   }
 
-  assert(rhs.bit_number<rhs_entry.bv.size());
+  DATA_INVARIANT(rhs.bit_number < rhs_entry.bv.size(), "bit index in range");
   return rhs_entry.bv[rhs.bit_number];
 }
 
@@ -665,12 +665,12 @@ void convert_trans_to_netlistt::add_equality(const equal_exprt &src)
     constraint_list.push_back(src);
     return;
   }
-  
-  assert(rhs_entry.width!=0);
+
+  DATA_INVARIANT(rhs_entry.width != 0, "no empty entries");
 
   std::size_t lhs_width=boolbv_width(lhs.type());
 
-  assert(lhs_width==rhs_entry.width);
+  DATA_INVARIANT(lhs_width == rhs_entry.width, "bit-width match");
 
   add_equality_rec(src, lhs, 0, lhs_width-1, rhs_entry);
 }
@@ -693,8 +693,8 @@ void convert_trans_to_netlistt::add_equality_rec(
   std::size_t lhs_from, std::size_t lhs_to,
   rhs_entryt &rhs_entry)
 {
-  assert(lhs_from<=lhs_to);
-  
+  PRECONDITION(lhs_from <= lhs_to);
+
   if(lhs.id()==ID_next_symbol ||
      lhs.id()==ID_symbol)
   { 
@@ -730,11 +730,11 @@ void convert_trans_to_netlistt::add_equality_rec(
   }
   else if(lhs.id()==ID_extractbit)
   {
-    assert(lhs_to==lhs_from);
+    PRECONDITION(lhs_to == lhs_from);
 
     mp_integer i;
     if(to_integer_non_constant(to_extractbit_expr(lhs).index(), i))
-      assert(false);
+      PRECONDITION(false);
 
     lhs_from = lhs_from + i.to_ulong();
     add_equality_rec(

--- a/src/trans-word-level/counterexample_word_level.cpp
+++ b/src/trans-word-level/counterexample_word_level.cpp
@@ -6,7 +6,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-#include <cassert>
 #include <iostream>
 
 #include <langapi/language_util.h>

--- a/src/trans-word-level/instantiate_word_level.cpp
+++ b/src/trans-word-level/instantiate_word_level.cpp
@@ -16,8 +16,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "property.h"
 
-#include <cassert>
-
 /*******************************************************************\
 
 Function: timeframe_identifier
@@ -166,7 +164,7 @@ wl_instantiatet::instantiate_rec(exprt expr, const mp_integer &t) const
 
       if(sva_cycle_delay_expr.to().id() == ID_infinity)
       {
-        assert(no_timeframes != 0);
+        DATA_INVARIANT(no_timeframes != 0, "must have timeframe");
         to = no_timeframes - 1;
       }
       else if(to_integer_non_constant(sva_cycle_delay_expr.to(), to))
@@ -283,9 +281,6 @@ wl_instantiatet::instantiate_rec(exprt expr, const mp_integer &t) const
           expr.id()==ID_sva_s_until)
   {
     // non-overlapping until
-  
-    assert(expr.operands().size()==2);
-    
     // we need a lasso to refute these
 
     // we expand: p U q <=> q || (p && X(p U q))
@@ -308,8 +303,6 @@ wl_instantiatet::instantiate_rec(exprt expr, const mp_integer &t) const
           expr.id()==ID_sva_s_until_with)
   {
     // overlapping until
-  
-    assert(expr.operands().size()==2);
     
     // we rewrite using 'next'
     binary_exprt tmp = to_binary_expr(expr);

--- a/src/verilog/verilog_typecheck_base.cpp
+++ b/src/verilog/verilog_typecheck_base.cpp
@@ -16,8 +16,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "expr2verilog.h"
 #include "verilog_types.h"
 
-#include <cassert>
-
 /*******************************************************************\
 
 Function: verilog_module_symbol
@@ -50,8 +48,10 @@ Function: strip_verilog_prefix
 irep_idt strip_verilog_prefix(const irep_idt &identifier)
 {
   std::string prefix="Verilog::";
-  assert(has_prefix(id2string(identifier), prefix));
-  assert(identifier.size()>=prefix.size());
+  DATA_INVARIANT(
+    has_prefix(id2string(identifier), prefix), "Verilog identifier syntax");
+  DATA_INVARIANT(
+    identifier.size() >= prefix.size(), "Verilog identifier syntax");
   return identifier.c_str()+prefix.size();
 }
 

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1553,7 +1553,7 @@ void verilog_typecheck_exprt::implicit_typecast(
       {
         const std::string &value=expr.get_string(ID_value);
         // least significant bit is last
-        assert(value.size()!=0);
+        DATA_INVARIANT(value.size() != 0, "no empty bitvector");
         expr = make_boolean_expr(value[value.size() - 1] == '1');
         return;
       }
@@ -1860,7 +1860,6 @@ exprt verilog_typecheck_exprt::convert_unary_expr(unary_exprt expr)
     expr.id() == ID_sva_cycle_delay_star || expr.id() == ID_sva_weak ||
     expr.id() == ID_sva_strong)
   {
-    assert(expr.operands().size()==1);
     convert_expr(expr.op());
     make_boolean(expr.op());
     expr.type()=bool_typet();
@@ -2163,7 +2162,7 @@ exprt verilog_typecheck_exprt::convert_binary_expr(binary_exprt expr)
   else if(expr.id()==ID_ashr)
   {
     // would only happen when re-typechecking, otherwise see above
-    assert(0);
+    DATA_INVARIANT(false, "no re-typechecking");
   }
   else if(expr.id()==ID_lshr)
   {
@@ -2452,7 +2451,6 @@ exprt verilog_typecheck_exprt::convert_trinary_expr(ternary_exprt expr)
   else if(expr.id()==ID_sva_cycle_delay) // #[1:2] something
   {
     expr.type()=bool_typet();
-    assert(expr.operands().size()==3);
     convert_expr(expr.op0());
     if(expr.op1().is_not_nil()) convert_expr(expr.op1());
     convert_expr(expr.op2());

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -16,7 +16,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "verilog_typecheck_base.h"
 
-#include <cassert>
 #include <stack>
 
 class function_call_exprt;
@@ -110,7 +109,7 @@ protected:
   // To be overridden, requires a Verilog interpreter.
   virtual exprt elaborate_constant_function_call(const function_call_exprt &)
   {
-    assert(false);
+    UNREACHABLE;
   }
 
 private:


### PR DESCRIPTION
This replaces uses of the `assert(...)` macro by suitable alternatives, or removes redundant assertions.