### PR TITLE
BMC: fix encoding of `p R q`

### DIFF
--- a/regression/ebmc/smv/smv_ltlspec_R1.desc
+++ b/regression/ebmc/smv/smv_ltlspec_R1.desc
@@ -2,9 +2,9 @@ CORE broken-smt-backend
 smv_ltlspec_R1.smv
 --bound 10
 ^\[.*\] x >= 1 R x = 1: PROVED up to bound 10$
-^\[.*\] FALSE R x != 4: REFUTED$
+^\[.*\] FALSE R x != 4: PROVED up to bound 10$
 ^\[.*\] x = 2 R x = 1: REFUTED$
-^\[.*\] x >= 1 R x = 1 & FALSE R x != 4: REFUTED$
+^\[.*\] x >= 1 R x = 1 & FALSE R x != 4: PROVED up to bound 10$
 ^\[.*\] x = 2 R x = 1 & x >= 1 R x = 1: REFUTED$
 ^\[.*\] x = 2 R x = 1 \| x >= 1 R x = 1: PROVED up to bound 10$
 ^EXIT=10$

--- a/regression/ebmc/smv/smv_ltlspec_R2.desc
+++ b/regression/ebmc/smv/smv_ltlspec_R2.desc
@@ -2,7 +2,7 @@ KNOWNBUG broken-smt-backend
 smv_ltlspec_R2.smv
 --bound 10
 ^\[.*\] FALSE R x != 3: REFUTED$
-^Counterexample with 4 states:$
+^Counterexample with 3 states:$
 ^x@0 = 1$
 ^x@1 = 2$
 ^x@2 = 3$

--- a/regression/ebmc/smv/smv_ltlspec_R3.desc
+++ b/regression/ebmc/smv/smv_ltlspec_R3.desc
@@ -1,4 +1,4 @@
-KNOWNBUG broken-smt-backend
+CORE broken-smt-backend
 smv_ltlspec_R3.smv
 --bound 1
 ^\[.*\] FALSE R x != 3: PROVED up to bound 1$
@@ -7,4 +7,3 @@ smv_ltlspec_R3.smv
 --
 ^warning: ignoring
 --
-The counterexample is wrong.

--- a/regression/ebmc/smv/smv_ltlspec_R4.desc
+++ b/regression/ebmc/smv/smv_ltlspec_R4.desc
@@ -1,4 +1,4 @@
-KNOWNBUG broken-smt-backend
+CORE broken-smt-backend
 smv_ltlspec_R4.smv
 --bound 10
 ^\[.*\] FALSE R x != 0: PROVED up to bound 10$
@@ -7,4 +7,3 @@ smv_ltlspec_R4.smv
 --
 ^warning: ignoring
 --
-Property fails.


### PR DESCRIPTION
The expansion needs to use `true` to replace `X(p R q)` when reaching the end of the BMC unwinding.
