### PR TITLE
SystemVerilog: package identifier tokens

### DIFF
--- a/src/verilog/Makefile
+++ b/src/verilog/Makefile
@@ -61,4 +61,4 @@ verilog_preprocessor_lex.yy.cpp: verilog_preprocessor_tokenizer.l
 # extra dependencies
 verilog_y.tab$(OBJEXT): verilog_y.tab.cpp verilog_y.tab.h
 verilog_lex.yy$(OBJEXT): verilog_y.tab.cpp verilog_lex.yy.cpp verilog_y.tab.h
-
+verilog_scope$(OBJEXT): verilog_y.tab.h

--- a/src/verilog/scanner.l
+++ b/src/verilog/scanner.l
@@ -65,10 +65,7 @@ static void preprocessor()
   { newstack(yyveriloglval); \
     irep_idt irep_id = text; \
     stack_expr(yyveriloglval).id(irep_id); \
-    auto name = PARSER.scopes.lookup(irep_id); \
-    return name == nullptr ? TOK_NON_TYPE_IDENTIFIER : \
-           name->kind == verilog_scopet::TYPEDEF ? TOK_TYPE_IDENTIFIER : \
-                             TOK_NON_TYPE_IDENTIFIER; \
+    return PARSER.scopes.identifier_token(irep_id); \
   }
 #define KEYWORD(s, x) \
   { if(PARSER.parse_tree.standard >= verilog_standardt::s) \

--- a/src/verilog/verilog_scope.cpp
+++ b/src/verilog/verilog_scope.cpp
@@ -10,6 +10,8 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include "verilog_y.tab.h"
 
+#include <ostream>
+
 const verilog_scopet *verilog_scopest::lookup(irep_idt base_name) const
 {
   // we start from the current scope, and walk upwards to the root
@@ -27,6 +29,13 @@ const verilog_scopet *verilog_scopest::lookup(irep_idt base_name) const
   return nullptr;
 }
 
+void verilog_scopet::print_rec(std::size_t indent, std::ostream &out) const
+{
+  out << std::string(indent, ' ') << prefix << '\n';
+  for(auto &scope_it : scope_map)
+    scope_it.second.print_rec(indent + 2, out);
+}
+
 void verilog_scopest::enter_package_scope(irep_idt base_name)
 {
   // look in the global scope
@@ -35,4 +44,34 @@ void verilog_scopest::enter_package_scope(irep_idt base_name)
     enter_scope(current_scope());
   else
     enter_scope(name_it->second); // found it
+}
+
+unsigned verilog_scopest::identifier_token(irep_idt base_name) const
+{
+  auto scope = lookup(base_name);
+  if(scope == nullptr)
+  {
+    return TOK_NON_TYPE_IDENTIFIER;
+  }
+  else
+  {
+    switch(scope->kind)
+    {
+    // clang-format off
+    case verilog_scopet::GLOBAL:    return TOK_NON_TYPE_IDENTIFIER;
+    case verilog_scopet::FILE:      return TOK_NON_TYPE_IDENTIFIER;
+    case verilog_scopet::PACKAGE:   return TOK_PACKAGE_IDENTIFIER;
+    case verilog_scopet::MODULE:    return TOK_NON_TYPE_IDENTIFIER;
+    case verilog_scopet::CLASS:     return TOK_NON_TYPE_IDENTIFIER;
+    case verilog_scopet::BLOCK:     return TOK_NON_TYPE_IDENTIFIER;
+    case verilog_scopet::ENUM_NAME: return TOK_NON_TYPE_IDENTIFIER;
+    case verilog_scopet::TASK:      return TOK_NON_TYPE_IDENTIFIER;
+    case verilog_scopet::FUNCTION:  return TOK_NON_TYPE_IDENTIFIER;
+    case verilog_scopet::TYPEDEF:   return TOK_TYPE_IDENTIFIER;
+    case verilog_scopet::OTHER:     return TOK_NON_TYPE_IDENTIFIER;
+      // clang-format on
+    }
+
+    UNREACHABLE;
+  }
 }

--- a/src/verilog/verilog_scope.h
+++ b/src/verilog/verilog_scope.h
@@ -11,6 +11,7 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include <util/irep.h>
 
+#include <iosfwd>
 #include <map>
 
 // parser scopes and identifiers
@@ -61,6 +62,13 @@ struct verilog_scopet
   {
     return __base_name;
   }
+
+  void print(std::ostream &out) const
+  {
+    print_rec(0, out);
+  }
+
+  void print_rec(std::size_t indent, std::ostream &) const;
 
   // sub-scopes
   using scope_mapt = std::map<irep_idt, verilog_scopet>;
@@ -121,6 +129,10 @@ public:
   // Look up an identifier, starting from the current scope,
   // going upwards until found. Returns nullptr when not found.
   const scopet *lookup(irep_idt base_name) const;
+
+  // token to be returned by the scanner for the given identifier
+  // in the current scope
+  unsigned identifier_token(irep_idt base_name) const;
 };
 
 #endif


### PR DESCRIPTION
This introduces a separate token type for package identifiers, to enable parsing with just one token lookahead.