### PR TITLE
ebmc: completeness threshold for SVA's `always` and `s_always`

### DIFF
--- a/regression/verilog/SVA/initial1.desc
+++ b/regression/verilog/SVA/initial1.desc
@@ -5,7 +5,8 @@ initial1.sv
 ^\[main\.p1\] main\.counter == 100: REFUTED$
 ^\[main\.p2\] ##1 main\.counter == 1: PROVED up to bound 5$
 ^\[main\.p3\] ##1 main\.counter == 100: REFUTED$
-^\[main\.p4\] s_nexttime main\.counter == 1: PROVED up to bound 5$
+^\[main\.p4\] s_nexttime main\.counter == 1: PROVED$
+^\[main\.p5\] always \[1:1\] main\.counter == 1: PROVED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/initial1.sv
+++ b/regression/verilog/SVA/initial1.sv
@@ -26,4 +26,7 @@ module main(input clk);
   // expected to pass if there are timeframes 0 and 1
   initial p4: assert property (s_nexttime counter == 1);
 
+  // expected to pass
+  initial p5: assert property (always [1:1] counter == 1);
+
 endmodule

--- a/src/temporal-logic/normalize_property.cpp
+++ b/src/temporal-logic/normalize_property.cpp
@@ -38,9 +38,7 @@ exprt normalize_pre_sva_cycle_delay(sva_cycle_delay_exprt expr)
 {
   if(expr.is_unbounded())
   {
-    if(
-      expr.from().is_constant() &&
-      numeric_cast_v<mp_integer>(to_constant_expr(expr.from())) == 0)
+    if(numeric_cast_v<mp_integer>(expr.from()) == 0)
     {
       // ##[0:$] φ --> s_eventually φ
       return sva_s_eventually_exprt{expr.op()};

--- a/src/trans-word-level/sequence.cpp
+++ b/src/trans-word-level/sequence.cpp
@@ -8,6 +8,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "sequence.h"
 
+#include <util/arith_tools.h>
 #include <util/ebmc_util.h>
 
 #include <verilog/sva_expr.h>
@@ -23,14 +24,11 @@ std::vector<std::pair<mp_integer, exprt>> instantiate_sequence(
   if(expr.id() == ID_sva_cycle_delay) // ##[1:2] something
   {
     auto &sva_cycle_delay_expr = to_sva_cycle_delay_expr(expr);
+    const auto from = numeric_cast_v<mp_integer>(sva_cycle_delay_expr.from());
 
     if(sva_cycle_delay_expr.to().is_nil()) // ##1 something
     {
-      mp_integer offset;
-      if(to_integer_non_constant(sva_cycle_delay_expr.from(), offset))
-        throw "failed to convert sva_cycle_delay offset";
-
-      const auto u = t + offset;
+      const auto u = t + from;
 
       // Do we exceed the bound? Make it 'true'
       if(u >= no_timeframes)
@@ -44,9 +42,7 @@ std::vector<std::pair<mp_integer, exprt>> instantiate_sequence(
     }
     else
     {
-      mp_integer from, to;
-      if(to_integer_non_constant(sva_cycle_delay_expr.from(), from))
-        throw "failed to convert sva_cycle_delay offsets";
+      mp_integer to;
 
       if(sva_cycle_delay_expr.to().id() == ID_infinity)
       {


### PR DESCRIPTION
This extends the completeness threshold logic to cover the bounded `always` and
`s_always` operators.