### PR TITLE
bump CBMC dependency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 * Verilog: bugfix for $onehot0
 * Verilog: fix for primitive gates with more than two inputs
 * Verilog: Support $past when using AIG-based engines
+* Verilog: fix for nor/nand/xnor primitive gates
 
 # EBMC 5.4
 

--- a/regression/verilog/primitive_gates/nand4.desc
+++ b/regression/verilog/primitive_gates/nand4.desc
@@ -1,0 +1,8 @@
+CORE broken-smt-backend
+nand4.sv
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/primitive_gates/nand4.sv
+++ b/regression/verilog/primitive_gates/nand4.sv
@@ -1,0 +1,15 @@
+module main(output [31:0] nand_out, input [31:0] nand_in1, nand_in2, nand_in3);
+
+  // An 'nand' with three inputs over 32 bits.
+  nand x1[31:0] (nand_out, nand_in1, nand_in2, nand_in3);
+
+  // should pass
+  nand_x1_ok: assert final (~(nand_in1 & nand_in2 & nand_in3)==nand_out);
+
+  // An 'nand' with one input over 32 bits.
+  nand x2[31:0] (nand_out, nand_in1);
+
+  // should pass
+  nand_x2_ok: assert final (~nand_in1==nand_out);
+
+endmodule

--- a/regression/verilog/primitive_gates/nor4.desc
+++ b/regression/verilog/primitive_gates/nor4.desc
@@ -1,0 +1,8 @@
+CORE broken-smt-backend
+nor4.sv
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/primitive_gates/nor4.sv
+++ b/regression/verilog/primitive_gates/nor4.sv
@@ -1,0 +1,15 @@
+module main(output [31:0] nor_out, input [31:0] nor_in1, nor_in2, nor_in3);
+
+  // An 'nor' with three inputs over 32 bits.
+  nor x1[31:0] (nor_out, nor_in1, nor_in2, nor_in3);
+
+  // should pass
+  nor_x1_ok: assert final (~(nor_in1 | nor_in2 | nor_in3)==nor_out);
+
+  // An 'nor' with one input over 32 bits.
+  nor x2[31:0] (nor_out, nor_in1);
+
+  // should pass
+  nor_x2_ok: assert final (~nor_in1==nor_out);
+
+endmodule

--- a/regression/verilog/primitive_gates/xnor4.desc
+++ b/regression/verilog/primitive_gates/xnor4.desc
@@ -1,0 +1,10 @@
+CORE broken-smt-backend
+xnor4.sv
+--bound 0
+^\[main\.xnor_x1_ok\] always ~\(main\.xnor_in1 \^ main\.xnor_in2 \^ main.xnor_in3\) == main.xnor_out: PROVED up to bound 0$
+^\[main\.xnor_x2_ok\] always ~main\.xnor_in1 == main.xnor_out: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/primitive_gates/xnor4.sv
+++ b/regression/verilog/primitive_gates/xnor4.sv
@@ -1,0 +1,15 @@
+module main(output [31:0] xnor_out, input [31:0] xnor_in1, xnor_in2, xnor_in3);
+
+  // An 'xnor' with three inputs over 32 bits.
+  xnor x1[31:0] (xnor_out, xnor_in1, xnor_in2, xnor_in3);
+
+  // should pass
+  xnor_x1_ok: assert final (~(xnor_in1 ^ xnor_in2 ^ xnor_in3)==xnor_out);
+
+  // An 'xnor' with one input over 32 bits.
+  xnor x2[31:0] (xnor_out, xnor_in1);
+
+  // should pass
+  xnor_x2_ok: assert final (~xnor_in1==xnor_out);
+
+endmodule


### PR DESCRIPTION
This allows removing the special-casing for `xnor` gates.