### PR TITLE
Veriog: synthesis of primitive not gates

### DIFF
--- a/regression/verilog/primitive_gates/not1.desc
+++ b/regression/verilog/primitive_gates/not1.desc
@@ -1,0 +1,7 @@
+CORE
+not1.sv
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/primitive_gates/not1.sv
+++ b/regression/verilog/primitive_gates/not1.sv
@@ -1,0 +1,11 @@
+module main(input not_in);
+
+  wire not_out1, not_out2;
+
+  not not_gate(not_out1, not_out2, not_in);
+
+  // should pass
+  not_out1_ok: assert final (not_out1 == !not_in);
+  not_out2_ok: assert final (not_out2 == !not_in);
+
+endmodule


### PR DESCRIPTION
For a primitive not gate with input i and output o, this now generates the constraint

  i = !o

as opposed to

  !i = o

While logically equivalent, the new constraint is easier to read, and enables the generation of netlists that are more compact.