### PR TITLE
Verilog: lowering for four-valued `<->`

### DIFF
--- a/regression/verilog/expressions/equality1.desc
+++ b/regression/verilog/expressions/equality1.desc
@@ -11,6 +11,8 @@ equality1.v
 ^\[.*\] always 32'b0000000000000000000000000000000z != 20 === 32'b0000000000000000000000000000000x: PROVED up to bound 0$
 ^\[.*\] always 1'sb1 == 2'b11 === 0: PROVED up to bound 0$
 ^\[.*\] always 2'sb11 == 2'sb11 === 1: PROVED up to bound 0$
+^\[.*\] always 1\.1 == 1\.1 == 1: PROVED up to bound 0$
+^\[.*\] always 1\.1 == 1 == 0: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/equality1.v
+++ b/regression/verilog/expressions/equality1.v
@@ -10,5 +10,7 @@ module main;
   always assert property08: ('bz!=20)==='bx;
   always assert property09: (1'sb1==2'b11)===0; // zero extension
   always assert property10: (1'sb1==2'sb11)===1; // sign extension
+  always assert property11: ((1.1==1.1)==1);
+  always assert property12: ((1.1==1)==0);
 
 endmodule

--- a/regression/verilog/expressions/iff1.desc
+++ b/regression/verilog/expressions/iff1.desc
@@ -1,0 +1,7 @@
+CORE broken-smt-backend
+iff1.sv
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/expressions/iff1.sv
+++ b/regression/verilog/expressions/iff1.sv
@@ -1,0 +1,13 @@
+module main;
+
+  // logical equivalence
+  // 1800-2017 11.4.7
+  property1: assert final ((1<->1)===1);
+  property2: assert final ((1<->2)===1);
+  property3: assert final ((1<->0)===0);
+  property4: assert final ((0<->0)===1);
+  property5: assert final ((3.145<->1)===1); // works on real
+  property6: assert final ((1'b1<->1'bx)===1'bx);
+  property7: assert final ((2'bxx<->2'bxx)===1'bx);
+
+endmodule

--- a/src/verilog/aval_bval_encoding.h
+++ b/src/verilog/aval_bval_encoding.h
@@ -52,6 +52,8 @@ exprt aval_bval(const verilog_wildcard_equality_exprt &);
 exprt aval_bval(const verilog_wildcard_inequality_exprt &);
 /// lowering for **
 exprt aval_bval(const power_exprt &);
+/// lowering for <->
+exprt aval_bval(const verilog_iff_exprt &);
 /// lowering for typecasts
 exprt aval_bval(const typecast_exprt &);
 

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -153,6 +153,30 @@ to_verilog_wildcard_inequality_expr(exprt &expr)
   return static_cast<verilog_wildcard_inequality_exprt &>(expr);
 }
 
+/// <->, not to be confused with SVA iff
+class verilog_iff_exprt : public binary_exprt
+{
+public:
+  verilog_iff_exprt(exprt lhs, exprt rhs)
+    : binary_exprt{std::move(lhs), ID_verilog_iff, std::move(rhs), bool_typet{}}
+  {
+  }
+};
+
+inline const verilog_iff_exprt &to_verilog_iff_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_verilog_iff);
+  binary_exprt::check(expr);
+  return static_cast<const verilog_iff_exprt &>(expr);
+}
+
+inline verilog_iff_exprt &to_verilog_iff_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_verilog_iff);
+  binary_exprt::check(expr);
+  return static_cast<verilog_iff_exprt &>(expr);
+}
+
 class function_call_exprt : public binary_exprt
 {
 public:

--- a/src/verilog/verilog_lowering.cpp
+++ b/src/verilog/verilog_lowering.cpp
@@ -320,6 +320,24 @@ exprt verilog_lowering(exprt expr)
     else
       return expr; // leave as is
   }
+  else if(expr.id() == ID_verilog_iff)
+  {
+    auto &iff = to_verilog_iff_expr(expr);
+
+    if(is_four_valued(iff.type()))
+    {
+      // encode into aval/bval
+      return aval_bval(iff);
+    }
+    else
+    {
+      auto lhs_boolean =
+        typecast_exprt::conditional_cast(iff.lhs(), bool_typet{});
+      auto rhs_boolean =
+        typecast_exprt::conditional_cast(iff.rhs(), bool_typet{});
+      return equal_exprt{lhs_boolean, rhs_boolean};
+    }
+  }
   else
     return expr; // leave as is
 

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -2682,9 +2682,7 @@ exprt verilog_typecheck_exprt::convert_binary_expr(binary_exprt expr)
     return convert_bit_select_expr(to_binary_expr(expr));
   else if(expr.id()==ID_replication)
     return convert_replication_expr(to_replication_expr(expr));
-  else if(
-    expr.id() == ID_and || expr.id() == ID_or || expr.id() == ID_verilog_iff ||
-    expr.id() == ID_implies)
+  else if(expr.id() == ID_and || expr.id() == ID_or || expr.id() == ID_implies)
   {
     Forall_operands(it, expr)
     {
@@ -2693,6 +2691,27 @@ exprt verilog_typecheck_exprt::convert_binary_expr(binary_exprt expr)
     }
 
     expr.type()=bool_typet();
+
+    return std::move(expr);
+  }
+  else if(expr.id() == ID_verilog_iff)
+  {
+    // 1800 2017 11.4.7 Logical operators
+    convert_expr(expr.lhs());
+    convert_expr(expr.rhs());
+
+    // This returns 'x' if either of the operands contains x or z.
+    if(
+      expr.lhs().type().id() == ID_verilog_signedbv ||
+      expr.lhs().type().id() == ID_verilog_unsignedbv ||
+      expr.rhs().type().id() == ID_verilog_signedbv ||
+      expr.rhs().type().id() == ID_verilog_unsignedbv)
+    {
+      // Four-valued case.
+      expr.type() = verilog_unsignedbv_typet{1};
+    }
+    else // Two-valued case.
+      expr.type() = bool_typet{};
 
     return std::move(expr);
   }


### PR DESCRIPTION
This adds a lowering for Verilog's `<->` iff expression, with four-valued semantics.