### PR TITLE
Verilog: lowering for `verilog_case_equality`

### DIFF
--- a/regression/verilog/SVA/if1.desc
+++ b/regression/verilog/SVA/if1.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 if1.sv
 --bound 2
 ^\[main\.p0\] always if\(main\.counter == 0\) nexttime main\.counter == 1: PROVED up to bound 2$

--- a/regression/verilog/SVA/immediate2.desc
+++ b/regression/verilog/SVA/immediate2.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 immediate2.sv
 --bound 0
 ^\[main\.assume\.1\] assume always 0: ASSUMED$

--- a/regression/verilog/SVA/sequence5.desc
+++ b/regression/verilog/SVA/sequence5.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 sequence5.sv
 --bound 0
 ^\[main\.p0\] 1: PROVED up to bound 0$

--- a/regression/verilog/case/case3.desc
+++ b/regression/verilog/case/case3.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 case3.v
 --module main --bound 3 --trace
 ^EXIT=10$

--- a/regression/verilog/case/case4.desc
+++ b/regression/verilog/case/case4.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 case4.v
 --module main --bound 1
 ^EXIT=0$

--- a/regression/verilog/expressions/bit-extract1.desc
+++ b/regression/verilog/expressions/bit-extract1.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 bit-extract1.v
 --bound 1
 ^EXIT=0$

--- a/regression/verilog/expressions/bit-extract2.desc
+++ b/regression/verilog/expressions/bit-extract2.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 bit-extract2.v
 --module main --bound 1 --trace
 ^EXIT=10$

--- a/regression/verilog/expressions/concatenation3.desc
+++ b/regression/verilog/expressions/concatenation3.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 concatenation3.sv
 --bound 0
 ^EXIT=0$

--- a/regression/verilog/expressions/equality2.desc
+++ b/regression/verilog/expressions/equality2.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 equality2.v
 --bound 0
 ^\[.*\] always 10 === 10 == 1: PROVED up to bound 0$

--- a/regression/verilog/expressions/iff1.desc
+++ b/regression/verilog/expressions/iff1.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 iff1.sv
 --bound 0
 ^EXIT=0$

--- a/regression/verilog/expressions/implies1.desc
+++ b/regression/verilog/expressions/implies1.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 implies1.sv
 --bound 0
 ^EXIT=0$

--- a/regression/verilog/expressions/negation1.desc
+++ b/regression/verilog/expressions/negation1.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 negation1.sv
 --bound 0
 ^EXIT=0$

--- a/regression/verilog/expressions/signed2.desc
+++ b/regression/verilog/expressions/signed2.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 signed2.sv
 --bound 0
 ^EXIT=0$

--- a/regression/verilog/expressions/wildcard_equality1.desc
+++ b/regression/verilog/expressions/wildcard_equality1.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 wildcard_equality1.sv
 --bound 0
 ^\[main\.property01\] always 10 ==\? 10 === 1: PROVED up to bound 0$

--- a/regression/verilog/modules/ports2.desc
+++ b/regression/verilog/modules/ports2.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 ports2.v
 --module main --bound 1
 ^EXIT=0$

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -108,6 +108,75 @@ to_verilog_logical_inequality_expr(exprt &expr)
   return static_cast<verilog_logical_inequality_exprt &>(expr);
 }
 
+/// ===
+/// returns true if operands are identical
+class verilog_case_equality_exprt : public binary_relation_exprt
+{
+public:
+  verilog_case_equality_exprt(exprt lhs, exprt rhs)
+    : binary_relation_exprt{
+        std::move(lhs),
+        ID_verilog_case_equality,
+        std::move(rhs)}
+  {
+  }
+
+  exprt lower() const
+  {
+    return equal_exprt{lhs(), rhs()};
+  }
+};
+
+inline const verilog_case_equality_exprt &
+to_verilog_case_equality_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_verilog_case_equality);
+  verilog_case_equality_exprt::check(expr);
+  return static_cast<const verilog_case_equality_exprt &>(expr);
+}
+
+inline verilog_case_equality_exprt &to_verilog_case_equality_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_verilog_case_equality);
+  verilog_case_equality_exprt::check(expr);
+  return static_cast<verilog_case_equality_exprt &>(expr);
+}
+
+/// !==
+/// returns true if the operands are different
+class verilog_case_inequality_exprt : public binary_relation_exprt
+{
+public:
+  verilog_case_inequality_exprt(exprt lhs, exprt rhs)
+    : binary_relation_exprt{
+        std::move(lhs),
+        ID_verilog_case_inequality,
+        std::move(rhs)}
+  {
+  }
+
+  exprt lower() const
+  {
+    return notequal_exprt{lhs(), rhs()};
+  }
+};
+
+inline const verilog_case_inequality_exprt &
+to_verilog_case_inequality_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_verilog_case_inequality);
+  verilog_case_inequality_exprt::check(expr);
+  return static_cast<const verilog_case_inequality_exprt &>(expr);
+}
+
+inline verilog_case_inequality_exprt &
+to_verilog_case_inequality_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_verilog_case_inequality);
+  verilog_case_inequality_exprt::check(expr);
+  return static_cast<verilog_case_inequality_exprt &>(expr);
+}
+
 /// ==?
 class verilog_wildcard_equality_exprt : public binary_exprt
 {

--- a/src/verilog/verilog_lowering.cpp
+++ b/src/verilog/verilog_lowering.cpp
@@ -294,6 +294,16 @@ exprt verilog_lowering(exprt expr)
     auto &part_select = to_verilog_indexed_part_select_plus_or_minus_expr(expr);
     return part_select.lower();
   }
+  else if(expr.id() == ID_verilog_case_equality)
+  {
+    // Result is two-valued, comparing x/z as given.
+    return to_verilog_case_equality_expr(expr).lower();
+  }
+  else if(expr.id() == ID_verilog_case_inequality)
+  {
+    // Result is two-valued, comparing x/z as given.
+    return to_verilog_case_inequality_expr(expr).lower();
+  }
   else if(expr.id() == ID_verilog_logical_equality)
   {
     return aval_bval(to_verilog_logical_equality_expr(expr));


### PR DESCRIPTION
This benefits the SMT2 backend, which does not implement `verilog_case_equality` and `verilog_case_inequality`.