### PR TITLE
Strengthen ring_buffer induction test

### DIFF
--- a/regression/ebmc/k-induction/ring_buffer.desc
+++ b/regression/ebmc/k-induction/ring_buffer.desc
@@ -1,0 +1,10 @@
+CORE
+ring_buffer.sv
+--k-induction
+^\[ring_buffer\.assume\.1\] always \(ring_buffer\.empty \|-> !ring_buffer\.read\): ASSUMED$
+^\[ring_buffer\.assume\.2\] always \(ring_buffer\.full \|-> !ring_buffer\.write\): ASSUMED$
+^\[ring_buffer\.p0\] always \(ring_buffer\.writeptr - ring_buffer\.readptr & 15\) == ring_buffer\.count\[3:0\]: PROVED$
+^\[ring_buffer\.p1\] always ring_buffer\.count <= 16: PROVED$
+^\[ring_buffer\.p2\] always ring_buffer.count != 17: INCONCLUSIVE$
+^EXIT=10$
+^SIGNAL=0$

--- a/regression/ebmc/k-induction/ring_buffer.sv
+++ b/regression/ebmc/k-induction/ring_buffer.sv
@@ -16,13 +16,14 @@ module ring_buffer(input clk, input read, input write);
 
   end
 
-  wire full=count==15;
+  wire full=count==16;
   wire empty=count==0;
 
   assume property (empty |-> !read);
   assume property (full |-> !write);
 
-  assert property (((writeptr-readptr)&'b1111)==count);
+  p0: assert property (((writeptr-readptr)&'b1111)==count[3:0]);
+  p1: assert property (count <= 16);
+  p2: assert property (count != 17);
 
 endmodule
-

--- a/regression/ebmc/ring_buffer_induction/test.desc
+++ b/regression/ebmc/ring_buffer_induction/test.desc
@@ -1,8 +1,0 @@
-CORE
-ring_buffer.sv
---k-induction
-^\[ring_buffer\.assert\.1\] assume always \(ring_buffer\.empty |-> !ring_buffer\.read\): ASSUMED$
-^\[ring_buffer\.assert\.2\] assume always \(ring_buffer\.full |-> !ring_buffer\.write\): ASSUMED$
-^\[ring_buffer\.assert\.3\] always \(ring_buffer\.writeptr - ring_buffer\.readptr & 15\) == ring_buffer\.count: PROVED$
-^EXIT=0$
-^SIGNAL=0$


### PR DESCRIPTION
The property that is checked can be strengthened by allowing the ring buffer to hold 16 elements, as opposed to just 15.