### PR TITLE
Verilog: error redeclaration of variable

### DIFF
--- a/regression/verilog/modules/inout_and_reg.desc
+++ b/regression/verilog/modules/inout_and_reg.desc
@@ -1,7 +1,7 @@
 CORE
 inout_and_reg.v
 
-^file .* line 4: symbol `some_var' is declared both as input and as register$
+^file .* line 4: variable `some_var' is already declared, at file .* line 3$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/input_and_reg.desc
+++ b/regression/verilog/modules/input_and_reg.desc
@@ -1,7 +1,7 @@
 CORE
 input_and_reg.v
 
-^file .* line 4: symbol `some_var' is declared both as input and as register$
+^file .* line 4: variable `some_var' is already declared, at file .* line 3$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/wire_and_reg.desc
+++ b/regression/verilog/modules/wire_and_reg.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
+CORE
 wire_and_reg.v
 
+^file .* line 4: variable `some_var' is already declared, at file .* line 3$
 ^EXIT=2$
 ^SIGNAL=0$
 --
 --
-This should be errored, as some_var must not be both wire and reg.


### PR DESCRIPTION
This errors redeclarations of variables, unless the original symbol is an output.