### PR TITLE
Verilog: `create_module` now returns `verilog_module_sourcet`

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -614,6 +614,7 @@ description_brace:
 
 description:
 	  module_declaration
+		{ PARSER.parse_tree.add_item(stack_expr($1)); }
 	| udp_declaration
 	| interface_declaration
  	| program_declaration
@@ -672,7 +673,8 @@ module_ansi_header:
 module_declaration:
           module_nonansi_header module_item_brace TOK_ENDMODULE endmodule_identifier_opt
           {
-            PARSER.parse_tree.create_module(
+            init($$);
+            stack_expr($$) = PARSER.parse_tree.create_module(
               stack_expr($1).operands()[0],
               stack_expr($1).operands()[1],
               stack_expr($1).operands()[2],
@@ -685,7 +687,8 @@ module_declaration:
           }
         | module_ansi_header module_item_brace TOK_ENDMODULE endmodule_identifier_opt
           {
-            PARSER.parse_tree.create_module(
+            init($$);
+            stack_expr($$) = PARSER.parse_tree.create_module(
               stack_expr($1).operands()[0],
               stack_expr($1).operands()[1],
               stack_expr($1).operands()[2],
@@ -697,9 +700,11 @@ module_declaration:
             pop_scope();
           }
         | TOK_EXTERN module_nonansi_header
-          /* ignored for now */
+		/* ignored for now */
+		{ init($$); }
         | TOK_EXTERN module_ansi_header
-          /* ignored for now */
+		/* ignored for now */
+		{ init($$); }
 	;
 
 module_keyword:

--- a/src/verilog/verilog_language.cpp
+++ b/src/verilog/verilog_language.cpp
@@ -83,6 +83,8 @@ bool verilog_languaget::parse(
 
   parse_tree.swap(verilog_parser.parse_tree);
 
+  parse_tree.build_module_map();
+
   return result;
 }
 

--- a/src/verilog/verilog_parse_tree.cpp
+++ b/src/verilog/verilog_parse_tree.cpp
@@ -21,7 +21,7 @@ Function: verilog_parse_treet::create_module
 
 \*******************************************************************/
 
-void verilog_parse_treet::create_module(
+exprt verilog_parse_treet::create_module(
   irept &attributes,
   irept &module_keyword,
   exprt &name,
@@ -41,10 +41,7 @@ void verilog_parse_treet::create_module(
     ((const exprt &)module_keyword).source_location();
   new_module.add(ID_module_items) = std::move(module_items);
 
-  auto &new_item = add_item(std::move(new_module));
-
-  // add to module map
-  module_map[name.id()] = &to_verilog_module_source(new_item);
+  return static_cast<exprt &>(static_cast<irept &>(new_module));
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_parse_tree.h
+++ b/src/verilog/verilog_parse_tree.h
@@ -48,7 +48,7 @@ public:
     return module_map.count(name)!=0;
   }
 
-  void create_module(
+  static exprt create_module(
     irept &attributes,
     irept &module_keyword,
     exprt &name,


### PR DESCRIPTION
Instead of storing the module via a side-effect, `create_module` now returns the `verilog_module_sourcet`.

This enables nested modules.