### PR TITLE
SMV: reject CTL in LTLSPEC, and LTL in CTLSPEC

### DIFF
--- a/regression/ebmc/smv/smv_ctlspec1.desc
+++ b/regression/ebmc/smv/smv_ctlspec1.desc
@@ -1,0 +1,7 @@
+CORE
+smv_ctlspec1.smv
+
+^file .* line 4: LTL operator not permitted here$
+^EXIT=2$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv/smv_ctlspec1.smv
+++ b/regression/ebmc/smv/smv_ctlspec1.smv
@@ -1,0 +1,4 @@
+MODULE main
+
+-- error, this is LTL
+SPEC F FALSE

--- a/regression/ebmc/smv/smv_ltlspec5.desc
+++ b/regression/ebmc/smv/smv_ltlspec5.desc
@@ -1,0 +1,7 @@
+CORE
+smv_ltlspec5.smv
+
+^file .* line 4: CTL operator not permitted here$
+^EXIT=2$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv/smv_ltlspec5.smv
+++ b/regression/ebmc/smv/smv_ltlspec5.smv
@@ -1,0 +1,4 @@
+MODULE main
+
+-- error, this is CTL
+LTLSPEC AF FALSE


### PR DESCRIPTION
The SMV typechecker now rejects CTL when checking LTLSPEC, and LTL when checking CTLSPEC.