### PR TITLE
SystemVerilog: retain explicit casts

### DIFF
--- a/regression/verilog/case/riscv-alu.desc
+++ b/regression/verilog/case/riscv-alu.desc
@@ -4,11 +4,11 @@ riscv-alu.sv
 ^\[alu\.pADD\] always alu\.op == \{ 7'b0000000, 3'b000 \} -> alu\.out == alu\.a \+ alu\.b: PROVED up to bound 0$
 ^\[alu\.pSUB\] always alu\.op == \{ 7'b0100000, 3'b000 \} -> alu\.out == alu\.a - alu\.b: PROVED up to bound 0$
 ^\[alu\.pSLL\] always alu\.op == \{ 7'b0000000, 3'b001 \} -> alu\.out == alu\.a << alu\.b\[4:0\]: PROVED up to bound 0$
-^\[alu\.pSLT\] always alu\.op == \{ 7'b0000000, 3'b010 \} -> alu\.out == alu\.a < alu\.b: PROVED up to bound 0$
+^\[alu\.pSLT\] always alu\.op == \{ 7'b0000000, 3'b010 \} -> alu\.out == \$signed\(alu\.a\) < \$signed\(alu\.b\): PROVED up to bound 0$
 ^\[alu\.pSLTU\] always alu\.op == \{ 7'b0000000, 3'b011 \} -> alu\.out == alu\.a < alu\.b: PROVED up to bound 0$
 ^\[alu\.pXOR\] always alu\.op == \{ 7'b0000000, 3'b100 \} -> alu\.out == \(alu\.a \^ alu\.b\): PROVED up to bound 0$
 ^\[alu\.pSRL\] always alu\.op == \{ 7'b0000000, 3'b101 \} -> alu\.out == alu\.a >> alu\.b\[4:0\]: PROVED up to bound 0$
-^\[alu\.pSRA\] always alu\.op == \{ 7'b0100000, 3'b101 \} -> alu\.out == alu\.a >>> alu\.b\[4:0\]: PROVED up to bound 0$
+^\[alu\.pSRA\] always alu\.op == \{ 7'b0100000, 3'b101 \} -> alu\.out == \$signed\(alu\.a\) >>> alu\.b\[4:0\]: PROVED up to bound 0$
 ^\[alu\.pOR\] always alu\.op == \{ 7'b0000000, 3'b110 \} -> alu\.out == \(alu\.a | alu\.b\): PROVED up to bound 0$
 ^\[alu\.pAND\] always alu\.op == \{ 7'b0000000, 3'b111 \} -> alu\.out == \(alu\.a & alu\.b\): PROVED up to bound 0$
 ^EXIT=0$

--- a/regression/verilog/enums/enum4.desc
+++ b/regression/verilog/enums/enum4.desc
@@ -3,5 +3,5 @@ enum4.sv
 --bound 0
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.p1\] always main\.A == 1: PROVED up to bound 0$
+^\[main\.p1\] always main\.A == \[7:0\]'\(1\): PROVED up to bound 0$
 --

--- a/regression/verilog/enums/enum_cast1.desc
+++ b/regression/verilog/enums/enum_cast1.desc
@@ -3,6 +3,6 @@ enum_cast1.sv
 --bound 0
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.p1\] always main.A == 1: PROVED up to bound 0$
-^\[main\.p2\] always main.B == 2: PROVED up to bound 0$
+^\[main\.p1\] always main.A == signed \[31:0\]'\(1\): PROVED up to bound 0$
+^\[main\.p2\] always main.B == signed \[31:0\]'\(2\): PROVED up to bound 0$
 --

--- a/regression/verilog/expressions/signed1.desc
+++ b/regression/verilog/expressions/signed1.desc
@@ -1,6 +1,14 @@
 CORE
 signed1.sv
 --module main --bound 0
+^\[main\.p1\] always main\.wire1 == main.wire2: PROVED up to bound 0$
+^\[main\.p2\] always main\.wire1 >>> 1 == -1: PROVED up to bound 0$
+^\[main\.p3\] always main\.wire2 >> 1 != -1: PROVED up to bound 0$
+^\[main\.p4\] always main\.wire1\[31:0\] >> 1 != -1: PROVED up to bound 0$
+^\[main\.p5\] always \$unsigned\(main\.wire1\) >> 1 != -1: PROVED up to bound 0$
+^\[main\.p6\] always \$signed\(main\.wire2\) >>> 1 == -1: PROVED up to bound 0$
+^\[main\.p7\] always -1 >> 1 != -1: PROVED up to bound 0$
+^\[main\.p8\] always -1 >>> 1 == -1: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/size_cast1.desc
+++ b/regression/verilog/expressions/size_cast1.desc
@@ -1,6 +1,10 @@
 CORE
 size_cast1.sv
 --module main --bound 0
