### PR TITLE
SystemVerilog: grammar for `break`/`continue`/`return`

### DIFF
--- a/regression/verilog/for/break1.desc
+++ b/regression/verilog/for/break1.desc
@@ -1,0 +1,9 @@
+CORE
+break1.sv
+--bound 0
+^file .* line 7: synthesis of break not supported$
+^EXIT=2$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/for/break1.sv
+++ b/regression/verilog/for/break1.sv
@@ -1,0 +1,12 @@
+module main;
+
+  initial begin
+    int i;
+    for(i = 0; i < 10; i++) begin
+      if(i == 5)
+        break;
+    end
+    assert(i==5);
+  end
+
+endmodule

--- a/regression/verilog/for/continue1.desc
+++ b/regression/verilog/for/continue1.desc
@@ -1,0 +1,9 @@
+CORE
+continue1.sv
+--bound 0
+^file .* line 8: synthesis of continue not supported$
+^EXIT=2$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/for/continue1.sv
+++ b/regression/verilog/for/continue1.sv
@@ -1,0 +1,14 @@
+module main;
+
+  initial begin
+    int i, j;
+    j = 0;
+    for(i = 0; i < 10; i++) begin
+      if(i == 5)
+        continue;
+      j++;
+    end
+    assert(j==9);
+  end
+
+endmodule

--- a/regression/verilog/functioncall/return1.desc
+++ b/regression/verilog/functioncall/return1.desc
@@ -1,9 +1,9 @@
-KNOWNBUG
+CORE
 return1.sv
 --bound 0
-^EXIT=0$
+^file .* line 4: synthesis of return not supported$
+^EXIT=2$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-This fails to parse.

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3269,6 +3269,7 @@ statement_item:
 	| disable_statement
 	| event_trigger
 	| loop_statement
+	| jump_statement
 	| par_block
 	| procedural_timing_control_statement
 	| procedural_continuous_assignment ';'
@@ -3337,6 +3338,17 @@ event_expression:
 		{ init($$, ID_posedge); mto($$, $2); }
 	| TOK_NEGEDGE expression
 		{ init($$, ID_negedge); mto($$, $2); }
+	;
+
+jump_statement:
+	  "return" ';'
+		{ init($$, ID_return); }
+	| "return" expression ';'
+		{ init($$, ID_return); mto($$, $2); }
+	| "break" ';'
+		{ init($$, ID_break); }
+	| "continue" ';'
+		{ init($$, ID_continue); }
 	;
 
 disable_statement: TOK_DISABLE hierarchical_task_or_block_identifier ';'

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -734,6 +734,15 @@ void verilog_typecheckt::collect_symbols(const verilog_statementt &statement)
   else if(statement.id() == ID_procedural_continuous_assign)
   {
   }
+  else if(statement.id() == ID_break)
+  {
+  }
+  else if(statement.id() == ID_continue)
+  {
+  }
+  else if(statement.id() == ID_return)
+  {
+  }
   else if(statement.id() == ID_wait)
   {
   }

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -1537,6 +1537,88 @@ inline verilog_fort &to_verilog_for(exprt &expr)
   return static_cast<verilog_fort &>(expr);
 }
 
