### PR TITLE
Verilog: fix precedence of function calls

### DIFF
--- a/regression/verilog/system-functions/past1.aig.desc
+++ b/regression/verilog/system-functions/past1.aig.desc
@@ -1,7 +1,7 @@
 CORE
 past1.sv
 --aig
-^\[main\.p0\] ##0 \(\$past\(main\.counter, 0\)\) == 0: FAILURE: property not supported by netlist BMC engine$
+^\[main\.p0\] ##0 \$past\(main\.counter, 0\) == 0: FAILURE: property not supported by netlist BMC engine$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/past1.bdd.desc
+++ b/regression/verilog/system-functions/past1.bdd.desc
@@ -1,7 +1,7 @@
 CORE
 past1.sv
 --bdd
-^\[main\.p0\] ##0 \(\$past\(main\.counter, 0\)\) == 0: FAILURE: property not supported by BDD engine$
+^\[main\.p0\] ##0 \$past\(main\.counter, 0\) == 0: FAILURE: property not supported by BDD engine$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/past2.desc
+++ b/regression/verilog/system-functions/past2.desc
@@ -1,7 +1,7 @@
 CORE
 past2.sv
 --bdd
-^\[main\.p0\] always \(main\.counter == 0 \|-> \(\$past\(main\.counter, 1\)\) == 0\): FAILURE: property not supported by BDD engine$
+^\[main\.p0\] always \(main\.counter == 0 \|-> \$past\(main\.counter, 1\) == 0\): FAILURE: property not supported by BDD engine$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -354,7 +354,7 @@ expr2verilogt::convert_function_call(const function_call_exprt &src)
 
   dest+=")";
 
-  return {verilog_precedencet::MIN, dest};
+  return {verilog_precedencet::MEMBER, dest};
 }
 
 /*******************************************************************\


### PR DESCRIPTION
Function calls bind strongly, and not weakly.