### PR TITLE
Verilog: typechecking for relations

### DIFF
--- a/regression/ebmc/example1/example1.sv
+++ b/regression/ebmc/example1/example1.sv
@@ -11,6 +11,6 @@ module main(input a, input b);
 
   my_add adder(a, b, result);
 
-  assert final (a+b==result);
+  assert final (2'(a)+b==result);
 
 endmodule

--- a/regression/verilog/SVA/immediate3.desc
+++ b/regression/verilog/SVA/immediate3.desc
@@ -1,7 +1,7 @@
 CORE
 immediate3.sv
 --bound 0
-^\[full_adder\.assert\.1\] always \{ full_adder\.carry, full_adder\.sum \} == full_adder\.a \+ full_adder\.b \+ full_adder\.c: PROVED up to bound 0$
+^\[full_adder\.assert\.1\] always \{ full_adder\.carry, full_adder\.sum \} == \{ 1'b0, full_adder\.a \} \+ full_adder\.b \+ full_adder\.c: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/immediate3.sv
+++ b/regression/verilog/SVA/immediate3.sv
@@ -4,6 +4,6 @@ module full_adder(input a, b, c, output sum, carry);
   assign carry = a & b | (a ^ b) & c;
 
   always @(*)
-    assert final({carry, sum} == a + b + c);
+    assert final({carry, sum} == {1'b0, a} + b + c);
 
 endmodule

--- a/regression/verilog/SVA/static_final1.desc
+++ b/regression/verilog/SVA/static_final1.desc
@@ -1,7 +1,7 @@
 CORE
 static_final1.sv
 --bound 0
-^\[full_adder\.p0\] always \{ full_adder\.carry, full_adder\.sum \} == full_adder\.a \+ full_adder\.b \+ full_adder\.c: PROVED up to bound 0$
+^\[full_adder\.p0\] always \{ full_adder\.carry, full_adder\.sum \} == \{ 1'b0, full_adder\.a \} \+ full_adder\.b \+ full_adder\.c: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/static_final1.sv
+++ b/regression/verilog/SVA/static_final1.sv
@@ -5,6 +5,6 @@ module full_adder(input a, b, c, output sum, carry);
 
   // 1800-2017
   // 16.4.3 Deferred assertions outside procedural code
-  p0: assert final ({carry, sum} == a + b + c);
+  p0: assert final ({carry, sum} == {1'b0, a} + b + c);
 
 endmodule

--- a/regression/verilog/expressions/concatenation1.v
+++ b/regression/verilog/expressions/concatenation1.v
@@ -7,7 +7,7 @@ module main(in1, in2);
   always @in1
     out = { in2, in1 };
 
-  always assert property1: out == ((in2<<16)|in1);
+  always assert property1: out == (({16'b0, in2}<<16)|in1);
 
   always assert property2: {4'b1001,4'b1011}==8'b10011011;
 

--- a/regression/verilog/expressions/equality1.desc
+++ b/regression/verilog/expressions/equality1.desc
@@ -9,9 +9,9 @@ equality1.v
 ^\[.*\] always 32'b0000000000000000000000000000000z == 20 === 32'b0000000000000000000000000000000x: PROVED up to bound 0$
 ^\[.*\] always 32'b0000000000000000000000000000000x != 10 === 32'b0000000000000000000000000000000x: PROVED up to bound 0$
 ^\[.*\] always 32'b0000000000000000000000000000000z != 20 === 32'b0000000000000000000000000000000x: PROVED up to bound 0$
-^\[.*\] always 2'b11 == 2'b11 === 0: REFUTED$
+^\[.*\] always 1'sb1 == 2'b11 === 0: PROVED up to bound 0$
 ^\[.*\] always 2'sb11 == 2'sb11 === 1: PROVED up to bound 0$
-^EXIT=10$
+^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring

--- a/regression/verilog/expressions/equality2.desc
+++ b/regression/verilog/expressions/equality2.desc
@@ -11,9 +11,9 @@ equality2.v
 ^\[.*\] always 32'b0000000000000000000000000000000x === 1 == 0: PROVED up to bound 0$
 ^\[.*\] always 32'b0000000000000000000000000000000z === 1 == 0: PROVED up to bound 0$
 ^\[.*\] always 1 === 1 == 1: PROVED up to bound 0$
-^\[.*\] always 3'b011 === 3'b111 == 1: REFUTED$
+^\[.*\] always 3'b011 === 2'sb11 == 1: PROVED up to bound 0$
 ^\[.*\] always 3'sb111 === 3'sb111 == 1: PROVED up to bound 0$
-^EXIT=10$
+^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring

--- a/regression/verilog/expressions/replication1.v
+++ b/regression/verilog/expressions/replication1.v
@@ -7,7 +7,7 @@ module main(in);
     out = { 4 { in } };
     
   always assert property1:
-    out==(in | (in<<8) | (in<<16) | (in<<24));
+    out==({24'b0, in} | (in<<8) | (in<<16) | (in<<24));
 
   // 1-replication
   always assert property2:

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -95,6 +95,7 @@ protected:
   {
   }
 
+  static typet enum_decay(const typet &);
   typet max_type(const typet &t1, const typet &t2);
 
   // named blocks
@@ -132,6 +133,7 @@ private:
   void implicit_typecast(exprt &, const typet &type);
   void tc_binary_expr(exprt &);
   void tc_binary_expr(const exprt &expr, exprt &op0, exprt &op1);
+  void typecheck_relation(binary_exprt &);
   void no_bool_ops(exprt &);
 
   // system functions


### PR DESCRIPTION
Relations are special-cased in 1800-2017 11.8.2.

If both operands are signed, both are sign-extended to the max width.

Otherwise, both are zero-extended to the max width.  In particular, signed operands are then **not** sign extended, which a typecast would do.