### PR TITLE
Verilog: grammar for combinational UDPs

### DIFF
--- a/regression/verilog/UDPs/multiplexer1.desc
+++ b/regression/verilog/UDPs/multiplexer1.desc
@@ -1,0 +1,7 @@
+CORE
+multiplexer1.sv
+--bound 0 --module main
+^no properties$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/verilog/UDPs/multiplexer1.sv
+++ b/regression/verilog/UDPs/multiplexer1.sv
@@ -1,0 +1,25 @@
+// 1800-2017 29.4
+primitive multiplexer (mux, control, dataA, dataB);
+   output mux;
+   input control, dataA, dataB;
+   table
+   // control  dataA  dataB   mux
+         0       1      0   :  1 ;
+         0       1      1   :  1 ;
+         0       1      x   :  1 ;
+         0       0      0   :  0 ;
+         0       0      1   :  0 ;
+         0       0      x   :  0 ;
+         1       0      1   :  1 ;
+         1       1      1   :  1 ;
+         1       x      1   :  1 ;
+         1       0      0   :  0 ;
+         1       1      0   :  0 ;
+         1       x      0   :  0 ;
+         x       0      0   :  0 ;
+         x       1      1   :  1 ;
+   endtable
+endprimitive
+
+module main;
+endmodule


### PR DESCRIPTION
This adds the 1800-2017 grammar for user-defined combinational primitives.