### PR TITLE
Verilog: aval/bval lowering for casts to Bool

### DIFF
--- a/regression/verilog/SVA/sequence5.desc
+++ b/regression/verilog/SVA/sequence5.desc
@@ -1,14 +1,12 @@
-KNOWNBUG
+CORE broken-smt-backend
 sequence5.sv
 --bound 0
 ^\[main\.p0\] 1: PROVED up to bound 0$
 ^\[main\.p1\] 0: REFUTED$
-^\[main\.p2\] 1'bx: PROVED up to bound 0$
-^\[main\.p3\] 1'bz: PROVED up to bound 0$
+^\[main\.p2\] 1'bx: REFUTED$
+^\[main\.p3\] 1'bz: REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-x and z are recognized as 'true', but 'true' is defined as a "nonzero known
-value" (1800-2017 12.4).

--- a/regression/verilog/SVA/sva_and1.desc
+++ b/regression/verilog/SVA/sva_and1.desc
@@ -3,7 +3,7 @@ sva_and1.sv
 --bound 0
 ^\[main\.p0\] always \(1 and 1\): PROVED up to bound 0$
 ^\[main\.p1\] always \(1 and 0\): REFUTED$
-^\[main\.p2\] always \(1 and 32'b0000000000000000000000000000000x\): PROVED up to bound 0$
+^\[main\.p2\] always \(1 and 32'b0000000000000000000000000000000x\): REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/sva_iff1.desc
+++ b/regression/verilog/SVA/sva_iff1.desc
@@ -3,7 +3,7 @@ sva_iff1.sv
 --bound 0
 ^\[main\.p0\] always \(1 iff 1\): PROVED up to bound 0$
 ^\[main\.p1\] always \(1 iff 0\): REFUTED$
-^\[main\.p2\] always \(1 iff 32'b0000000000000000000000000000000x\): PROVED up to bound 0$
+^\[main\.p2\] always \(1 iff 32'b0000000000000000000000000000000x\): REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/sva_implies1.desc
+++ b/regression/verilog/SVA/sva_implies1.desc
@@ -3,7 +3,7 @@ sva_implies1.sv
 --bound 0
 ^\[main\.p0\] always \(1 implies 1\): PROVED up to bound 0$
 ^\[main\.p1\] always \(1 implies 0\): REFUTED$
-^\[main\.p2\] always \(1 implies 32'b0000000000000000000000000000000x\): PROVED up to bound 0$
+^\[main\.p2\] always \(1 implies 32'b0000000000000000000000000000000x\): REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/src/verilog/aval_bval_encoding.h
+++ b/src/verilog/aval_bval_encoding.h
@@ -24,7 +24,9 @@ Author: Daniel Kroening, dkr@amazon.com
 //   1    1  |   Z
 
 bool is_four_valued(const typet &);
+bool is_four_valued(const exprt &);
 bool is_aval_bval(const typet &);
+bool is_aval_bval(const exprt &);
 std::size_t aval_bval_width(const typet &);
 typet aval_bval_underlying(const typet &);
 
@@ -50,5 +52,7 @@ exprt aval_bval(const verilog_wildcard_equality_exprt &);
 exprt aval_bval(const verilog_wildcard_inequality_exprt &);
 /// lowering for **
 exprt aval_bval(const power_exprt &);
+/// lowering for typecasts
+exprt aval_bval(const typecast_exprt &);
 
 #endif

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -304,6 +304,13 @@ exprt verilog_synthesist::synth_expr(exprt expr, symbol_statet symbol_state)
   }
   else if(expr.id()==ID_typecast)
   {
+    // When casting a four-valued scalar to bool,
+    // 'true' is defined as a "nonzero known value" (1800-2017 12.4).
+    if(is_aval_bval(to_typecast_expr(expr).op()) && expr.type().id() == ID_bool)
+    {
+      expr = aval_bval(to_typecast_expr(expr));
+    }
+    else
     {
       auto &op = to_typecast_expr(expr).op();
 


### PR DESCRIPTION
This implements casing four-valued ava/bval encoded cast to Bool.  In particular, values containing `x` or `z` cast to false, not true.