### PR TITLE
SystemVerilog: concurrent assertion items go into module namespace

### DIFF
--- a/regression/ebmc/BDD/BDD2.desc
+++ b/regression/ebmc/BDD/BDD2.desc
@@ -3,6 +3,6 @@ BDD2.sv
 --module main --bdd
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.property.my_prop1\] always main.counter < 199: PROVED$
-^\[main.property.my_prop2\] always main.counter < 198: REFUTED$
+^\[main\.my_prop1\] always main.counter < 199: PROVED$
+^\[main\.my_prop2\] always main.counter < 198: REFUTED$
 --

--- a/regression/ebmc/BDD/BDD3.desc
+++ b/regression/ebmc/BDD/BDD3.desc
@@ -3,6 +3,6 @@ BDD3.sv
 --module main --bdd
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.property.my_prop1\] always main.counter <= 10: PROVED$
-^\[main.property.my_prop2\] always main.counter < 10: REFUTED$
+^\[main\.my_prop1\] always main\.counter <= 10: PROVED$
+^\[main\.my_prop2\] always main\.counter < 10: REFUTED$
 --

--- a/regression/ebmc/BDD/BDD_SVA1.desc
+++ b/regression/ebmc/BDD/BDD_SVA1.desc
@@ -3,14 +3,14 @@ BDD_SVA1.sv
 --bdd
 ^EXIT=10$
 ^SIGNAL=0$
-^\[top\.property\.p0\] always top\.my_bit: PROVED$
-^\[top\.property\.p1\] always top\.my_bit: PROVED$
-^\[top\.property\.p2\] always \(top\.counter == 3 \|-> \(nexttime top\.counter == 4\)\): FAILURE: property not supported by BDD engine$
-^\[top\.property\.p3\] always \(top\.counter == 3 \|=> top\.counter == 4\): FAILURE: property not supported by BDD engine$
-^\[top\.property\.p4\] always \(top\.counter == 3 \|=> \(nexttime top\.counter == 5\)\): FAILURE: property not supported by BDD engine$
-^\[top\.property\.p5\] always s_eventually top\.counter == 8: PROVED$
-^\[top\.property\.p6\] always \(top\.counter == 0 \|-> \(s_eventually top\.counter == 8\)\): FAILURE: property not supported by BDD engine$
-^\[top\.property\.p7\] always \(top\.counter == 0 \|-> \(top\.counter <= 5 until top\.counter == 6\)\): FAILURE: property not supported by BDD engine$
-^\[top\.property\.p8\] always \(top\.counter == 0 \|-> \(top\.counter <= 5 until_with top\.counter == 5\)\): FAILURE: property not supported by BDD engine$
+^\[top\.p0\] always top\.my_bit: PROVED$
+^\[top\.p1\] always top\.my_bit: PROVED$
+^\[top\.p2\] always \(top\.counter == 3 \|-> \(nexttime top\.counter == 4\)\): FAILURE: property not supported by BDD engine$
+^\[top\.p3\] always \(top\.counter == 3 \|=> top\.counter == 4\): FAILURE: property not supported by BDD engine$
+^\[top\.p4\] always \(top\.counter == 3 \|=> \(nexttime top\.counter == 5\)\): FAILURE: property not supported by BDD engine$
+^\[top\.p5\] always s_eventually top\.counter == 8: PROVED$
+^\[top\.p6\] always \(top\.counter == 0 \|-> \(s_eventually top\.counter == 8\)\): FAILURE: property not supported by BDD engine$
+^\[top\.p7\] always \(top\.counter == 0 \|-> \(top\.counter <= 5 until top\.counter == 6\)\): FAILURE: property not supported by BDD engine$
+^\[top\.p8\] always \(top\.counter == 0 \|-> \(top\.counter <= 5 until_with top\.counter == 5\)\): FAILURE: property not supported by BDD engine$
 --
 ^warning: ignoring

--- a/regression/ebmc/Next-in-Property1/test.desc
+++ b/regression/ebmc/Next-in-Property1/test.desc
@@ -3,5 +3,5 @@ main.sv
 --module top --bound 10
 ^EXIT=0$
 ^SIGNAL=0$
