### PR TITLE
Verilog: lowering for concatenation of aval/bval encoded vectors

### DIFF
--- a/regression/verilog/case/case3.v
+++ b/regression/verilog/case/case3.v
@@ -14,9 +14,9 @@ module main(input clk, x, y);
 
   always @(posedge clk)
     casez (cnt1)
-      10'b0z00:;
-      10'b0z01:;
-      10'b0z1z: out=1;
+      {10'b0z, 2'b00}:;
+      {10'b0z, 2'b01}:;
+      {10'b0z, 2'b1z}: out=1;
     endcase
     
   always assert p1: out==0;

--- a/regression/verilog/case/case4.v
+++ b/regression/verilog/case/case4.v
@@ -4,7 +4,7 @@ module m(input [7:0] i, output reg [31:0] x);
     casex(i)
       8'b1x: x=1;
       8'bxx: x=2;
-      8'b11xx: x=3;
+      { 'b11, 'bx, 'bx }: x=3;
       default: x=4;
     endcase
 

--- a/regression/verilog/expressions/concatenation3.desc
+++ b/regression/verilog/expressions/concatenation3.desc
@@ -1,0 +1,8 @@
+CORE broken-smt-backend
+concatenation3.sv
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+^\[.*\] always \(\{ 5'bxz01\?, 4'b10zx \}\) === 9'bxz01\?10zx: PROVED up to bound 0$
+--
+^warning: ignoring

--- a/regression/verilog/expressions/concatenation3.sv
+++ b/regression/verilog/expressions/concatenation3.sv
@@ -1,0 +1,3 @@
+module main;
+  assert property ({5'bxz01?, 4'b10zx} === 9'bxz01?10zx);
+endmodule

--- a/src/verilog/aval_bval_encoding.h
+++ b/src/verilog/aval_bval_encoding.h
@@ -34,4 +34,6 @@ exprt bval(const exprt &);
 
 exprt aval_bval_conversion(const exprt &, const typet &);
 
+exprt aval_bval_concatenation(const exprt::operandst &, const typet &);
+
 #endif

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -217,6 +217,22 @@ exprt verilog_synthesist::synth_expr(exprt expr, symbol_statet symbol_state)
 
     return expr;
   }
+  else if(expr.id() == ID_concatenation)
+  {
+    for(auto &op : expr.operands())
+      op = synth_expr(op, symbol_state);
+
+    if(
+      expr.type().id() == ID_verilog_unsignedbv ||
+      expr.type().id() == ID_verilog_signedbv)
+    {
+      return aval_bval_concatenation(
+        to_concatenation_expr(expr).operands(),
+        lower_to_aval_bval(expr.type()));
+    }
+
+    return expr;
+  }
   else if(expr.id()==ID_function_call)
   {
     return expand_function_call(to_function_call_expr(expr));


### PR DESCRIPTION
This adds lowering for the concatenation of aval/bval encoded bit-vectors.