### PR TITLE
Verilog: KNOWNBUG test for input file without newline

### DIFF
--- a/regression/verilog/modules/error_first_line1.desc
+++ b/regression/verilog/modules/error_first_line1.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+error_first_line1.v
+
+
+^file error_first_line1.v: syntax error
+^EXIT=1$
+^SIGNAL=0$
+--
+--
+The line number is missing in the error message.

--- a/regression/verilog/modules/error_first_line1.v
+++ b/regression/verilog/modules/error_first_line1.v
@@ -1,0 +1,1 @@
+module test(some syntax error); // no newline


### PR DESCRIPTION
Given an input file without newline, the error message is missing the line number.