### PR TITLE
SystemVerilog: avoid casting to `integer_typet{}`

### DIFF
--- a/regression/verilog/data-types/vector_types2.desc
+++ b/regression/verilog/data-types/vector_types2.desc
@@ -1,0 +1,7 @@
+CORE
+vector_types2.sv
+--bound 0
+^\[.*\] always \$bits\(main\.x\) == \(1 << main\.p\) \+ 1: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/verilog/data-types/vector_types2.sv
+++ b/regression/verilog/data-types/vector_types2.sv
@@ -1,0 +1,8 @@
+module main;
+
+  localparam p = 1;
+  reg [1<<p:0] x;
+
+  assert final ($bits(x)==(1<<p)+1);
+
+endmodule

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1334,9 +1334,6 @@ verilog_typecheck_exprt::convert_integer_constant_expression(exprt expr)
   // copy the source location, we will modify 'expr'
   auto source_location = expr.source_location();
 
-  // this could be large
-  propagate_type(expr, integer_typet());
-
   exprt tmp = elaborate_constant_expression_check(expr);
 
   if(tmp.id() == ID_infinity)


### PR DESCRIPTION
This removes a cast to `integer_typet{}` when elaborating constants, to enable simplification of bit-level operators.