### PR TITLE
SVA: move rewrites for state-formula SVA into separate file

### DIFF
--- a/src/temporal-logic/Makefile
+++ b/src/temporal-logic/Makefile
@@ -1,6 +1,7 @@
 SRC = nnf.cpp \
       normalize_property.cpp \
       temporal_logic.cpp \
+      trivial_sva.cpp \
       #empty line
 
 include ../config.inc

--- a/src/temporal-logic/normalize_property.h
+++ b/src/temporal-logic/normalize_property.h
@@ -21,30 +21,17 @@ Author: Daniel Kroening, dkr@amazon.com
 /// (a -> b) --> ¬a ∨ b
 ///
 /// -----SVA-----
-/// a sva_iff b --> a <-> b
-/// a sva_implies b --> a -> b
-/// sva_not a --> ¬a
-/// a sva_and b --> a ∧ b                                   if a and b are not SVA sequences
-/// a sva_or b --> a ∨ b                                    if a and b are not SVA sequences
-/// sva_overlapped_implication --> ¬a ∨ b                   if a is not an SVA sequence
 /// sva_non_overlapped_implication --> ¬a ∨ always[1:1] b   if a is not an SVA sequence
 /// sva_nexttime φ --> sva_always[1:1] φ
 /// sva_nexttime[i] φ --> sva_always[i:i] φ
 /// sva_s_nexttime φ --> sva_always[1:1] φ
 /// sva_s_nexttime[i] φ --> sva_s_always[i:i] φ
-/// sva_if --> ? :
 /// ##[0:$] φ --> s_eventually φ
 /// ##[i:$] φ --> s_nexttime[i] s_eventually φ
 /// ##[*] φ --> s_eventually φ
 /// ##[+] φ --> always[1:1] s_eventually φ
 /// strong(φ) --> φ
 /// weak(φ) --> φ
-/// sva_case --> ? :
-/// a sva_disable_iff b --> a ∨ b
-/// a sva_accept_on b --> a ∨ b
-/// a sva_reject_on b --> ¬a ∧ b
-/// a sva_sync_accept_on b --> a ∨ b
-/// a sva_sync_reject_on b --> ¬a ∧ b
 /// ¬ sva_s_eventually φ --> sva_always ¬φ
 /// ¬ sva_always φ --> sva_s_eventually ¬φ
 ///

--- a/src/temporal-logic/trivial_sva.cpp
+++ b/src/temporal-logic/trivial_sva.cpp
@@ -1,0 +1,94 @@
+/*******************************************************************\
+
+Module: Trivial SVA
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#include "trivial_sva.h"
+
+#include <verilog/sva_expr.h>
+
+#include "temporal_logic.h"
+
+exprt trivial_sva(exprt expr)
+{
+  // pre-traversal
+  if(expr.id() == ID_sva_overlapped_implication)
+  {
+    // Same as regular implication if lhs and rhs are not sequences.
+    auto &sva_implication = to_sva_overlapped_implication_expr(expr);
+    if(
+      !is_SVA_sequence(sva_implication.lhs()) &&
+      !is_SVA_sequence(sva_implication.rhs()))
+    {
+      expr = implies_exprt{sva_implication.lhs(), sva_implication.rhs()};
+    }
+  }
+  else if(expr.id() == ID_sva_iff)
+  {
+    auto &sva_iff = to_sva_iff_expr(expr);
+    expr = equal_exprt{sva_iff.lhs(), sva_iff.rhs()};
+  }
+  else if(expr.id() == ID_sva_implies)
+  {
+    auto &sva_implies = to_sva_implies_expr(expr);
+    expr = implies_exprt{sva_implies.lhs(), sva_implies.rhs()};
+  }
+  else if(expr.id() == ID_sva_and)
+  {
+    // Same as a ∧ b if lhs and rhs are not sequences.
+    auto &sva_and = to_sva_and_expr(expr);
+    if(!is_SVA_sequence(sva_and.lhs()) && !is_SVA_sequence(sva_and.rhs()))
+      expr = and_exprt{sva_and.lhs(), sva_and.rhs()};
+  }
+  else if(expr.id() == ID_sva_or)
+  {
+    // Same as a ∧ b if lhs or rhs are not sequences.
+    auto &sva_or = to_sva_or_expr(expr);
+    if(!is_SVA_sequence(sva_or.lhs()) && !is_SVA_sequence(sva_or.rhs()))
+      expr = or_exprt{sva_or.lhs(), sva_or.rhs()};
+  }
+  else if(expr.id() == ID_sva_not)
+  {
+    // Same as regular 'not'. These do not apply to sequences.
+    expr = not_exprt{to_sva_not_expr(expr).op()};
+  }
+  else if(expr.id() == ID_sva_if)
+  {
+    auto &sva_if_expr = to_sva_if_expr(expr);
+    auto false_case = sva_if_expr.false_case().is_nil()
+                        ? true_exprt{}
+                        : sva_if_expr.false_case();
+    expr = if_exprt{sva_if_expr.cond(), sva_if_expr.true_case(), false_case};
+  }
+  else if(expr.id() == ID_sva_disable_iff)
+  {
+    auto &disable_iff_expr = to_sva_disable_iff_expr(expr);
+    expr = or_exprt{disable_iff_expr.lhs(), disable_iff_expr.rhs()};
+  }
+  else if(expr.id() == ID_sva_accept_on || expr.id() == ID_sva_sync_accept_on)
+  {
+    auto &sva_abort_expr = to_sva_abort_expr(expr);
+    expr = or_exprt{sva_abort_expr.condition(), sva_abort_expr.property()};
+  }
+  else if(expr.id() == ID_sva_reject_on || expr.id() == ID_sva_sync_reject_on)
+  {
+    auto &sva_abort_expr = to_sva_abort_expr(expr);
+    expr = and_exprt{
+      not_exprt{sva_abort_expr.condition()}, sva_abort_expr.property()};
+  }
+  else if(expr.id() == ID_sva_case)
+  {
+    expr = to_sva_case_expr(expr).lowering();
+  }
+
+  // rewrite the operands, recursively
+  for(auto &op : expr.operands())
+    op = trivial_sva(op);
+
+  // post-traversal
+
+  return expr;
+}

--- a/src/temporal-logic/trivial_sva.h
+++ b/src/temporal-logic/trivial_sva.h
@@ -1,0 +1,32 @@
+/*******************************************************************\
+
+Module: Trivial SVA
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_TEMPORAL_LOGIC_TRIVIAL_SVA_H
+#define CPROVER_TEMPORAL_LOGIC_TRIVIAL_SVA_H
+
+#include <util/expr.h>
+
+/// This applies the following rewrites, removing SVA operators
+/// that trivial in the sense that they are state predicates only.
+///
+/// a sva_iff b --> a <-> b
+/// a sva_implies b --> a -> b
+/// sva_not a --> ¬a
+/// a sva_and b --> a ∧ b                     if a and b are not sequences
+/// a sva_or b --> a ∨ b                      if a and b are not sequences
+/// sva_overlapped_implication --> a -> b     if a and b are not sequences
+/// sva_if --> ? :
+/// sva_case --> ? :
+/// a sva_disable_iff b --> a ∨ b
+/// a sva_accept_on b --> a ∨ b
+/// a sva_reject_on b --> ¬a ∧ b
+/// a sva_sync_accept_on b --> a ∨ b
+/// a sva_sync_reject_on b --> ¬a ∧ b
+exprt trivial_sva(exprt);
+
+#endif


### PR DESCRIPTION
Some of the SVA operators are not temporal operators, but state predicates only.  This moves the rewrites for these operators into a separate file.