-^\[top.property.p1\] always \(top.counter\[0\] |-> \(##1 top.counter <= 5\)\): SUCCESS$
+^\[top\.p1\] always \(top\.counter\[0\] |-> \(##1 top\.counter <= 5\)\): SUCCESS$
 --

--- a/regression/ebmc/SVA-LTL/freeze.desc
+++ b/regression/ebmc/SVA-LTL/freeze.desc
@@ -1,8 +1,8 @@
 CORE
 freeze.sv
 --bound 1
-^\[main\.property\.p1\] always s_eventually main\.w: REFUTED$
-^\[main\.property\.p2\] always s_eventually !main\.w: REFUTED$
+^\[main\.p1\] always s_eventually main\.w: REFUTED$
+^\[main\.p2\] always s_eventually !main\.w: REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/SVA-LTL/lasso1-counterexample.desc
+++ b/regression/ebmc/SVA-LTL/lasso1-counterexample.desc
@@ -3,7 +3,7 @@ lasso1.sv
 --bound 10 --waveform
 ^EXIT=10$
 ^SIGNAL=0$
-^\[top\.property\.p0\] .* REFUTED$
+^\[top\.p0\] .* REFUTED$
 ^             0  1  2  3  4  5  6  7  8  9 10$
 ^top\.counter  0  1  2  3  4  5  6  7  8  9  3$
 --

--- a/regression/ebmc/SVA-LTL/lasso1-small-bound.desc
+++ b/regression/ebmc/SVA-LTL/lasso1-small-bound.desc
@@ -3,6 +3,6 @@ lasso1.sv
 --bound 5
 ^EXIT=0$
 ^SIGNAL=0$
-^\[top\.property\.p0\] .* PROVED up to bound 5$
+^\[top\.p0\] .* PROVED up to bound 5$
 --
 --

--- a/regression/ebmc/SVA-LTL/simple_counterexamples_to_Fp.p0.desc
+++ b/regression/ebmc/SVA-LTL/simple_counterexamples_to_Fp.p0.desc
@@ -1,8 +1,8 @@
 CORE
 simple_counterexamples_to_Fp.sv
---bound 10 --property top.property.p0
+--bound 10 --property top.p0
 ^Adding lasso constraints$
 ^EXIT=10$
 ^SIGNAL=0$
-^\[top\.property\.p0\] .* REFUTED$
+^\[top\.p0\] .* REFUTED$
 --

--- a/regression/ebmc/SVA-LTL/simple_counterexamples_to_Fp.p1.desc
+++ b/regression/ebmc/SVA-LTL/simple_counterexamples_to_Fp.p1.desc
@@ -1,8 +1,8 @@
 CORE
 simple_counterexamples_to_Fp.sv
---bound 10 --property top.property.p1
+--bound 10 --property top.p1
 ^Adding lasso constraints$
 ^EXIT=10$
 ^SIGNAL=0$
-^\[top\.property\.p1\] .* REFUTED$
+^\[top\.p1\] .* REFUTED$
 --

--- a/regression/ebmc/SVA-LTL/simple_counterexamples_to_Fp.p2.desc
+++ b/regression/ebmc/SVA-LTL/simple_counterexamples_to_Fp.p2.desc
@@ -1,8 +1,8 @@
 CORE
 simple_counterexamples_to_Fp.sv
---bound 10 --property top.property.p2
+--bound 10 --property top.p2
 ^Adding lasso constraints$
 ^EXIT=10$
 ^SIGNAL=0$
-^\[top\.property\.p2\] .* REFUTED$
+^\[top\.p2\] .* REFUTED$
 --

--- a/regression/ebmc/SVA-LTL/simple_passing_LTL_properties.desc
+++ b/regression/ebmc/SVA-LTL/simple_passing_LTL_properties.desc
@@ -4,13 +4,13 @@ simple_passing_LTL_properties.sv
 ^Adding lasso constraints$
 ^EXIT=0$
 ^SIGNAL=0$
-^\[top.property.p0\] .* PROVED up to bound 10$
-^\[top.property.p1\] .* PROVED up to bound 10$
-^\[top.property.p2\] .* PROVED up to bound 10$
-^\[top.property.p3\] .* PROVED up to bound 10$
-^\[top.property.p4\] .* PROVED up to bound 10$
-^\[top.property.p5\] .* PROVED up to bound 10$
-^\[top.property.p6\] .* PROVED up to bound 10$
-^\[top.property.p7\] .* PROVED up to bound 10$
-^\[top.property.p8\] .* PROVED up to bound 10$
+^\[top\.p0\] .* PROVED up to bound 10$
+^\[top\.p1\] .* PROVED up to bound 10$
+^\[top\.p2\] .* PROVED up to bound 10$
+^\[top\.p3\] .* PROVED up to bound 10$
+^\[top\.p4\] .* PROVED up to bound 10$
+^\[top\.p5\] .* PROVED up to bound 10$
+^\[top\.p6\] .* PROVED up to bound 10$
+^\[top\.p7\] .* PROVED up to bound 10$
+^\[top\.p8\] .* PROVED up to bound 10$
 --

--- a/regression/ebmc/example3/test.desc
+++ b/regression/ebmc/example3/test.desc
@@ -1,8 +1,8 @@
 CORE
 example3.sv
 --bound 10
-^\[counter\.property\.1\] .* PROVED up to bound 10$
-^\[counter\.property\.2\] .* REFUTED$
+^\[counter\.assert\.1\] .* PROVED up to bound 10$
+^\[counter\.assert\.2\] .* REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 

--- a/regression/ebmc/example4_reset/test.desc
+++ b/regression/ebmc/example4_reset/test.desc
@@ -1,8 +1,8 @@
 CORE
 example4.sv
 --bound 10 --reset "reset==1"
-^\[counter\.property\.1\] .* PROVED up to bound 10$
-^\[counter\.property\.2\] .* PROVED up to bound 10$
+^\[counter\.assert\.1\] .* PROVED up to bound 10$
+^\[counter\.assert\.2\] .* PROVED up to bound 10$
 ^EXIT=0$
 ^SIGNAL=0$
 

--- a/regression/ebmc/example4_trace/test.desc
+++ b/regression/ebmc/example4_trace/test.desc
@@ -1,8 +1,8 @@
 CORE broken-smt-backend
 example4.sv
 --bound 10 --trace
-^\[counter\.property\.1\] .* PROVED up to bound 10$
-^\[counter\.property\.2\] .* REFUTED$
+^\[counter\.assert\.1\] .* PROVED up to bound 10$
+^\[counter\.assert\.2\] .* REFUTED$
 ^  counter\.state = 254 \(11111110\)$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/ebmc/ic3/bobmiterbm1multi.1033.desc
+++ b/regression/ebmc/ic3/bobmiterbm1multi.1033.desc
@@ -1,6 +1,6 @@
 CORE
 bobmiterbm1multi.sv
---ic3 --property bobmiterbm1multi.property.1033
+--ic3 --property bobmiterbm1multi.assert.1033
 ^EXIT=2$
 ^SIGNAL=0$
 ^property HOLDS

--- a/regression/ebmc/ic3/bobmiterbm1multi.1080.desc
+++ b/regression/ebmc/ic3/bobmiterbm1multi.1080.desc
@@ -1,6 +1,6 @@
 CORE
 bobmiterbm1multi.sv
---ic3 --property bobmiterbm1multi.property.1080
+--ic3 --property bobmiterbm1multi.assert.1080
 ^EXIT=1$
 ^SIGNAL=0$
 ^property FAILED

--- a/regression/ebmc/ic3/non_inductive1.desc
+++ b/regression/ebmc/ic3/non_inductive1.desc
@@ -1,6 +1,6 @@
 CORE
 non_inductive1.sv
---ic3 --property main.property.p0
+--ic3 --property main.p0
 ^EXIT=2$
 ^SIGNAL=0$
 ^property HOLDS$

--- a/regression/ebmc/ic3/not_supported1.desc
+++ b/regression/ebmc/ic3/not_supported1.desc
@@ -1,7 +1,7 @@
 CORE
 not_supported1.sv
 --ic3
-^\[main\.property\.p0\] always s_eventually main\.my_bit: FAILURE: property not supported by IC3 engine$
+^\[main\.p0\] always s_eventually main\.my_bit: FAILURE: property not supported by IC3 engine$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ic3/sm98a7multi.desc
+++ b/regression/ebmc/ic3/sm98a7multi.desc
@@ -1,6 +1,6 @@
 CORE
 sm98a7multi.sv
---ic3 --property sm98a7multi.property.2 --constr
+--ic3 --property sm98a7multi.assert.2 --constr
 ^EXIT=1$
 ^SIGNAL=0$
 ^property FAILED

--- a/regression/ebmc/k-induction/k-induction-unsupported2.desc
+++ b/regression/ebmc/k-induction/k-induction-unsupported2.desc
@@ -3,7 +3,7 @@ k-induction-unsupported2.sv
 --module main --k-induction
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main\.property\.p0\] always s_eventually main\.x == 10: FAILURE: property unsupported by k-induction$
-^\[main\.property\.p1\] always main\.x <= 10: PROVED$
+^\[main\.p0\] always s_eventually main\.x == 10: FAILURE: property unsupported by k-induction$
+^\[main\.p1\] always main\.x <= 10: PROVED$
 --
 ^warning: ignoring

--- a/regression/ebmc/k-induction/k-induction4.desc
+++ b/regression/ebmc/k-induction/k-induction4.desc
@@ -3,6 +3,6 @@ k-induction4.sv
 --module main --bound 1 --k-induction
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.property.p1] .* INCONCLUSIVE$
+^\[main\.p1] .* INCONCLUSIVE$
 --
 ^warning: ignoring

--- a/regression/ebmc/liveness-to-safety/failing1.desc
+++ b/regression/ebmc/liveness-to-safety/failing1.desc
@@ -3,5 +3,5 @@ failing1.sv
 --bound 1 --liveness-to-safety
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main\.property\.p0\] always s_eventually main\.my_bit: REFUTED$
+^\[main\.p0\] always s_eventually main\.my_bit: REFUTED$
 --

--- a/regression/ebmc/liveness-to-safety/failing1.k-1.desc
+++ b/regression/ebmc/liveness-to-safety/failing1.k-1.desc
@@ -3,5 +3,5 @@ failing1.sv
 --k-induction --bound 1 --liveness-to-safety
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main\.property\.p0\] always s_eventually main\.my_bit: REFUTED$
+^\[main\.p0\] always s_eventually main\.my_bit: REFUTED$
 --

