### PR TITLE
Verilog: introduce scope stack

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1447,8 +1447,7 @@ type_declaration:
 	   data_type any_identifier ';'
 		{ $$ = $2;
 		  // add to the scope as a type name
-		  auto &name = PARSER.scopes.add_name(stack_expr($4).get(ID_identifier), "", verilog_scopet::TYPEDEF);
-		  name.is_type = true;
+		  PARSER.scopes.add_name(stack_expr($4).get(ID_identifier), "", verilog_scopet::TYPEDEF);
 		  addswap($$, ID_type, $3);
 		  stack_expr($4).id(ID_declarator);
 		  mto($$, $4);
@@ -1537,7 +1536,7 @@ data_type:
 
 	          // We attach a dummy id to distinguish two syntactically
 	          // identical enum types.
-	          auto id = PARSER.scopes.current_scope->prefix + "enum-" + PARSER.get_next_id();
+	          auto id = PARSER.scopes.current_scope().prefix + "enum-" + PARSER.get_next_id();
 	          stack_expr($$).set(ID_identifier, id);
 	        }
 	| TOK_STRING
@@ -4429,7 +4428,7 @@ type_identifier: TOK_TYPE_IDENTIFIER
 		  init($$, ID_typedef_type);
 		  auto base_name = stack_expr($1).id();
 		  stack_expr($$).set(ID_base_name, base_name);
-		  stack_expr($$).set(ID_identifier, PARSER.scopes.current_scope->prefix+id2string(base_name));
+		  stack_expr($$).set(ID_identifier, PARSER.scopes.current_scope().prefix+id2string(base_name));
 		}
 	;
 

--- a/src/verilog/scanner.l
+++ b/src/verilog/scanner.l
@@ -67,7 +67,7 @@ static void preprocessor()
     stack_expr(yyveriloglval).id(irep_id); \
     auto name = PARSER.scopes.lookup(irep_id); \
     return name == nullptr ? TOK_NON_TYPE_IDENTIFIER : \
-           name->is_type ?   TOK_TYPE_IDENTIFIER : \
+           name->kind == verilog_scopet::TYPEDEF ? TOK_TYPE_IDENTIFIER : \
                              TOK_NON_TYPE_IDENTIFIER; \
   }
 #define KEYWORD(s, x) \

--- a/src/verilog/verilog_scope.cpp
+++ b/src/verilog/verilog_scope.cpp
@@ -8,13 +8,15 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include "verilog_scope.h"
 
-const verilog_scopet *verilog_scopest::lookup(irep_idt name) const
+#include "verilog_y.tab.h"
+
+const verilog_scopet *verilog_scopest::lookup(irep_idt base_name) const
 {
   // we start from the current scope, and walk upwards to the root
-  auto scope = current_scope;
+  auto scope = &current_scope();
   while(scope != nullptr)
   {
-    auto name_it = scope->scope_map.find(name);
+    auto name_it = scope->scope_map.find(base_name);
     if(name_it == scope->scope_map.end())
       scope = scope->parent;
     else
@@ -23,4 +25,14 @@ const verilog_scopet *verilog_scopest::lookup(irep_idt name) const
 
   // not found, give up
   return nullptr;
+}
+
+void verilog_scopest::enter_package_scope(irep_idt base_name)
+{
+  // look in the global scope
+  auto name_it = top_scope.scope_map.find(base_name);
+  if(name_it == top_scope.scope_map.end())
+    enter_scope(current_scope());
+  else
+    enter_scope(name_it->second); // found it
 }


### PR DESCRIPTION
This adds a scope stack to the Verilog parser, to enable entering named scopes using the `::` and member operators while parsing.