### PR TITLE
Verilog: KNOWNBUG test for signed base 2 literal

### DIFF
--- a/regression/verilog/expressions/signed2.desc
+++ b/regression/verilog/expressions/signed2.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+signed2.sv
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The signed base 2 literal should be sign-extended.

--- a/regression/verilog/expressions/signed2.sv
+++ b/regression/verilog/expressions/signed2.sv
@@ -1,0 +1,7 @@
+module main;
+
+  p0: assert final ('sb1 == -1);
+  p1: assert final ('sb11 == -1);
+  p2: assert final (4'sb111 == 7);
+
+endmodule


### PR DESCRIPTION
The signed base 2 literal should be sign-extended.