### PR TITLE
Verilog: add test for conditional immediate assertion

### DIFF
--- a/regression/verilog/SVA/immediate1.desc
+++ b/regression/verilog/SVA/immediate1.desc
@@ -1,0 +1,9 @@
+CORE
+immediate1.sv
+--bound 20
+^\[main\.assert\.1\] always \(main\.x == 11 \|-> main\.x & 1\): PROVED up to bound 20$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/immediate1.sv
+++ b/regression/verilog/SVA/immediate1.sv
@@ -1,0 +1,14 @@
+module main(input clk);
+
+  reg [31:0] x;
+
+  initial x=0;
+
+  always @(posedge clk) begin
+    if(x == 11)
+      assert(x & 1); // holds
+
+    x<=x+1;
+  end
+
+endmodule


### PR DESCRIPTION
This adds a test for an immediate SystemVerilog assertion that is guarded by an `if` statement.