### PR TITLE
bump CBMC dependency

### DIFF
--- a/regression/ebmc/random-traces/boolean1.desc
+++ b/regression/ebmc/random-traces/boolean1.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 boolean1.v
 --random-traces --trace-steps 0 --traces 2
 ^\*\*\* Trace 1$

--- a/regression/ebmc/random-traces/bv1.desc
+++ b/regression/ebmc/random-traces/bv1.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 bv1.v
 --random-traces --trace-steps 1 --traces 1
 ^Transition system state 0$

--- a/regression/ebmc/random-traces/counter_with_initial_value.desc
+++ b/regression/ebmc/random-traces/counter_with_initial_value.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 counter_with_initial_value.v
 --random-traces --trace-steps 10 --waveform --traces 2
 ^\*\*\* Trace 1$

--- a/regression/ebmc/random-traces/long_trace1.desc
+++ b/regression/ebmc/random-traces/long_trace1.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 long_trace1.v
 --random-traces --traces 1 --trace-steps 1000
 ^Transition system state 0$

--- a/regression/ebmc/random-traces/long_trace1.random-waveform.desc
+++ b/regression/ebmc/random-traces/long_trace1.random-waveform.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 long_trace1.v
 --random-waveform
 ^                0  1  2  3  4  5  6  7  8  9 10$

--- a/regression/ebmc/random-traces/with_submodule.desc
+++ b/regression/ebmc/random-traces/with_submodule.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 with_submodule.v
 --random-traces --trace-steps 0 --traces 2
 ^\*\*\* Trace 1$

--- a/regression/ebmc/smv/smv3.desc
+++ b/regression/ebmc/smv/smv3.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 smv3.smv
 --module main --bound 2 --k-induction
 ^EXIT=0$


### PR DESCRIPTION
This enables various tests that use the range type to work with Z3.