### PR TITLE
SystemVerilog: floating-point casts

### DIFF
--- a/regression/verilog/expressions/cast_from_real1.desc
+++ b/regression/verilog/expressions/cast_from_real1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE broken-smt-backend
 cast_from_real1.sv
 
 ^EXIT=0$
@@ -6,4 +6,3 @@ cast_from_real1.sv
 --
 ^warning: ignoring
 --
-Verilog casts from real to integer round, and do not truncate.

--- a/regression/verilog/expressions/cast_from_real1.sv
+++ b/regression/verilog/expressions/cast_from_real1.sv
@@ -3,7 +3,12 @@ module main;
   always assert (integer'(1.0) == 1);
   always assert (integer'(-1.0) == -1);
 
-  // Casting rounds away from zero (1800-2017 6.12.2)
-  always assert (integer'(1.9) == 2);
+  // Casting rounds to nearest-ties-away-from zero (1800-2017 6.12.2)
+  // Examples from the standard.
+  always assert (integer'(35.7) == 36);
+  always assert (integer'(35.5) == 36);
+  always assert (integer'(35.2) == 35);
+  always assert (integer'(-1.5) == -2);
+  always assert (integer'(1.5) == 2);
 
 endmodule

--- a/regression/verilog/expressions/cast_to_real1.sv
+++ b/regression/verilog/expressions/cast_to_real1.sv
@@ -1,11 +1,12 @@
 module main;
 
-  // no rounding
+  // No rounding.
   p0: assert final (real'(0) == 0.0);
   p1: assert final (real'(1) == 1.0);
 
-  // rounding, away from zero
+  // Rounding. The standard does not say how.  This is RNA.
+  // Icarus Verilog, Aldec Riviera, Questa, VCS agree.
+  // Cadence Xcelium disagrees.
   p2: assert final (real'('hffff_ffff_ffff_ffff) == real'('h1_0000_0000_0000_0000));
-  p3: assert final (real'(-'sh0_ffff_ffff_ffff_ffff) == real'(-'sh1_0000_0000_0000_0000));
 
 endmodule

--- a/regression/verilog/expressions/cast_to_real2.desc
+++ b/regression/verilog/expressions/cast_to_real2.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 cast_to_real2.sv
 
 ^EXIT=0$
@@ -6,4 +6,3 @@ cast_to_real2.sv
 --
 ^warning: ignoring
 --
-Typechecking yields inconsistent types.


### PR DESCRIPTION
Casts from `real`/`shortreal`/`realtime` to integers must use round-to-nearest-ties-to-away.
    
The standard doesn't specify how to round int-to-float or double-to-single. We use RNA for consistency.