### PR TITLE
emcc build: `-sALLOW_MEMORY_GROWTH=1`

### DIFF
--- a/.github/workflows/ebmc-release.yaml
+++ b/.github/workflows/ebmc-release.yaml
@@ -264,7 +264,7 @@ jobs:
           make -C src -j4 \
                BUILD_ENV=Unix \
                CXX="ccache emcc -fwasm-exceptions" \
-               LINKFLAGS="-sEXPORTED_RUNTIME_METHODS=callMain" \
+               LINKFLAGS="-sEXPORTED_RUNTIME_METHODS=callMain -sALLOW_MEMORY_GROWTH=1" \
                LINKLIB="emar rc \$@ \$^" \
                AR="emar" \
                EXEEXT=".html" \

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -324,7 +324,7 @@ jobs:
           make -C src -j4 \
                BUILD_ENV=Unix \
                CXX="ccache emcc -fwasm-exceptions" \
-               LINKFLAGS="-sEXPORTED_RUNTIME_METHODS=callMain" \
+               LINKFLAGS="-sEXPORTED_RUNTIME_METHODS=callMain -sALLOW_MEMORY_GROWTH=1" \
                LINKLIB="emar rc \$@ \$^" \
                AR="emar" \
                EXEEXT=".html" \
@@ -338,7 +338,7 @@ jobs:
           make -C unit unit_tests.html -j4 \
                BUILD_ENV=Unix \
                CXX="ccache emcc -fwasm-exceptions" \
-               LINKFLAGS="-sEXPORTED_RUNTIME_METHODS=callMain" \
+               LINKFLAGS="-sEXPORTED_RUNTIME_METHODS=callMain -sALLOW_MEMORY_GROWTH=1" \
                LINKLIB="emar rc \$@ \$^" \
                AR="emar" \
                EXEEXT=".html" \


### PR DESCRIPTION
This allows the emcc-generated code to request additional memory from the browser, as opposed to aborting with an error message.