### PR TITLE
Verilog: `convert_range` now returns range

### DIFF
--- a/src/verilog/verilog_elaborate_type.cpp
+++ b/src/verilog/verilog_elaborate_type.cpp
@@ -44,12 +44,10 @@ array_typet verilog_typecheck_exprt::convert_unpacked_array_type(
   if(range_expr.is_not_nil())
   {
     // these may be negative
-    mp_integer msb, lsb;
-    convert_range(range_expr, msb, lsb);
-    big_endian = (lsb > msb);
-    size = (big_endian ? lsb - msb : msb - lsb) + 1;
-    DATA_INVARIANT(size >= 0, "array size must not be negative");
-    offset = big_endian ? msb : lsb;
+    auto range = convert_range(range_expr);
+    big_endian = (range.lsb > range.msb);
+    size = range.length();
+    offset = range.smallest_index();
   }
   else if(size_expr.is_not_nil())
   {
@@ -96,16 +94,15 @@ typet verilog_typecheck_exprt::convert_packed_array_type(
 {
   PRECONDITION(src.id() == ID_verilog_packed_array);
 
-  const exprt &range = static_cast<const exprt &>(src.find(ID_range));
+  const exprt &range_expr = static_cast<const exprt &>(src.find(ID_range));
   const auto &source_location = src.source_location();
 
-  mp_integer msb, lsb;
-  convert_range(range, msb, lsb);
+  auto range = convert_range(range_expr);
 
-  bool big_endian = (lsb > msb);
+  bool big_endian = (range.lsb > range.msb);
 
-  mp_integer width = (big_endian ? lsb - msb : msb - lsb) + 1;
-  mp_integer offset = big_endian ? msb : lsb;
+  mp_integer width = range.length();
+  mp_integer offset = range.smallest_index();
 
   // let's look at the subtype
   const auto subtype =

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -163,14 +163,14 @@ void verilog_typecheckt::interface_inst(
   const verilog_instt::instancet &op)
 {
   bool primitive=statement.id()==ID_inst_builtin;
-  const exprt &range=static_cast<const exprt &>(op.find(ID_range));
+  const exprt &range_expr = static_cast<const exprt &>(op.find(ID_range));
 
-  mp_integer msb, lsb;
-  
-  if(range.is_nil() || range.id().empty())
-    msb=lsb=0;
+  ranget range;
+
+  if(range_expr.is_nil() || range_expr.id().empty())
+    range = ranget{0, 0};
   else
-    convert_range(range, msb, lsb);
+    range = convert_range(range_expr);
 
   irep_idt instantiated_module_identifier =
     verilog_module_symbol(id2string(statement.get(ID_module)));

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -81,14 +81,14 @@ void verilog_typecheckt::typecheck_port_connections(
   verilog_inst_baset::instancet &inst,
   const symbolt &symbol)
 {
-  const exprt &range=static_cast<const exprt &>(inst.find(ID_range));
+  const exprt &range_expr = static_cast<const exprt &>(inst.find(ID_range));
 
-  mp_integer msb, lsb;
-  
-  if(range.is_nil() || range.id()==irep_idt())
-    msb=lsb=0;
+  ranget range;
+
+  if(range_expr.is_nil() || range_expr.id() == irep_idt())
+    range.msb = range.lsb = 0;
   else
-    convert_range(range, msb, lsb);
+    range = convert_range(range_expr);
 
   const irept::subt &ports=symbol.type.find(ID_ports).get_sub();
 
@@ -203,18 +203,19 @@ Function: verilog_typecheckt::typecheck_builtin_port_connections
 void verilog_typecheckt::typecheck_builtin_port_connections(
   verilog_inst_baset::instancet &inst)
 {
-  exprt &range=static_cast<exprt &>(inst.add(ID_range));
+  exprt &range_expr = static_cast<exprt &>(inst.add(ID_range));
 
-  mp_integer msb, lsb;
-  
-  if(range.is_nil() || range.id()=="")
-    msb=lsb=0;
+  ranget range;
+
+  if(range_expr.is_nil() || range_expr.id() == irep_idt{})
+    range = ranget{0, 0};
   else
-    convert_range(range, msb, lsb);
+    range = convert_range(range_expr);
 
-  if(lsb>msb) std::swap(lsb, msb);
-  mp_integer width=msb-lsb+1;
-  
+  if(range.lsb > range.msb)
+    std::swap(range.lsb, range.msb);
+  mp_integer width = range.length();
+
   inst.remove(ID_range);
 
   typet &type=inst.type();

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -2101,10 +2101,8 @@ Function: verilog_typecheck_exprt::convert_range
 
 \*******************************************************************/
 
-void verilog_typecheck_exprt::convert_range(
-  const exprt &range,
-  mp_integer &msb,
-  mp_integer &lsb)
+verilog_typecheck_exprt::ranget
+verilog_typecheck_exprt::convert_range(const exprt &range)
 {
   if(range.operands().size()!=2)
   {
@@ -2112,8 +2110,11 @@ void verilog_typecheck_exprt::convert_range(
       << "range expected to have two operands";
   }
 
-  msb = convert_integer_constant_expression(to_binary_expr(range).op0());
-  lsb = convert_integer_constant_expression(to_binary_expr(range).op1());
+  auto &binary_expr = to_binary_expr(range);
+
+  return ranget{
+    convert_integer_constant_expression(binary_expr.op0()),
+    convert_integer_constant_expression(binary_expr.op1())};
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -65,10 +65,42 @@ protected:
   array_typet convert_unpacked_array_type(const type_with_subtypet &);
   typet convert_packed_array_type(const type_with_subtypet &);
 
-  void convert_range(
-    const exprt &range,
-    mp_integer &msb,
-    mp_integer &lsb);
+  struct ranget
+  {
+    // This is Verilog's [msb:lsb].
+    ranget(mp_integer _msb, mp_integer _lsb)
+      : msb(std::move(_msb)), lsb(std::move(_lsb))
+    {
+    }
+
+    ranget() : msb(0), lsb(0)
+    {
+    }
+
+    mp_integer msb, lsb;
+
+    /// return true iff the bit with the higest index
+    /// is the most significant bit
+    bool highest_index_is_msb() const
+    {
+      return msb >= lsb;
+    }
+
+    mp_integer length() const
+    {
+      if(msb >= lsb)
+        return msb - lsb + 1;
+      else // lsb > msb
+        return lsb - msb + 1;
+    }
+
+    mp_integer smallest_index() const
+    {
+      return msb >= lsb ? lsb : msb;
+    }
+  };
+
+  ranget convert_range(const exprt &range);
 
   // to be overridden
   virtual mp_integer genvar_value(const irep_idt &identifier)


### PR DESCRIPTION
The `convert_range` method now returns the range, as opposed to assigning to two reference parameters.