### PR TITLE
extract `verilog_typecheck_exprt::convert_expr_concatenation`

### DIFF
--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -176,6 +176,7 @@ protected:
   [[nodiscard]] exprt convert_unary_expr(unary_exprt);
   [[nodiscard]] exprt convert_binary_expr(binary_exprt);
   [[nodiscard]] exprt convert_trinary_expr(ternary_exprt);
+  [[nodiscard]] exprt convert_expr_concatenation(concatenation_exprt);
   [[nodiscard]] exprt convert_expr_function_call(function_call_exprt);
   [[nodiscard]] exprt
   convert_system_function(const irep_idt &identifier, function_call_exprt);


### PR DESCRIPTION
The code for typechecking Verilog concatenations is extracted without change.