### PR TITLE
Verilog: allow vector-typed operands to edge event control

### DIFF
--- a/regression/verilog/synthesis/posedge_vector.desc
+++ b/regression/verilog/synthesis/posedge_vector.desc
@@ -1,8 +1,8 @@
 CORE
 posedge_vector.v
 --module main
-^file posedge_vector.v line \d+: pos/negedge expected to have Boolean as operand, but got \[7:0\]$
-^EXIT=2$
+^no properties$
+^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring

--- a/regression/verilog/synthesis/posedge_vector.v
+++ b/regression/verilog/synthesis/posedge_vector.v
@@ -1,5 +1,6 @@
 module main(input [7:0] data);
 
+  // Allowed; only the LSB will be considered.
   always @(posedge data);
 
 endmodule


### PR DESCRIPTION
Edge event control operators accept vector-typed operands (1800 2017 9.4.2). Only the LSB is used.