### PR TITLE
Verilog: implement bit-vector to struct conversion

### DIFF
--- a/regression/verilog/structs/structs1.desc
+++ b/regression/verilog/structs/structs1.desc
@@ -1,8 +1,10 @@
-KNOWNBUG
+CORE
 structs1.sv
 --bound 0
+^\[main\.property\.p0\] always 9 == 9: PROVED up to bound 0$
+^\[main\.property\.p1\] always main\.s\.field1 == 1: PROVED up to bound 0$
+^\[main\.property\.p2\] always main\.s\.field2 == 0: PROVED up to bound 0$
+^\[main\.property\.p3\] always main\.s\.field3 == 115: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --
---
-cast bitvector to struct missing

--- a/regression/verilog/structs/structs1.sv
+++ b/regression/verilog/structs/structs1.sv
@@ -7,12 +7,12 @@ module main;
   } s;
 
   // bit-vectors can be converted without cast to packed structs
-  initial s = 8'b1011111;
+  initial s = 'b1_0_1110011;
 
   // Expected to pass.
   p0: assert property ($bits(s) == 9);
   p1: assert property (s.field1 == 1);
   p2: assert property (s.field2 == 0);
-  p3: assert property (s.field3 == 'b111111);
+  p3: assert property (s.field3 == 'b1110011);
 
 endmodule

--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -71,6 +71,11 @@ public:
 protected:
   const optionst &options;
 
+  static exprt extract(const exprt &, const mp_integer &offset, const typet &);
+  static exprt
+  from_bitvector(const exprt &, const mp_integer &offset, const typet &);
+  static exprt to_bitvector(const exprt &);
+
   // For $ND(...)
   std::size_t nondet_count = 0;
 


### PR DESCRIPTION
SystemVerilog allows converting bit-vectors to packed structs and vice versa.