### PR TITLE
SystemVerilog: delay expansion of string literals

### DIFF
--- a/regression/verilog/system-functions/typename1.desc
+++ b/regression/verilog/system-functions/typename1.desc
@@ -1,13 +1,13 @@
 CORE
 typename1.sv
 --module main --bound 0
-^\[.*\] always \$typename\(main\.some_bit\) == 24'h626974: PROVED up to bound 0$
-^\[.*\] always \$typename\(main\.vector1\) == 72'h6269745B33313A305D: PROVED up to bound 0$
-^\[.*\] always \$typename\(main\.vector2\) == 72'h6269745B303A33315D: PROVED up to bound 0$
-^\[.*\] always \$typename\(main\.vector3\) == 128'h626974207369676E65645B33313A305D: PROVED up to bound 0$
-^\[.*\] always \$typename\(real'\(1\)\) == 32'h7265616C: PROVED up to bound 0$
-^\[.*\] always \$typename\(shortreal'\(1\)\) == 72'h73686F72747265616C: PROVED up to bound 0$
-^\[.*\] always \$typename\(realtime'\(1\)\) == 64'h7265616C74696D65: PROVED up to bound 0$
+^\[.*\] always \$typename\(main\.some_bit\) == "bit": PROVED up to bound 0$
+^\[.*\] always \$typename\(main\.vector1\) == "bit\[31:0\]": PROVED up to bound 0$
+^\[.*\] always \$typename\(main\.vector2\) == "bit\[0:31\]": PROVED up to bound 0$
+^\[.*\] always \$typename\(main\.vector3\) == "bit signed\[31:0\]": PROVED up to bound 0$
+^\[.*\] always \$typename\(real'\(1\)\) == "real": PROVED up to bound 0$
+^\[.*\] always \$typename\(shortreal'\(1\)\) == "shortreal": PROVED up to bound 0$
+^\[.*\] always \$typename\(realtime'\(1\)\) == "realtime": PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/verilog/verilog_lowering.cpp
+++ b/src/verilog/verilog_lowering.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/ieee_float.h>
 
 #include "aval_bval_encoding.h"
+#include "convert_literals.h"
 #include "verilog_bits.h"
 #include "verilog_expr.h"
 
@@ -182,12 +183,14 @@ exprt verilog_lowering(exprt expr)
 
   if(expr.id() == ID_constant)
   {
+    auto &constant_expr = to_constant_expr(expr);
+
     if(
       expr.type().id() == ID_verilog_unsignedbv ||
       expr.type().id() == ID_verilog_signedbv)
     {
       // encode into aval/bval
-      return lower_to_aval_bval(to_constant_expr(expr));
+      return lower_to_aval_bval(constant_expr);
     }
     else if(
       expr.type().id() == ID_verilog_real ||
@@ -197,6 +200,12 @@ exprt verilog_lowering(exprt expr)
       // turn into floatbv -- same encoding,
       // no need to change value
       expr.type() = lower_verilog_real_types(expr.type());
+    }
+    else if(expr.type().id() == ID_string)
+    {
+      auto result = convert_string_literal(constant_expr.get_value());
+      result.add_source_location() = expr.source_location();
+      expr = std::move(result);
     }
 
     return expr;

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -756,7 +756,10 @@ exprt verilog_typecheck_exprt::typename_string(const exprt &expr)
   else
     s = "?";
 
-  return convert_constant(constant_exprt{s, string_typet{}});
+  auto result = convert_string_literal(s);
+  result.add_source_location() = expr.source_location();
+
+  return std::move(result);
 }
 
 /*******************************************************************\
@@ -1301,8 +1304,8 @@ exprt verilog_typecheck_exprt::convert_constant(constant_exprt expr)
   if(expr.type().id()==ID_string)
   {
     auto result = convert_string_literal(expr.get_value());
-    result.add_source_location() = source_location;
-    return std::move(result);
+    // only add a typecast for now
+    return typecast_exprt{std::move(expr), std::move(result.type())};
   }
   else if(expr.type().id()==ID_unsignedbv ||
           expr.type().id()==ID_signedbv ||


### PR DESCRIPTION
This delays the expansion of string literals to preserve these in property descriptions.