### PR TITLE
Verilog: set type of implicit nets

### DIFF
--- a/regression/verilog/nets/implicit1.desc
+++ b/regression/verilog/nets/implicit1.desc
@@ -1,6 +1,6 @@
 CORE
 implicit1.sv
---bound 0
+--bound 0 --warn-implicit-nets
 ^file .* line 4: implicit wire main\.O$
 ^file .* line 4: implicit wire main\.A$
 ^file .* line 4: implicit wire main\.B$

--- a/regression/verilog/nets/implicit2.desc
+++ b/regression/verilog/nets/implicit2.desc
@@ -1,9 +1,8 @@
-KNOWNBUG
+CORE
 implicit2.sv
---bound 0
+--bound 0 --warn-implicit-nets
 ^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-The width of the implicit net is set incorrectly.

--- a/regression/verilog/nets/implicit3.desc
+++ b/regression/verilog/nets/implicit3.desc
@@ -1,6 +1,6 @@
 CORE
 implicit3.sv
---bound 0
+--bound 0 --warn-implicit-nets
 ^file .* line 6: implicit wire main\.O$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/verilog/nets/implicit5.desc
+++ b/regression/verilog/nets/implicit5.desc
@@ -1,9 +1,9 @@
-KNOWNBUG
+CORE
 implicit5.sv
---bound 0
-^EXIT=0$
+--bound 0 --warn-implicit-nets
+^file .* line 4: unknown identifier A$
+^EXIT=2$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-This case should be errored.

--- a/regression/verilog/nets/implicit6.desc
+++ b/regression/verilog/nets/implicit6.desc
@@ -1,5 +1,5 @@
 CORE
-implicit4.sv
+implicit6.sv
 --bound 0 --warn-implicit-nets
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/verilog/nets/implicit6.sv
+++ b/regression/verilog/nets/implicit6.sv
@@ -1,0 +1,10 @@
+module main;
+
+  parameter P = 2;
+
+  // implicit nets are allowed in the port connection list of a module
+  and [P:0] (O, A, B);
+
+  assert final ($bits(O) == P+1);
+
+endmodule

--- a/regression/verilog/nets/implicit7.desc
+++ b/regression/verilog/nets/implicit7.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+implicit7.sv
+--bound 0 --warn-implicit-nets
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The implicit net is not known yet when evaluating parameters.

--- a/regression/verilog/nets/implicit7.sv
+++ b/regression/verilog/nets/implicit7.sv
@@ -1,0 +1,16 @@
+module main;
+
+  parameter P = 10;
+
+  // implicit nets are allowed in the port connection list of a module
+  sub #(P) my_sub(x);
+
+  // The type of the implict net could be used to define another parameter
+  parameter Q = $bits(x);
+
+  assert final (Q == P + 1);
+
+endmodule
+
+module sub #(parameter P = 1)(input [P:0] some_input);
+endmodule

--- a/src/ebmc/ebmc_parse_options.h
+++ b/src/ebmc/ebmc_parse_options.h
@@ -47,7 +47,8 @@ public:
         "(random-traces)(trace-steps):(random-seed):(traces):"
         "(random-trace)(random-waveform)"
         "(liveness-to-safety)"
-        "I:D:(preprocess)(systemverilog)(vl2smv-extensions)",
+        "I:D:(preprocess)(systemverilog)(vl2smv-extensions)"
+        "(warn-implicit-nets)",
         argc,
         argv,
         std::string("EBMC ") + EBMC_VERSION),

--- a/src/ebmc/transition_system.cpp
+++ b/src/ebmc/transition_system.cpp
@@ -112,6 +112,7 @@ int preprocess(const cmdlinet &cmdline, message_handlert &message_handler)
   optionst options;
   options.set_option("force-systemverilog", cmdline.isset("systemverilog"));
   options.set_option("vl2smv-extensions", cmdline.isset("vl2smv-extensions"));
+  options.set_option("warn-implicit-nets", cmdline.isset("warn-implicit-nets"));
 
   // do -D
   if(cmdline.isset('D'))
