### PR TITLE
Verilog: add tests for implicit nets

### DIFF
--- a/regression/verilog/nets/implicit1.desc
+++ b/regression/verilog/nets/implicit1.desc
@@ -1,0 +1,10 @@
+CORE
+implicit1.sv
+--bound 0
+^file .* line 4: implicit wire main\.O$
+^file .* line 4: implicit wire main\.A$
+^file .* line 4: implicit wire main\.B$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/nets/implicit1.sv
+++ b/regression/verilog/nets/implicit1.sv
@@ -1,0 +1,8 @@
+module main;
+
+  // implicit nets are allowed in the port connection list of a module
+  and (O, A, B);
+
+  always assert final (O == (A && B));
+
+endmodule

--- a/regression/verilog/nets/implicit2.desc
+++ b/regression/verilog/nets/implicit2.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+implicit2.sv
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The width of the implicit net is set incorrectly.

--- a/regression/verilog/nets/implicit2.sv
+++ b/regression/verilog/nets/implicit2.sv
@@ -1,0 +1,9 @@
+module main;
+
+  // implicit nets are allowed in the port connection list of a module
+  and [3:0] (O, A, B);
+
+  always assert final (O == (A & B));
+  always assert final ($bits(O) == 4);
+
+endmodule

--- a/regression/verilog/nets/implicit3.desc
+++ b/regression/verilog/nets/implicit3.desc
@@ -1,0 +1,8 @@
+CORE
+implicit3.sv
+--bound 0
+^file .* line 6: implicit wire main\.O$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/nets/implicit3.sv
+++ b/regression/verilog/nets/implicit3.sv
@@ -1,0 +1,10 @@
+module main;
+
+  wire A, B;
+
+  // implicit nets are allowed on the LHS of a continuous assignment
+  assign O = A & B;
+
+  always assert final (O == (A && B));
+
+endmodule

--- a/regression/verilog/nets/implicit4.desc
+++ b/regression/verilog/nets/implicit4.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+implicit4.sv
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The width of the implicit net is set incorrectly.

--- a/regression/verilog/nets/implicit4.sv
+++ b/regression/verilog/nets/implicit4.sv
@@ -1,0 +1,11 @@
+module main;
+
+  wire [3:0] A, B;
+
+  // implicit nets are allowed on the LHS of a continuous assignment
+  assign O = A & B;
+
+  always assert final (O == (A & B));
+  always assert final ($bits(O) == 4);
+
+endmodule

--- a/regression/verilog/nets/implicit5.desc
+++ b/regression/verilog/nets/implicit5.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+implicit5.sv
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This case should be errored.

--- a/regression/verilog/nets/implicit5.sv
+++ b/regression/verilog/nets/implicit5.sv
@@ -1,0 +1,6 @@
+module main;
+
+  // implicit nets are not allowed on the RHS of a continuous assignment
+  assign O = A & B;
+
+endmodule


### PR DESCRIPTION
SystemVerilog allows nets to be declared implicitly (1800 2017 Sec 6.10).