### PR TITLE
Verilog: error on wire redeclaration

### DIFF
--- a/regression/verilog/modules/wire_and_wire.desc
+++ b/regression/verilog/modules/wire_and_wire.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
-input_and_reg.v
+CORE
+wire_and_wire.v
 
+^file wire_and_wire\.v line 4: symbol `some_var' is already declared$
 ^EXIT=2$
 ^SIGNAL=0$
 --
 --
-The redeclaration must be errored.

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -433,7 +433,12 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
         // This is ok for certain symbols, e.g., input/wire, output/reg.
         symbolt &osymbol = *result;
 
-        if(osymbol.type.id() == ID_code)
+        if(osymbol.is_input || osymbol.is_output)
+        {
+          // wire + input is ok
+          // wire + output is ok
+        }
+        else
         {
           throw errort().with_location(decl.source_location())
             << "symbol `" << symbol.base_name << "' is already declared";


### PR DESCRIPTION
Redeclarations of wires (nets) is prohibited; this adds an error message.