### PR TITLE
Verilog: constant output now includes signedness and width

### DIFF
--- a/regression/ebmc/random-traces/bv1.desc
+++ b/regression/ebmc/random-traces/bv1.desc
@@ -3,10 +3,10 @@ bv1.v
 --random-traces --trace-steps 1 --traces 1
 ^Transition system state 0$
 ^  main\.some_reg = 0 .*$
-^  main\.input1 = 'h6FE4167A .*$
+^  main\.input1 = 32'h6FE4167A .*$
 ^Transition system state 1$
-^  main\.some_reg = 'h6FE4167A .*$
-^  main\.input1 = 'hB65F5E9A .*$
+^  main\.some_reg = 32'h6FE4167A .*$
+^  main\.input1 = 32'hB65F5E9A .*$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/random-traces/initial_state1.desc
+++ b/regression/ebmc/random-traces/initial_state1.desc
@@ -1,9 +1,9 @@
 CORE
 initial_state1.v
 --random-trace --trace-steps 1 --numbered-trace --random-seed 0
-^m\.x@0 = 'hBF9059EA$
+^m\.x@0 = 32'hBF9059EA$
 ^m\.y@0 = 123$
-^m\.x@1 = 'hBF9059EB$
+^m\.x@1 = 32'hBF9059EB$
 ^m\.y@1 = 124$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/ebmc/random-traces/long_trace1.desc
+++ b/regression/ebmc/random-traces/long_trace1.desc
@@ -5,7 +5,7 @@ long_trace1.v
 ^  main\.some_reg = 0 .*$
 ^  main\.increment = 0$
 ^Transition system state 1000$
-^  main\.some_reg = 'h1F8 .*$
+^  main\.some_reg = 32'h1F8 .*$
 ^  main\.increment = 1$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/verilog/expressions/constants1.desc
+++ b/regression/verilog/expressions/constants1.desc
@@ -1,6 +1,8 @@
 CORE
 constants1.v
 --bound 1
+^\[.*\] always main\.w == 32'hFFFF: PROVED up to bound 1$
+^\[.*\] always main\.X == 16: PROVED up to bound 1$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/equality1.desc
+++ b/regression/verilog/expressions/equality1.desc
@@ -10,7 +10,7 @@ equality1.v
 ^\[.*\] always 1'bx != 10 === 1'bx: PROVED up to bound 0$
 ^\[.*\] always 1'bz != 20 === 1'bx: PROVED up to bound 0$
 ^\[.*\] always 2'b11 == 2'b11 === 0: REFUTED$
-^\[.*\] always 2'sb-1 == 2'sb-1 === 1: PROVED up to bound 0$
+^\[.*\] always 2'sb11 == 2'sb11 === 1: PROVED up to bound 0$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/equality2.desc
+++ b/regression/verilog/expressions/equality2.desc
@@ -11,8 +11,8 @@ equality2.v
 ^\[.*\] always 1'bx === 1 == 0: PROVED up to bound 0$
 ^\[.*\] always 1'bz === 1 == 0: PROVED up to bound 0$
 ^\[.*\] always 1 === 1 == 1: PROVED up to bound 0$
-^\[.*\] always 3'b11 === 3'b111 == 1: REFUTED$
-^\[.*\] always 3'sb-1 === 3'sb-1 == 1: PROVED up to bound 0$
+^\[.*\] always 3'b011 === 3'b111 == 1: REFUTED$
+^\[.*\] always 3'sb111 === 3'sb111 == 1: PROVED up to bound 0$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/static_cast1.desc
+++ b/regression/verilog/expressions/static_cast1.desc
@@ -3,6 +3,6 @@ static_cast1.sv
 --module main --bound 0
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.p0\] always 'hFFFF == 255: PROVED up to bound 0$
+^\[main\.p0\] always 32'hFFFF == 255: PROVED up to bound 0$
 --
 ^warning: ignoring

--- a/regression/verilog/structs/structs4.desc
+++ b/regression/verilog/structs/structs4.desc
@@ -1,7 +1,7 @@
 CORE
 structs4.sv
 --bound 0
-^\[main\.p0\] always main\.w == 'h173: PROVED up to bound 0$
+^\[main\.p0\] always main\.w == 32'h173: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -1020,14 +1020,20 @@ std::string expr2verilogt::convert_constant(
     auto i = numeric_cast_v<mp_integer>(src);
 
     if(i>=256)
-      dest="'h"+integer2string(i, 16);
+    {
+      dest = std::to_string(width);
+      dest += "'h";
+      if(type.id() == ID_signedbv)
+        dest += 's';
+      dest += integer2string(i, 16);
+    }
     else if(width<=7)
     {
       dest=std::to_string(width);
       dest+="'";
       if(type.id()==ID_signedbv) dest+='s';
       dest+='b';
-      dest+=integer2string(i, 2);
+      dest += integer2binary(i, width);
     }
     else
       dest=integer2string(i);


### PR DESCRIPTION
The conversion of constants to Verilog source now includes the signedness and width when outputting hex or binary literals.