--- a/regression/ebmc/liveness-to-safety/failing2.desc
+++ b/regression/ebmc/liveness-to-safety/failing2.desc
@@ -3,6 +3,6 @@ failing2.sv
 --bound 6 --liveness-to-safety
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main\.property\.p0\] always s_eventually main\.counter == 0: REFUTED$
-^\[main\.property\.p1\] always s_eventually main\.counter == 6: REFUTED$
+^\[main\.p0\] always s_eventually main\.counter == 0: REFUTED$
+^\[main\.p1\] always s_eventually main\.counter == 6: REFUTED$
 --

--- a/regression/ebmc/liveness-to-safety/failing2.k-6.desc
+++ b/regression/ebmc/liveness-to-safety/failing2.k-6.desc
@@ -3,6 +3,6 @@ failing2.sv
 --k-induction --bound 6 --liveness-to-safety
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main\.property\.p0\] always s_eventually main\.counter == 0: REFUTED$
-^\[main\.property\.p1\] always s_eventually main\.counter == 6: REFUTED$
+^\[main\.p0\] always s_eventually main\.counter == 0: REFUTED$
+^\[main\.p1\] always s_eventually main\.counter == 6: REFUTED$
 --

--- a/regression/ebmc/liveness-to-safety/passing1.desc
+++ b/regression/ebmc/liveness-to-safety/passing1.desc
@@ -3,5 +3,5 @@ passing1.sv
 --bound 10 --liveness-to-safety
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.property\.p0\] always s_eventually main\.my_bit: PROVED up to bound 10$
+^\[main\.p0\] always s_eventually main\.my_bit: PROVED up to bound 10$
 --

