### PR TITLE
SystemVerilog: preserve scopes between compilation units

### DIFF
--- a/regression/verilog/packages/two_files1.desc
+++ b/regression/verilog/packages/two_files1.desc
@@ -1,8 +1,8 @@
 KNOWNBUG
 two_filesA1.sv
-two_filesB1.sv
-^EXIT=0$
+two_filesB1.sv --top top
+^no properties$
+^EXIT=10$
 ^SIGNAL=0$
 --
 --
-Support for typedefs in packages accross compilation units is missing.

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -28,8 +28,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #define mts(x, y) stack_expr(x).move_to_sub((irept &)stack_expr(y))
 #define swapop(x, y) stack_expr(x).operands().swap(stack_expr(y).operands())
 #define addswap(x, y, z) stack_expr(x).add(y).swap(stack_expr(z))
-#define push_scope(name, separator, kind) PARSER.scopes.push_scope(name, separator, kind)
-#define pop_scope() PARSER.scopes.pop_scope();
+#define push_scope(name, separator, kind) PARSER.scopes().push_scope(name, separator, kind)
+#define pop_scope() PARSER.scopes().pop_scope();
 
 int yyveriloglex();
 extern char *yyverilogtext;
@@ -1450,7 +1450,7 @@ type_declaration:
 	   data_type any_identifier ';'
 		{ $$ = $2;
 		  // add to the scope as a type name
-		  PARSER.scopes.add_name(stack_expr($4).get(ID_identifier), "", verilog_scopet::TYPEDEF);
+		  PARSER.scopes().add_name(stack_expr($4).get(ID_identifier), "", verilog_scopet::TYPEDEF);
 		  addswap($$, ID_type, $3);
 		  stack_expr($4).id(ID_declarator);
 		  mto($$, $4);
@@ -1539,7 +1539,7 @@ data_type:
 
 	          // We attach a dummy id to distinguish two syntactically
 	          // identical enum types.
-	          auto id = PARSER.scopes.current_scope().prefix + "enum-" + PARSER.get_next_id();
+	          auto id = PARSER.scopes().current_scope().prefix + "enum-" + PARSER.get_next_id();
 	          stack_expr($$).set(ID_identifier, id);
 	        }
 	| TOK_STRING
@@ -1576,7 +1576,7 @@ enum_name_declaration:
 	  TOK_NON_TYPE_IDENTIFIER enum_name_value_opt
 	  {
 	    init($$);
-	    auto &scope = PARSER.scopes.add_name(stack_expr($1).id(), "", verilog_scopet::ENUM_NAME);
+	    auto &scope = PARSER.scopes().add_name(stack_expr($1).id(), "", verilog_scopet::ENUM_NAME);
 	    stack_expr($$).set(ID_base_name, scope.base_name());
 	    stack_expr($$).set(ID_identifier, scope.identifier());
 	    stack_expr($$).add(ID_value).swap(stack_expr($2));
@@ -4393,7 +4393,7 @@ class_identifier: TOK_CLASS_IDENTIFIER
 		  init($$, ID_verilog_class_type);
 		  auto base_name = stack_expr($1).id();
 		  stack_expr($$).set(ID_base_name, base_name);
-		  stack_expr($$).set(ID_identifier, PARSER.scopes.current_scope().prefix+id2string(base_name));
+		  stack_expr($$).set(ID_identifier, PARSER.scopes().current_scope().prefix+id2string(base_name));
 		}
 	;
 
@@ -4429,7 +4429,7 @@ package_scope: package_identifier "::"
 		{
 		  init($$, ID_verilog_package_scope);
 		  // enter that scope
-		  PARSER.scopes.enter_package_scope(stack_expr($1).id());
+		  PARSER.scopes().enter_package_scope(stack_expr($1).id());
 		  mto($$, $1);
 		}
 	;
@@ -4452,7 +4452,7 @@ type_identifier: TOK_TYPE_IDENTIFIER
 		  init($$, ID_typedef_type);
 		  auto base_name = stack_expr($1).id();
 		  stack_expr($$).set(ID_base_name, base_name);
-		  stack_expr($$).set(ID_identifier, PARSER.scopes.current_scope().prefix+id2string(base_name));
+		  stack_expr($$).set(ID_identifier, PARSER.scopes().current_scope().prefix+id2string(base_name));
 		}
 	;
 

--- a/src/verilog/scanner.l
+++ b/src/verilog/scanner.l
@@ -65,7 +65,7 @@ static void preprocessor()
   { newstack(yyveriloglval); \
     irep_idt irep_id = text; \
     stack_expr(yyveriloglval).id(irep_id); \
-    return PARSER.scopes.identifier_token(irep_id); \
+    return PARSER.scopes().identifier_token(irep_id); \
   }
 #define KEYWORD(s, x) \
   { if(PARSER.parse_tree.standard >= verilog_standardt::s) \

--- a/src/verilog/verilog_language.h
+++ b/src/verilog/verilog_language.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <langapi/language.h>
 
 #include "verilog_parse_tree.h"
+#include "verilog_scope.h"
 
 class verilog_languaget:public languaget
 {

--- a/src/verilog/verilog_parser.cpp
+++ b/src/verilog/verilog_parser.cpp
@@ -16,6 +16,24 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <stdio.h>
 
 verilog_parsert *verilog_parser_ptr = nullptr;
+verilog_scopest verilog_scopes;
+
+/*******************************************************************\
+
+Function: verilog_parsert::scopes
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+verilog_scopest &verilog_parsert::scopes()
+{
+  return verilog_scopes;
+}
 
 /*******************************************************************\
 
@@ -29,7 +47,10 @@ Function:
 
 \*******************************************************************/
 
-bool parse_verilog_file(const std::string &filename, verilog_standardt standard)
+bool parse_verilog_file(
+  const std::string &filename,
+  verilog_standardt standard,
+  verilog_scopest &scopes)
 {
   std::ifstream in(widen_if_needed(filename));
   console_message_handlert console_message_handler;

--- a/src/verilog/verilog_parser.h
+++ b/src/verilog/verilog_parser.h
@@ -39,9 +39,7 @@ public:
     return yyverilogparse()!=0;
   }
 
-  explicit verilog_parsert(
-    verilog_standardt standard,
-    message_handlert &message_handler)
+  verilog_parsert(verilog_standardt standard, message_handlert &message_handler)
     : parsert(message_handler), parse_tree(standard)
   {
     PRECONDITION(verilog_parser_ptr == nullptr);
@@ -53,10 +51,9 @@ public:
     verilog_parser_ptr = nullptr;
   }
 
-  // parser scopes and identifiers
-  using scopet = verilog_scopet;
-
-  verilog_scopest scopes;
+  // parser scopes -- these need to be shared
+  // among compilation units
+  verilog_scopest &scopes();
 
   // These are used for anonymous gate instances
   // and to create a unique identifier for enum types.


### PR DESCRIPTION
SystemVerilog requires preserving the identifier scopes between compilation units, to derive identifier token types for identifiers in packages and classes.