### PR TITLE
SystemVerilog: add tests for `const`

### DIFF
--- a/regression/verilog/const/const1.sv
+++ b/regression/verilog/const/const1.sv
@@ -1,5 +1,10 @@
-module main;
+module main(input i);
+
+  // 1800 2017 6.20.6
   const bit my_true2 = 1;
   const var my_true3 = 1;
-  const logic my_true4 = 1;
+
+  // the value on the RHS does _not_ need to be constant
+  const logic my_true4 = i;
+
 endmodule

--- a/regression/verilog/const/const2.desc
+++ b/regression/verilog/const/const2.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+const2.sv
+
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Should be rejected owing to assignment to const variable.

--- a/regression/verilog/const/const2.sv
+++ b/regression/verilog/const/const2.sv
@@ -1,0 +1,11 @@
+module main(input clk, input [31:0] data);
+
+  // The value need not be constant.
+  const reg [31:0] data_const = data;
+
+  // 1800 2017 6.20.6
+  always @(posedge clk)
+    // But can't assign to it.
+    data_const = 123;
+
+endmodule


### PR DESCRIPTION
This adds tests for 1800 2017 6.20.6 `const`.