--- a/regression/ebmc/liveness-to-safety/passing1.k-10.desc
+++ b/regression/ebmc/liveness-to-safety/passing1.k-10.desc
@@ -3,5 +3,5 @@ passing1.sv
 --k-induction --bound 10 --liveness-to-safety
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.property\.p0\] always s_eventually main\.my_bit: PROVED$
+^\[main\.p0\] always s_eventually main\.my_bit: PROVED$
 --

--- a/regression/ebmc/liveness-to-safety/passing2.desc
+++ b/regression/ebmc/liveness-to-safety/passing2.desc
@@ -3,6 +3,6 @@ passing2.sv
 --bound 10 --liveness-to-safety
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.property\.p0\] always s_eventually main\.counter == 0: PROVED up to bound 10$
-^\[main\.property\.p1\] always s_eventually main\.counter == 8: PROVED up to bound 10$
+^\[main\.p0\] always s_eventually main\.counter == 0: PROVED up to bound 10$
+^\[main\.p1\] always s_eventually main\.counter == 8: PROVED up to bound 10$
 --

--- a/regression/ebmc/liveness-to-safety/passing2.k-10.desc
+++ b/regression/ebmc/liveness-to-safety/passing2.k-10.desc
@@ -3,6 +3,6 @@ passing2.sv
 --k-induction --bound 10 --liveness-to-safety
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main\.property\.p0\] always s_eventually main\.counter == 0: INCONCLUSIVE$
-^\[main\.property\.p1\] always s_eventually main\.counter == 8: INCONCLUSIVE$
+^\[main\.p0\] always s_eventually main\.counter == 0: INCONCLUSIVE$
+^\[main\.p1\] always s_eventually main\.counter == 8: INCONCLUSIVE$
 --

