### PR TITLE
Verilog: constant folding for nonindexed part select

### DIFF
--- a/regression/verilog/expressions/part-select-constant1.desc
+++ b/regression/verilog/expressions/part-select-constant1.desc
@@ -1,0 +1,8 @@
+CORE
+part-select-constant1.sv
+--bound 0
+^\[.*\] .* PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/expressions/part-select-constant1.sv
+++ b/regression/verilog/expressions/part-select-constant1.sv
@@ -1,0 +1,9 @@
+module main;
+
+  // part-select expressions yield constants
+  parameter p = 'b1010;
+  parameter q = p[3:1];
+
+  assert final (q == 'b101);
+
+endmodule

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1605,7 +1605,13 @@ exprt verilog_typecheck_exprt::elaborate_constant_expression(exprt expr)
         PRECONDITION(false);
     };
 
-    if(expr.id() == ID_reduction_or)
+    if(expr.id() == ID_verilog_non_indexed_part_select)
+    {
+      // Our simplifier does not know these, do lowering.
+      auto &part_select = to_verilog_non_indexed_part_select_expr(expr);
+      expr = part_select.lower();
+    }
+    else if(expr.id() == ID_reduction_or)
     {
       // The simplifier doesn't know how to simplify reduction_or
       auto &reduction_or = to_unary_expr(expr);


### PR DESCRIPTION
This implements constant folding for Verilog's nonindexed part select.

Fixes #751.