### PR TITLE
Verilog: parse tree now is a list of generic compilation unit items

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -616,7 +616,7 @@ description:
  	| package_declaration
 	| attribute_instance_brace package_item
 		{ add_attributes($2, $1);
-		  PARSER.parse_tree.create_package_item(stack_expr($2)); }
+		  PARSER.parse_tree.add_item(stack_expr($2)); }
  	| attribute_instance_brace bind_directive
  	| config_declaration
         ;

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -1893,9 +1893,8 @@ to_verilog_assume_statement(verilog_statementt &statement)
 class verilog_module_sourcet : public irept
 {
 public:
-  verilog_module_sourcet() = default;
-
   explicit verilog_module_sourcet(irep_idt _base_name)
+    : irept(ID_verilog_module)
   {
     base_name(_base_name);
   }

--- a/src/verilog/verilog_language.cpp
+++ b/src/verilog/verilog_language.cpp
@@ -136,7 +136,7 @@ void verilog_languaget::dependencies(
   {
     // dependencies on other Verilog modules
 
-    const auto &module = (it->second)->verilog_module;
+    const auto &module = *it->second;
 
     for(auto &identifier : module.submodules())
       module_set.insert(id2string(identifier));

--- a/src/verilog/verilog_parse_tree.h
+++ b/src/verilog/verilog_parse_tree.h
@@ -27,37 +27,10 @@ public:
 
   verilog_standardt standard;
 
-  struct itemt
-  {
-  public:
-    typedef enum
-    {
-      MODULE,
-      PACKAGE_ITEM
-    } item_typet;
-    item_typet type;
+  using itemt = irept;
 
-    explicit itemt(item_typet __type) : type(__type)
-    {
-    }
+  void show(const itemt &, std::ostream &) const;
 
-    verilog_module_sourcet verilog_module;
-
-    exprt verilog_package_item;
-
-    bool is_module() const
-    {
-      return type==MODULE;
-    }
-
-    bool is_package_item() const
-    {
-      return type == PACKAGE_ITEM;
-    }
-    
-    void show(std::ostream &out) const;
-  };
-  
   typedef std::list<itemt> itemst;
   itemst items;
 
@@ -83,10 +56,10 @@ public:
     exprt &ports,
     exprt &statements);
 
-  void create_package_item(exprt package_item)
+  itemt &add_item(itemt item)
   {
-    items.push_back(itemt(itemt::PACKAGE_ITEM));
-    items.back().verilog_package_item = std::move(package_item);
+    items.push_back(std::move(item));
+    return items.back();
   }
   
   void swap(verilog_parse_treet &parse_tree)
@@ -100,7 +73,9 @@ public:
   void modules_provided(
     std::set<std::string> &module_set) const;
 
-  typedef std::unordered_map<irep_idt, itemst::iterator, irep_id_hash> module_mapt;
+  typedef std::
+    unordered_map<irep_idt, const verilog_module_sourcet *, irep_id_hash>
+      module_mapt;
   module_mapt module_map;
   
   void build_module_map();

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1847,10 +1847,7 @@ bool verilog_typecheck(
   }
 
   return verilog_typecheck(
-    symbol_table,
-    it->second->verilog_module,
-    parse_tree.standard,
-    message_handler);
+    symbol_table, *it->second, parse_tree.standard, message_handler);
 }
 
 /*******************************************************************\


### PR DESCRIPTION
SystemVerilog allows a broad range of items to appear at the compilation unit level.  This changes the parse tree to be a list of generic compilation unit items.