--- a/regression/ebmc/netlist/netlist-trace1.desc
+++ b/regression/ebmc/netlist/netlist-trace1.desc
@@ -1,7 +1,7 @@
 CORE
 netlist-trace1.sv
 --bound 10 --trace --aig
-^\[counter\.property\.1\] always counter\.state != 3: REFUTED$
+^\[counter\.assert\.1\] always counter\.state != 3: REFUTED$
 ^  counter\.state = 3 \(00000011\)$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/ebmc/neural-liveness/counter1.desc
+++ b/regression/ebmc/neural-liveness/counter1.desc
@@ -1,7 +1,7 @@
 CORE
 counter1.sv
 --traces 2 --neural-liveness --neural-engine "echo Candidate: counter\\\\n"
-^\[main\.property\.p0\] always s_eventually main.counter == 0: PROVED$
+^\[main\.p0\] always s_eventually main.counter == 0: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/clock24h.day.desc
+++ b/regression/ebmc/ranking-function/clock24h.day.desc
@@ -1,7 +1,7 @@
 CORE
 clock24h.sv
---property main.property.p_day --ranking-function "{23-hours,59-minutes,59-seconds}"
-^\[main\.property\.p_day\] .*: PROVED$
+--property main.p_day --ranking-function "{23-hours,59-minutes,59-seconds}"
+^\[main\.p_day\] .*: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/clock24h.hour.desc
+++ b/regression/ebmc/ranking-function/clock24h.hour.desc
@@ -1,7 +1,7 @@
 CORE
 clock24h.sv
---property main.property.p_hour --ranking-function "{59-minutes,59-seconds}"
-^\[main\.property\.p_hour\] .*: PROVED$
+--property main.p_hour --ranking-function "{59-minutes,59-seconds}"
+^\[main\.p_hour\] .*: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/clock24h.minute.desc
+++ b/regression/ebmc/ranking-function/clock24h.minute.desc
@@ -1,7 +1,7 @@
 CORE
 clock24h.sv
---property main.property.p_minute --ranking-function "59-seconds"
-^\[main\.property\.p_minute\] .*: PROVED$
+--property main.p_minute --ranking-function "59-seconds"
+^\[main\.p_minute\] .*: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/counter1.fail.desc
+++ b/regression/ebmc/ranking-function/counter1.fail.desc
@@ -1,7 +1,7 @@
 CORE
 counter1.sv
 --ranking-function "(-counter)"
-^\[main\.property\.p0\] always s_eventually main.counter == 0: INCONCLUSIVE$
+^\[main\.p0\] always s_eventually main.counter == 0: INCONCLUSIVE$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/counter1.pass.desc
+++ b/regression/ebmc/ranking-function/counter1.pass.desc
@@ -1,7 +1,7 @@
 CORE
 counter1.sv
 --ranking-function counter
-^\[main\.property\.p0\] always s_eventually main.counter == 0: PROVED$
+^\[main\.p0\] always s_eventually main.counter == 0: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/counter2.fail.desc
+++ b/regression/ebmc/ranking-function/counter2.fail.desc
@@ -1,7 +1,7 @@
 CORE
 counter2.sv
 --ranking-function counter --numbered-trace
-^\[main\.property\.p0\] always s_eventually main.counter == 10: INCONCLUSIVE$
+^\[main\.p0\] always s_eventually main.counter == 10: INCONCLUSIVE$
 ^main\.counter@0 = .*$
 ^main\.counter@1 = .*$
 ^EXIT=10$

--- a/regression/ebmc/ranking-function/counter2.pass.desc
+++ b/regression/ebmc/ranking-function/counter2.pass.desc
@@ -1,7 +1,7 @@
 CORE
 counter2.sv
 --ranking-function 10-counter
-^\[main\.property\.p0\] always s_eventually main.counter == 10: PROVED$
+^\[main\.p0\] always s_eventually main.counter == 10: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/counter_in_module1.desc
+++ b/regression/ebmc/ranking-function/counter_in_module1.desc
@@ -1,7 +1,7 @@
 CORE
 counter_in_module1.sv
 --ranking-function my_instance.counter
