### PR TITLE
Mark k-induction test as CORE

### DIFF
--- a/regression/ebmc/k-induction/k-induction5.k-3.desc
+++ b/regression/ebmc/k-induction/k-induction5.k-3.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 k-induction5.v
 --module main --bound 3 --k-induction
 ^EXIT=10$


### PR DESCRIPTION
The test should have been marked as CORE when merging the bugfix.