### PR TITLE
vlindex: restrict index to given files

### DIFF
--- a/regression/vlindex/cmdline/cmdline.desc
+++ b/regression/vlindex/cmdline/cmdline.desc
@@ -1,0 +1,8 @@
+CORE
+file2.v
+--modules
+^top2 file2\.v line 1$
+^EXIT=0$
+^SIGNAL=0$
+--
+^top1 .*$

--- a/regression/vlindex/cmdline/file1.v
+++ b/regression/vlindex/cmdline/file1.v
@@ -1,0 +1,2 @@
+module top1;
+endmodule 

--- a/regression/vlindex/cmdline/file2.v
+++ b/regression/vlindex/cmdline/file2.v
@@ -1,0 +1,2 @@
+module top2;
+endmodule 

--- a/src/vlindex/verilog_indexer.cpp
+++ b/src/vlindex/verilog_indexer.cpp
@@ -1350,10 +1350,6 @@ void show_kind(
 
 int verilog_index(const cmdlinet &cmdline)
 {
-  // First find all .v and .sv files
-  auto files = verilog_files();
-
-  // Now index them.
   verilog_indexert indexer;
 
   verilog_standardt standard = [&cmdline]()
@@ -1378,13 +1374,28 @@ int verilog_index(const cmdlinet &cmdline)
       return verilog_standardt::SV2017;
   }();
 
-  for(const auto &file : files)
+  // Are we given file names on the command line?
+  if(cmdline.args.empty())
   {
+    // No, find all .v and .sv files
+    auto files = verilog_files();
+
+    for(const auto &file : files)
+    {
 #ifdef _WIN32
-    indexer(narrow(file), standard);
+      indexer(narrow(file), standard);
 #else
-    indexer(std::string(file), standard);
+      indexer(std::string(file), standard);
 #endif
+    }
+  }
+  else
+  {
+    // Yes, index the given files
+    for(const auto &file : cmdline.args)
+    {
+      indexer(file, standard);
+    }
   }
 
   if(cmdline.isset("hierarchy"))


### PR DESCRIPTION
The Verilog indexer can now be given file names on the command line, and indexing is restricted to those files.