-^\[main\.property\.p0\] always s_eventually main\.my_instance\.counter == 0: PROVED$
+^\[main\.p0\] always s_eventually main\.my_instance\.counter == 0: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/counter_with_reset1.fail.desc
+++ b/regression/ebmc/ranking-function/counter_with_reset1.fail.desc
@@ -1,7 +1,7 @@
 CORE
 counter_with_reset1.sv
---property main.property.p0 --ranking-function 10-counter
-^\[main\.property\.p0\] always s_eventually main.counter == 10: INCONCLUSIVE$
+--property main.p0 --ranking-function 10-counter
+^\[main\.p0\] always s_eventually main.counter == 10: INCONCLUSIVE$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/counter_with_reset1.pass.desc
+++ b/regression/ebmc/ranking-function/counter_with_reset1.pass.desc
@@ -1,7 +1,7 @@
 CORE
 counter_with_reset1.sv
---property main.property.p1 --ranking-function 10-counter
-^\[main\.property\.p1\] always s_eventually main.reset \|\| main.counter == 10: PROVED$
+--property main.p1 --ranking-function 10-counter
+^\[main\.p1\] always s_eventually main.reset \|\| main.counter == 10: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/lexicographic_ranking_function1.desc
+++ b/regression/ebmc/ranking-function/lexicographic_ranking_function1.desc
@@ -1,7 +1,7 @@
 CORE
 lexicographic_ranking_function1.sv
 --ranking-function "{digit1, digit2}"
-^\[main\.property\.p0\] always s_eventually main\.digit1 == 0: PROVED$
+^\[main\.p0\] always s_eventually main\.digit1 == 0: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ranking-function/signed1.desc
+++ b/regression/ebmc/ranking-function/signed1.desc
@@ -1,7 +1,7 @@
 CORE
 signed1.sv
 --ranking-function "(-$signed({1'b0,counter}))"
-^\[main\.property\.p0\] always s_eventually main.counter == 0: PROVED$
+^\[main\.p0\] always s_eventually main.counter == 0: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ring_buffer_induction/test.desc
+++ b/regression/ebmc/ring_buffer_induction/test.desc
@@ -1,9 +1,9 @@
 CORE
 ring_buffer.sv
 --k-induction
-^\[ring_buffer\.property\.1\] assume always \(ring_buffer\.empty |-> !ring_buffer\.read\): ASSUMED$
-^\[ring_buffer\.property\.2\] assume always \(ring_buffer\.full |-> !ring_buffer\.write\): ASSUMED$
-^\[ring_buffer\.property\.3\] always \(ring_buffer\.writeptr - ring_buffer\.readptr & 15\) == ring_buffer\.count: PROVED$
+^\[ring_buffer\.assert\.1\] assume always \(ring_buffer\.empty |-> !ring_buffer\.read\): ASSUMED$
+^\[ring_buffer\.assert\.2\] assume always \(ring_buffer\.full |-> !ring_buffer\.write\): ASSUMED$
+^\[ring_buffer\.assert\.3\] always \(ring_buffer\.writeptr - ring_buffer\.readptr & 15\) == ring_buffer\.count: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 

--- a/regression/verilog/SVA/case1.desc
+++ b/regression/verilog/SVA/case1.desc
@@ -1,7 +1,7 @@
 CORE
 case1.sv
 --bound 20 --numbered-trace
-^\[main\.property\.p0\] always \(case\(main\.x\) 10: 0; endcase\): REFUTED$
+^\[main\.p0\] always \(case\(main\.x\) 10: 0; endcase\): REFUTED$
 ^Counterexample with 11 states:$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/verilog/SVA/cover1.desc
+++ b/regression/verilog/SVA/cover1.desc
@@ -1,11 +1,11 @@
 CORE
 cover1.sv
 --bound 10 --numbered-trace
-^\[main\.property\.p0\] cover main\.counter == 1: PROVED$
+^\[main\.p0\] cover main\.counter == 1: PROVED$
 ^Trace with 2 states:$
 ^main\.counter@0 = 0$
 ^main\.counter@1 = 1$
-^\[main\.property\.p1\] cover main\.counter == 100: REFUTED up to bound 10$
+^\[main\.p1\] cover main\.counter == 100: REFUTED up to bound 10$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/eventually2.desc
+++ b/regression/verilog/SVA/eventually2.desc
@@ -1,7 +1,7 @@
 CORE
 eventually2.sv
 --bound 20
