### PR TITLE
SVA: KNOWNBUG test for `default disable iff`

### DIFF
--- a/regression/verilog/SVA/default_disable1.desc
+++ b/regression/verilog/SVA/default_disable1.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+default_disable1.sv
+
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/default_disable1.sv
+++ b/regression/verilog/SVA/default_disable1.sv
@@ -1,0 +1,7 @@
+module main(input clock, reset);
+
+  default clocking cb @(posedge clk);
+  endclocking
+  default disable iff (!reset);
+
+endmodule


### PR DESCRIPTION
The parser rules are incomplete, this causes a crash.

Replicates #974.