### PR TITLE
extract verilog_typecheck_exprt::convert_packed_array_type

### DIFF
--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -63,6 +63,7 @@ protected:
   typet convert_type(const typet &);
   typet convert_enum(const class verilog_enum_typet &);
   array_typet convert_unpacked_array_type(const type_with_subtypet &);
+  typet convert_packed_array_type(const type_with_subtypet &);
 
   void convert_range(
     const exprt &range,


### PR DESCRIPTION
This extracts the logic for typechecking packed array types into a separate method.