### PR TITLE
Netlist conversion: do not convert types

### DIFF
--- a/regression/verilog/enums/enum1.aig.desc
+++ b/regression/verilog/enums/enum1.aig.desc
@@ -1,0 +1,11 @@
+CORE
+enum1.sv
+--bound 3 --numbered-trace --aig
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.p1\] always main\.my_light != main.YELLOW2: REFUTED$
+^main\.my_light@0 = main\.RED$
+^main\.my_light@1 = main\.YELLOW1$
+^main\.my_light@2 = main\.GREEN$
+^main\.my_light@3 = main\.YELLOW2$
+--

--- a/src/trans-netlist/trans_to_netlist.cpp
+++ b/src/trans-netlist/trans_to_netlist.cpp
@@ -207,6 +207,8 @@ void convert_trans_to_netlistt::map_vars(
     else if (symbol.type.id() == ID_module ||
              symbol.type.id() == ID_module_instance)
       return; // ignore modules
+    else if(symbol.is_type)
+      return; // ignore types
     else if (symbol.is_input)
       vartype = var_mapt::vart::vartypet::INPUT;
     else if (symbol.is_state_var)


### PR DESCRIPTION
This prevents passing SystemVerilog enums to the decision procedure, which causes an error.

Fixes #623.