-^\[main\.property\.p0\] always \(eventually \[0:2\] main\.counter == 3\): REFUTED$
+^\[main\.p0\] always \(eventually \[0:2\] main\.counter == 3\): REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/if1.desc
+++ b/regression/verilog/SVA/if1.desc
@@ -1,8 +1,8 @@
 CORE broken-smt-backend
 if1.sv
 --bound 2
-^\[main\.property\.p0\] always if\(main\.counter == 0\) nexttime main\.counter == 1: PROVED up to bound 2$
-^\[main\.property\.p1\] always if\(main\.counter == 0\) nexttime main\.counter == 1 else nexttime main\.counter == 3: REFUTED$
+^\[main\.p0\] always if\(main\.counter == 0\) nexttime main\.counter == 1: PROVED up to bound 2$
+^\[main\.p1\] always if\(main\.counter == 0\) nexttime main\.counter == 1 else nexttime main\.counter == 3: REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/nexttime1.desc
+++ b/regression/verilog/SVA/nexttime1.desc
@@ -1,9 +1,9 @@
 KNOWNBUG
 nexttime1.sv
 --module main --bound 10
-^\[main\.property\.1\] s_nexttime\[0\] main\.counter == 0: PROVED up to bound 10$
-^\[main\.property\.2\] s_nexttime\[1\] main\.counter == 1: PROVED up to bound 10$
-^\[main\.property\.3\] nexttime\[8\] main\.counter == 8: PROVED up to bound 10$
+^\[main\.assert\.1\] s_nexttime\[0\] main\.counter == 0: PROVED up to bound 10$
+^\[main\.assert\.2\] s_nexttime\[1\] main\.counter == 1: PROVED up to bound 10$
+^\[main\.assert\.3\] nexttime\[8\] main\.counter == 8: PROVED up to bound 10$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/s_eventually3.desc
+++ b/regression/verilog/SVA/s_eventually3.desc
@@ -3,6 +3,6 @@ s_eventually3.sv
 --module main --bound 11
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main\.property\.p0\] always s_eventually main\.counter <= 5: REFUTED$
+^\[main\.p0\] always s_eventually main\.counter <= 5: REFUTED$
 --
 ^warning: ignoring

--- a/regression/verilog/SVA/system_verilog_assertion2.desc
+++ b/regression/verilog/SVA/system_verilog_assertion2.desc
@@ -4,6 +4,6 @@ system_verilog_assertion2.sv
 ^EXIT=10$
 ^SIGNAL=0$
 ^Counterexample:$
-^\[main.property.my_label\] .* REFUTED$
+^\[main\.my_label\] .* REFUTED$
 --
 ^warning: ignoring

--- a/regression/verilog/SVA/unbounded1.desc
+++ b/regression/verilog/SVA/unbounded1.desc
@@ -1,7 +1,7 @@
 CORE
 unbounded1.sv
 --module main --bound 1
-^\[main\.property\.1\] always \(main\.a ##\[0:\$\] main.b\): REFUTED$
+^\[main\.assert\.1\] always \(main\.a ##\[0:\$\] main.b\): REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/enums/enum1.desc
+++ b/regression/verilog/enums/enum1.desc
@@ -3,7 +3,7 @@ enum1.sv
 --bound 3 --numbered-trace
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main\.property\.p1\] always main\.my_light != main.YELLOW2: REFUTED$
+^\[main\.p1\] always main\.my_light != main.YELLOW2: REFUTED$
 ^main\.my_light@0 = main\.RED$
 ^main\.my_light@1 = main\.YELLOW1$
 ^main\.my_light@2 = main\.GREEN$

--- a/regression/verilog/enums/enum4.desc
+++ b/regression/verilog/enums/enum4.desc
@@ -3,5 +3,5 @@ enum4.sv
 --bound 0
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.property\.p1\] always main.A == main.A: PROVED up to bound 0$
+^\[main\.p1\] always main.A == main.A: PROVED up to bound 0$
 --

--- a/regression/verilog/enums/enum_cast1.desc
+++ b/regression/verilog/enums/enum_cast1.desc
@@ -3,6 +3,6 @@ enum_cast1.sv
 --bound 0
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.property\.p1\] always main.A == 1: PROVED up to bound 0$
-^\[main\.property\.p2\] always main.B == 2: PROVED up to bound 0$
+^\[main\.p1\] always main.A == 1: PROVED up to bound 0$
+^\[main\.p2\] always main.B == 2: PROVED up to bound 0$
 --

