### PR TITLE
enable passing Z3 tests

### DIFF
--- a/regression/ebmc/Properties1/test.desc
+++ b/regression/ebmc/Properties1/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.smv
 --bound 10 --property spec2
 ^EXIT=0$

--- a/regression/ebmc/example4_trace/test.desc
+++ b/regression/ebmc/example4_trace/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 example4.sv
 --bound 10 --trace
 ^\[counter\.assert\.1\] .* PROVED up to bound 10$

--- a/regression/ebmc/range_type/range_type2.desc
+++ b/regression/ebmc/range_type/range_type2.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 range_type2.smv
 --bound 10
 ^EXIT=0$

--- a/regression/ebmc/small-test1/test.desc
+++ b/regression/ebmc/small-test1/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.smv
 --bound 10 --trace
 ^EXIT=10$

--- a/regression/smv/LTL/smv_ltlspec4.desc
+++ b/regression/smv/LTL/smv_ltlspec4.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 smv_ltlspec4.smv
 --bound 10 --numbered-trace
 ^EXIT=10$


### PR DESCRIPTION
Various tests pass, owing to the CBMC submodule update.