### PR TITLE
SystemVerilog: delay expansion of `$typename`

### DIFF
--- a/regression/verilog/system-functions/typename1.desc
+++ b/regression/verilog/system-functions/typename1.desc
@@ -1,6 +1,13 @@
 CORE
 typename1.sv
 --module main --bound 0
+^\[.*\] always \$typename\(main\.some_bit\) == 24'h626974: PROVED up to bound 0$
+^\[.*\] always \$typename\(main\.vector1\) == 72'h6269745B33313A305D: PROVED up to bound 0$
+^\[.*\] always \$typename\(main\.vector2\) == 72'h6269745B303A33315D: PROVED up to bound 0$
+^\[.*\] always \$typename\(main\.vector3\) == 128'h626974207369676E65645B33313A305D: PROVED up to bound 0$
+^\[.*\] always \$typename\(real'\(1\)\) == 32'h7265616C: PROVED up to bound 0$
+^\[.*\] always \$typename\(shortreal'\(1\)\) == 72'h73686F72747265616C: PROVED up to bound 0$
+^\[.*\] always \$typename\(realtime'\(1\)\) == 64'h7265616C74696D65: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/verilog/verilog_lowering.cpp
+++ b/src/verilog/verilog_lowering.cpp
@@ -160,6 +160,21 @@ exprt verilog_lowering(exprt expr)
     auto &inside = to_verilog_inside_expr(expr);
     expr = inside.lower();
   }
+  else if(expr.id() == ID_function_call)
+  {
+    auto &call = to_function_call_expr(expr);
+    if(call.is_system_function_call())
+    {
+      auto identifier = to_symbol_expr(call.function()).get_identifier();
+      if(identifier == "$typename")
+      {
+        // Don't touch.
+        // Will be expanded by elaborate_constant_system_function_call,
+        // and we want the argument type as is.
+        return expr;
+      }
+    }
+  }
 
   // Do the operands recursively
   for(auto &op : expr.operands())

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -950,7 +950,12 @@ exprt verilog_typecheck_exprt::convert_system_function(
         << "$typename takes one argument";
     }
 
-    return typename_string(arguments[0]);
+    // just get the function return type for now
+    auto value = typename_string(arguments[0]);
+
+    expr.type() = value.type();
+
+    return std::move(expr);
   }
   else
   {
@@ -1624,6 +1629,11 @@ exprt verilog_typecheck_exprt::elaborate_constant_system_function_call(
 
       return from_integer(result, integer_typet());
     }
+  }
+  else if(identifier == "$typename")
+  {
+    DATA_INVARIANT(arguments.size() == 1, "$typename takes one argument");
+    return typename_string(arguments[0]);
   }
   else
     return std::move(expr); // don't know it, won't elaborate


### PR DESCRIPTION
This delays the expansion of `$typename` to preserve it in property descriptions.