### PR TITLE
Verilog: fix assignment for module output ports

### DIFF
--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -322,6 +322,7 @@ protected:
   void replace_symbols(const irep_idt &target, exprt &dest);
 
   void instantiate_port(
+    bool is_output,
     const symbol_exprt &port,
     const exprt &value,
     const replace_mapt &,


### PR DESCRIPTION
This flips the assignments generated by synthesis for module output ports to read

  `c := port`

for a connected signal `c`, instead of `port := c`.