### PR TITLE
SystemVerilog: grammar for distribution weights

### DIFF
--- a/regression/verilog/constraints/constraint1.desc
+++ b/regression/verilog/constraints/constraint1.desc
@@ -1,0 +1,7 @@
+CORE
+constraint1.sv
+
+^no module found$
+^EXIT=1$
+^SIGNAL=0$
+--

--- a/regression/verilog/constraints/constraint1.sv
+++ b/regression/verilog/constraints/constraint1.sv
@@ -1,0 +1,6 @@
+class data;
+  // rand bit [15:0] field1;
+  constraint c_f1 {
+    field1 dist {[0:31] :/ 1, [32:65535] :/ 1};
+  }
+endclass

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -394,6 +394,8 @@ int yyverilogerror(const char *error)
 %token TOK_HASHMINUSHASH        "#-#"
 %token TOK_HASHEQUALHASH        "#=#"
 %token TOK_COLONCOLON           "::"
+%token TOK_COLONEQUAL           ":="
+%token TOK_COLONSLASH           ":/"
 %token TOK_EQUALEQUALQUESTION   "==?"
 %token TOK_EXCLAMEQUALQUESTION  "!=?"
 %token TOK_LSQASTERIC           "[*"
@@ -941,9 +943,9 @@ class_item:
 //		{ add_attributes($2, $1); $$=$2; }
 //	| attribute_instance_brace class_method
 //		{ add_attributes($2, $1); $$=$2; }
-//	| attribute_instance_brace class_constraint
-//		{ add_attributes($2, $1); $$=$2; }
-	  attribute_instance_brace class_declaration
+	  attribute_instance_brace class_constraint
+		{ add_attributes($2, $1); $$=$2; }
+	| attribute_instance_brace class_declaration
 		{ add_attributes($2, $1); $$=$2; }
 	| attribute_instance_brace covergroup_declaration
 		{ add_attributes($2, $1); $$=$2; }
@@ -1046,7 +1048,22 @@ constraint_block_item:
 	;
 
 constraint_expression:
-	  expression
+	  expression_or_dist ';'
+	;
+
+dist_list:
+	  dist_item
+	| dist_list ',' dist_item
+	;
+
+dist_item:
+	  value_range
+	| value_range dist_weight
+	;
+
+dist_weight:
+	  ":=" expression
+	| ":/" expression
 	;
 
 constraint_prototype: TOK_CONSTRAINT constraint_identifier ';'
@@ -2314,6 +2331,7 @@ cycle_delay_const_range_expression:
 
 expression_or_dist:
 	  expression
+	| expression TOK_DIST '{' dist_list '}'
 	;
 
 // System Verilog standard 1800-2017
@@ -3598,6 +3616,11 @@ expression:
 		{ init($$, ID_if); mto($$, $1); mto($$, $3); mto($$, $5); }
 	| TOK_QSTRING
 		{ init($$, ID_constant); stack_expr($$).type()=typet(ID_string); addswap($$, ID_value, $1); }
+	;
+
+value_range:
+	  expression
+	| '[' expression TOK_COLON expression ']'
 	;
 
 indexed_range:

--- a/src/verilog/scanner.l
+++ b/src/verilog/scanner.l
@@ -264,6 +264,8 @@ void verilog_scanner_init()
 "->"            { SYSTEM_VERILOG_OPERATOR(TOK_MINUSGREATER, "->"); }
 "'"             { SYSTEM_VERILOG_OPERATOR('\'', "'"); }
 "::"            { SYSTEM_VERILOG_OPERATOR(TOK_COLONCOLON, "::"); }
+":="            { SYSTEM_VERILOG_OPERATOR(TOK_COLONEQUAL, ":="); }
+":/"            { SYSTEM_VERILOG_OPERATOR(TOK_COLONSLASH, ":/"); }
 "==?"           { SYSTEM_VERILOG_OPERATOR(TOK_EQUALEQUALQUESTION, "==?"); }
 "!=?"           { SYSTEM_VERILOG_OPERATOR(TOK_EXCLAMEQUALQUESTION, "!=?"); }
                 /* Table 16-1 in 1800-2017 suggests the following tokens for sequence operators */


### PR DESCRIPTION
This adds the 1800-2017 rules for distribution weights.