### PR TITLE
SMV: do not allow defining identifiers that are already declared

### DIFF
--- a/regression/smv/assign/assign1.desc
+++ b/regression/smv/assign/assign1.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+assign1.smv
+
+^file .* line 6: variable `x' already assigned.*$
+^EXIT=1$
+^SIGNAL=0$
+--
+--

--- a/regression/smv/assign/assign1.smv
+++ b/regression/smv/assign/assign1.smv
@@ -1,0 +1,8 @@
+MODULE main
+
+VAR x : 1..4;
+
+ASSIGN x := 1;
+
+-- not allowed, x is already assigned
+ASSIGN init(x) := 2;

--- a/regression/smv/assign/assign2.desc
+++ b/regression/smv/assign/assign2.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+assign1.smv
+
+^file .* line 6: variable `x' already assigned.*$
+^EXIT=1$
+^SIGNAL=0$
+--
+--

--- a/regression/smv/assign/assign2.smv
+++ b/regression/smv/assign/assign2.smv
@@ -1,0 +1,8 @@
+MODULE main
+
+VAR x : 1..4;
+
+ASSIGN x := 1;
+
+-- not allowed, x is already assigned
+ASSIGN next(x) := 2;

--- a/regression/smv/define/define2.desc
+++ b/regression/smv/define/define2.desc
@@ -1,0 +1,8 @@
+CORE
+define2.smv
+
+^file .* line 6: variable `x' already declared.*$
+^EXIT=1$
+^SIGNAL=0$
+--
+--

--- a/regression/smv/define/define2.smv
+++ b/regression/smv/define/define2.smv
@@ -1,0 +1,6 @@
+MODULE main
+
+VAR x : boolean;
+
+-- not allowed, x is already a variable
+DEFINE x := TRUE;

--- a/regression/smv/define/define3.desc
+++ b/regression/smv/define/define3.desc
@@ -1,0 +1,8 @@
+CORE
+define3.smv
+
+^file .* line 6: variable `x' already defined.*$
+^EXIT=1$
+^SIGNAL=0$
+--
+--

--- a/regression/smv/define/define3.smv
+++ b/regression/smv/define/define3.smv
@@ -1,0 +1,6 @@
+MODULE main
+
+DEFINE x := TRUE;
+
+-- not allowed, x is already defined
+VAR x : boolean;

--- a/regression/smv/define/define4.desc
+++ b/regression/smv/define/define4.desc
@@ -1,0 +1,8 @@
+CORE
+define4.smv
+
+^file .* line 6: variable `x' already defined.*$
+^EXIT=1$
+^SIGNAL=0$
+--
+--

--- a/regression/smv/define/define4.smv
+++ b/regression/smv/define/define4.smv
@@ -1,0 +1,6 @@
+MODULE main
+
+DEFINE x := TRUE;
+
+-- not allowed, x is already defined
+ASSIGN x := TRUE;

--- a/regression/smv/define/define5.desc
+++ b/regression/smv/define/define5.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+define5.smv
+
+^file .* line 6: variable `x' already defined.*$
+^EXIT=1$
+^SIGNAL=0$
+--
+--

--- a/regression/smv/define/define5.smv
+++ b/regression/smv/define/define5.smv
@@ -1,0 +1,6 @@
+MODULE main
+
+DEFINE x := TRUE;
+
+-- not allowed, x is already defined
+ASSIGN next(x) := TRUE;

--- a/regression/smv/define/define6.desc
+++ b/regression/smv/define/define6.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+define6.smv
+
+^file .* line 6: variable `x' already defined.*$
+^EXIT=1$
+^SIGNAL=0$
+--
+--

--- a/regression/smv/define/define6.smv
+++ b/regression/smv/define/define6.smv
@@ -1,0 +1,6 @@
+MODULE main
+
+DEFINE x := TRUE;
+
+-- not allowed, x is already defined
+ASSIGN init(x) := TRUE;

--- a/src/smvlang/parser.y
+++ b/src/smvlang/parser.y
@@ -489,7 +489,8 @@ define     : assignment_var BECOMES_Token formula ';'
                break;
 
              case smv_parse_treet::mc_vart::DECLARED:
-               var.var_class=smv_parse_treet::mc_vart::DEFINED;
+               yyerror("variable `"+id2string(identifier)+"' already declared");
+               YYERROR;
                break;
 
              case smv_parse_treet::mc_vart::DEFINED:

--- a/src/smvlang/parser.y
+++ b/src/smvlang/parser.y
@@ -477,39 +477,39 @@ defines:     define
            ;
 
 define     : assignment_var BECOMES_Token formula ';'
-{
-  const irep_idt &identifier=stack_expr($1).get(ID_identifier);
-  smv_parse_treet::mc_vart &var=PARSER.module->vars[identifier];
+           {
+             const irep_idt &identifier=stack_expr($1).get(ID_identifier);
+             smv_parse_treet::mc_vart &var=PARSER.module->vars[identifier];
 
-  switch(var.var_class)
-  {
-  case smv_parse_treet::mc_vart::UNKNOWN:
-    var.type.make_nil();
-    var.var_class=smv_parse_treet::mc_vart::DEFINED;
-    break;
+             switch(var.var_class)
+             {
+             case smv_parse_treet::mc_vart::UNKNOWN:
+               var.type.make_nil();
+               var.var_class=smv_parse_treet::mc_vart::DEFINED;
+               break;
 
-  case smv_parse_treet::mc_vart::DECLARED:
-    var.var_class=smv_parse_treet::mc_vart::DEFINED;
-    break;
+             case smv_parse_treet::mc_vart::DECLARED:
+               var.var_class=smv_parse_treet::mc_vart::DEFINED;
+               break;
 
-  case smv_parse_treet::mc_vart::DEFINED:
-    yyerror("variable `"+id2string(identifier)+"' already defined");
-    YYERROR;
-    break;
-  
-  case smv_parse_treet::mc_vart::ARGUMENT:
-    yyerror("variable `"+id2string(identifier)+"' already declared as argument");
-    YYERROR;
-    break;
-  
-  default:
-    DATA_INVARIANT(false, "unexpected variable class");
-  }
+             case smv_parse_treet::mc_vart::DEFINED:
+               yyerror("variable `"+id2string(identifier)+"' already defined");
+               YYERROR;
+               break;
 
-  binary($$, $1, ID_equal, $3);
-  PARSER.module->add_define(to_equal_expr(stack_expr($$)));
-}
-;
+             case smv_parse_treet::mc_vart::ARGUMENT:
+               yyerror("variable `"+id2string(identifier)+"' already declared as argument");
+               YYERROR;
+               break;
+
+             default:
+               DATA_INVARIANT(false, "unexpected variable class");
+             }
+
+             binary($$, $1, ID_equal, $3);
+             PARSER.module->add_define(to_equal_expr(stack_expr($$)));
+           }
+           ;
 
 formula    : term
            ;


### PR DESCRIPTION
`VAR x : ...` followed by `DEFINE x := ...` must be errored.