### PR TITLE
expr2smv: enum for precedence

### DIFF
--- a/regression/ebmc/smv/smv_iff2.desc
+++ b/regression/ebmc/smv/smv_iff2.desc
@@ -1,7 +1,7 @@
 CORE
 smv_iff2.smv
 --bdd
-^\[.*\] \(AG x != 5\) <-> \(x != 5 & AX AG x != 5\): PROVED$
+^\[.*\] AG x != 5 <-> x != 5 & AX AG x != 5: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/smvlang/parser.y
+++ b/src/smvlang/parser.y
@@ -177,7 +177,7 @@ static void new_module(YYSTYPE &module)
 %left  EQUAL_Token NOTEQUAL_Token LT_Token GT_Token LE_Token GE_Token
 %left  UNION_Token
 %left  IN_Token NOTIN_Token
-%left  MOD_Token
+%left  MOD_Token /* Precedence from CMU SMV, different from NuSMV */
 %left  PLUS_Token MINUS_Token
 %left  TIMES_Token DIVIDE_Token
 %left  UMINUS           /* supplies precedence for unary minus */


### PR DESCRIPTION
This replaces the use of `unsigned` and assorted integer literals for the expression precedence by an enum type.