### PR TITLE
SystemVerilog: parse integer atom types when using signing

### DIFF
--- a/regression/verilog/data-types/signed2.desc
+++ b/regression/verilog/data-types/signed2.desc
@@ -1,0 +1,6 @@
+CORE
+signed2.sv
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/verilog/data-types/signed2.sv
+++ b/regression/verilog/data-types/signed2.sv
@@ -1,0 +1,18 @@
+module main;
+
+  assert final ($typename(bit) == "bit");
+  assert final ($typename(bit unsigned) == "bit");
+  assert final ($typename(bit unsigned[1:0]) == "bit[1:0]");
+  assert final ($typename(bit signed) == "bit signed[0:0]");
+  assert final ($typename(bit signed[1:0]) == "bit signed[1:0]");
+  assert final ($typename(byte) == "bit signed[7:0]");
+  assert final ($typename(byte unsigned) == "bit[7:0]");
+  assert final ($typename(byte signed) == "bit signed[7:0]");
+  assert final ($typename(int) == "bit signed[31:0]");
+  assert final ($typename(int unsigned) == "bit[31:0]");
+  assert final ($typename(int signed) == "bit signed[31:0]");
+  assert final ($typename(integer) == "bit signed[31:0]");
+  assert final ($typename(integer unsigned) == "bit[31:0]");
+  assert final ($typename(integer signed) == "bit signed[31:0]");
+
+endmodule

--- a/regression/verilog/system_verilog_types1/test.desc
+++ b/regression/verilog/system_verilog_types1/test.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
+CORE
 main.sv
 --module main --bound 1
-^EXIT=0$
+^EXIT=10$
 ^SIGNAL=0$
-^UNSAT: No bug found within bound$
+^no properties$
 --
 ^warning: ignoring

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1445,13 +1445,17 @@ casting_type:
 data_type:
 	  integer_vector_type signing_opt packed_dimension_brace
 	        {
-                  $$=$3;
-                  add_as_subtype(stack_type($$), stack_type($2));
+	          // The integer type is a subtype of the signing.
+	          add_as_subtype(stack_type($2), stack_type($1));
+	          // That becomes a subtype of the packed dimension.
+                  add_as_subtype(stack_type($3), stack_type($2));
+                  $$ = $3;
                 }
 	| integer_atom_type signing_opt
 	        {
-                  $$=$1;
-                  add_as_subtype(stack_type($$), stack_type($2));
+	          // The integer type is a subtype of the signing.
+                  add_as_subtype(stack_type($2), stack_type($1));
+                  $$ = $2;
                 }
 	| non_integer_type
 	| struct_union packed_opt signing_opt 
@@ -1569,8 +1573,19 @@ enum_base_type_opt:
 	  /* Optional */
 		{ init($$, ID_nil); }
 	| integer_atom_type signing_opt
+	        {
+	          // The integer type is a subtype of the signing.
+                  add_as_subtype(stack_type($2), stack_type($1));
+                  $$ = $1;
+                }
 	| integer_vector_type signing_opt packed_dimension_opt
-		{ $$ = $3; add_as_subtype(stack_type($$), stack_type($1)); }
+	        {
+	          // The integer type is a subtype of the signing.
+	          add_as_subtype(stack_type($2), stack_type($1));
+	          // That becomes a subtype of the packed dimension.
+                  add_as_subtype(stack_type($3), stack_type($2));
+                  $$ = $3;
+                }
 	| type_identifier packed_dimension_opt
 		{ $$ = $2; add_as_subtype(stack_type($$), stack_type($1)); }
 	;
@@ -1606,9 +1621,11 @@ net_type_opt:
 
 net_port_type: net_type_opt signing_opt packed_dimension_brace
                 {
-                  $$=$3;
-                  add_as_subtype(stack_type($$), stack_type($2));
-                  // the net type is ignored right now
+	          // The net type is a subtype of the signing.
+	          add_as_subtype(stack_type($2), stack_type($1));
+	          // That becomes a subtype of the packed dimension.
+                  add_as_subtype(stack_type($3), stack_type($2));
+                  $$ = $3;
 	        }
         ;
 
@@ -1889,8 +1906,12 @@ signing_opt:
 	;
 
 signing:
-	  TOK_SIGNED { init($$, ID_signed); }
-	| TOK_UNSIGNED { init($$, ID_unsigned); }
+	  TOK_SIGNED
+		{ init($$, ID_signed);
+		  stack_type($$).add_subtype().make_nil(); }
+	| TOK_UNSIGNED
+		{ init($$, ID_unsigned);
+		  stack_type($$).add_subtype().make_nil(); }
 	;
 
 automatic_opt:


### PR DESCRIPTION
This changes the SystemVerilog parser to include an integer atom type when using `signed`/`unsigned`.