### PR TITLE
EBMC: basic engine selection heuristic

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 # EBMC 5.5
 
+* If no engine is given, EBMC now selects an engine heuristically, instead
+  of doing BMC with k=1
 * Verilog: bugfix for $onehot0
 * Verilog: fix for primitive gates with more than two inputs
 * Verilog: Support $past when using AIG-based engines

--- a/regression/ebmc/example1/test.desc
+++ b/regression/ebmc/example1/test.desc
@@ -1,6 +1,6 @@
 CORE
 example1.sv
---bound 10
-PROVED up to bound 10$
+
+^\[.*\] always 2'\(main\.a\) \+ main\.b == main\.result: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/smv/smv/bmc_unsupported_property1.desc
+++ b/regression/smv/smv/bmc_unsupported_property1.desc
@@ -1,6 +1,6 @@
 CORE
 bmc_unsupported_property1.smv
-
+--bound 1
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[spec1\] EG x = FALSE: FAILURE: property not supported by BMC engine$

--- a/regression/smv/smv/bmc_unsupported_property2.desc
+++ b/regression/smv/smv/bmc_unsupported_property2.desc
@@ -1,6 +1,6 @@
 CORE
 bmc_unsupported_property2.smv
-
+--bound 1
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[spec1\] EG x = FALSE: FAILURE: property not supported by BMC engine$

--- a/regression/verilog/SVA/immediate2.desc
+++ b/regression/verilog/SVA/immediate2.desc
@@ -1,8 +1,8 @@
 CORE
 immediate2.sv
---bound 0
+
 ^\[main\.assume\.1\] assume always 0: ASSUMED$
-^\[main\.assert\.2\] always main\.index < 10: PROVED up to bound 0$
+^\[main\.assert\.2\] always main\.index < 10: PROVED$
 ^\[main\.assert\.3\] always 0: REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/verilog/SVA/immediate3.desc
+++ b/regression/verilog/SVA/immediate3.desc
@@ -1,7 +1,7 @@
 CORE
 immediate3.sv