--- a/regression/verilog/enums/enum_initializers1.desc
+++ b/regression/verilog/enums/enum_initializers1.desc
@@ -1,8 +1,8 @@
 CORE
 enum_initializers1.sv
 --bound 0
-^\[main\.property\.pA\] always main.A == 1: PROVED up to bound 0$
-^\[main\.property\.pB\] always main.B == 11: PROVED up to bound 0$
+^\[main\.pA\] always main.A == 1: PROVED up to bound 0$
+^\[main\.pB\] always main.B == 11: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/static_cast1.desc
+++ b/regression/verilog/expressions/static_cast1.desc
@@ -3,6 +3,6 @@ static_cast1.sv
 --module main --bound 0
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.property\.p0\] always 255 == 255: PROVED up to bound 0$
+^\[main\.p0\] always 255 == 255: PROVED up to bound 0$
 --
 ^warning: ignoring

--- a/regression/verilog/modules/type_parameters1.desc
+++ b/regression/verilog/modules/type_parameters1.desc
@@ -1,8 +1,8 @@
 CORE
 type_parameters1.sv
 --bound 0
-^\[main\.property\.p1\] always 1 == 1: PROVED up to bound 0$
-^\[main\.property\.p2\] always 32 == 32: PROVED up to bound 0$
+^\[main\.p1\] always 1 == 1: PROVED up to bound 0$
+^\[main\.p2\] always 32 == 32: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/structs/structs1.desc
+++ b/regression/verilog/structs/structs1.desc
@@ -1,10 +1,10 @@
 CORE
 structs1.sv
 --bound 0
-^\[main\.property\.p0\] always 9 == 9: PROVED up to bound 0$
-^\[main\.property\.p1\] always main\.s\.field1 == 1: PROVED up to bound 0$
-^\[main\.property\.p2\] always main\.s\.field2 == 0: PROVED up to bound 0$
-^\[main\.property\.p3\] always main\.s\.field3 == 115: PROVED up to bound 0$
+^\[main\.p0\] always 9 == 9: PROVED up to bound 0$
+^\[main\.p1\] always main\.s\.field1 == 1: PROVED up to bound 0$
+^\[main\.p2\] always main\.s\.field2 == 0: PROVED up to bound 0$
+^\[main\.p3\] always main\.s\.field3 == 115: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/synthesis/always_ff1.desc
+++ b/regression/verilog/synthesis/always_ff1.desc
@@ -3,6 +3,6 @@ always_ff1.sv
 --module main --k-induction
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.property\.p0\] always main\.x >= 1 && main\.x <= 10: PROVED$
+^\[main\.p0\] always main\.x >= 1 && main\.x <= 10: PROVED$
 --
 ^warning: ignoring

--- a/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog.desc
+++ b/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog.desc
@@ -1,7 +1,7 @@
 CORE
 continuous_assignment_to_variable_systemverilog.sv
 --bound 0
-^\[main\.property\.p1\] always main\.some_reg == main\.i: PROVED up to bound 0$
+^\[main\.p1\] always main\.some_reg == main\.i: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1023,21 +1023,29 @@ void verilog_typecheckt::convert_assert_assume_cover(
 
   irep_idt base_name;
 
+  // The label is optional.
   if(identifier == irep_idt())
   {
+    std::string kind = module_item.id() == ID_verilog_assert_property ? "assert"
+                       : module_item.id() == ID_verilog_assume_property
+                         ? "assume"
+                       : module_item.id() == ID_verilog_cover_property ? "cover"
+                                                                       : "";
+
     assertion_counter++;
-    base_name = std::to_string(assertion_counter);
+    base_name = kind + "." + std::to_string(assertion_counter);
   }
   else
     base_name = identifier;
 
+  // The assert/assume/cover module items use the module name space
   std::string full_identifier =
-    id2string(module_identifier) + ".property." + id2string(base_name);
+    id2string(module_identifier) + '.' + id2string(base_name);
 
   if(symbol_table.symbols.find(full_identifier) != symbol_table.symbols.end())
   {
     throw errort().with_location(module_item.source_location())
-      << "property identifier `" << base_name << "' already used";
+      << "identifier `" << base_name << "' already used";
   }
 
   module_item.identifier(full_identifier);


### PR DESCRIPTION
Concurrent assertion items (assert/assume/cover) that are module items with a block label go into the module name space, not into a separate "property" name space.

Assertion items without block item now get a label based on the kind of the assertion item (assert/assume/cover).