### PR TITLE
Verilog: use lowering during constant elaboration

### DIFF
--- a/regression/verilog/expressions/constants2.sv
+++ b/regression/verilog/expressions/constants2.sv
@@ -41,12 +41,12 @@ module main;
 //  parameter p37 = 1!==1;
   parameter p38 = 1==1;
   parameter p39 = 1!=1;
-//  parameter p40 = 1==?1;
-//  parameter p41 = 1!=?1;
-//  parameter p42 = 1 inside {1};
+  parameter p40 = 1==?1;
+  parameter p41 = 1!=?1;
+  parameter p42 = 1 inside {1};
   parameter p43 = {1'b1, 1'b0};
   parameter p44 = {2{1'b1}};
-//  parameter p45 = {<<{3'b101}};
-//  parameter p46 = {>>{3'b101}};
+  parameter p45 = {<<{3'b101}};
+  parameter p46 = {>>{3'b101}};
 
 endmodule

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -154,6 +154,7 @@ protected:
   // elaboration (expansion and folding) of constant expressions and functions
   bool is_constant_expression(const exprt &, mp_integer &value);
   std::optional<mp_integer> is_constant_integer_post_convert(const exprt &);
+  exprt elaborate_constant_expression_rec(exprt);
   exprt elaborate_constant_expression(exprt);
   exprt elaborate_constant_expression_check(exprt);
   mp_integer elaborate_constant_integer_expression(exprt);


### PR DESCRIPTION
To avoid code duplication, use `verilog_lower`(...) during constant elaboration.