### PR TITLE
ebmc: hard error when giving an unknown property ID

### DIFF
--- a/regression/ebmc/CLI/property-not-found1.desc
+++ b/regression/ebmc/CLI/property-not-found1.desc
@@ -1,0 +1,7 @@
+CORE
+property-not-found1.sv
+--property main.something
+^error: Property main\.something not found$
+^EXIT=6$
+^SIGNAL=0$
+--

--- a/regression/ebmc/CLI/property-not-found1.sv
+++ b/regression/ebmc/CLI/property-not-found1.sv
@@ -1,0 +1,5 @@
+module main;
+
+  p0: assert final (0);
+
+endmodule

--- a/src/ebmc/ebmc_properties.cpp
+++ b/src/ebmc/ebmc_properties.cpp
@@ -102,7 +102,7 @@ ebmc_propertiest ebmc_propertiest::from_transition_system(
   return properties;
 }
 
-bool ebmc_propertiest::select_property(
+void ebmc_propertiest::select_property(
   const cmdlinet &cmdline,
   message_handlert &message_handler)
 {
@@ -126,15 +126,8 @@ bool ebmc_propertiest::select_property(
       }
 
     if(!found)
-    {
-      messaget message(message_handler);
-      message.error() << "Property " << property << " not found"
-                      << messaget::eom;
-      return true;
-    }
+      throw ebmc_errort() << "Property " << property << " not found";
   }
-
-  return false;
 }
 
 ebmc_propertiest ebmc_propertiest::from_command_line(

--- a/src/ebmc/ebmc_properties.h
+++ b/src/ebmc/ebmc_properties.h
@@ -195,7 +195,9 @@ public:
   static ebmc_propertiest
   from_transition_system(const transition_systemt &, message_handlert &);
 
-  bool select_property(const cmdlinet &, message_handlert &);
+  /// Implements --property ID.
+  /// Throws when given an unknown identifier.
+  void select_property(const cmdlinet &, message_handlert &);
 
   /// a map from property identifier to normalized expression
   std::map<irep_idt, exprt> make_property_map() const


### PR DESCRIPTION
When giving an unknown property ID to `--property`, abort, as opposed to continuing with an empty set of properties.