### PR TITLE
bump CBMC dependency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # EBMC 5.5
 
+* Verilog: bugfix for $onehot0
 * Verilog: fix for primitive gates with more than two inputs
 
 # EBMC 5.4

--- a/regression/verilog/SVA/system_verilog_assertion3.desc
+++ b/regression/verilog/SVA/system_verilog_assertion3.desc
@@ -1,6 +1,6 @@
-CORE broken-smt-backend
+CORE
 system_verilog_assertion3.sv
---module main --bound 1
+--module main --bound 0
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/system_verilog_assertion3.sv
+++ b/regression/verilog/SVA/system_verilog_assertion3.sv
@@ -3,8 +3,9 @@ module main();
   assert final ($onehot('b0001000));
   assert final (!$onehot('b0101000));
   assert final (!$onehot('b00000));
-  assert final ($onehot0('b00000));
-  assert final ($onehot0('b000100));
-  assert final (!$onehot0('b010100));
+  assert final (!$onehot0(6'b00000));
+  assert final (!$onehot0(6'b000100));
+  assert final (!$onehot0(6'b010100));
+  assert final ($onehot0(6'b111101));
 
 endmodule


### PR DESCRIPTION
The bump of the CBMC dependency fixes `$onehot0`.