@@ -163,6 +164,7 @@ static bool parse(
   optionst options;
   options.set_option("force-systemverilog", cmdline.isset("systemverilog"));
   options.set_option("vl2smv-extensions", cmdline.isset("vl2smv-extensions"));
+  options.set_option("warn-implicit-nets", cmdline.isset("warn-implicit-nets"));
 
   // do -D
   if(cmdline.isset('D'))

--- a/src/verilog/verilog_language.cpp
+++ b/src/verilog/verilog_language.cpp
@@ -37,6 +37,7 @@ void verilog_languaget::set_language_options(
   force_systemverilog = options.get_bool_option("force-systemverilog");
   vl2smv_extensions = options.get_bool_option("vl2smv-extensions");
   initial_defines = options.get_list_option("defines");
+  warn_implicit_nets = options.get_bool_option("warn-implicit-nets");
 }
 
 /*******************************************************************\
@@ -180,7 +181,8 @@ bool verilog_languaget::typecheck(
 {
   if(module=="") return false;
 
-  if(verilog_typecheck(parse_tree, symbol_table, module, message_handler))
+  if(verilog_typecheck(
+       parse_tree, symbol_table, module, warn_implicit_nets, message_handler))
     return true;
 
   messaget message(message_handler);

--- a/src/verilog/verilog_language.h
+++ b/src/verilog/verilog_language.h
@@ -93,6 +93,7 @@ public:
 protected:
   bool force_systemverilog = false;
   bool vl2smv_extensions = false;
+  bool warn_implicit_nets = false;
   std::list<std::string> initial_defines;
   verilog_parse_treet parse_tree;
 };

--- a/src/verilog/verilog_parameterize_module.cpp
+++ b/src/verilog/verilog_parameterize_module.cpp
@@ -289,7 +289,7 @@ irep_idt verilog_typecheckt::parameterize_module(
   // recursive call
 
   verilog_typecheckt verilog_typecheck(
-    standard, *new_symbol, symbol_table, get_message_handler());
+    standard, false, *new_symbol, symbol_table, get_message_handler());
 
   if(verilog_typecheck.typecheck_main())
     throw 0;

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -663,7 +663,7 @@ exprt verilog_synthesist::expand_function_call(
     {
       // Attempt to constant fold.
       verilog_typecheck_exprt verilog_typecheck_expr(
-        standard, ns, get_message_handler());
+        standard, false, ns, get_message_handler());
       auto result =
         verilog_typecheck_expr.elaborate_constant_system_function_call(call);
       if(!result.is_constant())

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -23,12 +23,14 @@ bool verilog_typecheck(
   const verilog_parse_treet &parse_tree,
   symbol_table_baset &,
   const std::string &module,
+  bool warn_implicit_nets,
   message_handlert &message_handler);
 
 bool verilog_typecheck(
   symbol_table_baset &,
   const verilog_module_sourcet &verilog_module_source,
   verilog_standardt,
+  bool warn_implicit_nets,
   message_handlert &message_handler);
 
 bool verilog_typecheck(
@@ -57,10 +59,15 @@ class verilog_typecheckt:
 public:
   verilog_typecheckt(
     verilog_standardt _standard,
+    bool warn_implicit_nets,
     symbolt &_module_symbol,
     symbol_table_baset &_symbol_table,
     message_handlert &_message_handler)
-    : verilog_typecheck_exprt(_standard, ns, _message_handler),
+    : verilog_typecheck_exprt(
+        _standard,
+        warn_implicit_nets,
+        ns,
+        _message_handler),
       verilog_symbol_tablet(_symbol_table),
       ns(_symbol_table),
       module_symbol(_module_symbol),
@@ -204,8 +211,10 @@ protected:
   virtual void convert_statements(verilog_module_exprt &);
 
   // to be overridden
-  bool implicit_wire(const irep_idt &identifier,
-                     const symbolt *&symbol) override;
+  bool implicit_wire(
+    const irep_idt &identifier,
+    const symbolt *&,
+    const typet &) override;
 
   // generate constructs
   void elaborate_generate_assign(

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -26,18 +26,22 @@ class verilog_typecheck_exprt:public verilog_typecheck_baset
 public:
   verilog_typecheck_exprt(
     verilog_standardt _standard,
+    bool _warn_implicit_nets,
     const namespacet &_ns,
     message_handlert &_message_handler)
-    : verilog_typecheck_baset(_standard, _ns, _message_handler)
+    : verilog_typecheck_baset(_standard, _ns, _message_handler),
+      warn_implicit_nets(_warn_implicit_nets)
   { }
 
   verilog_typecheck_exprt(
     verilog_standardt _standard,
+    bool _warn_implicit_nets,
     const namespacet &_ns,
     const std::string &_module_identifier,
     message_handlert &_message_handler)
     : verilog_typecheck_baset(_standard, _ns, _message_handler),
-      module_identifier(_module_identifier)
+      module_identifier(_module_identifier),
+      warn_implicit_nets(_warn_implicit_nets)
   { }
 
   virtual void convert_expr(exprt &expr)
@@ -126,11 +130,14 @@ protected:
     PRECONDITION(false);
   }
 
-  virtual bool implicit_wire(const irep_idt &identifier,
-                             const symbolt *&symbol) {
+  bool warn_implicit_nets = false;
+
+  virtual bool
+  implicit_wire(const irep_idt &identifier, const symbolt *&, const typet &)
+  {
     return true;
   }
-   
+
   void typecheck() override
   {
   }
@@ -156,10 +163,11 @@ protected:
     UNREACHABLE;
   }
 
-private:
+protected:
   [[nodiscard]] exprt convert_expr_rec(exprt expr);
   [[nodiscard]] exprt convert_constant(constant_exprt);
-  [[nodiscard]] exprt convert_symbol(symbol_exprt);
+  [[nodiscard]] exprt
+  convert_symbol(symbol_exprt, const std::optional<typet> &implicit_net_type);
   [[nodiscard]] exprt
     convert_hierarchical_identifier(class hierarchical_identifier_exprt);
   [[nodiscard]] exprt convert_nullary_expr(nullary_exprt);


### PR DESCRIPTION
1800 2017 6.10 allows implicit declarations of nets.  The type of these nets is to be derived from the LHS of the assignment or the type of the port connection.