### PR TITLE
Dangling references in namespacet usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,23 @@
 .DS_Store
+*.o
+*.d
+*.a
+*~
+.*.swp
+.*.swo
+
+# Compiled binaries
+src/ebmc/ebmc
+src/hw-cbmc/hw-cbmc
+src/vlindex/vlindex
+
+# Flex/Yacc generated files
+*.yy.cpp
+*.output
+*.tab.cpp
+*.tab.h
+*.inc
+
+# Regression
+*.out
+*tests.log

--- a/src/ebmc/output_verilog.cpp
+++ b/src/ebmc/output_verilog.cpp
@@ -336,8 +336,8 @@ void output_verilog_rtlt::assign_symbol(
     throw 0;
   }
   
-  const symbolt &symbol=
-    namespacet(symbol_table).lookup(symbol_expr.get(ID_identifier));
+  namespacet ns(symbol_table);
+  const symbolt &symbol = ns.lookup(symbol_expr.get(ID_identifier));
   
   if(symbol.is_state_var)
   {

--- a/src/hw-cbmc/hw_cbmc_parse_options.cpp
+++ b/src/hw-cbmc/hw_cbmc_parse_options.cpp
@@ -206,8 +206,8 @@ int hw_cbmc_parse_optionst::get_modules(std::list<exprt> &bmc_constraints) {
     {
       if(cmdline.isset("gen-interface"))
       {
-        const symbolt &symbol =
-            namespacet(goto_model.symbol_table).lookup(top_module);
+        namespacet ns(goto_model.symbol_table);
+        const symbolt &symbol = ns.lookup(top_module);
 
         if(cmdline.isset("outfile"))
         {


### PR DESCRIPTION
While compiling for **Fedora release 40 (Forty)** with gcc **gcc version 14.2.1 20240912 (Red Hat 14.2.1-3) (GCC)** I observed the following problems:

1) Danging reference in `hw_cbmc_parse_options.cpp`
```
hw_cbmc_parse_options.cpp: In member function ‘virtual int hw_cbmc_parse_optionst::get_modules(std::__cxx11::list<exprt>&)’:
hw_cbmc_parse_options.cpp:209:24: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
  209 |         const symbolt &symbol =
```

2) Dangling reference in `output_verilog.cpp`
```
output_verilog.cpp: In member function ‘virtual void output_verilog_rtlt::assign_symbol(const exprt&, const exprt&)’:
output_verilog.cpp:339:18: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
  339 |   const symbolt &symbol=
      |                  ^~~~~~
```

After creating named namespace objects with appropriate lifetimes in both files, the compilation errors are gone and the regression (__verilog__) runs fine [? - unless the `39` skipped tests are not expected]:

```
  Running unions/unions3.desc  [OK] in 0 seconds
  Running unions/unions4.desc  [OK] in 0 seconds
  Running vl2smv-extensions/traffic-1.desc  [OK] in 0 seconds
  Running vl2smv-extensions/traffic-2.desc  [OK] in 0 seconds
  Running vl2smv-extensions/traffic-3.desc  [OK] in 0 seconds

All tests were successful, 39 tests skipped
```

Feel free to drop the PR or suggest any other change.