### PR TITLE
Verilog: fix continuous assignments to variables

### DIFF
--- a/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog3.desc
+++ b/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog3.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE
 continuous_assignment_to_variable_systemverilog3.sv
 --bound 0
 ^EXIT=0$
 ^SIGNAL=0$
 --
 --
-This yields a type inconsistency error in the synthesis phase.

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -2472,17 +2472,18 @@ void verilog_synthesist::synth_force_rec(
 
   auto rhs_synth = synth_expr(rhs, symbol_statet::CURRENT);
 
-  // If it's a variable, synth_assignments will
-  // generate the constraint.
+  // If the symbol is marked as a state variable,
+  // turn it into a wire now.
   if(symbol.is_state_var)
   {
-    assignment.next.value = rhs_synth;
+    warning().source_location = symbol.location;
+    warning() << "Making " << symbol.display_name() << " a wire" << eom;
+    symbolt &writeable_symbol = symbol_table_lookup(symbol.name);
+    writeable_symbol.is_state_var = false;
   }
-  else
-  {
-    equal_exprt equality(lhs, rhs_synth);
-    invars.push_back(equality);
-  }
+
+  equal_exprt equality{lhs, rhs_synth};
+  invars.push_back(equality);
 }
 
 /*******************************************************************\


### PR DESCRIPTION
This fixes the case when there are multiple continuous assignments to the same variable in the Verilog synthesis code.