### PR TITLE
IC3: use property_checker interface

### DIFF
--- a/regression/ebmc/ic3/bobcount.desc
+++ b/regression/ebmc/ic3/bobcount.desc
@@ -1,10 +1,10 @@
 CORE
 bobcount.sv
 --ic3
-^\[bobcount\.assert\.1\] always !bobcount\.p0: PROVED$
 ^property HOLDS
 ^inductive invariant verification is ok
-^EXIT=2$
+^\[bobcount\.assert\.1\] always !bobcount\.p0: PROVED$
+^EXIT=0$
 ^SIGNAL=0$
 --
 ^inductive invariant verification failed

--- a/regression/ebmc/ic3/bobmiterbm1multi.1033.desc
+++ b/regression/ebmc/ic3/bobmiterbm1multi.1033.desc
@@ -1,10 +1,10 @@
 CORE
 bobmiterbm1multi.sv
 --ic3 --property bobmiterbm1multi.assert.1033
-^\[bobmiterbm1multi\.assert\.1033\] always !bobmiterbm1multi\.p1032: PROVED$
 ^property HOLDS
 ^inductive invariant verification is ok
-^EXIT=2$
+^\[bobmiterbm1multi\.assert\.1033\] always !bobmiterbm1multi\.p1032: PROVED$
+^EXIT=0$
 ^SIGNAL=0$
 --
 ^inductive invariant verification failed

--- a/regression/ebmc/ic3/bobmiterbm1multi.1080.desc
+++ b/regression/ebmc/ic3/bobmiterbm1multi.1080.desc
@@ -1,10 +1,10 @@
 CORE
 bobmiterbm1multi.sv
 --ic3 --property bobmiterbm1multi.assert.1080
-^\[bobmiterbm1multi\.assert\.1080\] always !bobmiterbm1multi\.p1079: REFUTED$
 ^property FAILED
 ^cex verification is ok
-^EXIT=1$
+^\[bobmiterbm1multi\.assert\.1080\] always !bobmiterbm1multi\.p1079: REFUTED$
+^EXIT=10$
 ^SIGNAL=0$
 --
 ^cex verification failed

--- a/regression/ebmc/ic3/eijks208o.desc
+++ b/regression/ebmc/ic3/eijks208o.desc
@@ -1,10 +1,10 @@
 CORE
 eijks208o.sv
 --ic3
-^\[eijks208o\.assert\.1\] always !eijks208o\.p0: PROVED$
 ^property HOLDS
 ^inductive invariant verification is ok
-^EXIT=2$
+^\[eijks208o\.assert\.1\] always !eijks208o\.p0: PROVED$
+^EXIT=0$
 ^SIGNAL=0$
 --
 ^inductive invariant verification failed

--- a/regression/ebmc/ic3/non_inductive1.desc
+++ b/regression/ebmc/ic3/non_inductive1.desc
@@ -1,10 +1,10 @@
 CORE
 non_inductive1.sv
 --ic3 --property main.p0
-^\[main\.p0\] always main\.s11: PROVED$
 ^property HOLDS$
 ^inductive invariant verification is ok
-^EXIT=2$
+^\[main\.p0\] always main\.s11: PROVED$
+^EXIT=0$
 ^SIGNAL=0$
 --
 ^inductive invariant verification failed

--- a/regression/ebmc/ic3/pdtvispeterson.desc
+++ b/regression/ebmc/ic3/pdtvispeterson.desc
@@ -1,10 +1,10 @@
 CORE
 pdtvispeterson.sv
 --ic3
-^\[pdtvispeterson\.assert\.1\] always !pdtvispeterson\.p0: PROVED$
 ^property HOLDS
 ^inductive invariant verification is ok
-^EXIT=2$
+^\[pdtvispeterson\.assert\.1\] always !pdtvispeterson\.p0: PROVED$
+^EXIT=0$
 ^SIGNAL=0$
 --
 ^inductive invariant verification failed

--- a/regression/ebmc/ic3/ringp0.desc
+++ b/regression/ebmc/ic3/ringp0.desc
@@ -1,10 +1,10 @@
 CORE
 ringp0.sv
 --ic3
-^\[ringp0\.assert\.1\] always !ringp0\.p0: REFUTED$
 ^property FAILED
 ^cex verification is ok
-^EXIT=1$
+^\[ringp0\.assert\.1\] always !ringp0\.p0: REFUTED$
+^EXIT=10$
 ^SIGNAL=0$
 --
 ^cex verification failed

--- a/regression/ebmc/ic3/sm98a7multi.desc
+++ b/regression/ebmc/ic3/sm98a7multi.desc
@@ -1,10 +1,10 @@
 CORE
 sm98a7multi.sv
 --ic3 --property sm98a7multi.assert.2 --constr
