### PR TITLE
introduce `property_checker_resultt`

### DIFF
--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -22,8 +22,6 @@ Author: Daniel Kroening, daniel.kroening@inf.ethz.ch
 #include <trans-netlist/unwind_netlist.h>
 #include <verilog/sva_expr.h>
 
-#include "report_results.h"
-
 #include <algorithm>
 #include <iostream>
 
@@ -51,7 +49,7 @@ public:
   {
   }
 
-  int operator()();
+  property_checker_resultt operator()();
 
 protected:
   using propertiest = ebmc_propertiest;
@@ -173,7 +171,7 @@ Function: bdd_enginet::operator()
 
 \*******************************************************************/
 
-int bdd_enginet::operator()()
+property_checker_resultt bdd_enginet::operator()()
 {
   try
   {
@@ -216,30 +214,29 @@ int bdd_enginet::operator()()
       }
 
       std::cout << '\n';
-        
-      return 0;
+
+      return property_checker_resultt::SUCCESS;
     }
 
     if(properties.properties.empty())
     {
       message.error() << "no properties" << messaget::eom;
-      return 1;
+      return property_checker_resultt::ERROR;
     }
 
     for(propertyt &p : properties.properties)
       check_property(p);
 
-    report_results(cmdline, properties, ns, message.get_message_handler());
-    return properties.exit_code();
+    return property_checker_resultt::VERIFICATION_RESULT;
   }
   catch(const char *error_msg)
   {
     message.error() << error_msg << messaget::eom;
-    return 1;
+    return property_checker_resultt::ERROR;
   }
   catch(int)
   {
-    return 1;
+    return property_checker_resultt::ERROR;
   }
 }
 
@@ -1002,7 +999,7 @@ Function: bdd_engine
 
 \*******************************************************************/
 
-int bdd_engine(
+property_checker_resultt bdd_engine(
   const cmdlinet &cmdline,
   transition_systemt &transition_system,
   ebmc_propertiest &properties,

--- a/src/ebmc/bdd_engine.h
+++ b/src/ebmc/bdd_engine.h
@@ -9,12 +9,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_EBMC_BDD_ENGINE_H
 #define CPROVER_EBMC_BDD_ENGINE_H
 
-#include <util/cmdline.h>
-#include <util/message.h>
+#include "property_checker.h"
 
-#include "ebmc_properties.h"
-
-int bdd_engine(
+property_checker_resultt bdd_engine(
   const cmdlinet &,
   transition_systemt &,
   ebmc_propertiest &,

--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -19,7 +19,6 @@ Author: Daniel Kroening, daniel.kroening@inf.ethz.ch
 #include "ebmc_error.h"
 #include "ebmc_solver_factory.h"
 #include "liveness_to_safety.h"
-#include "report_results.h"
 
 #include <fstream>
 
@@ -118,7 +117,7 @@ Function: k_induction
 
 \*******************************************************************/
 
-int k_induction(
+property_checker_resultt k_induction(
   const cmdlinet &cmdline,
   transition_systemt &transition_system,
   ebmc_propertiest &properties,
@@ -154,9 +153,7 @@ int k_induction(
   k_induction(
     k, transition_system, properties, solver_factory, message_handler);
 
-  const namespacet ns(transition_system.symbol_table);
-  report_results(cmdline, properties, ns, message_handler);
-  return properties.exit_code();
+  return property_checker_resultt::VERIFICATION_RESULT;
 }
 
 /*******************************************************************\

--- a/src/ebmc/k_induction.h
+++ b/src/ebmc/k_induction.h
@@ -13,11 +13,12 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/message.h>
 
 #include "ebmc_solver_factory.h"
+#include "property_checker.h"
 
 class transition_systemt;
 class ebmc_propertiest;
 
-int k_induction(
+property_checker_resultt k_induction(
   const cmdlinet &,
   transition_systemt &,
   ebmc_propertiest &,

--- a/src/ebmc/property_checker.h
+++ b/src/ebmc/property_checker.h
@@ -12,6 +12,13 @@ Author: Daniel Kroening, dkr@amazon.com
 #include "ebmc_properties.h"
 #include "transition_system.h"
 
+enum class property_checker_resultt
+{
+  VERIFICATION_RESULT,
+  SUCCESS,
+  ERROR
+};
+
 int property_checker(
   const cmdlinet &,
   transition_systemt &,


### PR DESCRIPTION
This introduces a type for the result from an engine, as a replacement for `int`.