---bound 0
-^\[full_adder\.assert\.1\] always \{ full_adder\.carry, full_adder\.sum \} == \{ 1'b0, full_adder\.a \} \+ full_adder\.b \+ full_adder\.c: PROVED up to bound 0$
+
+^\[full_adder\.assert\.1\] always \{ full_adder\.carry, full_adder\.sum \} == \{ 1'b0, full_adder\.a \} \+ full_adder\.b \+ full_adder\.c: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/named_property1.desc
+++ b/regression/verilog/SVA/named_property1.desc
@@ -1,7 +1,7 @@
 CORE
 named_property1.sv
---bound 0
-^\[main\.assert\.1\] always main\.x_is_ten: PROVED up to bound 0$
+
+^\[main\.assert\.1\] always main\.x_is_ten: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/named_sequence1.desc
+++ b/regression/verilog/SVA/named_sequence1.desc
@@ -1,7 +1,7 @@
 CORE
 named_sequence1.sv
---bound 0
-^\[main\.assert\.1\] always main\.x_is_ten: PROVED up to bound 0$
+
+^\[main\.assert\.1\] always main\.x_is_ten: PROVED up to bound 5$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/sequence5.desc
+++ b/regression/verilog/SVA/sequence5.desc
@@ -1,7 +1,7 @@
 CORE
 sequence5.sv
---bound 0
-^\[main\.p0\] 1: PROVED up to bound 0$
+
+^\[main\.p0\] 1: PROVED up to bound 5$
 ^\[main\.p1\] 0: REFUTED$
 ^\[main\.p2\] 1'bx: REFUTED$
 ^\[main\.p3\] 1'bz: REFUTED$

--- a/regression/verilog/SVA/sequence_first_match1.desc
+++ b/regression/verilog/SVA/sequence_first_match1.desc
@@ -1,6 +1,6 @@
 CORE
 sequence_first_match1.sv
-
+--bound 5
 ^\[.*\] first_match\(main\.x == 0\): FAILURE: property not supported by BMC engine$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/verilog/SVA/sequence_within1.desc
+++ b/regression/verilog/SVA/sequence_within1.desc
@@ -1,6 +1,6 @@
 CORE
 sequence_within1.sv
-
+--bound 5
 ^\[.*\] main\.x == 0 within main\.x == 1: FAILURE: property not supported by BMC engine$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/verilog/SVA/static_final1.desc
+++ b/regression/verilog/SVA/static_final1.desc
@@ -1,7 +1,7 @@
 CORE
 static_final1.sv
---bound 0
-^\[full_adder\.p0\] always \{ full_adder\.carry, full_adder\.sum \} == \{ 1'b0, full_adder\.a \} \+ full_adder\.b \+ full_adder\.c: PROVED up to bound 0$
+
+^\[full_adder\.p0\] always \{ full_adder\.carry, full_adder\.sum \} == \{ 1'b0, full_adder\.a \} \+ full_adder\.b \+ full_adder\.c: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/sva_and1.desc
+++ b/regression/verilog/SVA/sva_and1.desc
@@ -1,7 +1,7 @@
 CORE
 sva_and1.sv
---bound 0
-^\[main\.p0\] always \(1 and 1\): PROVED up to bound 0$
+
+^\[main\.p0\] always \(1 and 1\): PROVED$
 ^\[main\.p1\] always \(1 and 0\): REFUTED$
 ^\[main\.p2\] always \(1 and 32'b0000000000000000000000000000000x\): REFUTED$
 ^EXIT=10$

--- a/regression/verilog/SVA/sva_iff1.desc
+++ b/regression/verilog/SVA/sva_iff1.desc
@@ -1,7 +1,7 @@
 CORE
 sva_iff1.sv
---bound 0
-^\[main\.p0\] always \(1 iff 1\): PROVED up to bound 0$
+
+^\[main\.p0\] always \(1 iff 1\): PROVED$
 ^\[main\.p1\] always \(1 iff 0\): REFUTED$
 ^\[main\.p2\] always \(1 iff 32'b0000000000000000000000000000000x\): REFUTED$
 ^EXIT=10$

--- a/regression/verilog/SVA/sva_implies1.desc
+++ b/regression/verilog/SVA/sva_implies1.desc
@@ -1,7 +1,7 @@
 CORE
 sva_implies1.sv
---bound 0
-^\[main\.p0\] always \(1 implies 1\): PROVED up to bound 0$
+
+^\[main\.p0\] always \(1 implies 1\): PROVED$
 ^\[main\.p1\] always \(1 implies 0\): REFUTED$
 ^\[main\.p2\] always \(1 implies 32'b0000000000000000000000000000000x\): REFUTED$
 ^EXIT=10$

--- a/regression/verilog/SVA/sva_until1.desc
+++ b/regression/verilog/SVA/sva_until1.desc
@@ -1,6 +1,6 @@
 CORE
 sva_until1.sv
---bound 1
+
 ^\[main\.p0\] always \(main.a until_with main.b\): REFUTED$
 ^\[main\.p1\] always \(main.a until main.b\): REFUTED$
 ^\[main\.p2\] always \(main.a s_until main.b\): REFUTED$

--- a/regression/verilog/SVA/system_verilog_assertion3.desc
+++ b/regression/verilog/SVA/system_verilog_assertion3.desc
@@ -1,6 +1,6 @@
 CORE
 system_verilog_assertion3.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/UDPs/multiplexer1.desc
+++ b/regression/verilog/UDPs/multiplexer1.desc
@@ -1,6 +1,6 @@
 CORE
 multiplexer1.sv
---bound 0 --module main
+--module main
 ^no properties$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/verilog/arrays/array1.desc
+++ b/regression/verilog/arrays/array1.desc
@@ -1,6 +1,6 @@
 CORE
 array1.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/arrays/packed_real1.desc
+++ b/regression/verilog/arrays/packed_real1.desc
@@ -1,6 +1,6 @@
 CORE
 packed_real1.sv
---module main --bound 0
+--module main
 ^file .* line 6: packed array must use packed element type$
 ^EXIT=2$
 ^SIGNAL=0$

--- a/regression/verilog/arrays/packed_typedef1.desc
+++ b/regression/verilog/arrays/packed_typedef1.desc
@@ -1,6 +1,6 @@
 CORE
 packed_typedef1.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/assignments/procedural_assignments1.desc
+++ b/regression/verilog/assignments/procedural_assignments1.desc
@@ -1,6 +1,6 @@
 CORE
 procedural_assignments1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/case/nested_case1.desc
+++ b/regression/verilog/case/nested_case1.desc
@@ -1,8 +1,8 @@
 CORE
 nested_case1.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.property.p1\] .* PROVED up to bound 0$
+^\[main.property.p1\] .* PROVED$
 --
 ^warning: ignoring

--- a/regression/verilog/case/riscv-alu.desc
+++ b/regression/verilog/case/riscv-alu.desc
@@ -1,16 +1,16 @@
 CORE
 riscv-alu.sv
---module alu --bound 0
-^\[alu\.pADD\] always alu\.op == \{ 7'b0000000, 3'b000 \} -> alu\.out == alu\.a \+ alu\.b: PROVED up to bound 0$
-^\[alu\.pSUB\] always alu\.op == \{ 7'b0100000, 3'b000 \} -> alu\.out == alu\.a - alu\.b: PROVED up to bound 0$
-^\[alu\.pSLL\] always alu\.op == \{ 7'b0000000, 3'b001 \} -> alu\.out == alu\.a << alu\.b\[4:0\]: PROVED up to bound 0$
-^\[alu\.pSLT\] always alu\.op == \{ 7'b0000000, 3'b010 \} -> alu\.out == \$signed\(alu\.a\) < \$signed\(alu\.b\): PROVED up to bound 0$
-^\[alu\.pSLTU\] always alu\.op == \{ 7'b0000000, 3'b011 \} -> alu\.out == alu\.a < alu\.b: PROVED up to bound 0$
-^\[alu\.pXOR\] always alu\.op == \{ 7'b0000000, 3'b100 \} -> alu\.out == \(alu\.a \^ alu\.b\): PROVED up to bound 0$
-^\[alu\.pSRL\] always alu\.op == \{ 7'b0000000, 3'b101 \} -> alu\.out == alu\.a >> alu\.b\[4:0\]: PROVED up to bound 0$
-^\[alu\.pSRA\] always alu\.op == \{ 7'b0100000, 3'b101 \} -> alu\.out == \$signed\(alu\.a\) >>> alu\.b\[4:0\]: PROVED up to bound 0$
-^\[alu\.pOR\] always alu\.op == \{ 7'b0000000, 3'b110 \} -> alu\.out == \(alu\.a | alu\.b\): PROVED up to bound 0$
-^\[alu\.pAND\] always alu\.op == \{ 7'b0000000, 3'b111 \} -> alu\.out == \(alu\.a & alu\.b\): PROVED up to bound 0$
+--module alu
+^\[alu\.pADD\] always alu\.op == \{ 7'b0000000, 3'b000 \} -> alu\.out == alu\.a \+ alu\.b: PROVED$
+^\[alu\.pSUB\] always alu\.op == \{ 7'b0100000, 3'b000 \} -> alu\.out == alu\.a - alu\.b: PROVED$
+^\[alu\.pSLL\] always alu\.op == \{ 7'b0000000, 3'b001 \} -> alu\.out == alu\.a << alu\.b\[4:0\]: PROVED$
+^\[alu\.pSLT\] always alu\.op == \{ 7'b0000000, 3'b010 \} -> alu\.out == \$signed\(alu\.a\) < \$signed\(alu\.b\): PROVED$
+^\[alu\.pSLTU\] always alu\.op == \{ 7'b0000000, 3'b011 \} -> alu\.out == alu\.a < alu\.b: PROVED$
+^\[alu\.pXOR\] always alu\.op == \{ 7'b0000000, 3'b100 \} -> alu\.out == \(alu\.a \^ alu\.b\): PROVED$
+^\[alu\.pSRL\] always alu\.op == \{ 7'b0000000, 3'b101 \} -> alu\.out == alu\.a >> alu\.b\[4:0\]: PROVED$
+^\[alu\.pSRA\] always alu\.op == \{ 7'b0100000, 3'b101 \} -> alu\.out == \$signed\(alu\.a\) >>> alu\.b\[4:0\]: PROVED$
+^\[alu\.pOR\] always alu\.op == \{ 7'b0000000, 3'b110 \} -> alu\.out == \(alu\.a | alu\.b\): PROVED$
+^\[alu\.pAND\] always alu\.op == \{ 7'b0000000, 3'b111 \} -> alu\.out == \(alu\.a & alu\.b\): PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/data-types/associative_array1.desc
+++ b/regression/verilog/data-types/associative_array1.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 associative_array1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/data-types/chandle1.desc
+++ b/regression/verilog/data-types/chandle1.desc
@@ -1,8 +1,8 @@
 CORE
 chandle1.sv
---bound 0
-^\[main\.p0\] always main\.some_handle == null: PROVED up to bound 0$
-^\[main\.p1\] always \$typename\(main\.some_handle\) == "chandle": PROVED up to bound 0$
+
+^\[main\.p0\] always main\.some_handle == null: PROVED$
+^\[main\.p1\] always \$typename\(main\.some_handle\) == "chandle": PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/data-types/integer_atom_types1.desc
+++ b/regression/verilog/data-types/integer_atom_types1.desc
@@ -1,6 +1,6 @@
 CORE
 integer_atom_types1.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/data-types/queue1.desc
+++ b/regression/verilog/data-types/queue1.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 queue1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/data-types/signed1.desc
+++ b/regression/verilog/data-types/signed1.desc
@@ -1,6 +1,6 @@
 CORE
 signed1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/data-types/signed2.desc
+++ b/regression/verilog/data-types/signed2.desc
@@ -1,6 +1,6 @@
 CORE
 signed2.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/data-types/type_operator.desc
+++ b/regression/verilog/data-types/type_operator.desc
@@ -1,6 +1,6 @@
 CORE
 type_operator.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/data-types/vector_types1.desc
+++ b/regression/verilog/data-types/vector_types1.desc
@@ -1,6 +1,6 @@
 CORE
 vector_types1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/data-types/vector_types2.desc
+++ b/regression/verilog/data-types/vector_types2.desc
@@ -1,7 +1,7 @@
 CORE
 vector_types2.sv
---bound 0
-^\[.*\] always \$bits\(main\.x\) == \(1 << main\.p\) \+ 1: PROVED up to bound 0$
+
+^\[.*\] always \$bits\(main\.x\) == \(1 << main\.p\) \+ 1: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/elaboration/type_operator.desc
+++ b/regression/verilog/elaboration/type_operator.desc
@@ -1,6 +1,6 @@
 CORE
 type_operator.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/elaboration/var_bits.desc
+++ b/regression/verilog/elaboration/var_bits.desc
@@ -1,6 +1,6 @@
 CORE
 var_bits.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/elaboration/wire_bits.desc
+++ b/regression/verilog/elaboration/wire_bits.desc
@@ -1,6 +1,6 @@
 CORE
 wire_bits.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/enums/enum4.desc
+++ b/regression/verilog/enums/enum4.desc
@@ -1,7 +1,7 @@
 CORE
 enum4.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.p1\] always main\.A == \[7:0\]'\(1\): PROVED up to bound 0$
+^\[main\.p1\] always main\.A == \[7:0\]'\(1\): PROVED$
 --

--- a/regression/verilog/enums/enum5.desc
+++ b/regression/verilog/enums/enum5.desc
@@ -1,6 +1,6 @@
 CORE
 enum5.sv
---bound 0
+
 ^file .* line 6: expected constant expression, but got `main\.some_wire'$
 ^EXIT=2$
 ^SIGNAL=0$

--- a/regression/verilog/enums/enum_base_type1.desc
+++ b/regression/verilog/enums/enum_base_type1.desc
@@ -1,7 +1,7 @@
 CORE
 enum_base_type1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
-^\[.*\] always \$bits\(main\.A\) == 8: PROVED up to bound 0$
+^\[.*\] always \$bits\(main\.A\) == 8: PROVED$
 --

--- a/regression/verilog/enums/enum_base_type2.desc
+++ b/regression/verilog/enums/enum_base_type2.desc
@@ -1,7 +1,7 @@
 CORE
 enum_base_type2.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
-^\[.*\] always \$bits\(main\.A\) == main\.p: PROVED up to bound 0$
+^\[.*\] always \$bits\(main\.A\) == main\.p: PROVED$
 --

--- a/regression/verilog/enums/enum_cast1.desc
+++ b/regression/verilog/enums/enum_cast1.desc
@@ -1,8 +1,8 @@
 CORE
 enum_cast1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.p1\] always main.A == signed \[31:0\]'\(1\): PROVED up to bound 0$
-^\[main\.p2\] always main.B == signed \[31:0\]'\(2\): PROVED up to bound 0$
+^\[main\.p1\] always main.A == signed \[31:0\]'\(1\): PROVED$
+^\[main\.p2\] always main.B == signed \[31:0\]'\(2\): PROVED$
 --

--- a/regression/verilog/enums/enum_initializers1.desc
+++ b/regression/verilog/enums/enum_initializers1.desc
@@ -1,8 +1,8 @@
 CORE
 enum_initializers1.sv
---bound 0
-^\[main\.pA\] always main.A == 1: PROVED up to bound 0$
-^\[main\.pB\] always main.B == 11: PROVED up to bound 0$
+
+^\[main\.pA\] always main.A == 1: PROVED$
+^\[main\.pB\] always main.B == 11: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/enums/enum_with_hierarchy1.desc
+++ b/regression/verilog/enums/enum_with_hierarchy1.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 enum_with_hierarchy1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/bit-extract3.desc
+++ b/regression/verilog/expressions/bit-extract3.desc
@@ -1,12 +1,12 @@
 CORE
 bit-extract3.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.property1\] .*: PROVED up to bound 0$
-^\[main\.property2\] .*: PROVED up to bound 0$
-^\[main\.property3\] .*: PROVED up to bound 0$
-^\[main\.property4\] .*: PROVED up to bound 0$
-^\[main\.property5\] .*: PROVED up to bound 0$
+^\[main\.property1\] .*: PROVED$
+^\[main\.property2\] .*: PROVED$
+^\[main\.property3\] .*: PROVED$
+^\[main\.property4\] .*: PROVED$
+^\[main\.property5\] .*: PROVED$
 --
 ^warning: ignoring

--- a/regression/verilog/expressions/bit-extract4.desc
+++ b/regression/verilog/expressions/bit-extract4.desc
@@ -1,6 +1,6 @@
 CORE
 bit-extract4.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/bit-extract5.desc
+++ b/regression/verilog/expressions/bit-extract5.desc
@@ -1,10 +1,10 @@
 CORE
 bit-extract5.sv
---module main --bound 0
-^\[main\.p0\] always main\.w1\[0\] && !main\.w1\[31\]: PROVED up to bound 0$
-^\[main\.p1\] always main\.w2\[0\] && !main\.w2\[31\]: PROVED up to bound 0$
-^\[main\.p2\] always main\.w3\[0\] && !main\.w3\[31\]: PROVED up to bound 0$
-^\[main\.p3\] always main\.w4\[0\] && !main\.w4\[31\]: PROVED up to bound 0$
+--module main
+^\[main\.p0\] always main\.w1\[0\] && !main\.w1\[31\]: PROVED$
+^\[main\.p1\] always main\.w2\[0\] && !main\.w2\[31\]: PROVED$
+^\[main\.p2\] always main\.w3\[0\] && !main\.w3\[31\]: PROVED$
+^\[main\.p3\] always main\.w4\[0\] && !main\.w4\[31\]: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/bit-extract6.desc
+++ b/regression/verilog/expressions/bit-extract6.desc
@@ -1,8 +1,8 @@
 CORE
 bit-extract6.sv
---module main --bound 0
-^\[main\.p0\] always main\.index == 8 -> main\.vector\[7 - main\.index - 1\] == 1: PROVED up to bound 0$
-^\[main\.p1\] always main\.index >= 1 \&\& main\.index <= 7 -> main\.vector\[7 - main\.index - 1\] == 0: PROVED up to bound 0$
+--module main
+^\[main\.p0\] always main\.index == 8 -> main\.vector\[7 - main\.index - 1\] == 1: PROVED$
+^\[main\.p1\] always main\.index >= 1 \&\& main\.index <= 7 -> main\.vector\[7 - main\.index - 1\] == 0: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/cast_from_real1.desc
+++ b/regression/verilog/expressions/cast_from_real1.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 cast_from_real1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/cast_to_real1.desc
+++ b/regression/verilog/expressions/cast_to_real1.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
 cast_to_real1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/cast_to_real2.desc
+++ b/regression/verilog/expressions/cast_to_real2.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 cast_to_real2.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/cast_to_real3.desc
+++ b/regression/verilog/expressions/cast_to_real3.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 cast_to_real3.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/concatenation1.desc
+++ b/regression/verilog/expressions/concatenation1.desc
@@ -1,6 +1,6 @@
 CORE
 concatenation1.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/concatenation2.desc
+++ b/regression/verilog/expressions/concatenation2.desc
@@ -1,9 +1,9 @@
 CORE
 concatenation2.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.property\.pA\] always main\.A == -1: PROVED up to bound 0$
-^\[main\.property\.pB\] always main\.B == 15: PROVED up to bound 0$
+^\[main\.property\.pA\] always main\.A == -1: PROVED$
+^\[main\.property\.pB\] always main\.B == 15: PROVED$
 --
 ^warning: ignoring

--- a/regression/verilog/expressions/concatenation3.desc
+++ b/regression/verilog/expressions/concatenation3.desc
@@ -1,8 +1,8 @@
 CORE
 concatenation3.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
-^\[.*\] always \{ 5'bxz01\?, 4'b10zx \} === 9'bxz01\?10zx: PROVED up to bound 0$
+^\[.*\] always \{ 5'bxz01\?, 4'b10zx \} === 9'bxz01\?10zx: PROVED$
 --
 ^warning: ignoring

--- a/regression/verilog/expressions/concatenation4.desc
+++ b/regression/verilog/expressions/concatenation4.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 concatenation4.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/concatenation5.desc
+++ b/regression/verilog/expressions/concatenation5.desc
@@ -1,6 +1,6 @@
 CORE
 concatenation5.v
---bound 0
+
 ^file .* line 4: operand 1.1 must be integral$
 ^EXIT=2$
 ^SIGNAL=0$

--- a/regression/verilog/expressions/concatenation6.desc
+++ b/regression/verilog/expressions/concatenation6.desc
@@ -1,7 +1,7 @@
 CORE
 concatenation6.sv
---bound 0
-^\[.*\] always main\.x == \{ 0, 1 \}: PROVED up to bound 0$
+
+^\[.*\] always main\.x == \{ 0, 1 \}: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/constants2.desc
+++ b/regression/verilog/expressions/constants2.desc
@@ -1,6 +1,6 @@
 CORE
 constants2.sv
---bound 0
+
 ^no properties$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/verilog/expressions/equality1.desc
+++ b/regression/verilog/expressions/equality1.desc
@@ -1,18 +1,18 @@
 CORE broken-smt-backend
 equality1.v
---bound 0
-^\[.*\] always 10 == 10 === 1: PROVED up to bound 0$
-^\[.*\] always 10 == 20 === 0: PROVED up to bound 0$
-^\[.*\] always 10 != 20 === 1: PROVED up to bound 0$
-^\[.*\] always 10 == 20 === 0: PROVED up to bound 0$
-^\[.*\] always 32'b0000000000000000000000000000000x == 10 === 32'b0000000000000000000000000000000x: PROVED up to bound 0$
-^\[.*\] always 32'b0000000000000000000000000000000z == 20 === 32'b0000000000000000000000000000000x: PROVED up to bound 0$
-^\[.*\] always 32'b0000000000000000000000000000000x != 10 === 32'b0000000000000000000000000000000x: PROVED up to bound 0$
-^\[.*\] always 32'b0000000000000000000000000000000z != 20 === 32'b0000000000000000000000000000000x: PROVED up to bound 0$
-^\[.*\] always 1'sb1 == 2'b11 === 0: PROVED up to bound 0$
-^\[.*\] always 2'sb11 == 2'sb11 === 1: PROVED up to bound 0$
-^\[.*\] always 1\.1 == 1\.1 == 1: PROVED up to bound 0$
-^\[.*\] always 1\.1 == 1 == 0: PROVED up to bound 0$
+
+^\[.*\] always 10 == 10 === 1: PROVED$
+^\[.*\] always 10 == 20 === 0: PROVED$
+^\[.*\] always 10 != 20 === 1: PROVED$
+^\[.*\] always 10 == 20 === 0: PROVED$
+^\[.*\] always 32'b0000000000000000000000000000000x == 10 === 32'b0000000000000000000000000000000x: PROVED$
+^\[.*\] always 32'b0000000000000000000000000000000z == 20 === 32'b0000000000000000000000000000000x: PROVED$
+^\[.*\] always 32'b0000000000000000000000000000000x != 10 === 32'b0000000000000000000000000000000x: PROVED$
+^\[.*\] always 32'b0000000000000000000000000000000z != 20 === 32'b0000000000000000000000000000000x: PROVED$
+^\[.*\] always 1'sb1 == 2'b11 === 0: PROVED$
+^\[.*\] always 2'sb11 == 2'sb11 === 1: PROVED$
+^\[.*\] always 1\.1 == 1\.1 == 1: PROVED$
+^\[.*\] always 1\.1 == 1 == 0: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/equality2.desc
+++ b/regression/verilog/expressions/equality2.desc
@@ -1,18 +1,18 @@
 CORE
 equality2.v
---bound 0
-^\[.*\] always 10 === 10 == 1: PROVED up to bound 0$
-^\[.*\] always 10 === 20 == 0: PROVED up to bound 0$
-^\[.*\] always 10 !== 10 == 0: PROVED up to bound 0$
-^\[.*\] always 10 !== 20 == 1: PROVED up to bound 0$
-^\[.*\] always 32'b0000000000000000000000000000000x === 32'b0000000000000000000000000000000x == 1: PROVED up to bound 0$
-^\[.*\] always 32'b0000000000000000000000000000000z === 32'b0000000000000000000000000000000z == 1: PROVED up to bound 0$
-^\[.*\] always 32'b0000000000000000000000000000000x === 32'b0000000000000000000000000000000z == 0: PROVED up to bound 0$
-^\[.*\] always 32'b0000000000000000000000000000000x === 1 == 0: PROVED up to bound 0$
-^\[.*\] always 32'b0000000000000000000000000000000z === 1 == 0: PROVED up to bound 0$
-^\[.*\] always 1 === 1 == 1: PROVED up to bound 0$
-^\[.*\] always 3'b011 === 2'sb11 == 1: PROVED up to bound 0$
-^\[.*\] always 3'sb111 === 3'sb111 == 1: PROVED up to bound 0$
+
+^\[.*\] always 10 === 10 == 1: PROVED$
+^\[.*\] always 10 === 20 == 0: PROVED$
+^\[.*\] always 10 !== 10 == 0: PROVED$
+^\[.*\] always 10 !== 20 == 1: PROVED$
+^\[.*\] always 32'b0000000000000000000000000000000x === 32'b0000000000000000000000000000000x == 1: PROVED$
+^\[.*\] always 32'b0000000000000000000000000000000z === 32'b0000000000000000000000000000000z == 1: PROVED$
+^\[.*\] always 32'b0000000000000000000000000000000x === 32'b0000000000000000000000000000000z == 0: PROVED$
+^\[.*\] always 32'b0000000000000000000000000000000x === 1 == 0: PROVED$
+^\[.*\] always 32'b0000000000000000000000000000000z === 1 == 0: PROVED$
+^\[.*\] always 1 === 1 == 1: PROVED$
+^\[.*\] always 3'b011 === 2'sb11 == 1: PROVED$
+^\[.*\] always 3'sb111 === 3'sb111 == 1: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/equality3.desc
+++ b/regression/verilog/expressions/equality3.desc
@@ -1,6 +1,6 @@
 CORE
 equality3.v
---bound 0
+
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/iff1.desc
+++ b/regression/verilog/expressions/iff1.desc
@@ -1,6 +1,6 @@
 CORE
 iff1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/implies1.desc
+++ b/regression/verilog/expressions/implies1.desc
@@ -1,6 +1,6 @@
 CORE
 implies1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/inside1.desc
+++ b/regression/verilog/expressions/inside1.desc
@@ -1,12 +1,12 @@
 CORE broken-smt-backend
 inside1.sv
---bound 0
-^\[.*\] always 2 inside \{1, 2, 3\}: PROVED up to bound 0$
-^\[.*\] always 2 inside \{3'b0\?0\}: PROVED up to bound 0$
-^\[.*\] always !\(2 inside \{3'b0\?1\}\): PROVED up to bound 0$
-^\[.*\] always 2 inside \{\[1:3\], \[6:8\]\}: PROVED up to bound 0$
-^\[.*\] always !\(4 inside \{\[1:3\], \[6:8\]\}\): PROVED up to bound 0$
-^\[.*\] always \(1 && 1\) inside \{1, 2, 3\}: PROVED up to bound 0$
+
+^\[.*\] always 2 inside \{1, 2, 3\}: PROVED$
+^\[.*\] always 2 inside \{3'b0\?0\}: PROVED$
+^\[.*\] always !\(2 inside \{3'b0\?1\}\): PROVED$
+^\[.*\] always 2 inside \{\[1:3\], \[6:8\]\}: PROVED$
+^\[.*\] always !\(4 inside \{\[1:3\], \[6:8\]\}\): PROVED$
+^\[.*\] always \(1 && 1\) inside \{1, 2, 3\}: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/mod2.desc
+++ b/regression/verilog/expressions/mod2.desc
@@ -1,6 +1,6 @@
 CORE
 mod2.v
---bound 0
+
 ^file .* line 4: operand 1\.1 must be integral$
 ^EXIT=2$
 ^SIGNAL=0$

--- a/regression/verilog/expressions/negation1.desc
+++ b/regression/verilog/expressions/negation1.desc
@@ -1,6 +1,6 @@
 CORE
 negation1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/part-select-constant1.desc
+++ b/regression/verilog/expressions/part-select-constant1.desc
@@ -1,7 +1,7 @@
 CORE
 part-select-constant1.sv
---bound 0
-^\[.*\] .* PROVED up to bound 0$
+
+^\[.*\] .* PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/power1.desc
+++ b/regression/verilog/expressions/power1.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
 power1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/power2.desc
+++ b/regression/verilog/expressions/power2.desc
@@ -1,6 +1,6 @@
 CORE
 power2.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/reduction1.desc
+++ b/regression/verilog/expressions/reduction1.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
 reduction1.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/reduction2.desc
+++ b/regression/verilog/expressions/reduction2.desc
@@ -1,6 +1,6 @@
 CORE
 reduction2.v
---bound 0
+
 ^file .* line 4: operand 1\.1 must be integral$
 ^EXIT=2$
 ^SIGNAL=0$

--- a/regression/verilog/expressions/replication1.desc
+++ b/regression/verilog/expressions/replication1.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
 replication1.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/replication2.desc
+++ b/regression/verilog/expressions/replication2.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 replication2.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/replication3.desc
+++ b/regression/verilog/expressions/replication3.desc
@@ -1,6 +1,6 @@
 CORE
 replication3.v
---bound 0
+
 ^file .* line 3: operand 1\.1 must be integral$
 ^EXIT=2$
 ^SIGNAL=0$

--- a/regression/verilog/expressions/shr2.desc
+++ b/regression/verilog/expressions/shr2.desc
@@ -1,6 +1,6 @@
 CORE
 shr2.v
---bound 0
+
 ^file .* line 4: operand 1\.1 must be integral$
 ^EXIT=2$
 ^SIGNAL=0$

--- a/regression/verilog/expressions/signed1.desc
+++ b/regression/verilog/expressions/signed1.desc
@@ -1,14 +1,14 @@
 CORE
 signed1.sv
---module main --bound 0
-^\[main\.p1\] always main\.wire1 == main.wire2: PROVED up to bound 0$
-^\[main\.p2\] always main\.wire1 >>> 1 == -1: PROVED up to bound 0$
-^\[main\.p3\] always main\.wire2 >> 1 != -1: PROVED up to bound 0$
-^\[main\.p4\] always main\.wire1\[31:0\] >> 1 != -1: PROVED up to bound 0$
-^\[main\.p5\] always \$unsigned\(main\.wire1\) >> 1 != -1: PROVED up to bound 0$
-^\[main\.p6\] always \$signed\(main\.wire2\) >>> 1 == -1: PROVED up to bound 0$
-^\[main\.p7\] always -1 >> 1 != -1: PROVED up to bound 0$
-^\[main\.p8\] always -1 >>> 1 == -1: PROVED up to bound 0$
+--module main
+^\[main\.p1\] always main\.wire1 == main.wire2: PROVED$
+^\[main\.p2\] always main\.wire1 >>> 1 == -1: PROVED$
+^\[main\.p3\] always main\.wire2 >> 1 != -1: PROVED$
+^\[main\.p4\] always main\.wire1\[31:0\] >> 1 != -1: PROVED$
+^\[main\.p5\] always \$unsigned\(main\.wire1\) >> 1 != -1: PROVED$
+^\[main\.p6\] always \$signed\(main\.wire2\) >>> 1 == -1: PROVED$
+^\[main\.p7\] always -1 >> 1 != -1: PROVED$
+^\[main\.p8\] always -1 >>> 1 == -1: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/signed2.desc
+++ b/regression/verilog/expressions/signed2.desc
@@ -1,6 +1,6 @@
 CORE
 signed2.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/signing_cast1.desc
+++ b/regression/verilog/expressions/signing_cast1.desc
@@ -1,12 +1,12 @@
 CORE broken-smt-backend
 signing_cast1.sv
---module main --bound 0
-^\[main\.p0\] always signed'\(1'b1\) == -1: PROVED up to bound 0$
-^\[main\.p1\] always signed'\(4'b1110\) == -2: PROVED up to bound 0$
-^\[main\.p2\] always signed'\(4'b0111\) == 7: PROVED up to bound 0$
-^\[main\.p3\] always signed'\(!0\) == -1: PROVED up to bound 0$
-^\[main\.p4\] always unsigned'\(!0\) == 1: PROVED up to bound 0$
-^\[main\.p5\] always unsigned'\(-1\) == 32'hFFFFFFFF: PROVED up to bound 0$
+--module main
+^\[main\.p0\] always signed'\(1'b1\) == -1: PROVED$
+^\[main\.p1\] always signed'\(4'b1110\) == -2: PROVED$
+^\[main\.p2\] always signed'\(4'b0111\) == 7: PROVED$
+^\[main\.p3\] always signed'\(!0\) == -1: PROVED$
+^\[main\.p4\] always unsigned'\(!0\) == 1: PROVED$
+^\[main\.p5\] always unsigned'\(-1\) == 32'hFFFFFFFF: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/size_cast1.desc
+++ b/regression/verilog/expressions/size_cast1.desc
@@ -1,10 +1,10 @@
 CORE
 size_cast1.sv
---module main --bound 0
-^\[main\.p0\] always \$bits\(10'\(1\)\) == 10: PROVED up to bound 0$
-^\[main\.p1\] always \$bits\(20'\(1\)\) == 20: PROVED up to bound 0$
-^\[main\.p2\] always 10'\(-1\) == -1: PROVED up to bound 0$
-^\[main\.p3\] always 2'\(1 == 1\) == 1: PROVED up to bound 0$
+--module main
+^\[main\.p0\] always \$bits\(10'\(1\)\) == 10: PROVED$
+^\[main\.p1\] always \$bits\(20'\(1\)\) == 20: PROVED$
+^\[main\.p2\] always 10'\(-1\) == -1: PROVED$
+^\[main\.p3\] always 2'\(1 == 1\) == 1: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/static_cast1.desc
+++ b/regression/verilog/expressions/static_cast1.desc
@@ -1,7 +1,7 @@
 CORE
 static_cast1.sv
---module main --bound 0
-^\[main\.p0\] always \[7:0\]'\(32'hFFFF\) == 255: PROVED up to bound 0$
+--module main
+^\[main\.p0\] always \[7:0\]'\(32'hFFFF\) == 255: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/streaming_concatenation1.desc
+++ b/regression/verilog/expressions/streaming_concatenation1.desc
@@ -1,10 +1,10 @@
 CORE
 streaming_concatenation1.sv
---bound 0
-^\[.*\] always \{<<\{4'b1010\}\} == 4'b0101: PROVED up to bound 0$
-^\[.*\] always \{<<\{1 == 1\}\} == 1: PROVED up to bound 0$
-^\[.*\] always \{<<4\{16'hABCD\}\} == 16'hDCBA: PROVED up to bound 0$
-^\[.*\] always \{<<8\{16'hABCD\}\} == 16'hCDAB: PROVED up to bound 0$
+
+^\[.*\] always \{<<\{4'b1010\}\} == 4'b0101: PROVED$
+^\[.*\] always \{<<\{1 == 1\}\} == 1: PROVED$
+^\[.*\] always \{<<4\{16'hABCD\}\} == 16'hDCBA: PROVED$
+^\[.*\] always \{<<8\{16'hABCD\}\} == 16'hCDAB: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/streaming_concatenation2.desc
+++ b/regression/verilog/expressions/streaming_concatenation2.desc
@@ -1,6 +1,6 @@
 CORE
 streaming_concatenation2.sv
---bound 0
+
 ^file .* line 4: operand 1\.1 must be integral$
 ^EXIT=2$
 ^SIGNAL=0$

--- a/regression/verilog/expressions/wildcard_equality1.desc
+++ b/regression/verilog/expressions/wildcard_equality1.desc
@@ -1,16 +1,16 @@
 CORE
 wildcard_equality1.sv
---bound 0
-^\[main\.property01\] always 10 ==\? 10 === 1: PROVED up to bound 0$
-^\[main\.property02\] always 10 ==\? 20 === 0: PROVED up to bound 0$
-^\[main\.property03\] always 10 !=\? 20 === 1: PROVED up to bound 0$
-^\[main\.property04\] always 10 ==\? 20 === 0: PROVED up to bound 0$
-^\[main\.property05\] always 2'b00 ==\? 2'b0x === 1: PROVED up to bound 0$
-^\[main\.property06\] always 2'b10 ==\? 2'b0x === 0: PROVED up to bound 0$
-^\[main\.property07\] always 2'b00 !=\? 2'b0x === 0: PROVED up to bound 0$
-^\[main\.property08\] always 2'b10 !=\? 2'b0x === 1: PROVED up to bound 0$
+
+^\[main\.property01\] always 10 ==\? 10 === 1: PROVED$
+^\[main\.property02\] always 10 ==\? 20 === 0: PROVED$
+^\[main\.property03\] always 10 !=\? 20 === 1: PROVED$
+^\[main\.property04\] always 10 ==\? 20 === 0: PROVED$
+^\[main\.property05\] always 2'b00 ==\? 2'b0x === 1: PROVED$
+^\[main\.property06\] always 2'b10 ==\? 2'b0x === 0: PROVED$
+^\[main\.property07\] always 2'b00 !=\? 2'b0x === 0: PROVED$
+^\[main\.property08\] always 2'b10 !=\? 2'b0x === 1: PROVED$
 ^\[main\.property09\] always 2'b11 ==\? 2'b11 === 0: REFUTED$
-^\[main\.property10\] always 2'sb11 ==\? 2'sb11 === 1: PROVED up to bound 0$
+^\[main\.property10\] always 2'sb11 ==\? 2'sb11 === 1: PROVED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/wildcard_equality2.desc
+++ b/regression/verilog/expressions/wildcard_equality2.desc
@@ -1,6 +1,6 @@
 CORE
 wildcard_equality2.v
---bound 0
+
 ^file .* line 4: operand 1\.1 must be integral$
 ^EXIT=2$
 ^SIGNAL=0$

--- a/regression/verilog/for/break1.desc
+++ b/regression/verilog/for/break1.desc
@@ -1,6 +1,6 @@
 CORE
 break1.sv
---bound 0
+
 ^file .* line 7: synthesis of break not supported$
 ^EXIT=2$
 ^SIGNAL=0$

--- a/regression/verilog/for/continue1.desc
+++ b/regression/verilog/for/continue1.desc
@@ -1,6 +1,6 @@
 CORE
 continue1.sv
---bound 0
+
 ^file .* line 8: synthesis of continue not supported$
 ^EXIT=2$
 ^SIGNAL=0$

--- a/regression/verilog/for/for_with_reg.desc
+++ b/regression/verilog/for/for_with_reg.desc
@@ -1,6 +1,6 @@
 CORE
 for_with_reg.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/functioncall/function_ports1.desc
+++ b/regression/verilog/functioncall/function_ports1.desc
@@ -1,8 +1,8 @@
 CORE
 function_ports1.v
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.property\.test16\] always .*: PROVED up to bound 0$
+^\[main\.property\.test16\] always .*: PROVED$
 --
 ^warning: ignoring

--- a/regression/verilog/functioncall/functioncall1.desc
+++ b/regression/verilog/functioncall/functioncall1.desc
@@ -1,8 +1,8 @@
 CORE
 functioncall1.v
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.property\.test1\] always .*: PROVED up to bound 0$
+^\[main\.property\.test1\] always .*: PROVED$
 --
 ^warning: ignoring

--- a/regression/verilog/functioncall/functioncall3.desc
+++ b/regression/verilog/functioncall/functioncall3.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
 functioncall3.v
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 ^UNSAT: .*$

--- a/regression/verilog/functioncall/functioncall4.desc
+++ b/regression/verilog/functioncall/functioncall4.desc
@@ -1,6 +1,6 @@
 CORE
 functioncall4.v
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 ^UNSAT: .*$

--- a/regression/verilog/functioncall/functioncall5.desc
+++ b/regression/verilog/functioncall/functioncall5.desc
@@ -1,6 +1,6 @@
 CORE
 functioncall5.v
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/functioncall/functioncall6.desc
+++ b/regression/verilog/functioncall/functioncall6.desc
@@ -1,8 +1,8 @@
 CORE
 functioncall6.v
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main\.property\.p1\] always .*: PROVED up to bound 0$
+^\[main\.property\.p1\] always .*: PROVED$
 --
 ^warning: ignoring

--- a/regression/verilog/functioncall/functioncall7.desc
+++ b/regression/verilog/functioncall/functioncall7.desc
@@ -1,6 +1,6 @@
 CORE
 functioncall7.v
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/functioncall/functioncall_as_constant1.desc
+++ b/regression/verilog/functioncall/functioncall_as_constant1.desc
@@ -1,6 +1,6 @@
 CORE
 functioncall_as_constant1.v
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/functioncall/functioncall_as_input1.desc
+++ b/regression/verilog/functioncall/functioncall_as_input1.desc
@@ -1,6 +1,6 @@
 CORE
 functioncall_as_input1.v
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/functioncall/return1.desc
+++ b/regression/verilog/functioncall/return1.desc
@@ -1,6 +1,6 @@
 CORE
 return1.sv
---bound 0
+
 ^file .* line 4: synthesis of return not supported$
 ^EXIT=2$
 ^SIGNAL=0$

--- a/regression/verilog/functioncall/void_function1.desc
+++ b/regression/verilog/functioncall/void_function1.desc
@@ -1,6 +1,6 @@
 CORE
 void_function1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/generate/generate-for2.desc
+++ b/regression/verilog/generate/generate-for2.desc
@@ -1,6 +1,6 @@
 CORE
 generate-for2.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/generate/generate-inst2.desc
+++ b/regression/verilog/generate/generate-inst2.desc
@@ -1,6 +1,6 @@
 CORE
 generate-inst2.v
---module main --bound 0
+--module main
 ^EXIT=10$
 ^SIGNAL=0$
 ^no properties$

--- a/regression/verilog/generate/generate-localparam1.desc
+++ b/regression/verilog/generate/generate-localparam1.desc
@@ -1,6 +1,6 @@
 CORE
 generate-localparam1.v
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/generate/generate-reg1.desc
+++ b/regression/verilog/generate/generate-reg1.desc
@@ -1,6 +1,6 @@
 CORE
 generate-reg1.v
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/generate/generate-reg2.desc
+++ b/regression/verilog/generate/generate-reg2.desc
@@ -1,6 +1,6 @@
 CORE
 generate-reg2.v
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/hierarchical_identifiers/hierarchical_identifiers1.desc
+++ b/regression/verilog/hierarchical_identifiers/hierarchical_identifiers1.desc
@@ -1,6 +1,6 @@
 CORE
 hierarchical_identifiers1.v
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/let/let1.desc
+++ b/regression/verilog/let/let1.desc
@@ -1,6 +1,6 @@
 CORE
 let1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/let/let_ports1.desc
+++ b/regression/verilog/let/let_ports1.desc
@@ -1,6 +1,6 @@
 CORE
 let_ports1.sv
---bound 0
+
 ^file .* line 5: let ports not supported yet$
 ^EXIT=2$
 ^SIGNAL=0$

--- a/regression/verilog/modules/localparam2.desc
+++ b/regression/verilog/modules/localparam2.desc
@@ -1,6 +1,6 @@
 CORE
 localparam2.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/localparam3.desc
+++ b/regression/verilog/modules/localparam3.desc
@@ -1,6 +1,6 @@
 CORE
 localparam3.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/parameter_ports1.desc
+++ b/regression/verilog/modules/parameter_ports1.desc
@@ -1,6 +1,6 @@
 CORE
 parameter_ports1.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/parameter_ports2.desc
+++ b/regression/verilog/modules/parameter_ports2.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 parameter_ports2.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/parameter_ports3.desc
+++ b/regression/verilog/modules/parameter_ports3.desc
@@ -1,6 +1,6 @@
 CORE
 parameter_ports3.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/parameter_ports4.desc
+++ b/regression/verilog/modules/parameter_ports4.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 parameter_ports4.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/parameters10.desc
+++ b/regression/verilog/modules/parameters10.desc
@@ -1,6 +1,6 @@
 CORE
 parameters10.v
---bound 0
+
 ^file .* line 6: expected constant expression, but got `main\.x'$
 ^EXIT=2$
 ^SIGNAL=0$

--- a/regression/verilog/modules/parameters4.desc
+++ b/regression/verilog/modules/parameters4.desc
@@ -1,6 +1,6 @@
 CORE
 parameters4.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/parameters5.desc
+++ b/regression/verilog/modules/parameters5.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 parameters5.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/ports3.desc
+++ b/regression/verilog/modules/ports3.desc
@@ -1,6 +1,6 @@
 CORE
 ports3.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/ports4.desc
+++ b/regression/verilog/modules/ports4.desc
@@ -1,6 +1,6 @@
 CORE
 ports4.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/ports5.desc
+++ b/regression/verilog/modules/ports5.desc
@@ -1,6 +1,6 @@
 CORE
 ports5.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/ports6.desc
+++ b/regression/verilog/modules/ports6.desc
@@ -1,6 +1,6 @@
 CORE
 ports6.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/ports7.desc
+++ b/regression/verilog/modules/ports7.desc
@@ -1,6 +1,6 @@
 CORE
 ports7.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/ports8.desc
+++ b/regression/verilog/modules/ports8.desc
@@ -1,6 +1,6 @@
 CORE
 ports8.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/type_parameters1.desc
+++ b/regression/verilog/modules/type_parameters1.desc
@@ -1,8 +1,8 @@
 CORE
 type_parameters1.sv
---bound 0
-^\[main\.p1\] always \$bits\(main\.T1\) == 1: PROVED up to bound 0$
-^\[main\.p2\] always \$bits\(main\.T2\) == 32: PROVED up to bound 0$
+
+^\[main\.p1\] always \$bits\(main\.T1\) == 1: PROVED$
+^\[main\.p2\] always \$bits\(main\.T2\) == 32: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/variable_module_port1.desc
+++ b/regression/verilog/modules/variable_module_port1.desc
@@ -1,6 +1,6 @@
 CORE
 variable_module_port1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/nets/implicit1.desc
+++ b/regression/verilog/nets/implicit1.desc
@@ -1,6 +1,6 @@
 CORE
 implicit1.sv
---bound 0 --warn-implicit-nets
+--warn-implicit-nets
 ^file .* line 4: implicit wire main\.O$
 ^file .* line 4: implicit wire main\.A$
 ^file .* line 4: implicit wire main\.B$

--- a/regression/verilog/nets/implicit2.desc
+++ b/regression/verilog/nets/implicit2.desc
@@ -1,6 +1,6 @@
 CORE
 implicit2.sv
---bound 0 --warn-implicit-nets
+--warn-implicit-nets
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/nets/implicit3.desc
+++ b/regression/verilog/nets/implicit3.desc
@@ -1,6 +1,6 @@
 CORE
 implicit3.sv
---bound 0 --warn-implicit-nets
+--warn-implicit-nets
 ^file .* line 6: implicit wire main\.O$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/verilog/nets/implicit4.desc
+++ b/regression/verilog/nets/implicit4.desc
@@ -1,6 +1,6 @@
 CORE
 implicit4.sv
---bound 0 --warn-implicit-nets
+--warn-implicit-nets
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/nets/implicit5.desc
+++ b/regression/verilog/nets/implicit5.desc
@@ -1,6 +1,6 @@
 CORE
 implicit5.sv
---bound 0 --warn-implicit-nets
+--warn-implicit-nets
 ^file .* line 4: unknown identifier A$
 ^EXIT=2$
 ^SIGNAL=0$

--- a/regression/verilog/nets/implicit6.desc
+++ b/regression/verilog/nets/implicit6.desc
@@ -1,6 +1,6 @@
 CORE
 implicit6.sv
---bound 0 --warn-implicit-nets
+--warn-implicit-nets
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/nets/implicit7.desc
+++ b/regression/verilog/nets/implicit7.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 implicit7.sv
---bound 0 --warn-implicit-nets
+--warn-implicit-nets
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/part-select/indexed-part-select1.desc
+++ b/regression/verilog/part-select/indexed-part-select1.desc
@@ -1,6 +1,6 @@
 CORE
 indexed-part-select1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/part-select/indexed-part-select3.desc
+++ b/regression/verilog/part-select/indexed-part-select3.desc
@@ -1,6 +1,6 @@
 CORE
 indexed-part-select3.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/part-select/indexed-part-select4.desc
+++ b/regression/verilog/part-select/indexed-part-select4.desc
@@ -1,6 +1,6 @@
 CORE
 indexed-part-select4.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/part-select/indexed-part-select5.desc
+++ b/regression/verilog/part-select/indexed-part-select5.desc
@@ -1,6 +1,6 @@
 CORE
 indexed-part-select5.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/primitive_gates/nand1.desc
+++ b/regression/verilog/primitive_gates/nand1.desc
@@ -1,6 +1,6 @@
 CORE
 nand1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/primitive_gates/nand2.desc
+++ b/regression/verilog/primitive_gates/nand2.desc
@@ -1,8 +1,8 @@
 CORE broken-smt-backend
 nand2.sv
---bound 0
-^\[main\.nand_ok\] always !main\.nand_in1 == main\.nand_out: PROVED up to bound 0$
-^\[main\.nand_is_reduction_nand\] always ~\&\{ main\.nand_in1 \} == main\.nand_out: PROVED up to bound 0$
+
+^\[main\.nand_ok\] always !main\.nand_in1 == main\.nand_out: PROVED$
+^\[main\.nand_is_reduction_nand\] always ~\&\{ main\.nand_in1 \} == main\.nand_out: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/primitive_gates/nand4.desc
+++ b/regression/verilog/primitive_gates/nand4.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
 nand4.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/primitive_gates/nor1.desc
+++ b/regression/verilog/primitive_gates/nor1.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
 nor1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/primitive_gates/nor2.desc
+++ b/regression/verilog/primitive_gates/nor2.desc
@@ -1,8 +1,8 @@
 CORE broken-smt-backend
 nor2.sv
---bound 0
-^\[main\.nor_ok\] always !main\.nor_in1 == main\.nor_out: PROVED up to bound 0$
-^\[main\.nor_is_reduction_nor\] always ~\|\{ main\.nor_in1 \} == main\.nor_out: PROVED up to bound 0$
+
+^\[main\.nor_ok\] always !main\.nor_in1 == main\.nor_out: PROVED$
+^\[main\.nor_is_reduction_nor\] always ~\|\{ main\.nor_in1 \} == main\.nor_out: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/primitive_gates/nor4.desc
+++ b/regression/verilog/primitive_gates/nor4.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
 nor4.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/primitive_gates/not1.desc
+++ b/regression/verilog/primitive_gates/not1.desc
@@ -1,6 +1,6 @@
 CORE
 not1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/primitive_gates/or1.desc
+++ b/regression/verilog/primitive_gates/or1.desc
@@ -1,6 +1,6 @@
 CORE
 or1.sv
---bound 0
+
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/primitive_gates/xnor1.desc
+++ b/regression/verilog/primitive_gates/xnor1.desc
@@ -1,9 +1,9 @@
 CORE broken-smt-backend
 xnor1.sv
---bound 0
-^\[main\.xnor_ok\] always !\(xor\(xor\(main\.xnor_in1, main\.xnor_in2\), main\.xnor_in3\)\) == main\.xnor_out: PROVED up to bound 0$
+
+^\[main\.xnor_ok\] always !\(xor\(xor\(main\.xnor_in1, main\.xnor_in2\), main\.xnor_in3\)\) == main\.xnor_out: PROVED$
 ^\[main\.xnor_fail\] always main\.xnor_in1 == main\.xnor_in2 == main\.xnor_in3 == main\.xnor_out: REFUTED$
-^\[main\.xnor_is_reduction_xnor\] always ~\^\{ main\.xnor_in1, main\.xnor_in2, main\.xnor_in3 \} == main\.xnor_out: PROVED up to bound 0$
+^\[main\.xnor_is_reduction_xnor\] always ~\^\{ main\.xnor_in1, main\.xnor_in2, main\.xnor_in3 \} == main\.xnor_out: PROVED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/primitive_gates/xnor2.desc
+++ b/regression/verilog/primitive_gates/xnor2.desc
@@ -1,8 +1,8 @@
 CORE broken-smt-backend
 xnor2.sv
---bound 0
-^\[main\.xnor_ok\] always !main\.xnor_in1 == main\.xnor_out: PROVED up to bound 0$
-^\[main\.xnor_is_reduction_xnor\] always ~\^\{ main\.xnor_in1 \} == main\.xnor_out: PROVED up to bound 0$
+
+^\[main\.xnor_ok\] always !main\.xnor_in1 == main\.xnor_out: PROVED$
+^\[main\.xnor_is_reduction_xnor\] always ~\^\{ main\.xnor_in1 \} == main\.xnor_out: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/primitive_gates/xnor3.desc
+++ b/regression/verilog/primitive_gates/xnor3.desc
@@ -1,7 +1,7 @@
 CORE
 xnor3.sv
---bound 0
-^\[main\.xnor_ok\] always main\.xnor_in1 ~\^ main\.xnor_in2 == main\.xnor_out: PROVED up to bound 0$
+
+^\[main\.xnor_ok\] always main\.xnor_in1 ~\^ main\.xnor_in2 == main\.xnor_out: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/primitive_gates/xnor4.desc
+++ b/regression/verilog/primitive_gates/xnor4.desc
@@ -1,8 +1,8 @@
 CORE broken-smt-backend
 xnor4.sv
---bound 0
-^\[main\.xnor_x1_ok\] always ~\(main\.xnor_in1 \^ main\.xnor_in2 \^ main.xnor_in3\) == main.xnor_out: PROVED up to bound 0$
-^\[main\.xnor_x2_ok\] always ~main\.xnor_in1 == main.xnor_out: PROVED up to bound 0$
+
+^\[main\.xnor_x1_ok\] always ~\(main\.xnor_in1 \^ main\.xnor_in2 \^ main.xnor_in3\) == main.xnor_out: PROVED$
+^\[main\.xnor_x2_ok\] always ~main\.xnor_in1 == main.xnor_out: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/string/string_literals1.desc
+++ b/regression/verilog/string/string_literals1.desc
@@ -1,6 +1,6 @@
 CORE
 string_literals1.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/structs/structs1.desc
+++ b/regression/verilog/structs/structs1.desc
@@ -1,10 +1,10 @@
 CORE
 structs1.sv
---bound 0
-^\[main\.p0\] always \$bits\(main\.s\) == 9: PROVED up to bound 0$
-^\[main\.p1\] always main\.s\.field1 == 1: PROVED up to bound 0$
-^\[main\.p2\] always main\.s\.field2 == 0: PROVED up to bound 0$
-^\[main\.p3\] always main\.s\.field3 == 115: PROVED up to bound 0$
+
+^\[main\.p0\] always \$bits\(main\.s\) == 9: PROVED$
+^\[main\.p1\] always main\.s\.field1 == 1: PROVED$
+^\[main\.p2\] always main\.s\.field2 == 0: PROVED$
+^\[main\.p3\] always main\.s\.field3 == 115: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/structs/structs2.desc
+++ b/regression/verilog/structs/structs2.desc
@@ -1,6 +1,6 @@
 CORE
 structs2.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/structs/structs3.desc
+++ b/regression/verilog/structs/structs3.desc
@@ -1,6 +1,6 @@
 CORE
 structs3.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/structs/structs4.desc
+++ b/regression/verilog/structs/structs4.desc
@@ -1,7 +1,7 @@
 CORE
 structs4.sv
---bound 0
-^\[main\.p0\] always main\.w == 32'h173: PROVED up to bound 0$
+
+^\[main\.p0\] always main\.w == 32'h173: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/structs/structs5.desc
+++ b/regression/verilog/structs/structs5.desc
@@ -1,9 +1,9 @@
 CORE
 structs5.sv
---bound 0
-^\[main\.p1\] always main\.s\.field1 == 1: PROVED up to bound 0$
-^\[main\.p2\] always main\.s\.field2 == 0: PROVED up to bound 0$
-^\[main\.p3\] always main\.s\.field3 == 115: PROVED up to bound 0$
+
+^\[main\.p1\] always main\.s\.field1 == 1: PROVED$
+^\[main\.p2\] always main\.s\.field2 == 0: PROVED$
+^\[main\.p3\] always main\.s\.field3 == 115: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/synthesis/always_comb1.desc
+++ b/regression/verilog/synthesis/always_comb1.desc
@@ -1,6 +1,6 @@
 CORE
 always_comb1.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/synthesis/always_comb2.desc
+++ b/regression/verilog/synthesis/always_comb2.desc
@@ -1,9 +1,9 @@
 CORE
 always_comb2.sv
---bound 0
-^\[main\.p0\] always main\.data == 0 -> main\.decoded == 1: PROVED up to bound 0$
-^\[main\.p1\] always main\.data == 1 -> main\.decoded == 2: PROVED up to bound 0$
-^\[main\.p2\] always main\.data == 2 -> main\.decoded == 4: PROVED up to bound 0$
+
+^\[main\.p0\] always main\.data == 0 -> main\.decoded == 1: PROVED$
+^\[main\.p1\] always main\.data == 1 -> main\.decoded == 2: PROVED$
+^\[main\.p2\] always main\.data == 2 -> main\.decoded == 4: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/synthesis/continuous_assignment1.desc
+++ b/regression/verilog/synthesis/continuous_assignment1.desc
@@ -1,6 +1,6 @@
 CORE
 continuous_assignment1.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/synthesis/continuous_assignment2.desc
+++ b/regression/verilog/synthesis/continuous_assignment2.desc
@@ -1,6 +1,6 @@
 CORE
 continuous_assignment2.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/synthesis/continuous_assignment3.desc
+++ b/regression/verilog/synthesis/continuous_assignment3.desc
@@ -1,6 +1,6 @@
 CORE
 continuous_assignment3.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/synthesis/continuous_assignment_to_net_part_select1.desc
+++ b/regression/verilog/synthesis/continuous_assignment_to_net_part_select1.desc
@@ -1,7 +1,7 @@
 KNOWNBUG
 continuous_assignment_to_net_part_select1.sv
---bound 0
-^\[main\.p0\] always main\.some_wire\[1:0\] == 1: PROVED up to bound 0$
+
+^\[main\.p0\] always main\.some_wire\[1:0\] == 1: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog.desc
+++ b/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog.desc
@@ -1,7 +1,7 @@
 CORE
 continuous_assignment_to_variable_systemverilog.sv
---bound 0
-^\[main\.p1\] always main\.some_reg == main\.i: PROVED up to bound 0$
+
+^\[main\.p1\] always main\.some_reg == main\.i: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog3.desc
+++ b/regression/verilog/synthesis/continuous_assignment_to_variable_systemverilog3.desc
@@ -1,6 +1,6 @@
 CORE
 continuous_assignment_to_variable_systemverilog3.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/synthesis/continuous_assignment_to_variable_verilog.desc
+++ b/regression/verilog/synthesis/continuous_assignment_to_variable_verilog.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 continuous_assignment_to_variable_verilog.v
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/array_functions1.desc
+++ b/regression/verilog/system-functions/array_functions1.desc
@@ -1,21 +1,21 @@
 CORE
 array_functions1.sv
---module main --bound 0
-^\[main\.pP0\] always \$left\(main\.packed1\) == 32 && \$right\(main\.packed1\) == 1: PROVED up to bound 0$
-^\[main\.pP1\] always \$left\(main\.packed2\) == 0 && \$right\(main\.packed2\) == 31: PROVED up to bound 0$
-^\[main\.pP2\] always \$low\(main\.packed1\) == 1 && \$high\(main\.packed1\) == 32: PROVED up to bound 0$
-^\[main\.pP3\] always \$low\(main\.packed2\) == 0 && \$high\(main\.packed2\) == 31: PROVED up to bound 0$
-^\[main\.pP4\] always \$increment\(main\.packed1\) == 1: PROVED up to bound 0$
-^\[main\.pP5\] always \$increment\(main\.packed2\) == -1: PROVED up to bound 0$
-^\[main\.pU0\] always \$left\(main\.unpacked1\) == 32 && \$right\(main\.unpacked1\) == 1: PROVED up to bound 0$
-^\[main\.pU1\] always \$left\(main\.unpacked2\) == 0 && \$right\(main\.unpacked2\) == 31: PROVED up to bound 0$
-^\[main\.pU2\] always \$left\(main\.unpacked3\) == 31 && \$right\(main\.unpacked3\) == 0: PROVED up to bound 0$
-^\[main\.pU3\] always \$low\(main\.unpacked1\) == 1 && \$high\(main\.unpacked1\) == 32: PROVED up to bound 0$
-^\[main\.pU4\] always \$low\(main\.unpacked2\) == 0 && \$high\(main\.unpacked2\) == 31: PROVED up to bound 0$
-^\[main\.pU5\] always \$low\(main\.unpacked3\) == 0 && \$high\(main\.unpacked3\) == 31: PROVED up to bound 0$
-^\[main\.pU6\] always \$increment\(main\.unpacked1\) == 1: PROVED up to bound 0$
-^\[main\.pU7\] always \$increment\(main\.unpacked2\) == -1: PROVED up to bound 0$
-^\[main\.pU8\] always \$increment\(main\.unpacked3\) == 1: PROVED up to bound 0$
+--module main
+^\[main\.pP0\] always \$left\(main\.packed1\) == 32 && \$right\(main\.packed1\) == 1: PROVED$
+^\[main\.pP1\] always \$left\(main\.packed2\) == 0 && \$right\(main\.packed2\) == 31: PROVED$
+^\[main\.pP2\] always \$low\(main\.packed1\) == 1 && \$high\(main\.packed1\) == 32: PROVED$
+^\[main\.pP3\] always \$low\(main\.packed2\) == 0 && \$high\(main\.packed2\) == 31: PROVED$
+^\[main\.pP4\] always \$increment\(main\.packed1\) == 1: PROVED$
+^\[main\.pP5\] always \$increment\(main\.packed2\) == -1: PROVED$
+^\[main\.pU0\] always \$left\(main\.unpacked1\) == 32 && \$right\(main\.unpacked1\) == 1: PROVED$
+^\[main\.pU1\] always \$left\(main\.unpacked2\) == 0 && \$right\(main\.unpacked2\) == 31: PROVED$
+^\[main\.pU2\] always \$left\(main\.unpacked3\) == 31 && \$right\(main\.unpacked3\) == 0: PROVED$
+^\[main\.pU3\] always \$low\(main\.unpacked1\) == 1 && \$high\(main\.unpacked1\) == 32: PROVED$
+^\[main\.pU4\] always \$low\(main\.unpacked2\) == 0 && \$high\(main\.unpacked2\) == 31: PROVED$
+^\[main\.pU5\] always \$low\(main\.unpacked3\) == 0 && \$high\(main\.unpacked3\) == 31: PROVED$
+^\[main\.pU6\] always \$increment\(main\.unpacked1\) == 1: PROVED$
+^\[main\.pU7\] always \$increment\(main\.unpacked2\) == -1: PROVED$
+^\[main\.pU8\] always \$increment\(main\.unpacked3\) == 1: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/bits1.desc
+++ b/regression/verilog/system-functions/bits1.desc
@@ -1,6 +1,6 @@
 CORE
 bits1.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/bitstoreal1.desc
+++ b/regression/verilog/system-functions/bitstoreal1.desc
@@ -1,6 +1,6 @@
 CORE
 bitstoreal1.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/bitstoshortreal1.desc
+++ b/regression/verilog/system-functions/bitstoshortreal1.desc
@@ -1,6 +1,6 @@
 CORE
 bitstoshortreal1.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/clog2.desc
+++ b/regression/verilog/system-functions/clog2.desc
@@ -3,12 +3,12 @@ clog2.v
 
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.property.p0\] .* PROVED up to bound 1$
-^\[main.property.p1\] .* PROVED up to bound 1$
-^\[main.property.p2\] .* PROVED up to bound 1$
-^\[main.property.p3\] .* PROVED up to bound 1$
-^\[main.property.p4\] .* PROVED up to bound 1$
-^\[main.property.p5\] .* PROVED up to bound 1$
-^\[main.property.p6\] .* PROVED up to bound 1$
+^\[main.property.p0\] .* PROVED$
+^\[main.property.p1\] .* PROVED$
+^\[main.property.p2\] .* PROVED$
+^\[main.property.p3\] .* PROVED$
+^\[main.property.p4\] .* PROVED$
+^\[main.property.p5\] .* PROVED$
+^\[main.property.p6\] .* PROVED$
 --
 ^warning: ignoring

--- a/regression/verilog/system-functions/countones1.desc
+++ b/regression/verilog/system-functions/countones1.desc
@@ -1,6 +1,6 @@
 CORE
 countones1.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/itor1.desc
+++ b/regression/verilog/system-functions/itor1.desc
@@ -1,6 +1,6 @@
 CORE
 itor1.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/low1.desc
+++ b/regression/verilog/system-functions/low1.desc
@@ -1,6 +1,6 @@
 CORE
 low1.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/realtobits1.desc
+++ b/regression/verilog/system-functions/realtobits1.desc
@@ -1,6 +1,6 @@
 CORE
 realtobits1.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/rtoi1.desc
+++ b/regression/verilog/system-functions/rtoi1.desc
@@ -1,6 +1,6 @@
 CORE
 rtoi1.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/shortrealtobits1.desc
+++ b/regression/verilog/system-functions/shortrealtobits1.desc
@@ -1,6 +1,6 @@
 CORE
 shortrealtobits1.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/signed1.desc
+++ b/regression/verilog/system-functions/signed1.desc
@@ -1,6 +1,6 @@
 CORE
 signed1.v
---bound 0
+
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/signed2.desc
+++ b/regression/verilog/system-functions/signed2.desc
@@ -1,10 +1,10 @@
 CORE
 signed2.sv
---bound 0
-^\[main\.p0\] always \$signed\(1\) == 1: PROVED up to bound 0$
-^\[main\.p1\] always \$signed\(1'b1\) == -1: PROVED up to bound 0$
-^\[main\.p2\] always \$signed\(-1\) == -1: PROVED up to bound 0$
-^\[main\.p3\] always \$signed\(!0\) == -1: PROVED up to bound 0$
+
+^\[main\.p0\] always \$signed\(1\) == 1: PROVED$
+^\[main\.p1\] always \$signed\(1'b1\) == -1: PROVED$
+^\[main\.p2\] always \$signed\(-1\) == -1: PROVED$
+^\[main\.p3\] always \$signed\(!0\) == -1: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/test.desc
+++ b/regression/verilog/system-functions/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.sv
---module main --bound 0
+--module main
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/typename1.desc
+++ b/regression/verilog/system-functions/typename1.desc
@@ -1,13 +1,13 @@
 CORE
 typename1.sv
---module main --bound 0
-^\[.*\] always \$typename\(main\.some_bit\) == "bit": PROVED up to bound 0$
-^\[.*\] always \$typename\(main\.vector1\) == "bit\[31:0\]": PROVED up to bound 0$
-^\[.*\] always \$typename\(main\.vector2\) == "bit\[0:31\]": PROVED up to bound 0$
-^\[.*\] always \$typename\(main\.vector3\) == "bit signed\[31:0\]": PROVED up to bound 0$
-^\[.*\] always \$typename\(real'\(1\)\) == "real": PROVED up to bound 0$
-^\[.*\] always \$typename\(shortreal'\(1\)\) == "shortreal": PROVED up to bound 0$
-^\[.*\] always \$typename\(realtime'\(1\)\) == "realtime": PROVED up to bound 0$
+--module main
+^\[.*\] always \$typename\(main\.some_bit\) == "bit": PROVED$
+^\[.*\] always \$typename\(main\.vector1\) == "bit\[31:0\]": PROVED$
+^\[.*\] always \$typename\(main\.vector2\) == "bit\[0:31\]": PROVED$
+^\[.*\] always \$typename\(main\.vector3\) == "bit signed\[31:0\]": PROVED$
+^\[.*\] always \$typename\(real'\(1\)\) == "real": PROVED$
+^\[.*\] always \$typename\(shortreal'\(1\)\) == "shortreal": PROVED$
+^\[.*\] always \$typename\(realtime'\(1\)\) == "realtime": PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/typedef/global_typedef.desc
+++ b/regression/verilog/typedef/global_typedef.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 global_typedef.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/typedef/typedef1.desc
+++ b/regression/verilog/typedef/typedef1.desc
@@ -1,6 +1,6 @@
 CORE
 typedef1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/unions/unions1.desc
+++ b/regression/verilog/unions/unions1.desc
@@ -1,6 +1,6 @@
 CORE
 unions1.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/unions/unions2.desc
+++ b/regression/verilog/unions/unions2.desc
@@ -1,6 +1,6 @@
 CORE
 unions2.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/unions/unions3.desc
+++ b/regression/verilog/unions/unions3.desc
@@ -1,6 +1,6 @@
 CORE
 unions3.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/unions/unions4.desc
+++ b/regression/verilog/unions/unions4.desc
@@ -1,6 +1,6 @@
 CORE
 unions4.sv
---bound 0
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/ebmc/ebmc_properties.h
+++ b/src/ebmc/ebmc_properties.h
@@ -208,6 +208,13 @@ public:
         result.emplace(p.identifier, p.normalized_expr);
     return result;
   }
+
+  void reset_failure_to_unknown()
+  {
+    for(auto &p : properties)
+      if(p.is_failure())
+        p.unknown();
+  }
 };
 
 #endif // CPROVER_EBMC_PROPERTIES_H


### PR DESCRIPTION
This adds a trivial engine selection heuristic, as follows:

1) First, try 1-induction, which may refute (base case) or prove (step case) the property.

2) If still unresolved, try BMC with bound 5.

The heuristic is activated when no engine is specified on the command line.