### PR TITLE
Verilog: generate ... endgenerate is optional

### DIFF
--- a/regression/verilog/generate/generate-for3.desc
+++ b/regression/verilog/generate/generate-for3.desc
@@ -1,0 +1,9 @@
+CORE
+generate-for3.v
+--module main --bound 1
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+The generate ... endgenerate keywords became optional with 1364-2005.
+https://github.com/diffblue/hw-cbmc/issues/747

--- a/regression/verilog/generate/generate-for3.v
+++ b/regression/verilog/generate/generate-for3.v
@@ -1,0 +1,13 @@
+module main;
+
+  wire [15:0] some_wire;
+
+  // The generate ... endgenerate became optional with 1364-2005.
+  genvar i;
+  for (i = 0; i <= 15; i = i + 1)
+    assign some_wire[i] = (i%2) == 0;
+
+  // should pass
+  always assert property1: some_wire == 'b0101_0101_0101_0101;
+
+endmodule

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -862,7 +862,9 @@ verilog_typecheckt::elaborate_level(const module_itemst &module_items)
 
   for(auto &module_item : module_items)
   {
-    if(module_item.id() == ID_generate_block)
+    if(
+      module_item.id() == ID_generate_block ||
+      module_item.id() == ID_generate_for || module_item.id() == ID_generate_if)
     {
       // elaborate_generate_item calls elaborate_level
       // recursively.


### PR DESCRIPTION
The use of `generate` ... `endgenerate` became optional with 1364-2005.

Fixes issue #747.