### PR TITLE
copy constructors for exception classes

### DIFF
--- a/src/ebmc/ebmc_error.h
+++ b/src/ebmc/ebmc_error.h
@@ -16,6 +16,16 @@ Author: Daniel Kroening, dkr@amazon.com
 class ebmc_errort
 {
 public:
+  ebmc_errort() = default;
+  ebmc_errort(const ebmc_errort &other)
+  {
+    // ostringstream does not have a copy constructor
+    message << other.message.str();
+    __exit_code = other.__exit_code;
+    __location = other.__location;
+  }
+  ebmc_errort(ebmc_errort &&) = default;
+
   std::string what() const
   {
     return message.str();

--- a/src/verilog/verilog_preprocessor_error.h
+++ b/src/verilog/verilog_preprocessor_error.h
@@ -15,6 +15,14 @@ Author: Daniel Kroening, kroening@kroening.com
 class verilog_preprocessor_errort
 {
 public:
+  verilog_preprocessor_errort() = default;
+  verilog_preprocessor_errort(verilog_preprocessor_errort &&) = default;
+  verilog_preprocessor_errort(const verilog_preprocessor_errort &other)
+  {
+    // ostringstream does not have a copy constructor
+    message << other.message.str();
+  }
+
   std::string what() const
   {
     return message.str();


### PR DESCRIPTION
C++11 15.1 §5 requires that objects that are thrown have an accessible copy/move constructor and a destructor.

This adds an explicit copy constructor to a few classes where the compiler cannot build the default copy constructor.