### PR TITLE
Verilog: constant folding for replication

### DIFF
--- a/regression/verilog/expressions/replication1.v
+++ b/regression/verilog/expressions/replication1.v
@@ -21,4 +21,12 @@ module main(in);
   always assert property4:
     {{ 1 { 1'b0 }}, in } == in;
 
+  // constant folding
+  parameter P = { 2 { 2'b01 } };
+
+  wire [P:0] some_wire;
+
+  always assert property5:
+    P == 'b0101;
+
 endmodule

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1552,6 +1552,17 @@ exprt verilog_typecheck_exprt::elaborate_constant_expression(exprt expr)
       expr = notequal_exprt(
         reduction_or.op(), from_integer(0, reduction_or.op().type()));
     }
+    else if(expr.id() == ID_replication)
+    {
+      auto &replication = to_replication_expr(expr);
+      auto times = numeric_cast_v<std::size_t>(replication.times());
+      // lower to a concatenation
+      exprt::operandst ops;
+      ops.reserve(times);
+      for(std::size_t i = 0; i < times; i++)
+        ops.push_back(replication.op());
+      expr = concatenation_exprt{ops, expr.type()};
+    }
 
     // We fall back to the simplifier to approximate
     // the standard's definition of 'constant expression'.


### PR DESCRIPTION
This adds constant folding for replication operators to the Verilog typechecker.