### PR TITLE
Verilog: fix for signed constants

### DIFF
--- a/regression/verilog/expressions/equality1.desc
+++ b/regression/verilog/expressions/equality1.desc
@@ -5,10 +5,10 @@ equality1.v
 ^\[.*\] always 10 == 20 === 0: PROVED up to bound 0$
 ^\[.*\] always 10 != 20 === 1: PROVED up to bound 0$
 ^\[.*\] always 10 == 20 === 0: PROVED up to bound 0$
-^\[.*\] always 1'bx == 10 === 1'bx: PROVED up to bound 0$
-^\[.*\] always 1'bz == 20 === 1'bx: PROVED up to bound 0$
-^\[.*\] always 1'bx != 10 === 1'bx: PROVED up to bound 0$
-^\[.*\] always 1'bz != 20 === 1'bx: PROVED up to bound 0$
+^\[.*\] always 32'b0000000000000000000000000000000x == 10 === 32'b0000000000000000000000000000000x: PROVED up to bound 0$
+^\[.*\] always 32'b0000000000000000000000000000000z == 20 === 32'b0000000000000000000000000000000x: PROVED up to bound 0$
+^\[.*\] always 32'b0000000000000000000000000000000x != 10 === 32'b0000000000000000000000000000000x: PROVED up to bound 0$
+^\[.*\] always 32'b0000000000000000000000000000000z != 20 === 32'b0000000000000000000000000000000x: PROVED up to bound 0$
 ^\[.*\] always 2'b11 == 2'b11 === 0: REFUTED$
 ^\[.*\] always 2'sb11 == 2'sb11 === 1: PROVED up to bound 0$
 ^EXIT=10$

--- a/regression/verilog/expressions/equality2.desc
+++ b/regression/verilog/expressions/equality2.desc
@@ -5,11 +5,11 @@ equality2.v
 ^\[.*\] always 10 === 20 == 0: PROVED up to bound 0$
 ^\[.*\] always 10 !== 10 == 0: PROVED up to bound 0$
 ^\[.*\] always 10 !== 20 == 1: PROVED up to bound 0$
-^\[.*\] always 1'bx === 1'bx == 1: PROVED up to bound 0$
-^\[.*\] always 1'bz === 1'bz == 1: PROVED up to bound 0$
-^\[.*\] always 1'bx === 1'bz == 0: PROVED up to bound 0$
-^\[.*\] always 1'bx === 1 == 0: PROVED up to bound 0$
-^\[.*\] always 1'bz === 1 == 0: PROVED up to bound 0$
+^\[.*\] always 32'b0000000000000000000000000000000x === 32'b0000000000000000000000000000000x == 1: PROVED up to bound 0$
+^\[.*\] always 32'b0000000000000000000000000000000z === 32'b0000000000000000000000000000000z == 1: PROVED up to bound 0$
+^\[.*\] always 32'b0000000000000000000000000000000x === 32'b0000000000000000000000000000000z == 0: PROVED up to bound 0$
+^\[.*\] always 32'b0000000000000000000000000000000x === 1 == 0: PROVED up to bound 0$
+^\[.*\] always 32'b0000000000000000000000000000000z === 1 == 0: PROVED up to bound 0$
 ^\[.*\] always 1 === 1 == 1: PROVED up to bound 0$
 ^\[.*\] always 3'b011 === 3'b111 == 1: REFUTED$
 ^\[.*\] always 3'sb111 === 3'sb111 == 1: PROVED up to bound 0$

--- a/regression/verilog/expressions/signed2.desc
+++ b/regression/verilog/expressions/signed2.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE broken-smt-backend
 signed2.sv
 --bound 0
 ^EXIT=0$
@@ -6,4 +6,3 @@ signed2.sv
 --
 ^warning: ignoring
 --
-The signed base 2 literal should be sign-extended.

--- a/regression/verilog/expressions/signed2.sv
+++ b/regression/verilog/expressions/signed2.sv
@@ -1,7 +1,30 @@
 module main;
 
-  p0: assert final ('sb1 == -1);
-  p1: assert final ('sb11 == -1);
-  p2: assert final (4'sb111 == 7);
+  // base 2
+  pA0: assert final ('sb1 == -1);
+  pA1: assert final ('sb01 == 1);
+  pA2: assert final ('sb1x === 'sb1111111111111111111111111111111x);
+  pA3: assert final ($bits('sb1) == 32);
+  pA4: assert final ('sb11 == -1);
+  pA5: assert final (4'sb111 == 7);
+  pA6: assert final ($bits(4'sb111) == 4);
+
+  // base 8
+  pB0: assert final ('so7 == -1);
+  pB1: assert final ('so1 == 1);
+  pB2: assert final ('so7x === 'so3777777777x);
+  pB3: assert final ($bits('so1) == 32);
+  pB4: assert final ('so77 == -1);
+  pB5: assert final (4'so7 == 7);
+  pB6: assert final ($bits(4'so7) == 4);
+
+  // base 16
+  pC0: assert final ('shf == -1);
+  pC1: assert final ('sh1 == 1);
+  pC2: assert final ('shfx === 'shfffffffx);
+  pC3: assert final ($bits('sh1) == 32);
+  pC4: assert final ('shff == -1);
+  pC5: assert final (8'shf == 15);
+  pC6: assert final ($bits(8'shf) == 8);
 
 endmodule


### PR DESCRIPTION
Verilog allows constants to be marked as signed (e.g., 'sb1).  When using base 2, 8 and 16, these need to be sign extended to 32 bits unless the number of bits is given.