### PR TITLE
SMV: type check SMV enum literals

### DIFF
--- a/regression/smv/enums/enum3.desc
+++ b/regression/smv/enums/enum3.desc
@@ -1,9 +1,9 @@
-KNOWNBUG
+CORE
 enum3.smv
 
-^EXIT=0$
+^file .* line 7: enum c not a member of \{ a, b \}$
+^EXIT=2$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-This should be a type error.


### PR DESCRIPTION
This adds a check that SMV enum literals are in the target type.