### PR TITLE
SystemVerilog: KNOWNBUG test for queue

### DIFF
--- a/regression/verilog/data-types/queue1.desc
+++ b/regression/verilog/data-types/queue1.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+queue1.sv
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Parsing fails.

--- a/regression/verilog/data-types/queue1.sv
+++ b/regression/verilog/data-types/queue1.sv
@@ -1,0 +1,6 @@
+module main;
+
+  byte queue_of_bytes[$];
+  string queue_of_strings[$:10] = { "foobar" };
+
+endmodule


### PR DESCRIPTION
SystemVerilog offers queues, and this adds a KNOWNBUG test to track the missing support.