### PR TITLE
better error reporting when $past is unsupported

### DIFF
--- a/regression/verilog/system-functions/past1.aig.desc
+++ b/regression/verilog/system-functions/past1.aig.desc
@@ -1,0 +1,7 @@
+CORE
+past1.sv
+--aig
+^\[main\.p0\] ##0 \(\$past\(main\.counter, 0\)\) == 0: FAILURE: property not supported by netlist BMC engine$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/verilog/system-functions/past1.bdd.desc
+++ b/regression/verilog/system-functions/past1.bdd.desc
@@ -1,0 +1,7 @@
+CORE
+past1.sv
+--bdd
+^\[main\.p0\] ##0 \(\$past\(main\.counter, 0\)\) == 0: FAILURE: property not supported by BDD engine$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/verilog/system-functions/past2.desc
+++ b/regression/verilog/system-functions/past2.desc
@@ -1,8 +1,8 @@
 CORE
 past2.sv
 --bdd
-^file .* line \d+: error: no support for \$past when using AIG backends$
-^EXIT=6$
+^\[main\.p0\] always \(main\.counter == 0 \|-> \(\$past\(main\.counter, 1\)\) == 0\): FAILURE: property not supported by BDD engine$
+^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring

--- a/src/ebmc/ebmc_properties.h
+++ b/src/ebmc/ebmc_properties.h
@@ -182,6 +182,15 @@ public:
     return true;
   }
 
+  bool has_unknown_property() const
+  {
+    for(const auto &p : properties)
+      if(p.is_unknown())
+        return true;
+
+    return false;
+  }
+
   bool requires_lasso_constraints() const
   {
     for(const auto &p : properties)

--- a/src/trans-netlist/unwind_netlist.cpp
+++ b/src/trans-netlist/unwind_netlist.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "unwind_netlist.h"
 
 #include <util/ebmc_util.h>
+#include <util/expr_util.h>
 
 #include <temporal-logic/temporal_expr.h>
 #include <temporal-logic/temporal_logic.h>
@@ -170,6 +171,10 @@ Function: netlist_bmc_supports_property
 
 bool netlist_bmc_supports_property(const exprt &expr)
 {
+  // No $past.
+  if(has_subexpr(expr, ID_verilog_past))
+    return false;
+
   // We do AG p only.
   if(expr.id() == ID_AG)
     return !has_temporal_operator(to_AG_expr(expr).op());


### PR DESCRIPTION
The AIG-based backends currently do not support `$past` -- this improves the error message.