### PR TITLE
Verilog: size-cast expression with Boolean operand

### DIFF
--- a/regression/verilog/expressions/size_cast1.sv
+++ b/regression/verilog/expressions/size_cast1.sv
@@ -5,5 +5,6 @@ module main;
   p0: assert final ($bits(10'(1)) == 10);
   p1: assert final ($bits(P'(1)) == 20);
   p2: assert final (10'(-1) == -1);
+  p3: assert final (2'(1==1) == 1);
 
 endmodule

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -2730,7 +2730,7 @@ exprt verilog_typecheck_exprt::convert_binary_expr(binary_exprt expr)
       return typecast_exprt{expr.rhs(), signedbv_typet{new_size_int}}
         .with_source_location(expr);
     }
-    else if(op_type.id() == ID_unsignedbv)
+    else if(op_type.id() == ID_unsignedbv || op_type.id() == ID_bool)
     {
       return typecast_exprt{expr.rhs(), unsignedbv_typet{new_size_int}}
         .with_source_location(expr);


### PR DESCRIPTION
This allows applying size-casts to Boolean operands.