### PR TITLE
BMC: extend CTL fragment

### DIFF
--- a/regression/ebmc/smv/smv_ctlspec_F1.desc
+++ b/regression/ebmc/smv/smv_ctlspec_F1.desc
@@ -1,0 +1,13 @@
+CORE broken-smt-backend
+smv_ctlspec_F1.smv
+--bound 10
+^\[.*\] AF x = 0: REFUTED$
+^\[.*\] AF x = 1: PROVED up to bound 10$
+^\[.*\] AF x = 2: PROVED up to bound 10$
+^\[.*\] AF x = 1 & AF x = 2: PROVED up to bound 10$
+^\[.*\] AF x = 0 & AF x = 1: REFUTED$
+^\[.*\] EF x = 0: FAILURE: property not supported by BMC engine$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/ebmc/smv/smv_ctlspec_F1.smv
+++ b/regression/ebmc/smv/smv_ctlspec_F1.smv
@@ -1,0 +1,19 @@
+MODULE main
+
+VAR x : 0..3;
+
+ASSIGN
+  init(x) := 1;
+
+  next(x) :=
+    case
+      x=3 : 3;
+      TRUE: x+1;
+    esac;
+
+SPEC AF x = 0 -- should fail
+SPEC AF x = 1 -- should pass
+SPEC AF x = 2 -- should pass
+SPEC AF x = 1 & AF x = 2 -- should pass
+SPEC AF x = 0 & AF x = 1 -- should fail
+SPEC EF x = 0 -- not supported

--- a/regression/ebmc/smv/smv_ctlspec_G1.desc
+++ b/regression/ebmc/smv/smv_ctlspec_G1.desc
@@ -1,0 +1,13 @@
+CORE broken-smt-backend
+smv_ctlspec_G1.smv
+--bound 10
+^\[.*\] AG x != 5: PROVED up to bound 10$
+^\[.*\] AG x != 6: PROVED up to bound 10$
+^\[.*\] AG x != 2: REFUTED$
+^\[.*\] AG x != 5 & AG x != 6: PROVED up to bound 10$
+^\[.*\] AG x != 2 & AG x != 5: REFUTED$
+^\[.*\] EG x != 2: FAILURE: property not supported by BMC engine$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/ebmc/smv/smv_ctlspec_G1.smv
+++ b/regression/ebmc/smv/smv_ctlspec_G1.smv
@@ -1,0 +1,19 @@
+MODULE main
+
+VAR x : 0..10;
+
+ASSIGN
+  init(x) := 1;
+
+  next(x) :=
+    case
+      x>=3 : 3;
+      TRUE: x+1;
+    esac;
+
+SPEC AG x != 5 -- should pass
+SPEC AG x != 6 -- should pass
+SPEC AG x != 2 -- should fail
+SPEC AG x != 5 & AG x != 6 -- should pass
+SPEC AG x != 2 & AG x != 5 -- should fail
+SPEC EG x != 2 -- not supported

--- a/src/temporal-logic/temporal_logic.cpp
+++ b/src/temporal-logic/temporal_logic.cpp
@@ -34,6 +34,11 @@ bool is_CTL_operator(const exprt &expr)
          id == ID_AR || id == ID_ER;
 }
 
+bool has_CTL_operator(const exprt &expr)
+{
+  return has_subexpr(expr, is_CTL_operator);
+}
+
 bool is_CTL(const exprt &expr)
 {
   auto non_CTL_operator = [](const exprt &expr) {

--- a/src/temporal-logic/temporal_logic.h
+++ b/src/temporal-logic/temporal_logic.h
@@ -29,6 +29,9 @@ bool is_CTL(const exprt &);
 /// as its root
 bool is_CTL_operator(const exprt &);
 
+/// Returns true iff the given expression contains a CTL operator
+bool has_CTL_operator(const exprt &);
+
 /// Returns true iff the given expression is an LTL formula
 bool is_LTL(const exprt &);
 


### PR DESCRIPTION
This extends the fragment of CTL that is accepted by the BMC engine.