### PR TITLE
Verilog: fix precedence of typecasts

### DIFF
--- a/regression/verilog/system-functions/past1.aig.desc
+++ b/regression/verilog/system-functions/past1.aig.desc
@@ -1,7 +1,7 @@
 CORE
 past1.sv
 --aig
-^\[main\.p0\] ##0 \(\$past\(main\.counter, 0\)\) == 0: FAILURE: property not supported by netlist BMC engine$
+^\[main\.p0\] ##0 \$past\(main\.counter, 0\) == 0: FAILURE: property not supported by netlist BMC engine$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/past1.bdd.desc
+++ b/regression/verilog/system-functions/past1.bdd.desc
@@ -1,7 +1,7 @@
 CORE
 past1.sv
 --bdd
-^\[main\.p0\] ##0 \(\$past\(main\.counter, 0\)\) == 0: FAILURE: property not supported by BDD engine$
+^\[main\.p0\] ##0 \$past\(main\.counter, 0\) == 0: FAILURE: property not supported by BDD engine$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/past2.desc
+++ b/regression/verilog/system-functions/past2.desc
@@ -1,7 +1,7 @@
 CORE
 past2.sv
 --bdd
-^\[main\.p0\] always \(main\.counter == 0 \|-> \(\$past\(main\.counter, 1\)\) == 0\): FAILURE: property not supported by BDD engine$
+^\[main\.p0\] always \(main\.counter == 0 \|-> \$past\(main\.counter, 1\) == 0\): FAILURE: property not supported by BDD engine$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -675,9 +675,8 @@ Function: expr2verilogt::convert_typecast
 
 \*******************************************************************/
 
-expr2verilogt::resultt expr2verilogt::convert_typecast(
-  const typecast_exprt &src,
-  verilog_precedencet &precedence)
+expr2verilogt::resultt
+expr2verilogt::convert_typecast(const typecast_exprt &src)
 {
   if(src.operands().size()==1)
   {
@@ -685,9 +684,10 @@ expr2verilogt::resultt expr2verilogt::convert_typecast(
     //const typet &to=src.type();
 
     // just ignore them for now
-    return {precedence, convert_rec(src.op()).s};
+    return convert_rec(src.op());
   }
 
+  verilog_precedencet precedence;
   return convert_norep(src, precedence);
 }
 
@@ -1380,7 +1380,7 @@ expr2verilogt::resultt expr2verilogt::convert_rec(const exprt &src)
       to_bitnot_expr(src), "~", precedence = verilog_precedencet::NOT);
 
   else if(src.id()==ID_typecast)
-    return convert_typecast(to_typecast_expr(src), precedence);
+    return convert_typecast(to_typecast_expr(src));
 
   else if(src.id()==ID_and)
     return convert_binary(

--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -354,7 +354,7 @@ expr2verilogt::convert_function_call(const function_call_exprt &src)
 
   dest+=")";
 
-  return {verilog_precedencet::MIN, dest};
+  return {verilog_precedencet::MEMBER, dest};
 }
 
 /*******************************************************************\

--- a/src/verilog/expr2verilog_class.h
+++ b/src/verilog/expr2verilog_class.h
@@ -105,7 +105,7 @@ protected:
 
   resultt convert_constant(const constant_exprt &, verilog_precedencet &);
 
-  resultt convert_typecast(const typecast_exprt &, verilog_precedencet &);
+  resultt convert_typecast(const typecast_exprt &);
 
   resultt
   convert_concatenation(const concatenation_exprt &, verilog_precedencet);


### PR DESCRIPTION
These are skipped, so need to have the precedence of the operand.