-^\[sm98a7multi\.assert\.2\] always !sm98a7multi\.p1: REFUTED$
 ^property FAILED
 ^cex verification is ok
-^EXIT=1$
+^\[sm98a7multi\.assert\.2\] always !sm98a7multi\.p1: REFUTED$
+^EXIT=10$
 ^SIGNAL=0$
 --
 ^cex verification failed

--- a/regression/ebmc/ic3/unconstrained_initial.desc
+++ b/regression/ebmc/ic3/unconstrained_initial.desc
@@ -1,7 +1,7 @@
 KNOWNBUG
 unconstrained_initial.sv
 --ic3
-^EXIT=1$
+^EXIT=10$
 ^SIGNAL=0$
 ^property FAILED
 ^cex verification is ok

--- a/regression/ebmc/ic3/visbakery.desc
+++ b/regression/ebmc/ic3/visbakery.desc
@@ -1,10 +1,10 @@
 CORE
 visbakery.sv
 --ic3
-^\[visbakery\.assert\.1\] always !visbakery\.p0: REFUTED$
 ^property FAILED
 ^cex verification is ok
-^EXIT=1$
+^\[visbakery\.assert\.1\] always !visbakery\.p0: REFUTED$
+^EXIT=10$
 ^SIGNAL=0$
 --
 ^cex verification failed

--- a/regression/ebmc/ic3/viseisenberg.desc
+++ b/regression/ebmc/ic3/viseisenberg.desc
@@ -1,10 +1,10 @@
 CORE
 viseisenberg.sv
 --ic3
-^\[viseisenberg\.assert\.1\] always !viseisenberg\.p0: REFUTED$
 ^property FAILED
 ^cex verification is ok
-^EXIT=1$
+^\[viseisenberg\.assert\.1\] always !viseisenberg\.p0: REFUTED$
+^EXIT=10$
 ^SIGNAL=0$
 --
 ^cex verification failed

--- a/regression/ebmc/liveness-to-safety/failing1.ic3.desc
+++ b/regression/ebmc/liveness-to-safety/failing1.ic3.desc
@@ -1,7 +1,7 @@
 CORE
 failing1.sv
 --ic3 --liveness-to-safety
-^EXIT=1$
+^EXIT=10$
 ^SIGNAL=0$
 ^property FAILED$
 --

--- a/regression/ebmc/liveness-to-safety/failing2.ic3.desc
+++ b/regression/ebmc/liveness-to-safety/failing2.ic3.desc
@@ -1,7 +1,7 @@
 CORE
 failing2.sv
 --ic3 --liveness-to-safety
-^EXIT=1$
+^EXIT=10$
 ^SIGNAL=0$
 ^property FAILED$
 --

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -17,7 +17,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "ebmc_base.h"
 #include "ebmc_error.h"
 #include "ebmc_version.h"
-#include "ic3_engine.h"
 #include "liveness_to_safety.h"
 #include "neural_liveness.h"
 #include "output_file.h"
@@ -154,11 +153,6 @@ int ebmc_parse_optionst::doit()
 
     if(cmdline.isset("random-trace") || cmdline.isset("random-waveform"))
       return random_trace(cmdline, ui_message_handler);
-
-#ifndef _WIN32
-    if(cmdline.isset("ic3"))
-      return do_ic3(cmdline, ui_message_handler);
-#endif
 
     if(cmdline.isset("neural-liveness"))
       return do_neural_liveness(cmdline, ui_message_handler);

--- a/src/ebmc/ic3_engine.h
+++ b/src/ebmc/ic3_engine.h
@@ -6,8 +6,10 @@ Author: Eugene Goldberg, eu.goldberg@gmail.com
 
 \*******************************************************************/
 
-#include <util/cmdline.h>
-#include <util/ui_message.h>
+#include "property_checker.h"
 
-int do_ic3(const cmdlinet &, ui_message_handlert &);
-
+property_checker_resultt ic3_engine(
+  const cmdlinet &,
+  transition_systemt &,
+  ebmc_propertiest &,
+  message_handlert &);

--- a/src/ebmc/property_checker.cpp
+++ b/src/ebmc/property_checker.cpp
@@ -19,6 +19,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #include "dimacs_writer.h"
 #include "ebmc_error.h"
 #include "ebmc_solver_factory.h"
+#include "ic3_engine.h"
 #include "k_induction.h"
 #include "netlist.h"
 #include "output_file.h"
