### PR TITLE
Verilog: error on real operand for edge control

### DIFF
--- a/regression/verilog/synthesis/posedge_real.desc
+++ b/regression/verilog/synthesis/posedge_real.desc
@@ -1,0 +1,9 @@
+CORE
+posedge_real.v
+--module main
+^file posedge_real.v line \d+: edge event controls do not take real operands$
+^EXIT=2$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/synthesis/posedge_real.v
+++ b/regression/verilog/synthesis/posedge_real.v
@@ -1,0 +1,7 @@
+module main;
+
+  real data;
+
+  always @(posedge data);
+
+endmodule

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -2568,6 +2568,17 @@ exprt verilog_typecheck_exprt::convert_unary_expr(unary_exprt expr)
   else if(expr.id() == ID_posedge || expr.id() == ID_negedge)
   {
     convert_expr(expr.op());
+
+    // 1800-2017 6.12.1
+    // Edge event controls must not be given real operands.
+    if(
+      expr.op().type().id() == ID_verilog_shortreal ||
+      expr.op().type().id() == ID_verilog_real)
+    {
+      throw errort().with_location(expr.source_location())
+        << "edge event controls do not take real operands";
+    }
+
     expr.type() = bool_typet{};
   }
   else if(expr.id() == ID_verilog_smv_eventually)


### PR DESCRIPTION
1800-2017 6.12.1 prohibits real operands given to edge control operators. This adds an error message for this case.