### PR TITLE
Verilog: fix string generated for indexed part select

### DIFF
--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -793,6 +793,8 @@ expr2verilogt::resultt expr2verilogt::convert_indexed_part_select(
   else
     dest += '-';
 
+  dest += ':';
+
   dest += convert_rec(src.width()).s;
   dest += ']';
 


### PR DESCRIPTION
The `:` is missing.