### PR TITLE
word-level BMC: remove parameters for solver + ns

### DIFF
--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -261,7 +261,7 @@ void k_inductiont::induction_step()
         const exprt &p = to_unary_expr(property.normalized_expr).op();
         for(std::size_t c = 0; c < no_timeframes; c++)
         {
-          exprt tmp = instantiate(p, c, no_timeframes, ns);
+          exprt tmp = instantiate(p, c, no_timeframes);
           solver.set_to_true(tmp);
         }
       }
@@ -272,15 +272,13 @@ void k_inductiont::induction_step()
     // assumption: time frames 0,...,k-1
     for(std::size_t c = 0; c < no_timeframes - 1; c++)
     {
-      exprt tmp=
-        instantiate(p, c, no_timeframes-1, ns);
+      exprt tmp = instantiate(p, c, no_timeframes - 1);
       solver.set_to_true(tmp);
     }
     
     // property: time frame k
     {
-      exprt tmp=
-        instantiate(p, no_timeframes-1, no_timeframes, ns);
+      exprt tmp = instantiate(p, no_timeframes - 1, no_timeframes);
       solver.set_to_false(tmp);
     }
 

--- a/src/ebmc/random_traces.cpp
+++ b/src/ebmc/random_traces.cpp
@@ -478,8 +478,7 @@ void random_tracest::freeze(
   {
     for(auto &symbol : symbols)
     {
-      auto symbol_in_timeframe =
-        instantiate(symbol, i, number_of_timeframes, ns);
+      auto symbol_in_timeframe = instantiate(symbol, i, number_of_timeframes);
       (void)solver.handle(symbol_in_timeframe);
     }
   }
@@ -508,7 +507,7 @@ std::vector<exprt> random_tracest::random_input_constraints(
   {
     for(auto &input : inputs)
     {
-      auto input_in_timeframe = instantiate(input, i, number_of_timeframes, ns);
+      auto input_in_timeframe = instantiate(input, i, number_of_timeframes);
       auto constraint =
         equal_exprt(input_in_timeframe, random_value(input.type()));
       result.push_back(constraint);
@@ -538,7 +537,7 @@ std::vector<exprt> random_tracest::random_initial_state_constraints(
 
   for(auto &symbol : state_variables)
   {
-    auto symbol_in_timeframe = instantiate(symbol, 0, 1, ns);
+    auto symbol_in_timeframe = instantiate(symbol, 0, 1);
     auto constraint =
       equal_exprt(symbol_in_timeframe, random_value(symbol.type()));
     result.push_back(std::move(constraint));

--- a/src/ebmc/ranking_function.cpp
+++ b/src/ebmc/ranking_function.cpp
@@ -171,14 +171,13 @@ std::pair<tvt, std::optional<trans_tracet>> is_ranking_function(
   // c) p holds in timeframe 1
 
   exprt ranking_function_decreases = less_than_exprt(
-    instantiate(ranking_function, 1, 2, ns),
-    instantiate(ranking_function, 0, 2, ns));
+    instantiate(ranking_function, 1, 2), instantiate(ranking_function, 0, 2));
   solver.set_to_false(ranking_function_decreases);
 
-  exprt p_at_0 = instantiate(p, 0, 2, ns);
+  exprt p_at_0 = instantiate(p, 0, 2);
   solver.set_to_false(p_at_0);
 
-  exprt p_at_1 = instantiate(p, 1, 2, ns);
+  exprt p_at_1 = instantiate(p, 1, 2);
   solver.set_to_false(p_at_1);
 
   decision_proceduret::resultt dec_result = solver();

--- a/src/trans-word-level/counterexample_word_level.cpp
+++ b/src/trans-word-level/counterexample_word_level.cpp
@@ -6,15 +6,17 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-#include <iostream>
-
-#include <langapi/language_util.h>
-
-#include "instantiate_word_level.h"
 #include "counterexample_word_level.h"
 
 #include <util/std_expr.h>
 #include <util/symbol_table.h>
+
+#include <langapi/language_util.h>
+#include <solvers/decision_procedure.h>
+
+#include "instantiate_word_level.h"
+
+#include <iostream>
 
 /*******************************************************************\
 

--- a/src/trans-word-level/instantiate_word_level.cpp
+++ b/src/trans-word-level/instantiate_word_level.cpp
@@ -72,8 +72,8 @@ symbol_exprt timeframe_symbol(const mp_integer &timeframe, symbol_exprt src)
 class wl_instantiatet
 {
 public:
-  wl_instantiatet(const mp_integer &_no_timeframes, const namespacet &_ns)
-    : no_timeframes(_no_timeframes), ns(_ns)
+  explicit wl_instantiatet(const mp_integer &_no_timeframes)
+    : no_timeframes(_no_timeframes)
   {
   }
 
@@ -86,7 +86,6 @@ public:
 
 protected:
   const mp_integer &no_timeframes;
-  const namespacet &ns;
 
   [[nodiscard]] std::pair<mp_integer, exprt>
   instantiate_rec(exprt, const mp_integer &t) const;
@@ -145,7 +144,7 @@ wl_instantiatet::instantiate_rec(exprt expr, const mp_integer &t) const
   {
     // sequence expressions -- these may have multiple potential
     // match points, and evaluate to true if any of them matches
-    const auto match_points = instantiate_sequence(expr, t, no_timeframes, ns);
+    const auto match_points = instantiate_sequence(expr, t, no_timeframes);
     exprt::operandst disjuncts;
     disjuncts.reserve(match_points.size());
     mp_integer max = t;
@@ -228,10 +227,9 @@ Function: instantiate
 exprt instantiate(
   const exprt &expr,
   const mp_integer &t,
-  const mp_integer &no_timeframes,
-  const namespacet &ns)
+  const mp_integer &no_timeframes)
 {
-  wl_instantiatet wl_instantiate(no_timeframes, ns);
+  wl_instantiatet wl_instantiate(no_timeframes);
   return wl_instantiate(expr, t).second;
 }
 
@@ -250,9 +248,8 @@ Function: instantiate_property
 std::pair<mp_integer, exprt> instantiate_property(
   const exprt &expr,
   const mp_integer &current,
-  const mp_integer &no_timeframes,
-  const namespacet &ns)
+  const mp_integer &no_timeframes)
 {
-  wl_instantiatet wl_instantiate(no_timeframes, ns);
+  wl_instantiatet wl_instantiate(no_timeframes);
   return wl_instantiate(expr, current);
 }

--- a/src/trans-word-level/instantiate_word_level.h
+++ b/src/trans-word-level/instantiate_word_level.h
@@ -10,21 +10,17 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_BMC_INSTANTIATE_WORD_LEVEL_H
 
 #include <util/mp_arith.h>
-#include <util/namespace.h>
-
-#include <solvers/prop/prop_conv.h>
+#include <util/std_expr.h>
 
 exprt instantiate(
   const exprt &expr,
   const mp_integer &current,
-  const mp_integer &no_timeframes,
-  const namespacet &);
+  const mp_integer &no_timeframes);
 
 std::pair<mp_integer, exprt> instantiate_property(
   const exprt &,
   const mp_integer &current,
-  const mp_integer &no_timeframes,
-  const namespacet &);
+  const mp_integer &no_timeframes);
 
 std::string
 timeframe_identifier(const mp_integer &timeframe, const irep_idt &identifier);

--- a/src/trans-word-level/sequence.cpp
+++ b/src/trans-word-level/sequence.cpp
@@ -17,8 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 std::vector<std::pair<mp_integer, exprt>> instantiate_sequence(
   exprt expr,
   const mp_integer &t,
-  const mp_integer &no_timeframes,
-  const namespacet &ns)
+  const mp_integer &no_timeframes)
 {
   if(expr.id() == ID_sva_cycle_delay) // ##[1:2] something
   {
@@ -40,7 +39,7 @@ std::vector<std::pair<mp_integer, exprt>> instantiate_sequence(
       }
       else
         return instantiate_sequence(
-          sva_cycle_delay_expr.op(), u, no_timeframes, ns);
+          sva_cycle_delay_expr.op(), u, no_timeframes);
     }
     else
     {
@@ -71,7 +70,7 @@ std::vector<std::pair<mp_integer, exprt>> instantiate_sequence(
       for(mp_integer u = lower; u <= upper; ++u)
       {
         auto sub_result =
-          instantiate_sequence(sva_cycle_delay_expr.op(), u, no_timeframes, ns);
+          instantiate_sequence(sva_cycle_delay_expr.op(), u, no_timeframes);
         for(auto &match_point : sub_result)
           match_points.push_back(match_point);
       }
@@ -89,7 +88,7 @@ std::vector<std::pair<mp_integer, exprt>> instantiate_sequence(
 
     // This is the product of the match points on the LHS and RHS
     const auto lhs_match_points =
-      instantiate_sequence(implication.lhs(), t, no_timeframes, ns);
+      instantiate_sequence(implication.lhs(), t, no_timeframes);
     for(auto &lhs_match_point : lhs_match_points)
     {
       // The RHS of the non-overlapped implication starts one timeframe later
@@ -105,7 +104,7 @@ std::vector<std::pair<mp_integer, exprt>> instantiate_sequence(
       }
 
       const auto rhs_match_points =
-        instantiate_sequence(implication.rhs(), t_rhs, no_timeframes, ns);
+        instantiate_sequence(implication.rhs(), t_rhs, no_timeframes);
 
       for(auto &rhs_match_point : rhs_match_points)
       {
@@ -157,8 +156,7 @@ std::vector<std::pair<mp_integer, exprt>> instantiate_sequence(
     exprt::operandst conjuncts;
 
     for(auto &op : expr.operands())
-      conjuncts.push_back(
-        instantiate_property(op, t, no_timeframes, ns).second);
+      conjuncts.push_back(instantiate_property(op, t, no_timeframes).second);
 
     exprt condition = conjunction(conjuncts);
     return {{t, condition}};
@@ -171,7 +169,7 @@ std::vector<std::pair<mp_integer, exprt>> instantiate_sequence(
     std::vector<std::pair<mp_integer, exprt>> result;
 
     for(auto &op : expr.operands())
-      for(auto &match_point : instantiate_sequence(op, t, no_timeframes, ns))
+      for(auto &match_point : instantiate_sequence(op, t, no_timeframes))
         result.push_back(match_point);
 
     return result;
@@ -179,6 +177,6 @@ std::vector<std::pair<mp_integer, exprt>> instantiate_sequence(
   else
   {
     // not a sequence, evaluate as state predicate
-    return {instantiate_property(expr, t, no_timeframes, ns)};
+    return {instantiate_property(expr, t, no_timeframes)};
   }
 }

--- a/src/trans-word-level/sequence.h
+++ b/src/trans-word-level/sequence.h
@@ -17,7 +17,6 @@ Author: Daniel Kroening, kroening@kroening.com
 [[nodiscard]] std::vector<std::pair<mp_integer, exprt>> instantiate_sequence(
   exprt expr,
   const mp_integer &t,
-  const mp_integer &no_timeframes,
-  const namespacet &);
+  const mp_integer &no_timeframes);
 
 #endif // CPROVER_TRANS_WORD_LEVEL_SEQUENCE_H

--- a/src/trans-word-level/unwind.cpp
+++ b/src/trans-word-level/unwind.cpp
@@ -6,12 +6,15 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-#include <util/namespace.h>
-#include <util/find_symbols.h>
+#include "unwind.h"
+
 #include <util/expr_util.h>
+#include <util/find_symbols.h>
+#include <util/namespace.h>
+
+#include <solvers/decision_procedure.h>
 
 #include "instantiate_word_level.h"
-#include "unwind.h"
 
 /*******************************************************************\
 
@@ -44,8 +47,7 @@ void unwind(
 
   if(!op_invar.is_true())
     for(std::size_t c = 0; c < no_timeframes; c++)
-      decision_procedure.set_to_true(
-        instantiate(op_invar, c, no_timeframes, ns));
+      decision_procedure.set_to_true(instantiate(op_invar, c, no_timeframes));
 
   // initial state
 
@@ -54,8 +56,7 @@ void unwind(
     message.progress() << "Initial state" << messaget::eom;
 
     if(!op_init.is_true())
-      decision_procedure.set_to_true(
-        instantiate(op_init, 0, no_timeframes, ns));
+      decision_procedure.set_to_true(instantiate(op_init, 0, no_timeframes));
   }
 
   // transition relation
@@ -74,7 +75,6 @@ void unwind(
         message.progress() << "Transition " << t << "->" << t + 1
                            << messaget::eom;
 
-      decision_procedure.set_to_true(
-        instantiate(op_trans, t, no_timeframes, ns));
+      decision_procedure.set_to_true(instantiate(op_trans, t, no_timeframes));
     }
 }


### PR DESCRIPTION
The solver and namespace objects are not used, and hence do not need to be given as parameters.