### PR TITLE
SystemVerilog: packed arrays must not use real element type

### DIFF
--- a/regression/verilog/arrays/packed_real1.desc
+++ b/regression/verilog/arrays/packed_real1.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
+CORE
 packed_real1.sv
 --module main --bound 0
-^EXIT=10$
+^file .* line 6: packed array must use packed element type$
+^EXIT=2$
 ^SIGNAL=0$
 --
 --
-A packed array of reals must be rejected.

--- a/regression/verilog/arrays/packed_typedef1.desc
+++ b/regression/verilog/arrays/packed_typedef1.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE
 packed_typedef1.sv
 --module main --bound 0
 ^EXIT=0$
 ^SIGNAL=0$
 --
 --
-The packed array type must not be dropped.


### PR DESCRIPTION
This adds an error message when given `real` as element type of a packed array.