+class verilog_breakt : public verilog_statementt
+{
+public:
+  verilog_breakt() : verilog_statementt(ID_break)
+  {
+  }
+};
+
+inline const verilog_breakt &to_verilog_break(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_break);
+  return static_cast<const verilog_breakt &>(expr);
+}
+
+inline verilog_breakt &to_verilog_break(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_break);
+  return static_cast<verilog_breakt &>(expr);
+}
+
+class verilog_continuet : public verilog_statementt
+{
+public:
+  verilog_continuet() : verilog_statementt(ID_continue)
+  {
+  }
+};
+
+inline const verilog_continuet &to_verilog_continue(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_continue);
+  return static_cast<const verilog_continuet &>(expr);
+}
+
+inline verilog_continuet &to_verilog_continue(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_continue);
+  return static_cast<verilog_continuet &>(expr);
+}
+
+class verilog_returnt : public verilog_statementt
+{
+public:
+  verilog_returnt() : verilog_statementt(ID_return)
+  {
+  }
+
+  explicit verilog_returnt(exprt value) : verilog_statementt(ID_return)
+  {
+    add_to_operands(std::move(value));
+  }
+
+  bool has_value() const
+  {
+    return operands().size() == 1;
+  }
+
+  exprt &value()
+  {
+    PRECONDITION(has_value());
+    return op0();
+  }
+
+  const exprt &value() const
+  {
+    PRECONDITION(has_value());
+    return op0();
+  }
+};
+
+inline const verilog_returnt &to_verilog_return(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_return);
+  return static_cast<const verilog_returnt &>(expr);
+}
+
+inline verilog_returnt &to_verilog_return(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_return);
+  return static_cast<verilog_returnt &>(expr);
+}
+
 class verilog_forevert:public verilog_statementt
 {
 public:

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -3105,6 +3105,11 @@ void verilog_synthesist::synth_statement(
 {
   if(statement.id()==ID_block)
     synth_block(to_verilog_block(statement));
+  else if(statement.id() == ID_break)
+  {
+    throw errort().with_location(statement.source_location())
+      << "synthesis of break not supported";
+  }
   else if(statement.id()==ID_case ||
           statement.id()==ID_casex ||
           statement.id()==ID_casez)
@@ -3125,6 +3130,11 @@ void verilog_synthesist::synth_statement(
     statement.id() == ID_verilog_blocking_assign_ashl)
   {
     synth_assign(to_verilog_assign(statement));
+  }
+  else if(statement.id() == ID_continue)
+  {
+    throw errort().with_location(statement.source_location())
+      << "synthesis of continue not supported";
   }
   else if(statement.id() == ID_procedural_continuous_assign)
   {
@@ -3170,6 +3180,11 @@ void verilog_synthesist::synth_statement(
     synth_while(to_verilog_while(statement));
   else if(statement.id()==ID_repeat)
     synth_repeat(to_verilog_repeat(statement));
+  else if(statement.id() == ID_return)
+  {
+    throw errort().with_location(statement.source_location())
+      << "synthesis of return not supported";
+  }
   else if(statement.id()==ID_forever)
     synth_forever(to_verilog_forever(statement));
   else if(statement.id()==ID_function_call)

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1359,6 +1359,30 @@ void verilog_typecheckt::convert_for(verilog_fort &statement)
 
 /*******************************************************************\
 
+Function: verilog_typecheckt::convert_return
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void verilog_typecheckt::convert_return(verilog_returnt &statement)
+{
+  if(function_or_task_name.empty())
+  {
+    throw errort().with_location(statement.source_location())
+      << "return statement outside of function or task";
+  }
+
+  if(statement.has_value())
+    convert_expr(statement.value());
+}
+
+/*******************************************************************\
+
 Function: verilog_typecheckt::convert_prepostincdec
 
   Inputs:
@@ -1571,6 +1595,16 @@ void verilog_typecheckt::convert_statement(
     }
 
     convert_statement(sub_statement);
+  }
+  else if(statement.id() == ID_break)
+  {
+  }
+  else if(statement.id() == ID_continue)
+  {
+  }
+  else if(statement.id() == ID_return)
+  {
+    convert_return(to_verilog_return(statement));
   }
   else if(statement.id() == ID_wait)
   {

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -166,6 +166,7 @@ protected:
   void convert_forever(class verilog_forevert &);
   void convert_while(class verilog_whilet &);
   void convert_repeat(class verilog_repeatt &);
+  void convert_return(class verilog_returnt &);
   void convert_assign(class verilog_assignt &, bool blocking);
   void convert_procedural_continuous_assign(
     class verilog_procedural_continuous_assignt &);


### PR DESCRIPTION
This adds the 1800-2017 rules for the SystemVerilog jump statements `break`, `continue` and `return`.

Synthesis support is still missing.