### PR TITLE
Verilog: zero_extend now considers genvar

### DIFF
--- a/regression/verilog/system-functions/low1.desc
+++ b/regression/verilog/system-functions/low1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE broken-smt-backend
 low1.sv
 --module main --bound 0
 ^EXIT=0$
@@ -6,4 +6,3 @@ low1.sv
 --
 ^warning: ignoring
 --
-This yields an error in the typechecker.

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -2351,8 +2351,9 @@ Function: zero_extend
 
 static exprt zero_extend(const exprt &expr, const typet &type)
 {
-  auto old_width = expr.type().id() == ID_bool
-                     ? 1
+  auto old_width = expr.type().id() == ID_bool ? 1
+                   : expr.type().id() == ID_integer
+                     ? 32
                      : to_bitvector_type(expr.type()).get_width();
 
   // first make unsigned


### PR DESCRIPTION
zero_extend now handles genvar-typed variables.