### PR TITLE
SystemVerilog: endmodule identifiers

### DIFF
--- a/regression/verilog/modules/endmodule_identifier.desc
+++ b/regression/verilog/modules/endmodule_identifier.desc
@@ -1,0 +1,7 @@
+CORE
+endmodule_identifier.sv
+--show-modules
+.*Name:.* some_module$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/verilog/modules/endmodule_identifier.sv
+++ b/regression/verilog/modules/endmodule_identifier.sv
@@ -1,0 +1,4 @@
+module some_module;
+  // endmodule identifiers are a SystemVerilog feature
+endmodule : some_module
+

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -641,7 +641,7 @@ module_ansi_header:
         ;
 
 module_declaration:
-          module_nonansi_header module_item_brace TOK_ENDMODULE module_identifier_opt
+          module_nonansi_header module_item_brace TOK_ENDMODULE endmodule_identifier_opt
           {
             PARSER.parse_tree.create_module(
               stack_expr($1).operands()[0],
@@ -654,7 +654,7 @@ module_declaration:
             // close the module scope
             pop_scope();
           }
-        | module_ansi_header module_item_brace TOK_ENDMODULE module_identifier_opt
+        | module_ansi_header module_item_brace TOK_ENDMODULE endmodule_identifier_opt
           {
             PARSER.parse_tree.create_module(
               stack_expr($1).operands()[0],
@@ -3677,9 +3677,9 @@ interface_identifier:
 
 module_identifier: TOK_NON_TYPE_IDENTIFIER;
 
-module_identifier_opt:
+endmodule_identifier_opt:
 	  /* Optional */
-	| module_identifier
+	| TOK_COLON module_identifier
 	;
 
 net_identifier: identifier;


### PR DESCRIPTION
SystemVerilog allows repeating the module identifier at after the endmodule keyword.