### PR TITLE
vlindex: unbounded lookahead

### DIFF
--- a/regression/vlindex/hierarchy1/hierarchy1.desc
+++ b/regression/vlindex/hierarchy1/hierarchy1.desc
@@ -1,8 +1,9 @@
 CORE
 
 --hierarchy
-^sub$
-^subsub$
 ^top$
+^  sub instance1$
+^    subsub instance3$
+^  sub instance2$
 ^EXIT=0$
 ^SIGNAL=0$


### PR DESCRIPTION
Without a scope and symbol table, parsing SystemVerilog requires three tokens lookahead to distinguish module instances from variable declarations.

This replaces the two tokens used for lookahead by a `std::deque`, enabling unbounded lookahead.