### PR TITLE
Verilog: precedence of function application expressions

### DIFF
--- a/regression/verilog/primitive_gates/xnor1.desc
+++ b/regression/verilog/primitive_gates/xnor1.desc
@@ -1,7 +1,7 @@
 CORE broken-smt-backend
 xnor1.sv
 
-^\[main\.xnor_ok\] always !\(xor\(xor\(main\.xnor_in1, main\.xnor_in2\), main\.xnor_in3\)\) == main\.xnor_out: PROVED$
+^\[main\.xnor_ok\] always !xor\(xor\(main\.xnor_in1, main\.xnor_in2\), main\.xnor_in3\) == main\.xnor_out: PROVED$
 ^\[main\.xnor_fail\] always main\.xnor_in1 == main\.xnor_in2 == main\.xnor_in3 == main\.xnor_out: REFUTED$
 ^\[main\.xnor_is_reduction_xnor\] always ~\^\{ main\.xnor_in1, main\.xnor_in2, main\.xnor_in3 \} == main\.xnor_out: PROVED$
 ^EXIT=10$

--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -367,7 +367,7 @@ expr2verilogt::convert_function(const std::string &name, const exprt &src)
 
   dest+=")";
 
-  return {verilog_precedencet::MIN, dest};
+  return {verilog_precedencet::MAX, dest};
 }
 
 /*******************************************************************\


### PR DESCRIPTION
There is no need to add parentheses around function application expressions.