### PR TITLE
Verilog: fix for implicit nets for port connections

### DIFF
--- a/regression/verilog/nets/implicit2.sv
+++ b/regression/verilog/nets/implicit2.sv
@@ -1,9 +1,11 @@
 module main;
 
-  // implicit nets are allowed in the port connection list of a module
+  // Implicit nets are allowed in the port connection list of a module.
+  // The type of the implicit net is _not_ the type of the port,
+  // but an "implicit scalar net of default net type".
   and [3:0] (O, A, B);
 
   always assert final (O == (A & B));
-  always assert final ($bits(O) == 4);
+  always assert final ($bits(O) == 1);
 
 endmodule

--- a/regression/verilog/nets/implicit6.sv
+++ b/regression/verilog/nets/implicit6.sv
@@ -2,9 +2,11 @@ module main;
 
   parameter P = 2;
 
-  // implicit nets are allowed in the port connection list of a module
+  // Implicit nets are allowed in the port connection list of a module.
+  // The type of the implicit net is _not_ the type of the port,
+  // but an "implicit scalar net of default net type".
   and [P:0] (O, A, B);
 
-  assert final ($bits(O) == P+1);
+  assert final ($bits(O) == 1);
 
 endmodule

--- a/regression/verilog/nets/implicit7.sv
+++ b/regression/verilog/nets/implicit7.sv
@@ -5,10 +5,11 @@ module main;
   // implicit nets are allowed in the port connection list of a module
   sub #(P) my_sub(x);
 
-  // The type of the implict net could be used to define another parameter
+  // The type of the implicit net is _not_ the type of the port,
+  // but an "implicit scalar net of default net type".
   parameter Q = $bits(x);
 
-  assert final (Q == P + 1);
+  assert final (Q == 1);
 
 endmodule
 

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -60,7 +60,9 @@ void verilog_typecheckt::typecheck_port_connection(
     // used in a port connection.
     if(op.id() == ID_symbol)
     {
-      op = convert_symbol(to_symbol_expr(op), port.type());
+      // The type of the implicit net is _not_ the type of the port,
+      // but an "implicit scalar net of default net type".
+      op = convert_symbol(to_symbol_expr(op), bool_typet{});
     }
     else
     {
@@ -242,7 +244,9 @@ void verilog_typecheckt::typecheck_builtin_port_connections(
     // used in a port connection.
     if(connection.id() == ID_symbol)
     {
-      connection = convert_symbol(to_symbol_expr(connection), type);
+      // The type of the implicit net is _not_ the type of the port,
+      // but an "implicit scalar net of default net type".
+      connection = convert_symbol(to_symbol_expr(connection), bool_typet{});
     }
     else
     {


### PR DESCRIPTION
The type of the implicit net created for a port connection is _not_ the type of the port, but an "implicit scalar net of default net type".