### PR TITLE
Verilog: rename convert_type method to elaborate_type

### DIFF
--- a/src/verilog/Makefile
+++ b/src/verilog/Makefile
@@ -2,6 +2,7 @@ SRC = aval_bval_encoding.cpp \
       expr2verilog.cpp \
       sva_expr.cpp \
       verilog_elaborate.cpp \
+      verilog_elaborate_type.cpp \
       verilog_expr.cpp \
       verilog_generate.cpp \
       verilog_interfaces.cpp \
@@ -20,7 +21,6 @@ SRC = aval_bval_encoding.cpp \
       verilog_typecheck.cpp \
       verilog_typecheck_base.cpp \
       verilog_typecheck_expr.cpp \
-      verilog_typecheck_type.cpp \
       verilog_y.tab.cpp \
       vtype.cpp
 

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -34,7 +34,7 @@ void verilog_typecheckt::collect_port_symbols(const verilog_declt &decl)
   else
   {
     // add the symbol
-    typet type = convert_type(declarator.merged_type(decl.type()));
+    typet type = elaborate_type(declarator.merged_type(decl.type()));
 
     symbolt new_symbol{identifier, type, mode};
 
@@ -245,7 +245,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
 
         symbol.base_name = declarator.base_name();
         symbol.location = declarator.source_location();
-        symbol.type = convert_type(declarator.merged_type(decl.type()));
+        symbol.type = elaborate_type(declarator.merged_type(decl.type()));
 
         if(symbol.base_name.empty())
         {
@@ -330,7 +330,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
             << "empty symbol name";
         }
 
-        symbol.type = convert_type(declarator.merged_type(decl.type()));
+        symbol.type = elaborate_type(declarator.merged_type(decl.type()));
         symbol.name = hierarchical_identifier(symbol.base_name);
         symbol.pretty_name = strip_verilog_prefix(symbol.name);
 
@@ -409,7 +409,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
 
       symbol.base_name = declarator.base_name();
       symbol.location = declarator.source_location();
-      symbol.type = convert_type(declarator.merged_type(decl.type()));
+      symbol.type = elaborate_type(declarator.merged_type(decl.type()));
 
       if(symbol.base_name.empty())
       {
@@ -470,7 +470,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
 
       symbol.base_name = declarator.base_name();
       symbol.location = declarator.source_location();
-      symbol.type = convert_type(declarator.merged_type(decl.type()));
+      symbol.type = elaborate_type(declarator.merged_type(decl.type()));
 
       if(symbol.base_name.empty())
       {
@@ -522,7 +522,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
     typet return_type;
 
     if(decl_class == ID_function)
-      return_type = convert_type(decl.type());
+      return_type = elaborate_type(decl.type());
     else
       return_type = empty_typet();
 
@@ -939,7 +939,7 @@ void verilog_typecheckt::elaborate_symbol_rec(irep_idt identifier)
     {
       // No, elaborate the type.
       auto elaborated_type =
-        convert_type(to_type_with_subtype(symbol.type).subtype());
+        elaborate_type(to_type_with_subtype(symbol.type).subtype());
       symbol.type = elaborated_type;
 
       // Now elaborate the value, possibly recursively, if any.

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -916,7 +916,7 @@ exprt verilog_typecheck_exprt::convert_nullary_expr(nullary_exprt expr)
   else if(expr.id() == ID_type)
   {
     // Used, e.g., for $bits
-    expr.type() = convert_type(expr.type());
+    expr.type() = elaborate_type(expr.type());
     return std::move(expr);
   }
   else
@@ -2432,13 +2432,13 @@ exprt verilog_typecheck_exprt::convert_unary_expr(unary_exprt expr)
     // SystemVerilog has got type'(expr). This is an explicit
     // type cast.
     convert_expr(expr.op());
-    auto new_type = convert_type(expr.type());
+    auto new_type = elaborate_type(expr.type());
     return typecast_exprt{expr.op(), new_type}.with_source_location(expr);
   }
   else if(expr.id() == ID_verilog_implicit_typecast)
   {
     // We generate implict casts during elaboration.
-    expr.type() = convert_type(expr.type());
+    expr.type() = elaborate_type(expr.type());
     convert_expr(expr.op());
     expr.id(ID_typecast);
   }

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -60,7 +60,7 @@ protected:
 
   void propagate_type(exprt &expr, const typet &type);
 
-  typet convert_type(const typet &);
+  typet elaborate_type(const typet &);
   typet convert_enum(const class verilog_enum_typet &);
   array_typet convert_unpacked_array_type(const type_with_subtypet &);
   typet convert_packed_array_type(const type_with_subtypet &);


### PR DESCRIPTION
This renames the method that elaborates types, given that it follows the elaboration procedure in the Verilog standard.