### PR TITLE
SystemVerilog: ignore default_nettype directive

### DIFF
--- a/regression/verilog/directives/default_nettype1.desc
+++ b/regression/verilog/directives/default_nettype1.desc
@@ -1,0 +1,7 @@
+CORE
+default_nettype1.sv
+
+^no properties$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/verilog/directives/default_nettype1.sv
+++ b/regression/verilog/directives/default_nettype1.sv
@@ -1,0 +1,5 @@
+`default_nettype none
+`default_nettype wire
+
+module main;
+endmodule

--- a/src/verilog/scanner.l
+++ b/src/verilog/scanner.l
@@ -556,6 +556,7 @@ prove           { VL2SMV_VERILOG_KEYWORD(TOK_PROVE); }
 \'line          { continue; }
 \'file          { continue; }
 \`line{WS}[^\n]*{NL} { line_directive(); continue; }
+\`default_nettype{WS}[^\n]*{NL} { /* ignore for now */ continue; }
 \`{Word}        { preprocessor(); continue; }
 
 \f              { /* ignore */ }

--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -608,6 +608,21 @@ void verilog_preprocessort::directive()
     // ignored
     tokenizer().skip_until_eol();
   }
+  else if(text == "default_nettype")
+  {
+    // pass through
+    out << '`' << text;
+    while(true)
+    {
+      auto token = tokenizer().peek();
+      if(token.is_eof())
+        break;
+      out << token.text;
+      tokenizer().next_token(); // eat
+      if(token == '\n')
+        break;
+    }
+  }
   else
   {
     // check defines


### PR DESCRIPTION
The preprocessor now passes default_nettype to the parser.  The parser ignores it for now.