### PR TITLE
SystemVerilog: use typedefs from package scopes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * SystemVerilog: package scope operator
 * SystemVerilog: checkers
 * SystemVerilog: clocking block declarations
+* SystemVerilog: typedefs from package scopes
 
 # EBMC 5.4
 

--- a/regression/verilog/packages/package_typedef1.sv
+++ b/regression/verilog/packages/package_typedef1.sv
@@ -10,6 +10,6 @@ module main;
 
   moo::my_type some_var;
 
-  assert final ($typename(some_var) == "byte");
+  assert final ($typename(some_var) == "bit signed[7:0]");
 
 endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1546,10 +1546,13 @@ data_type:
 	        { init($$, ID_verilog_chandle); }
 	| TOK_VIRTUAL interface_opt interface_identifier
 	        { init($$, "virtual_interface"); }
-	| /*scope_opt*/ type_identifier packed_dimension_brace
-		{ stack_expr($1).id(ID_typedef_type);
-                  add_as_subtype(stack_type($2), stack_type($1));
+	| type_identifier packed_dimension_brace
+		{ add_as_subtype(stack_type($2), stack_type($1));
                   $$ = $2; }
+	| package_scope type_identifier packed_dimension_brace
+		{ mto($1, $2);
+		  add_as_subtype(stack_type($3), stack_type($2));
+		  $$ = $3; }
 //	| class_type
 	| TOK_EVENT
 	        { init($$, ID_verilog_event); }

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -66,6 +66,7 @@ protected:
   void propagate_type(exprt &expr, const typet &type);
 
   typet elaborate_type(const typet &);
+  typet elaborate_package_scope_typedef(const type_with_subtypest &);
   typet convert_enum(const class verilog_enum_typet &);
   array_typet convert_unpacked_array_type(const type_with_subtypet &);
   typet convert_packed_array_type(const type_with_subtypet &);

--- a/src/verilog/verilog_types.h
+++ b/src/verilog/verilog_types.h
@@ -618,4 +618,42 @@ inline verilog_event_typet &to_verilog_event_type(typet &type)
   return static_cast<verilog_event_typet &>(type);
 }
 
+/// A typedef
+class verilog_typedef_typet : public typet
+{
+public:
+  explicit verilog_typedef_typet(const irep_idt &_identifier)
+    : typet(ID_typedef_type)
+  {
+    identifier(_identifier);
+  }
+
+  void identifier(const irep_idt &identifier)
+  {
+    set(ID_identifier, identifier);
+  }
+
+  const irep_idt &identifier() const
+  {
+    return get(ID_identifier);
+  }
+};
+
+/// Cast a generic typet to a \ref verilog_typedef_typet. This is an unchecked
+/// conversion. \a type must be known to be \ref verilog_typedef_typet.
+/// \param type: Source type
+/// \return Object of type \ref verilog_typedef_typet
+inline const verilog_typedef_typet &to_verilog_typedef_type(const typet &type)
+{
+  PRECONDITION(type.id() == ID_typedef_type);
+  return static_cast<const verilog_typedef_typet &>(type);
+}
+
+/// \copydoc to_verilog_typedef_type(const typet &)
+inline verilog_typedef_typet &to_verilog_typedef_type(typet &type)
+{
+  PRECONDITION(type.id() == ID_typedef_type);
+  return static_cast<verilog_typedef_typet &>(type);
+}
+
 #endif


### PR DESCRIPTION
This adds support for using typedefs defined inside a package using the `::` package scope operator.