### PR TITLE
ebmc: `property_checker_resultt` now includes property status

### DIFF
--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -185,7 +185,7 @@ property_checker_resultt bdd_enginet::operator()()
 
     // any properties left?
     if(!properties.has_unknown_property())
-      return property_checker_resultt::VERIFICATION_RESULT;
+      return property_checker_resultt{properties};
 
     const auto property_map = properties.make_property_map();
 
@@ -227,28 +227,28 @@ property_checker_resultt bdd_enginet::operator()()
 
       std::cout << '\n';
 
-      return property_checker_resultt::SUCCESS;
+      return property_checker_resultt::success();
     }
 
     if(properties.properties.empty())
     {
       message.error() << "no properties" << messaget::eom;
-      return property_checker_resultt::ERROR;
+      return property_checker_resultt::error();
     }
 
     for(propertyt &p : properties.properties)
       check_property(p);
 
-    return property_checker_resultt::VERIFICATION_RESULT;
+    return property_checker_resultt{properties};
   }
   catch(const char *error_msg)
   {
     message.error() << error_msg << messaget::eom;
-    return property_checker_resultt::ERROR;
+    return property_checker_resultt::error();
   }
   catch(int)
   {
-    return property_checker_resultt::ERROR;
+    return property_checker_resultt::error();
   }
 }
 

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -296,11 +296,13 @@ int ebmc_parse_optionst::doit()
       if(cmdline.isset("compute-ct"))
         return ebmc_base.do_compute_ct();
 
-      return property_checker(
+      auto checker_result = property_checker(
         cmdline,
         ebmc_base.transition_system,
         ebmc_base.properties,
         ui_message_handler);
+
+      return checker_result.exit_code();
     }
   }
   catch(const ebmc_errort &ebmc_error)

--- a/src/ebmc/ebmc_properties.cpp
+++ b/src/ebmc/ebmc_properties.cpp
@@ -197,10 +197,3 @@ ebmc_propertiest ebmc_propertiest::from_command_line(
     return properties;
   }
 }
-
-int ebmc_propertiest::exit_code() const
-{
-  // We return '0' if all properties are proved,
-  // and '10' otherwise.
-  return all_properties_proved() ? 0 : 10;
-}

--- a/src/ebmc/ebmc_properties.h
+++ b/src/ebmc/ebmc_properties.h
@@ -169,19 +169,6 @@ public:
   typedef std::list<propertyt> propertiest;
   propertiest properties;
 
-  bool all_properties_proved() const
-  {
-    for(const auto &p : properties)
-      if(
-        !p.is_proved() && !p.is_proved_with_bound() && !p.is_disabled() &&
-        !p.is_assumed())
-      {
-        return false;
-      }
-
-    return true;
-  }
-
   bool has_unknown_property() const
   {
     for(const auto &p : properties)
@@ -219,9 +206,6 @@ public:
         result.emplace(p.identifier, p.normalized_expr);
     return result;
   }
-
-  // command-line tool exit code, depending on property status
-  int exit_code() const;
 };
 
 #endif // CPROVER_EBMC_PROPERTIES_H

