### PR TITLE
Verilog: use verilog_module_sourcet to discover instantiated modules

### DIFF
--- a/src/verilog/verilog_expr.cpp
+++ b/src/verilog/verilog_expr.cpp
@@ -30,3 +30,29 @@ bool function_call_exprt::is_system_function_call() const
          has_prefix(
            id2string(to_symbol_expr(function()).get_identifier()), "$");
 }
+
+void verilog_module_sourcet::show(std::ostream &out) const
+{
+  out << "Module: " << base_name() << '\n';
+
+  out << "  Parameters:\n";
+
+  for(auto &parameter : parameter_port_list())
+    out << "    " << parameter.pretty() << '\n';
+
+  out << '\n';
+
+  out << "  Ports:\n";
+
+  for(auto &port : ports())
+    out << "    " << port.pretty() << '\n';
+
+  out << '\n';
+
+  out << "  Module items:\n";
+
+  for(auto &item : module_items())
+    out << "    " << item.pretty() << '\n';
+
+  out << '\n';
+}

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -1944,6 +1944,8 @@ public:
   {
     return static_cast<source_locationt &>(add(ID_C_source_location));
   }
+
+  void show(std::ostream &) const;
 };
 
 inline const verilog_module_sourcet &to_verilog_module_source(const irept &irep)

--- a/src/verilog/verilog_language.cpp
+++ b/src/verilog/verilog_language.cpp
@@ -137,7 +137,7 @@ void verilog_languaget::dependencies(
     
     const verilog_modulet &module=(it->second)->verilog_module;
 
-    for(auto &identifier : module.submodules())
+    for(auto &identifier : submodules(module.to_irep()))
       module_set.insert(id2string(identifier));
   }
 }

--- a/src/verilog/verilog_language.cpp
+++ b/src/verilog/verilog_language.cpp
@@ -134,10 +134,10 @@ void verilog_languaget::dependencies(
   if(it!=parse_tree.module_map.end())
   {
     // dependencies on other Verilog modules
-    
-    const verilog_modulet &module=(it->second)->verilog_module;
 
-    for(auto &identifier : submodules(module.to_irep()))
+    const auto &module = (it->second)->verilog_module;
+
+    for(auto &identifier : submodules(module))
       module_set.insert(id2string(identifier));
   }
 }

--- a/src/verilog/verilog_module.cpp
+++ b/src/verilog/verilog_module.cpp
@@ -53,7 +53,7 @@ void verilog_modulet::show(std::ostream &out) const
 
 /*******************************************************************\
 
-Function: verilog_modulet::submodules_rec
+Function: submodules_rec
 
   Inputs:
 
@@ -63,8 +63,8 @@ Function: verilog_modulet::submodules_rec
 
 \*******************************************************************/
 
-void verilog_modulet::submodules_rec(
-  const exprt &module_item,
+void submodules_rec(
+  const verilog_module_itemt &module_item,
   std::vector<irep_idt> &dest)
 {
   if(module_item.id() == ID_inst)
@@ -92,7 +92,7 @@ void verilog_modulet::submodules_rec(
 
 /*******************************************************************\
 
-Function: verilog_modulet::submodules
+Function: submodules
 
   Inputs:
 
@@ -102,12 +102,12 @@ Function: verilog_modulet::submodules
 
 \*******************************************************************/
 
-std::vector<irep_idt> verilog_modulet::submodules() const
+std::vector<irep_idt> submodules(const verilog_module_sourcet &module)
 {
   std::vector<irep_idt> result;
 
-  for(auto &item : module_items.get_sub())
-    submodules_rec(static_cast<const exprt &>(item), result);
+  for(auto &item : module.module_items())
+    submodules_rec(item, result);
 
   return result;
 }

--- a/src/verilog/verilog_module.h
+++ b/src/verilog/verilog_module.h
@@ -37,16 +37,12 @@ struct verilog_modulet
     m.module_items.swap(module_items);
     m.location.swap(location);
   }
-  
+
   void show(std::ostream &out) const;
-
-  // The identifiers of the submodules
-  // (not: the identifiers of the instances)
-  std::vector<irep_idt> submodules() const;
-
-private:
-  static void
-  submodules_rec(const exprt &module_item, std::vector<irep_idt> &dest);
 };
+
+// The identifiers of the submodules
+// (not: the identifiers of the instances)
+std::vector<irep_idt> submodules(const verilog_module_sourcet &);
 
 #endif

--- a/src/verilog/verilog_parse_tree.cpp
+++ b/src/verilog/verilog_parse_tree.cpp
@@ -30,19 +30,20 @@ void verilog_parse_treet::create_module(
   exprt &module_items)
 {
   items.push_back(itemt(itemt::MODULE));
-  itemt &item=items.back();
-
-  verilog_modulet &new_module=item.verilog_module;
 
   if(ports.get_sub().size()==1 &&
      ports.get_sub().front().is_nil())
     ports.clear();
+
+  verilog_modulet new_module;
 
   new_module.name=name.id();
   new_module.parameter_port_list.swap(parameter_port_list);
   new_module.ports.swap(ports);
   new_module.location=((const exprt &)module_keyword).source_location();
   new_module.module_items.swap(module_items);
+
+  items.back().verilog_module = new_module.to_irep();
 
   // add to module map  
   module_map[new_module.name]=--items.end();
@@ -68,7 +69,7 @@ void verilog_parse_treet::modules_provided(
       it++)
     if(it->is_module())
       module_set.insert(
-        id2string(verilog_module_symbol(it->verilog_module.name)));
+        id2string(verilog_module_symbol(it->verilog_module.base_name())));
 }
 
 /*******************************************************************\
@@ -91,7 +92,7 @@ void verilog_parse_treet::build_module_map()
       it!=items.end();
       it++)
     if(it->is_module())
-      module_map[it->verilog_module.name]=it;
+      module_map[it->verilog_module.base_name()] = it;
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_parse_tree.h
+++ b/src/verilog/verilog_parse_tree.h
@@ -41,7 +41,7 @@ public:
     {
     }
 
-    verilog_modulet verilog_module;
+    verilog_module_sourcet verilog_module;
 
     exprt verilog_package_item;
 

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1848,7 +1848,7 @@ bool verilog_typecheck(
 
   return verilog_typecheck(
     symbol_table,
-    it->second->verilog_module.to_irep(),
+    it->second->verilog_module,
     parse_tree.standard,
     message_handler);
 }


### PR DESCRIPTION
This strengthens the typing in the code that does the iterating.