@@ -377,6 +378,15 @@ property_checker_resultt property_checker(
     {
       return k_induction(
         cmdline, transition_system, properties, message_handler);
+    }
+    else if(cmdline.isset("ic3"))
+    {
+#ifdef _WIN32
+      throw ebmc_errort() << "No support for IC3 on Windows";
+#else
+      return ic3_engine(
+        cmdline, transition_system, properties, message_handler);
+#endif
     }
     else
     {

--- a/src/ic3/ebmc_ic3_interface.hh
+++ b/src/ic3/ebmc_ic3_interface.hh
@@ -7,17 +7,23 @@ class ic3_enginet
 public:
   ic3_enginet(
     const cmdlinet &_cmdline,
-    ui_message_handlert &_ui_message_handler)
-    : cmdline(_cmdline), message(_ui_message_handler)
+    transition_systemt &_transition_system,
+    ebmc_propertiest &_properties,
+    message_handlert &_message_handler)
+    : cmdline(_cmdline),
+      transition_system(_transition_system),
+      properties(_properties),
+      message(_message_handler)
   {
   }
 
 protected:
   const cmdlinet &cmdline;
+  transition_systemt &transition_system;
+  using propertyt = ebmc_propertiest::propertyt;
+  ebmc_propertiest &properties;
   messaget message;
 
-  using propertyt = ebmc_propertiest::propertyt;
-  ebmc_propertiest properties;
   netlistt netlist;
 
 public:
@@ -29,7 +35,7 @@ public:
   bool const0,const1;
   bool orig_names;
 
-  int operator()();
+  property_checker_resultt operator()();
   void read_ebmc_input();  
   void find_prop_lit();
   void ebmc_form_latches();

--- a/src/ic3/p1arameters.cc
+++ b/src/ic3/p1arameters.cc
@@ -5,13 +5,16 @@ Module: Reading and ininitialization of parameters
 Author: Eugene Goldberg, eu.goldberg@gmail.com
 
 ******************************************************/
+
+// clang-format off
 #include <queue>
 #include <set>
 #include <map>
 #include <algorithm>
 #include <iostream>
 
-#include <ebmc/ebmc_base.h>
+#include <ebmc/property_checker.h>
+#include <trans-netlist/netlist.h>
 
 #include "minisat/core/Solver.h"
 #include "minisat/simp/SimpSolver.h"
@@ -21,6 +24,7 @@ Author: Eugene Goldberg, eu.goldberg@gmail.com
 
 #include <util/cmdline.h>
 #include "ebmc_ic3_interface.hh"
+// clang-format on
 
 /*=====================================
 

--- a/src/ic3/r0ead_input.cc
+++ b/src/ic3/r0ead_input.cc
@@ -6,21 +6,28 @@ Module: Converting Verilog description into an internal
 Author: Eugene Goldberg, eu.goldberg@gmail.com
 
 ******************************************************/
+
+// clang-format off
 #include <iostream>
 #include <queue>
 #include <set>
 #include <map>
 #include <algorithm>
+
 #include "minisat/core/Solver.h"
 #include "minisat/simp/SimpSolver.h"
 #include "dnf_io.hh"
 #include "ccircuit.hh"
 #include "m0ic3.hh"
 
+#include <trans-netlist/netlist.h>
 
-#include <ebmc/ebmc_base.h>
+#include <ebmc/property_checker.h>
+
 #include <util/cmdline.h>
+
 #include "ebmc_ic3_interface.hh"
+// clang-format on
 
 /*=================================
 

--- a/src/ic3/r1ead_input.cc
+++ b/src/ic3/r1ead_input.cc
@@ -6,15 +6,18 @@ Module: Converting Verilog description into an internal
 Author: Eugene Goldberg, eu.goldberg@gmail.com
 
 ******************************************************/
+
+// clang-format off
 #include <queue>
 #include <set>
 #include <map>
 #include <algorithm>
 #include <iostream>
 
-#include <ebmc/ebmc_base.h>
+#include <ebmc/property_checker.h>
 #include <trans-netlist/aig_prop.h>
 #include <trans-netlist/instantiate_netlist.h>
+#include <trans-netlist/netlist.h>
 
 #include "minisat/core/Solver.h"
 #include "minisat/simp/SimpSolver.h"
@@ -23,6 +26,7 @@ Author: Eugene Goldberg, eu.goldberg@gmail.com
 #include "m0ic3.hh"
 
 #include "ebmc_ic3_interface.hh"
+// clang-format on
 
 /*====================================
 

--- a/src/ic3/r2ead_input.cc
+++ b/src/ic3/r2ead_input.cc
@@ -6,13 +6,17 @@ Module: Converting Verilog description into an internal
 Author: Eugene Goldberg, eu.goldberg@gmail.com
 
 ******************************************************/
+
+// clang-format off
 #include <queue>
 #include <set>
 #include <map>
 #include <algorithm>
 #include <iostream>
 
-#include <ebmc/ebmc_base.h>
+#include <trans-netlist/netlist.h>
+
+#include <ebmc/property_checker.h>
 
 #include "minisat/core/Solver.h"
 #include "minisat/simp/SimpSolver.h"
@@ -21,7 +25,7 @@ Author: Eugene Goldberg, eu.goldberg@gmail.com
 #include "m0ic3.hh"
 
 #include "ebmc_ic3_interface.hh"
-
+// clang-format on
 
 /*=====================================================
 

--- a/src/ic3/r3ead_input.cc
+++ b/src/ic3/r3ead_input.cc
@@ -6,13 +6,17 @@ Module: Converting Verilog description into an internal
 Author: Eugene Goldberg, eu.goldberg@gmail.com
 
 ******************************************************/
+
+// clang-format off
 #include <queue>
 #include <set>
 #include <map>
 #include <algorithm>
 #include <iostream>
 
-#include <ebmc/ebmc_base.h>
+#include <trans-netlist/netlist.h>
+
+#include <ebmc/property_checker.h>
 
 #include "minisat/core/Solver.h"
 #include "minisat/simp/SimpSolver.h"
@@ -21,6 +25,8 @@ Author: Eugene Goldberg, eu.goldberg@gmail.com
 #include "m0ic3.hh"
 
 #include "ebmc_ic3_interface.hh"
+// clang-format on
+
 /*====================================
 
      F O R M _ G A T E _ F U N

--- a/src/ic3/r4ead_input.cc
+++ b/src/ic3/r4ead_input.cc
@@ -6,13 +6,17 @@ Module: Converting Verilog description into an internal
 Author: Eugene Goldberg, eu.goldberg@gmail.com
 
 ******************************************************/
+
+// clang-format off
 #include <queue>
 #include <set>
 #include <map>
 #include <algorithm>
 #include <iostream>
 
-#include <ebmc/ebmc_base.h>
+#include <trans-netlist/netlist.h>
+
+#include <ebmc/property_checker.h>
 
 #include "minisat/core/Solver.h"
 #include "minisat/simp/SimpSolver.h"
@@ -21,7 +25,7 @@ Author: Eugene Goldberg, eu.goldberg@gmail.com
 #include "m0ic3.hh"
 
 #include "ebmc_ic3_interface.hh"
-
+// clang-format on
 
 /*=========================================
 

--- a/src/ic3/r5ead_input.cc
+++ b/src/ic3/r5ead_input.cc
@@ -6,13 +6,17 @@ Module: Converting Verilog description into an internal
 Author: Eugene Goldberg, eu.goldberg@gmail.com
 
 ******************************************************/
+
+// clang-format off
 #include <queue>
 #include <set>
 #include <map>
 #include <algorithm>
 #include <iostream>
 
-#include <ebmc/ebmc_base.h>
+#include <trans-netlist/netlist.h>
+
+#include <ebmc/property_checker.h>
 
 #include "minisat/core/Solver.h"
 #include "minisat/simp/SimpSolver.h"
@@ -21,6 +25,7 @@ Author: Eugene Goldberg, eu.goldberg@gmail.com
 #include "m0ic3.hh"
 
 #include "ebmc_ic3_interface.hh"
+// clang-format on
 
 /*================================
 

--- a/src/ic3/r6ead_input.cc
+++ b/src/ic3/r6ead_input.cc
@@ -6,6 +6,8 @@ Module: Converting Verilog description into an internal
 Author: Eugene Goldberg, eu.goldberg@gmail.com
 
 ********************************************************/
+
+// clang-format off
 #include <queue>
 #include <set>
 #include <map>
@@ -19,13 +21,14 @@ Author: Eugene Goldberg, eu.goldberg@gmail.com
 #include "m0ic3.hh"
 
 #include <trans-netlist/aig_prop.h>
-#include <trans-netlist/instantiate_netlist.h>
+#include <trans-netlist/netlist.h>
 
 #include <util/cmdline.h>
 
-#include <ebmc/ebmc_base.h>
+#include <ebmc/property_checker.h>
 
 #include "ebmc_ic3_interface.hh"
+// clang-format on
 
 /*===================================
 

--- a/src/ic3/r7ead_input.cc
+++ b/src/ic3/r7ead_input.cc
@@ -6,6 +6,8 @@ Module: Converting Verilog description into an internal
 Author: Eugene Goldberg, eu.goldberg@gmail.com
 
 ********************************************************/
+
+// clang-format off
 #include <queue>
 #include <set>
 #include <map>
@@ -19,11 +21,12 @@ Author: Eugene Goldberg, eu.goldberg@gmail.com
 #include "m0ic3.hh"
 
 #include <trans-netlist/aig_prop.h>
-#include <trans-netlist/instantiate_netlist.h>
+#include <trans-netlist/netlist.h>
 
-#include <ebmc/ebmc_base.h>
+#include <ebmc/property_checker.h>
 
 #include "ebmc_ic3_interface.hh"
+// clang-format on
 
 /*=====================================
 


### PR DESCRIPTION
This switches the IC3 engine to use the property_checker interface.
Consequently, the exit codes now match that of the other engines.