+^\[main\.p0\] always \$bits\(10'\(1\)\) == 10: PROVED up to bound 0$
+^\[main\.p1\] always \$bits\(20'\(1\)\) == 20: PROVED up to bound 0$
+^\[main\.p2\] always 10'\(-1\) == -1: PROVED up to bound 0$
+^\[main\.p3\] always 2'\(1 == 1\) == 1: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/size_cast1.sv
+++ b/regression/verilog/expressions/size_cast1.sv
@@ -7,4 +7,7 @@ module main;
   p2: assert final (10'(-1) == -1);
   p3: assert final (2'(1==1) == 1);
 
+  // size-casts yield constants
+  parameter Q = 10'(1);
+
 endmodule

--- a/regression/verilog/expressions/static_cast1.desc
+++ b/regression/verilog/expressions/static_cast1.desc
@@ -1,8 +1,8 @@
 CORE
 static_cast1.sv
 --module main --bound 0
+^\[main\.p0\] always \[7:0\]'\(32'hFFFF\) == 255: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.p0\] always 32'hFFFF == 255: PROVED up to bound 0$
 --
 ^warning: ignoring

--- a/regression/verilog/expressions/static_cast1.sv
+++ b/regression/verilog/expressions/static_cast1.sv
@@ -4,4 +4,7 @@ module main;
 
   p0: assert final (eight_bits'('hffff) == 'hff);
 
+  // static casts yield constants
+  parameter Q = eight_bits'('hffff);
+
 endmodule

--- a/regression/verilog/system-functions/signed1.desc
+++ b/regression/verilog/system-functions/signed1.desc
@@ -1,0 +1,7 @@
+CORE
+signed1.v
+--bound 0
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/system-functions/signed1.v
+++ b/regression/verilog/system-functions/signed1.v
@@ -1,0 +1,5 @@
+module main;
+
+  parameter Q = $signed(123);
+
+endmodule

--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -694,6 +694,46 @@ expr2verilogt::convert_typecast(const typecast_exprt &src)
 
 /*******************************************************************\
 
+Function: expr2verilogt::convert_explicit_cast
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+expr2verilogt::resultt
+expr2verilogt::convert_explicit_cast(const verilog_explicit_cast_exprt &src)
+{
+  return {
+    verilog_precedencet::MAX,
+    convert(src.type()) + "'(" + convert_rec(src.op()).s + ')'};
+}
+
+/*******************************************************************\
+
+Function: expr2verilogt::convert_size_cast
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+expr2verilogt::resultt
+expr2verilogt::convert_size_cast(const verilog_size_cast_exprt &src)
+{
+  return {
+    verilog_precedencet::MAX,
+    convert_rec(src.size()).s + "'(" + convert_rec(src.op()).s + ')'};
+}
+
+/*******************************************************************\
+
 Function: expr2verilogt::convert_index
 
   Inputs:
@@ -1449,6 +1489,12 @@ expr2verilogt::resultt expr2verilogt::convert_rec(const exprt &src)
   else if(src.id()==ID_bitnot)
     return convert_unary(
       to_bitnot_expr(src), "~", precedence = verilog_precedencet::NOT);
+
+  else if(src.id() == ID_verilog_explicit_cast)
+    return convert_explicit_cast(to_verilog_explicit_cast_expr(src));
+
+  else if(src.id() == ID_verilog_size_cast)
+    return convert_size_cast(to_verilog_size_cast_expr(src));
 
   else if(src.id()==ID_typecast)
     return convert_typecast(to_typecast_expr(src));

--- a/src/verilog/expr2verilog_class.h
+++ b/src/verilog/expr2verilog_class.h
@@ -105,7 +105,11 @@ protected:
 
   resultt convert_constant(const constant_exprt &, verilog_precedencet &);
 
+  resultt convert_explicit_cast(const class verilog_explicit_cast_exprt &);
+
   resultt convert_typecast(const typecast_exprt &);
+
+  resultt convert_size_cast(const class verilog_size_cast_exprt &);
 
   resultt
   convert_concatenation(const concatenation_exprt &, verilog_precedencet);

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -2461,6 +2461,86 @@ inline verilog_udpt &to_verilog_udp(irept &irep)
   return static_cast<verilog_udpt &>(irep);
 }
 
+/// size'(expression)
+class verilog_size_cast_exprt : public binary_exprt
+{
+public:
+  verilog_size_cast_exprt(exprt __size, exprt __op, typet __type)
+    : binary_exprt(
+        std::move(__size),
+        ID_verilog_size_cast,
+        std::move(__op),
+        std::move(__type))
+  {
+  }
+
+  const exprt &size() const
+  {
+    return op0();
+  }
+
+  exprt &size()
+  {
+    return op0();
+  }
+
+  const exprt &op() const
+  {
+    return op1();
+  }
+
+  exprt &op()
+  {
+    return op1();
+  }
+
+  // lower to typecast
+  exprt lower() const
+  {
+    return typecast_exprt{op(), type()};
+  }
+};
+
+inline const verilog_size_cast_exprt &
+to_verilog_size_cast_expr(const exprt &expr)
+{
+  verilog_size_cast_exprt::check(expr);
+  return static_cast<const verilog_size_cast_exprt &>(expr);
+}
+
+inline verilog_size_cast_exprt &to_verilog_size_cast_expr(exprt &expr)
+{
+  verilog_size_cast_exprt::check(expr);
+  return static_cast<verilog_size_cast_exprt &>(expr);
+}
+
+class verilog_explicit_cast_exprt : public unary_exprt
+{
+public:
+  verilog_explicit_cast_exprt(exprt __op, typet __type)
+    : unary_exprt(ID_verilog_explicit_cast, std::move(__op), std::move(__type))
+  {
+  }
+
+  exprt lower() const
+  {
+    return typecast_exprt{op(), type()};
+  }
+};
+
+inline const verilog_explicit_cast_exprt &
+to_verilog_explicit_cast_expr(const exprt &expr)
+{
+  verilog_explicit_cast_exprt::check(expr);
+  return static_cast<const verilog_explicit_cast_exprt &>(expr);
+}
+
+inline verilog_explicit_cast_exprt &to_verilog_explicit_cast_expr(exprt &expr)
+{
+  verilog_explicit_cast_exprt::check(expr);
+  return static_cast<verilog_explicit_cast_exprt &>(expr);
+}
+
 class verilog_implicit_typecast_exprt : public unary_exprt
 {
 public:


### PR DESCRIPTION
This preserves the explicit casts when typechecking SystemVerilog, which enables outputting them as part of property descriptions.

They are subsequently lowered during synthesis.