### PR TITLE
Verilog: directives inside ``include` argument

### DIFF
--- a/examples/Hazard3/Hazard3-vlindex.sh
+++ b/examples/Hazard3/Hazard3-vlindex.sh
@@ -29,6 +29,6 @@ Number of functions.......: 7
 Number of tasks...........: 0
 Number of properties......: 0
 Number of sequences.......: 0
-Number of module instances: 71
+Number of module instances: 70
 Number of configurations..: 0
 EOM

--- a/regression/verilog/preprocessor/include3.desc
+++ b/regression/verilog/preprocessor/include3.desc
@@ -1,13 +1,7 @@
-KNOWNBUG
-include2.v
+CORE
+include3.v
 --preprocess
-// Enable multi-line checking
-activate-multi-line-match
-`line 1 "include3\.v" 0
-`line 1 "include_file2\.vh" 1
-
-`line 2 "include3\.v" 2
-^EXIT=0$
+^file include3.v line 2: preprocessor directive inside `include directive$
+^EXIT=1$
 ^SIGNAL=0$
 --
-Giving the include file name as a macro doesn't work.


### PR DESCRIPTION
This changes the behavior when processing a Verilog preprocessor `include directive.

1.  When the argument contains a directive, a better error message is issued.  Other tools process (at least some) directives within the argument.

2.  When the argument is a file name enclosed in " quotes, the character sequence is used as is, and no string literal processing is performed.  This behavior matches what other tools implement.

Note that 1800-2017 does not specify the required behavior for either one of these scenarios.