### PR TITLE
Verilog: separate synthesis for LHS expressions

### DIFF
--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -179,6 +179,7 @@ protected:
   };
 
   // expressions
+  [[nodiscard]] exprt synth_lhs_expr(exprt expr);
   [[nodiscard]] std::optional<mp_integer> synthesis_constant(const exprt &);
 
   exprt current_value(


### PR DESCRIPTION
The left-hand side of assignments requires special-case synthesis; the symbol to be assigned must not be replaced by its value, but any array indices must be.