### PR TITLE
Verilog: extract `verilog_synthesist::synthesis_constant`

### DIFF
--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -177,7 +177,10 @@ protected:
 
     exprt guarded_expr(exprt) const;
   };
-   
+
+  // expressions
+  [[nodiscard]] std::optional<mp_integer> synthesis_constant(const exprt &);
+
   exprt current_value(
     const value_mapt::mapt &map,
     const symbolt &symbol,


### PR DESCRIPTION
This extracts the conversion of expressions into synthesis-time constants into a new method.