### PR TITLE
SystemVerilog: grammar for `sequence_expr`

### DIFF
--- a/regression/verilog/SVA/cycle_delay_star1.desc
+++ b/regression/verilog/SVA/cycle_delay_star1.desc
@@ -1,0 +1,9 @@
+CORE
+cycle_delay_star1.sv
+--bound 10
+^\[main.p0\] ##\[\*\] main\.x == 2 ##1 main\.x == 3: PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/cycle_delay_star1.sv
+++ b/regression/verilog/SVA/cycle_delay_star1.sv
@@ -1,0 +1,15 @@
+module main;
+
+  reg [31:0] x;
+  wire clk;
+
+  initial x=0;
+
+  always @(posedge clk)
+    if(x < 5)
+      x<=x+1;
+
+  // Same as ##[0:$] x==2 ##1 x==3
+  initial p0: assert property (##[*] x==2 ##1 x==3);
+
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -565,6 +565,9 @@ int yyverilogerror(const char *error)
 %left "or"
 %left "and"
 %nonassoc "not" "nexttime" "s_nexttime"
+%left "intersect"
+%left "within"
+%right "throughout"
 %left "##"
 %nonassoc "[*" "[=" "[->"
 
@@ -2391,9 +2394,9 @@ expression_or_dist_brace:
 	;
 
 sequence_expr:
-	  cycle_delay_range sequence_expr
+	  cycle_delay_range sequence_expr %prec "##"
 		{ $$=$1; mto($$, $2); }
-        | expression cycle_delay_range sequence_expr
+        | sequence_expr cycle_delay_range sequence_expr %prec "##"
                 { init($$, ID_sva_sequence_concatenation); mto($$, $1); mto($2, $3); mto($$, $2); }
 	| expression_or_dist
 	| expression_or_dist boolean_abbrev
@@ -2401,15 +2404,15 @@ sequence_expr:
 		  // preserve the operand ordering as in the source code
 		  stack_expr($$).operands().insert(stack_expr($$).operands().begin(), stack_expr($1));
 		}
-	| expression "intersect" sequence_expr
+	| sequence_expr "intersect" sequence_expr
                 { init($$, ID_sva_sequence_intersect); mto($$, $1); mto($$, $3); }
         | "first_match" '(' sequence_expr ')'
                 { init($$, ID_sva_sequence_first_match); mto($$, $3); }
         | "first_match" '(' sequence_expr ',' sequence_match_item_brace ')'
                 { init($$, ID_sva_sequence_first_match); mto($$, $3); mto($$, $5); }
-        | expression "throughout" sequence_expr
+        | expression_or_dist "throughout" sequence_expr
                 { init($$, ID_sva_sequence_throughout); mto($$, $1); mto($$, $3); }
-        | expression "within" sequence_expr
+        | sequence_expr "within" sequence_expr
                 { init($$, ID_sva_sequence_within); mto($$, $1); mto($$, $3); }
         ;
 

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2391,16 +2391,16 @@ expression_or_dist_brace:
 	;
 
 sequence_expr:
-          expression_or_dist
-        | expression_or_dist boolean_abbrev
+	  cycle_delay_range sequence_expr
+		{ $$=$1; mto($$, $2); }
+        | expression cycle_delay_range sequence_expr
+                { init($$, ID_sva_sequence_concatenation); mto($$, $1); mto($2, $3); mto($$, $2); }
+	| expression_or_dist
+	| expression_or_dist boolean_abbrev
 		{ $$ = $2;
 		  // preserve the operand ordering as in the source code
 		  stack_expr($$).operands().insert(stack_expr($$).operands().begin(), stack_expr($1));
 		}
-        | cycle_delay_range sequence_expr
-                { $$=$1; mto($$, $2); }
-        | expression cycle_delay_range sequence_expr
-                { init($$, ID_sva_sequence_concatenation); mto($$, $1); mto($2, $3); mto($$, $2); }
 	| expression "intersect" sequence_expr
                 { init($$, ID_sva_sequence_intersect); mto($$, $1); mto($$, $3); }
         | "first_match" '(' sequence_expr ')'


### PR DESCRIPTION
This re-orders the rules for `sequence_expr` to match 1800-2017.