--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -153,7 +153,7 @@ property_checker_resultt k_induction(
   k_induction(
     k, transition_system, properties, solver_factory, message_handler);
 
-  return property_checker_resultt::VERIFICATION_RESULT;
+  return property_checker_resultt{properties};
 }
 
 /*******************************************************************\

--- a/src/ebmc/neural_liveness.cpp
+++ b/src/ebmc/neural_liveness.cpp
@@ -21,6 +21,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #include "ebmc_solver_factory.h"
 #include "live_signal.h"
 #include "output_file.h"
+#include "property_checker.h"
 #include "random_traces.h"
 #include "ranking_function.h"
 #include "report_results.h"
@@ -118,8 +119,9 @@ int neural_livenesst::operator()()
 
   // report outcomes
   const namespacet ns(transition_system.symbol_table);
-  report_results(cmdline, properties, ns, message.get_message_handler());
-  return properties.exit_code();
+  property_checker_resultt result{properties};
+  report_results(cmdline, result, ns, message.get_message_handler());
+  return result.exit_code();
 }
 
 int neural_livenesst::show_traces()

--- a/src/ebmc/property_checker.h
+++ b/src/ebmc/property_checker.h
@@ -12,14 +12,68 @@ Author: Daniel Kroening, dkr@amazon.com
 #include "ebmc_properties.h"
 #include "transition_system.h"
 
-enum class property_checker_resultt
+class property_checker_resultt
 {
-  VERIFICATION_RESULT,
-  SUCCESS,
-  ERROR
+public:
+  enum class statust
+  {
+    VERIFICATION_RESULT, // property status populated
+    SUCCESS,             // exit without error, but no property status
+    ERROR                // error
+  } status;
+
+  explicit property_checker_resultt(statust _status) : status(_status)
+  {
+  }
+
+  // copy
+  explicit property_checker_resultt(const ebmc_propertiest &_properties)
+    : status(statust::VERIFICATION_RESULT), properties(_properties.properties)
+  {
+  }
+
+  static property_checker_resultt error()
+  {
+    return property_checker_resultt{statust::ERROR};
+  }
+
+  static property_checker_resultt success()
+  {
+    return property_checker_resultt{statust::SUCCESS};
+  }
+
+  using propertyt = ebmc_propertiest::propertyt;
+  using propertiest = ebmc_propertiest::propertiest;
+
+  propertiest properties;
+
+  bool all_properties_proved() const
+  {
+    for(const auto &p : properties)
+      if(
+        !p.is_proved() && !p.is_proved_with_bound() && !p.is_disabled() &&
+        !p.is_assumed())
+      {
+        return false;
+      }
+
+    return true;
+  }
+
+  bool has_unknown_property() const
+  {
+    for(const auto &p : properties)
+      if(p.is_unknown())
+        return true;
+
+    return false;
+  }
+
+  // command-line tool exit code, depending on property status
+  int exit_code() const;
 };
 
-int property_checker(
+property_checker_resultt property_checker(
   const cmdlinet &,
   transition_systemt &,
   ebmc_propertiest &,

--- a/src/ebmc/ranking_function.cpp
+++ b/src/ebmc/ranking_function.cpp
@@ -24,6 +24,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #include "ebmc_base.h"
 #include "ebmc_error.h"
 #include "ebmc_solver_factory.h"
+#include "property_checker.h"
 #include "report_results.h"
 
 exprt parse_ranking_function(
@@ -126,8 +127,9 @@ int do_ranking_function(
   }
 
   const namespacet ns(transition_system.symbol_table);
-  report_results(cmdline, properties, ns, message_handler);
-  return properties.exit_code();
+  property_checker_resultt checker_result{properties};
+  report_results(cmdline, checker_result, ns, message_handler);
+  return checker_result.exit_code();
 }
 
 std::pair<tvt, std::optional<trans_tracet>> is_ranking_function(

--- a/src/ebmc/report_results.cpp
+++ b/src/ebmc/report_results.cpp
@@ -34,7 +34,7 @@ Function: ebmc_baset::report_results
 
 void report_results(
   const cmdlinet &cmdline,
-  const ebmc_propertiest &properties,
+  const property_checker_resultt &result,
   const namespacet &ns,
   message_handlert &message_handler)
 {
@@ -46,7 +46,7 @@ void report_results(
     json_objectt json_results;
     auto &json_properties = json_results["properties"].make_array();
 
-    for(const auto &property : properties.properties)
+    for(const auto &property : result.properties)
     {
       if(property.is_disabled())
         continue;
@@ -69,7 +69,7 @@ void report_results(
     static_cast<ui_message_handlert &>(message_handler).get_ui() ==
     ui_message_handlert::uit::XML_UI)
   {
-    for(const auto &property : properties.properties)
+    for(const auto &property : result.properties)
     {
       if(property.is_disabled())
         continue;
@@ -90,7 +90,7 @@ void report_results(
     message.status() << messaget::eom;
     message.status() << "** Results:" << messaget::eom;
 
-    for(const auto &property : properties.properties)
+    for(const auto &property : result.properties)
     {
       if(property.is_disabled())
         continue;
@@ -159,7 +159,7 @@ void report_results(
 
   if(cmdline.isset("vcd"))
   {
-    for(const auto &property : properties.properties)
+    for(const auto &property : result.properties)
     {
       if(property.has_witness_trace())
       {

--- a/src/ebmc/report_results.h
+++ b/src/ebmc/report_results.h
@@ -12,14 +12,14 @@ Author: Daniel Kroening, dkr@amazon.com
 #ifndef EBMC_REPORT_RESULTS
 #define EBMC_REPORT_RESULTS
 
-#include "ebmc_properties.h"
+#include "property_checker.h"
 
 class message_handlert;
 class namespacet;
 
 void report_results(
   const cmdlinet &,
-  const ebmc_propertiest &,
+  const property_checker_resultt &,
   const namespacet &,
   message_handlert &);
 

--- a/src/ic3/m1ain.cc
+++ b/src/ic3/m1ain.cc
@@ -11,7 +11,7 @@ Author: Eugene Goldberg, eu.goldberg@gmail.com
 #include <util/cmdline.h>
 #include <util/ui_message.h>
 
-#include <ebmc/ebmc_properties.h>
+#include <ebmc/property_checker.h>
 #include <ebmc/report_results.h>
 
 #include <trans-netlist/netlist.h>
@@ -135,8 +135,9 @@ int ic3_enginet::operator()()
     if(number_of_properties == 0)
     {
       namespacet ns(transition_system.symbol_table);
-      report_results(cmdline, properties, ns, message.get_message_handler());
-      return properties.exit_code();
+      property_checker_resultt result{properties};
+      report_results(cmdline, result, ns, message.get_message_handler());
+      return result.exit_code();
     }
   }
   catch(const std::string &error_str)


### PR DESCRIPTION
The return value of the property checker now includes the property status. This is to replace status reporting as a side effect.