### PR TITLE
Verilog: lowering for `real`/`shortreal`/`realtime`

### DIFF
--- a/regression/verilog/expressions/equality1.desc
+++ b/regression/verilog/expressions/equality1.desc
@@ -11,6 +11,8 @@ equality1.v
 ^\[.*\] always 32'b0000000000000000000000000000000z != 20 === 32'b0000000000000000000000000000000x: PROVED up to bound 0$
 ^\[.*\] always 1'sb1 == 2'b11 === 0: PROVED up to bound 0$
 ^\[.*\] always 2'sb11 == 2'sb11 === 1: PROVED up to bound 0$
+^\[.*\] always 1\.1 == 1\.1 == 1: PROVED up to bound 0$
+^\[.*\] always 1\.1 == 1 == 0: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/equality1.v
+++ b/regression/verilog/expressions/equality1.v
@@ -10,5 +10,7 @@ module main;
   always assert property08: ('bz!=20)==='bx;
   always assert property09: (1'sb1==2'b11)===0; // zero extension
   always assert property10: (1'sb1==2'sb11)===1; // sign extension
+  always assert property11: ((1.1==1.1)==1);
+  always assert property12: ((1.1==1)==0);
 
 endmodule


### PR DESCRIPTION
This lowers Verilog's `real`/`shortreal`/`realtime` to floatbv.