### PR TITLE
Verilog: reject non-constant parameters

### DIFF
--- a/regression/verilog/enums/enum5.desc
+++ b/regression/verilog/enums/enum5.desc
@@ -1,0 +1,7 @@
+CORE
+enum5.sv
+--bound 0
+^file .* line 6: expected constant expression, but got `main\.some_wire'$
+^EXIT=2$
+^SIGNAL=0$
+--

--- a/regression/verilog/enums/enum5.sv
+++ b/regression/verilog/enums/enum5.sv
@@ -1,0 +1,8 @@
+module main;
+
+  wire some_wire;
+
+  // some_wire is not a constant
+  typedef enum bit [7:0] { A = some_wire } enum_t;
+
+endmodule

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -97,6 +97,7 @@ protected:
   collect_symbols(const typet &, const verilog_parameter_declt::declaratort &);
   void collect_port_symbols(const verilog_declt &);
   std::vector<irep_idt> symbols_added;
+  std::set<irep_idt> let_symbols;
 
   // instances
   irep_idt parameterize_module(

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -148,6 +148,7 @@ protected:
   bool is_constant_expression(const exprt &, mp_integer &value);
   std::optional<mp_integer> is_constant_integer_post_convert(const exprt &);
   exprt elaborate_constant_expression(exprt);
+  exprt elaborate_constant_expression_check(exprt);
 
   // To be overridden, requires a Verilog interpreter.
   virtual exprt elaborate_constant_function_call(const function_call_exprt &)


### PR DESCRIPTION
Module parameters, local parameters and enums must be elaboration time constants.  This adds an error when they are not.
