### PR TITLE
Engine heuristic: fix for assumptions unsupported by k-induction

### DIFF
--- a/regression/ebmc/engine-heuristic/basic1.desc
+++ b/regression/ebmc/engine-heuristic/basic1.desc
@@ -1,0 +1,10 @@
+CORE
+basic1.sv
+
+^\[main\.a0\] always not s_eventually !main\.x: ASSUMED$
+^\[main\.p0\] always main\.x: PROVED up to bound 5$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/ebmc/engine-heuristic/basic1.sv
+++ b/regression/ebmc/engine-heuristic/basic1.sv
@@ -1,0 +1,8 @@
+module main(input clk, input x);
+
+  // not supported by k-induction
+  a0: assume property (not s_eventually !x);
+
+  p0: assert property (x);
+
+endmodule

--- a/regression/ebmc/engine-heuristic/basic2.desc
+++ b/regression/ebmc/engine-heuristic/basic2.desc
@@ -1,0 +1,11 @@
+CORE
+basic2.sv
+
+^\[main\.a0\] always not s_eventually !main\.y: UNSUPPORTED: unsupported by k-induction$
+^\[main\.a1\] always !main\.x: ASSUMED$
+^\[main\.p0\] always !main\.z: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/ebmc/engine-heuristic/basic2.sv
+++ b/regression/ebmc/engine-heuristic/basic2.sv
@@ -1,0 +1,15 @@
+module main(input clk, input x, input y);
+
+  reg z = 0;
+  always_ff @(posedge clk) z <= z || x;
+
+  // unsupported assumption
+  a0: assume property (not s_eventually !y);
+
+  // supported assumption
+  a1: assume property (!x);
+
+  // inductive property
+  p0: assert property (!z);
+
+endmodule

--- a/regression/ebmc/engine-heuristic/basic3.desc
+++ b/regression/ebmc/engine-heuristic/basic3.desc
@@ -1,0 +1,10 @@
+CORE
+basic3.sv
+
+^\[main\.a0\] always not s_eventually !main\.x: ASSUMED$
+^\[main\.p0\] always 0: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/ebmc/engine-heuristic/basic3.sv
+++ b/regression/ebmc/engine-heuristic/basic3.sv
@@ -1,0 +1,9 @@
+module main(input clk, input x);
+
+  // unsupported
+  a0: assume property (not s_eventually !x);
+
+  // should fail
+  p0: assert property (0);
+
+endmodule

--- a/regression/ebmc/k-induction/k-induction-unsupported2.desc
+++ b/regression/ebmc/k-induction/k-induction-unsupported2.desc
@@ -3,7 +3,7 @@ k-induction-unsupported2.sv
 --module main --k-induction
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main\.p0\] always s_eventually main\.x == 10: FAILURE: property unsupported by k-induction$
+^\[main\.p0\] always s_eventually main\.x == 10: UNSUPPORTED: unsupported by k-induction$
 ^\[main\.p1\] always main\.x <= 10: PROVED$
 --
 ^warning: ignoring

--- a/regression/ebmc/k-induction/k-induction6.desc
+++ b/regression/ebmc/k-induction/k-induction6.desc
@@ -1,9 +1,10 @@
-KNOWNBUG
+CORE
 k-induction6.sv
-
+--k-induction
+^\[main\.a0\] always not s_eventually !main\.x: UNSUPPORTED: unsupported by k-induction$
+^\[main\.p0\] always main\.x: INCONCLUSIVE$
 ^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-The property should hold, but is reported as refuted.

--- a/regression/ebmc/k-induction/k-induction7.desc
+++ b/regression/ebmc/k-induction/k-induction7.desc
@@ -1,0 +1,11 @@
+CORE
+k-induction7.sv
+--k-induction
+^\[main\.a0\] always not s_eventually !main\.y: UNSUPPORTED: unsupported by k-induction$
+^\[main\.a1\] always !main\.x: ASSUMED$
+^\[main\.p0\] always !main\.z: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/ebmc/k-induction/k-induction7.sv
+++ b/regression/ebmc/k-induction/k-induction7.sv
@@ -1,0 +1,15 @@
+module main(input clk, input x, input y);
+
+  reg z = 0;
+  always_ff @(posedge clk) z <= z || x;
+
+  // unsupported assumption
+  a0: assume property (not s_eventually !y);
+
+  // supported assumption
+  a1: assume property (!x);
+
+  // inductive property
+  p0: assert property (!z);
+
+endmodule

