### PR TITLE
Verilog: lowering for four-valued zero-extend

### DIFF
--- a/regression/verilog/expressions/equality4.desc
+++ b/regression/verilog/expressions/equality4.desc
@@ -1,9 +1,8 @@
-KNOWNBUG
-equality4.v
+CORE
+equality4.sv
 
 ^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-zero_extend doesn't work for four-valued operands.

--- a/src/verilog/aval_bval_encoding.cpp
+++ b/src/verilog/aval_bval_encoding.cpp
@@ -537,6 +537,25 @@ exprt aval_bval(const shift_exprt &expr)
   return if_exprt{distance_has_xz, x, combined};
 }
 
+exprt aval_bval(const zero_extend_exprt &expr)
+{
+  PRECONDITION(is_four_valued(expr));
+
+  auto expr_aval_bval_type = lower_to_aval_bval(expr.type());
+
+  // zero-extend aval and bval separately!
+  auto op_aval = aval(expr.op());
+  auto op_bval = bval(expr.op());
+
+  auto aval_ext_width = aval_bval_width(expr_aval_bval_type);
+  auto ext_type = bv_typet{aval_ext_width};
+
+  auto aval_extended = zero_extend_exprt{op_aval, ext_type};
+  auto bval_extended = zero_extend_exprt{op_bval, ext_type};
+
+  return combine_aval_bval(aval_extended, bval_extended, expr_aval_bval_type);
+}
+
 exprt default_aval_bval_lowering(const exprt &expr)
 {
   auto &type = expr.type();

--- a/src/verilog/aval_bval_encoding.h
+++ b/src/verilog/aval_bval_encoding.h
@@ -67,6 +67,8 @@ exprt aval_bval(const verilog_implies_exprt &);
 exprt aval_bval(const typecast_exprt &);
 /// lowering for shifts
 exprt aval_bval(const shift_exprt &);
+/// lowering for zero extension
+exprt aval_bval(const zero_extend_exprt &);
 
 /// If any operand has x/z, then the result is 'x'.
 /// Otherwise, the result is the expression applied to the aval

--- a/src/verilog/verilog_lowering.cpp
+++ b/src/verilog/verilog_lowering.cpp
@@ -650,6 +650,20 @@ exprt verilog_lowering(exprt expr)
     else
       return expr;
   }
+  else if(expr.id() == ID_zero_extend)
+  {
+    auto &zero_extend = to_zero_extend_expr(expr);
+
+    if(
+      is_four_valued(zero_extend.type()) ||
+      is_four_valued(zero_extend.op().type()))
+    {
+      // encode into aval/bval
+      return aval_bval(zero_extend);
+    }
+    else
+      return expr; // leave as is
+  }
   else
     return expr; // leave as is
 


### PR DESCRIPTION
This adds a lowering for `zero_extend` expressions for four-valued operands.