### PR TITLE
Verilog: aval/bval encoding for `!`

### DIFF
--- a/regression/verilog/expressions/negation1.desc
+++ b/regression/verilog/expressions/negation1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE broken-smt-backend
 negation1.sv
 --bound 0
 ^EXIT=0$
@@ -6,4 +6,3 @@ negation1.sv
 --
 ^warning: ignoring
 --
-Lowering for negation on three-valued logic is missing.

--- a/src/verilog/aval_bval_encoding.h
+++ b/src/verilog/aval_bval_encoding.h
@@ -22,6 +22,7 @@ Author: Daniel Kroening, dkr@amazon.com
 //   1    0  |   X
 //   1    1  |   Z
 
+bool is_four_valued(const typet &);
 bool is_aval_bval(const typet &);
 std::size_t aval_bval_width(const typet &);
 typet aval_bval_underlying(const typet &);
@@ -40,6 +41,8 @@ exprt aval_bval_concatenation(const exprt::operandst &, const typet &);
 exprt aval_bval(const verilog_logical_equality_exprt &);
 exprt aval_bval(const verilog_logical_inequality_exprt &);
 
+/// lowering for !
+exprt aval_bval(const not_exprt &);
 /// lowering for ==?
 exprt aval_bval(const verilog_wildcard_equality_exprt &);
 /// lowering for !=?

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -439,6 +439,17 @@ exprt verilog_synthesist::synth_expr(exprt expr, symbol_statet symbol_state)
       op = synth_expr(op, symbol_state);
     return aval_bval(to_verilog_wildcard_inequality_expr(expr));
   }
+  else if(expr.id() == ID_not)
+  {
+    auto &not_expr = to_not_expr(expr);
+    not_expr.op() = synth_expr(not_expr.op(), symbol_state);
+
+    // encode into aval/bval
+    if(is_four_valued(expr.type()))
+      return aval_bval(not_expr);
+    else
+      return expr; // leave as is
+  }
   else if(expr.has_operands())
   {
     for(auto &op : expr.operands())


### PR DESCRIPTION
This adds the aval/bval encoding for Verilog negation.