--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -180,7 +180,7 @@ property_checker_resultt bdd_enginet::operator()()
   try
   {
     // any properties left?
-    if(!properties.has_unknown_property())
+    if(!properties.has_unfinished_property())
       return property_checker_resultt{properties};
 
     // possibly apply liveness-to-safety

--- a/src/ebmc/ebmc_properties.cpp
+++ b/src/ebmc/ebmc_properties.cpp
@@ -18,6 +18,8 @@ Author: Daniel Kroening, dkr@amazon.com
 
 std::string ebmc_propertiest::propertyt::status_as_string() const
 {
+  auto suffix = failure_reason.has_value() ? ": " + failure_reason.value() : "";
+
   switch(status)
   {
   case statust::ASSUMED:
@@ -31,14 +33,15 @@ std::string ebmc_propertiest::propertyt::status_as_string() const
   case statust::REFUTED_WITH_BOUND:
     return "REFUTED up to bound " + std::to_string(bound);
   case statust::UNKNOWN:
-    return "UNKNOWN";
+    return "UNKNOWN" + suffix;
+  case statust::UNSUPPORTED:
+    return "UNSUPPORTED" + suffix;
   case statust::INCONCLUSIVE:
-    return "INCONCLUSIVE";
+    return "INCONCLUSIVE" + suffix;
   case statust::FAILURE:
-    return failure_reason.has_value() ? "FAILURE: " + failure_reason.value()
-                                      : "FAILURE";
+    return "FAILURE" + suffix;
   case statust::DROPPED:
-    return "DROPPED";
+    return "DROPPED" + suffix;
   case statust::DISABLED:
   default:
     UNREACHABLE;
@@ -78,9 +81,9 @@ ebmc_propertiest ebmc_propertiest::from_transition_system(
         id2string(symbol.location.get_comment());
 
       // Don't try to prove assumption properties.
-      if(symbol.value.id() == ID_sva_assume)
+      if(properties.properties.back().is_assumption())
       {
-        properties.properties.back().status = propertyt::statust::ASSUMED;
+        properties.properties.back().assumed();
         properties.properties.back().normalized_expr =
           normalize_property(to_sva_assume_expr(symbol.value).op());
       }

--- a/src/ebmc/property_checker.cpp
+++ b/src/ebmc/property_checker.cpp
@@ -372,7 +372,7 @@ property_checker_resultt engine_heuristic(
 
   auto solver_factory = ebmc_solver_factory(cmdline);
 
-  if(!properties.has_unknown_property())
+  if(!properties.has_unfinished_property())
     return property_checker_resultt{properties}; // done
 
   message.status() << "No engine given, attempting heuristic engine selection"
@@ -384,12 +384,15 @@ property_checker_resultt engine_heuristic(
   k_induction(
     1, transition_system, properties, solver_factory, message_handler);
 
-  properties.reset_failure_to_unknown();
-
-  if(!properties.has_unknown_property())
+  if(!properties.has_unfinished_property())
     return property_checker_resultt{properties}; // done
 
+  properties.reset_failure();
+  properties.reset_inconclusive();
+  properties.reset_unsupported();
+
   // Now try BMC with bound 5, word-level
+  message.status() << "Attempting BMC with bound 5" << messaget::eom;
 
   bmc(
     5,     // bound
@@ -400,10 +403,10 @@ property_checker_resultt engine_heuristic(
     solver_factory,
     message_handler);
 
-  properties.reset_failure_to_unknown();
-
-  if(!properties.has_unknown_property())
+  if(!properties.has_unfinished_property())
     return property_checker_resultt{properties}; // done
+
+  properties.reset_failure();
 
   // Give up
   return property_checker_resultt{properties}; // done

--- a/src/ebmc/property_checker.h
+++ b/src/ebmc/property_checker.h
@@ -50,12 +50,18 @@ public:
   bool all_properties_proved() const
   {
     for(const auto &p : properties)
-      if(
+    {
+      if(p.is_assumption())
+      {
+        // ignore
+      }
+      else if(
         !p.is_proved() && !p.is_proved_with_bound() && !p.is_disabled() &&
         !p.is_assumed())
       {
         return false;
       }
+    }
 
     return true;
   }

--- a/src/ebmc/report_results.cpp
+++ b/src/ebmc/report_results.cpp
@@ -111,6 +111,7 @@ void report_results(
       case statust::DROPPED: message.status() << messaget::red; break;
       case statust::FAILURE: message.status() << messaget::red; break;
       case statust::UNKNOWN: message.status() << messaget::yellow; break;
+      case statust::UNSUPPORTED: message.status() << messaget::yellow; break;
       case statust::DISABLED: break;
       case statust::INCONCLUSIVE: message.status() << messaget::yellow; break;
       }

--- a/src/trans-word-level/property.cpp
+++ b/src/trans-word-level/property.cpp
@@ -696,6 +696,7 @@ void property(
   auto obligations = property_obligations(property_expr, no_timeframes);
 
   // Map obligations onto timeframes.
+  prop_handles.clear();
   prop_handles.resize(no_timeframes, true_exprt());
   for(auto &obligation_it : obligations.map)
   {


### PR DESCRIPTION
The k-induction engine now correctly reports unsupported assumptions, and is then skipped by the engine selection heuristic.
    
Fixes #921.