### PR TITLE
tighten test for supported word-level BMC properties

### DIFF
--- a/regression/verilog/SVA/sva_until1.desc
+++ b/regression/verilog/SVA/sva_until1.desc
@@ -1,0 +1,12 @@
+KNOWNBUG
+sva_until1.sv
+--bound 1
+^\[main\.p0\] always (main.a until_with main.b): REFUTED$
+^\[main\.p1\] always (main.a until main.b): REFUTED$
+^\[main\.p2\] always (main.a s_until main.b): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+These properties are not supported by the BMC engine.

--- a/regression/verilog/SVA/sva_until1.sv
+++ b/regression/verilog/SVA/sva_until1.sv
@@ -1,0 +1,9 @@
+module main(input a, b);
+
+  wire a, b;
+
+  p0: assert property (a until_with b);
+  p1: assert property (a until b);
+  p2: assert property (a s_until b);
+
+endmodule


### PR DESCRIPTION
This tightens the test performed for properties supported by the word-level BMC engine, to avoid incorrect results when given an unsupported property.