### PR TITLE
Verilog: fix for continuous assignments to state variables

### DIFF
--- a/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog2.desc
+++ b/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog2.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+continuous_assignment_to_variable_systemverilog2.sv
+--bound 1
+^\[main\.cover1\] cover 1: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This creates inconsistent constraints, which yields UNSAT.

--- a/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog2.desc
+++ b/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog2.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 continuous_assignment_to_variable_systemverilog2.sv
 --bound 1
 ^\[main\.cover1\] cover 1: PROVED$
@@ -6,4 +6,3 @@ continuous_assignment_to_variable_systemverilog2.sv
 ^SIGNAL=0$
 --
 --
-This creates inconsistent constraints, which yields UNSAT.

--- a/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog2.sv
+++ b/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog2.sv
@@ -1,0 +1,15 @@
+module main(input clk);
+
+  bit state = 0;
+
+  always_ff @(posedge clk)
+    state = 1;
+
+  logic data;
+
+  // continuous assignment to variable
+  assign data = state;
+
+  cover1: cover property (@(posedge clk) (1));
+
+endmodule


### PR DESCRIPTION
SystemVerilog allows continous assignments to variables.

This test exposes that inconsistent constraints get generated for this case.

This replicates issue #635.