### PR TITLE
aval/bval for bitwise not

### DIFF
--- a/regression/verilog/expressions/bitwise_not1.desc
+++ b/regression/verilog/expressions/bitwise_not1.desc
@@ -1,0 +1,7 @@
+CORE
+bitwise_not1.sv
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/expressions/bitwise_not1.sv
+++ b/regression/verilog/expressions/bitwise_not1.sv
@@ -1,0 +1,12 @@
+module main;
+
+  assert final (~0 === 'hffff_ffff);
+  assert final (~1 === 'hffff_fffe);
+  assert final (~(-('sd1)) === 0);
+  assert final (~3'b101 === 3'b010);
+  assert final (~3'bxxx === 3'bxxx);
+  assert final (~3'bzzz === 3'bxxx);
+  assert final (~3'b10x === 3'b01x);
+  assert final (~3'b10z === 3'b01x);
+
+endmodule

--- a/src/verilog/aval_bval_encoding.h
+++ b/src/verilog/aval_bval_encoding.h
@@ -9,6 +9,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #ifndef CPROVER_VERILOG_AVAL_BVAL_H
 #define CPROVER_VERILOG_AVAL_BVAL_H
 
+#include <util/bitvector_expr.h>
 #include <util/bitvector_types.h>
 #include <util/mathematical_expr.h>
 
@@ -46,6 +47,8 @@ exprt aval_bval(const verilog_logical_inequality_exprt &);
 
 /// lowering for !
 exprt aval_bval(const not_exprt &);
+/// lowering for ~
+exprt aval_bval(const bitnot_exprt &);
 /// lowering for ==?
 exprt aval_bval(const verilog_wildcard_equality_exprt &);
 /// lowering for !=?

--- a/src/verilog/verilog_lowering.cpp
+++ b/src/verilog/verilog_lowering.cpp
@@ -503,6 +503,16 @@ exprt verilog_lowering(exprt expr)
     else
       return expr; // leave as is
   }
+  else if(expr.id() == ID_bitnot)
+  {
+    auto &bitnot_expr = to_bitnot_expr(expr);
+
+    // encode into aval/bval
+    if(is_four_valued(expr.type()))
+      return aval_bval(bitnot_expr);
+    else
+      return expr; // leave as is
+  }
   else if(expr.id() == ID_verilog_iff)
   {
     auto &iff = to_verilog_iff_expr(expr);


### PR DESCRIPTION
This adds an aval/bval encoding for 4-valued bitwise NOT expressions.