### PR TITLE
change Fφ BMC encoding

### DIFF
--- a/regression/verilog/SVA/sva_iff2.sv
+++ b/regression/verilog/SVA/sva_iff2.sv
@@ -1,8 +1,8 @@
 module main(input a, b);
 
-  // p0: assert property ((always a) iff (always a));
+  p0: assert property ((always a) iff (always a));
   p1: assert property ((eventually[0:1] a) iff (eventually[0:1] a));
-  // p2: assert property ((s_eventually a) iff (s_eventually a));
+  p2: assert property ((s_eventually a) iff (s_eventually a));
   p3: assert property ((a until b) iff (a until b));
   // p4: assert property ((a s_until b) iff (a s_until a));
   p5: assert property ((a until_with b) iff (a until_with b));

--- a/regression/verilog/SVA/sva_implies2.desc
+++ b/regression/verilog/SVA/sva_implies2.desc
@@ -1,5 +1,5 @@
 CORE
-eventually4.sv
+sva_implies2.sv
 --bound 2
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/verilog/SVA/sva_implies2.sv
+++ b/regression/verilog/SVA/sva_implies2.sv
@@ -1,0 +1,12 @@
+module main(input a, b);
+
+  p0: assert property ((always a) implies (always a));
+  p1: assert property ((a or (always b)) implies (a or (always b)));
+  p2: assert property ((eventually[0:1] a) implies (eventually[0:1] a));
+  p3: assert property ((s_eventually a) implies (s_eventually a));
+  p4: assert property ((a until b) implies (a until b));
+  // p5: assert property ((a s_until b) implies (a s_until a));
+  p6: assert property ((a until_with b) implies (a until_with b));
+  p7: assert property ((a s_until_with b) implies (a s_until_with a));
+
+endmodule

--- a/src/temporal-logic/normalize_property.cpp
+++ b/src/temporal-logic/normalize_property.cpp
@@ -91,8 +91,8 @@ exprt normalize_property_rec(exprt expr)
   }
   else if(expr.id() == ID_sva_cycle_delay_plus)
   {
-    expr = sva_s_eventually_exprt{
-      sva_s_nexttime_exprt{to_sva_cycle_delay_plus_expr(expr).op()}};
+    expr = sva_s_nexttime_exprt{
+      sva_s_eventually_exprt{to_sva_cycle_delay_plus_expr(expr).op()}};
   }
   else if(expr.id() == ID_sva_cycle_delay_star)
   {


### PR DESCRIPTION
This changes the word-level BMC encoding for Fφ properties to remove counterexample traces that exhibit the following:
    
1) a ¬φ loop,
2) followed by one or more φ states.
    
While these traces demonstrate that a counterexample exists (constructed by simply expanding the ¬φ loop), they are not themselves counterexamples to Fφ.