### PR TITLE
Verilog: conversion for real literals

### DIFF
--- a/regression/verilog/expressions/real-index.sv
+++ b/regression/verilog/expressions/real-index.sv
@@ -2,6 +2,6 @@ module main;
 
   // 1800-2017 6.12.1
   reg [7:0] vector;
-  wire x = vector[real'(1.5)];
+  wire x = vector[1.5];
 
 endmodule

--- a/regression/verilog/system-functions/typename1.sv
+++ b/regression/verilog/system-functions/typename1.sv
@@ -9,6 +9,9 @@ module main;
   assert final ($typename(vector1)=="bit[31:0]");
   assert final ($typename(vector2)=="bit[0:31]");
   assert final ($typename(vector3)=="bit signed[31:0]");
+  assert final ($typename(real'(1))=="real");
+  assert final ($typename(shortreal'(1))=="shortreal");
+  assert final ($typename(realtime'(1))=="realtime");
 
   // $typename yields an elaboration-time constant
   parameter P = $typename(some_bit);

--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/ieee_float.h>
 #include <util/lispexpr.h>
 #include <util/lispirep.h>
 #include <util/namespace.h>
@@ -1119,6 +1120,14 @@ expr2verilogt::resultt expr2verilogt::convert_constant(
     // these have a decimal representation
     const irep_idt &value = src.get_value();
     dest=id2string(value);
+  }
+  else if(type.id() == ID_verilog_real)
+  {
+    constant_exprt tmp = src;
+    tmp.type() = ieee_float_spect::double_precision().to_type();
+    ieee_floatt ieee_float;
+    ieee_float.from_expr(tmp);
+    return {precedence, ieee_float.to_ansi_c_string()};
   }
   else
     return convert_norep(src, precedence);

--- a/src/verilog/vtype.cpp
+++ b/src/verilog/vtype.cpp
@@ -63,10 +63,15 @@ vtypet::vtypet(const typet &type)
     vtype=VERILOG_UNSIGNED;
     width=to_verilog_unsignedbv_type(type).get_width();
   }
-  else if(type.id()==ID_verilog_realtime)
+  else if(type.id() == ID_verilog_realtime || type.id() == ID_verilog_real)
   {
-    vtype=VERILOG_REALTIME;
-    width=0;
+    vtype = VERILOG_REAL;
+    width = 64;
+  }
+  else if(type.id() == ID_verilog_shortreal)
+  {
+    vtype = VERILOG_REAL;
+    width = 32;
   }
   else 
   {
@@ -109,8 +114,8 @@ std::ostream &operator << (std::ostream &out, const vtypet &vtype)
   case vtypet::BOOL:
     return out << "bool";
 
-  case vtypet::VERILOG_REALTIME:
-    return out << "bool";
+  case vtypet::VERILOG_REAL:
+    return out << "real";
 
   case vtypet::UNKNOWN:
   case vtypet::OTHER:

--- a/src/verilog/vtype.h
+++ b/src/verilog/vtype.h
@@ -27,13 +27,25 @@ public:
   inline bool is_integer() const { return vtype==INTEGER; }
   inline bool is_verilog_signed() const { return vtype==VERILOG_SIGNED; }
   inline bool is_verilog_unsigned() const { return vtype==VERILOG_UNSIGNED; }
-  inline bool is_verilog_realtime() const { return vtype==VERILOG_REALTIME; }
+  inline bool is_verilog_real() const
+  {
+    return vtype == VERILOG_REAL;
+  }
   inline bool is_other() const { return vtype==OTHER; }
 
 protected:
-  typedef enum { UNKNOWN, BOOL, SIGNED, UNSIGNED, INTEGER,
-                 VERILOG_SIGNED, VERILOG_UNSIGNED, 
-                 VERILOG_REALTIME, OTHER } _vtypet;
+  typedef enum
+  {
+    UNKNOWN,
+    BOOL,
+    SIGNED,
+    UNSIGNED,
+    INTEGER,
+    VERILOG_SIGNED,
+    VERILOG_UNSIGNED,
+    VERILOG_REAL,
+    OTHER
+  } _vtypet;
   _vtypet vtype;
   unsigned width;
   


### PR DESCRIPTION
This adds conversion for real-typed literals, represented as IEEE double precision.