### PR TITLE
SVA: bugfix for sequence implication operators

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * SystemVerilog: assignment patterns with keys for structs
 * SystemVerilog: unbased unsigned literals '0, '1, 'x, 'z
 * SystemVerilog: first_match
+* SystemVerilog: bugfix for |-> and |=>
 * Verilog: 'dx, 'dz
 * SMV: LTL V operator, xnor operator
 * SMV: word types and operators

--- a/regression/verilog/SVA/sequence_first_match2.desc
+++ b/regression/verilog/SVA/sequence_first_match2.desc
@@ -1,11 +1,11 @@
 CORE
 sequence_first_match2.sv
 --bound 5
-^\[.*\] \(\(##1 1\) or \(##2 1\)\) \|-> main.x == 1: PROVED up to bound 5$
+^\[.*\] \(\(##1 1\) or \(##2 1\)\) \|-> main.x == 1: REFUTED$
 ^\[.*\] first_match\(\(##1 1\) or \(##2 1\)\) \|-> main\.x == 1: PROVED up to bound 5$
-^\[.*\] \(1 or \(##1 1\)\) \|-> main\.x == 0: PROVED up to bound 5$
+^\[.*\] \(1 or \(##1 1\)\) \|-> main\.x == 0: REFUTED$
 ^\[.*\] first_match\(1 or \(##1 1\)\) \|-> main\.x == 0: PROVED up to bound 5$
-^EXIT=0$
+^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring

--- a/regression/verilog/SVA/sequence_implication1.desc
+++ b/regression/verilog/SVA/sequence_implication1.desc
@@ -1,7 +1,11 @@
 CORE
 sequence_implication1.sv
 --bound 20
-^EXIT=0$
+^\[.*\] always \(\(main\.counter == 1 ##1 main\.counter == 2\) \|-> \(##1 main.counter == 0\)\): PROVED up to bound 20$
+^\[.*\] always \(\(main\.counter == 1 ##1 main\.counter == 2\) \|=> main\.counter == 0\): PROVED up to bound 20$
+^\[.*\] always \(0 \|-> 0\): PROVED up to bound 20$
+^\[.*\] \(1 or \(##1 1\)\) \|-> main\.counter == 0: REFUTED$
+^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring

--- a/regression/verilog/SVA/sequence_implication1.sv
+++ b/regression/verilog/SVA/sequence_implication1.sv
@@ -15,4 +15,10 @@ module main(input clk);
   // same with non-overlapping implication
   assert property (@(posedge clk) counter == 1 ##1 counter == 2 |=> counter == 0);
 
+  // if the LHS doesn't match the implication is vacuously true
+  assert property (0 |-> 0);
+
+  // the implication must hold for _all_ matches of the LHS, not just one
+  initial assert property (1 or ##1 1 |-> counter==0);
+
 endmodule : main

--- a/src/temporal-logic/temporal_logic.cpp
+++ b/src/temporal-logic/temporal_logic.cpp
@@ -95,12 +95,11 @@ bool is_LTL_past(const exprt &expr)
 bool is_SVA_sequence_operator(const exprt &expr)
 {
   auto id = expr.id();
-  // Note that ID_sva_overlapped_followed_by and ID_sva_nonoverlapped_followed_by
+  // Note that ID_sva_overlapped_followed_by, ID_sva_nonoverlapped_followed_by,
+  // ID_sva_non_overlapped_implication and ID_sva_overlapped_implication
   // are property expressions, not sequence expressions.
   // Note that ID_sva_not does not yield a sequence expression.
-  return id == ID_sva_and || id == ID_sva_or ||
-         id == ID_sva_overlapped_implication ||
-         id == ID_sva_non_overlapped_implication || id == ID_sva_cycle_delay ||
+  return id == ID_sva_and || id == ID_sva_or || id == ID_sva_cycle_delay ||
          id == ID_sva_sequence_concatenation ||
          id == ID_sva_sequence_intersect || id == ID_sva_sequence_first_match ||
          id == ID_sva_sequence_throughout || id == ID_sva_sequence_within ||
@@ -124,6 +123,8 @@ bool is_SVA_operator(const exprt &expr)
          id == ID_sva_until_with || id == ID_sva_s_until_with ||
          id == ID_sva_eventually || id == ID_sva_s_eventually ||
          id == ID_sva_ranged_s_eventually || id == ID_sva_cycle_delay ||
+         id == ID_sva_overlapped_implication ||
+         id == ID_sva_non_overlapped_implication ||
          id == ID_sva_overlapped_followed_by ||
          id == ID_sva_nonoverlapped_followed_by;
 }

--- a/src/trans-word-level/sequence.cpp
+++ b/src/trans-word-level/sequence.cpp
@@ -75,10 +75,7 @@ std::vector<std::pair<mp_integer, exprt>> instantiate_sequence(
       return match_points;
     }
   }
-  else if(
-    expr.id() == ID_sva_sequence_concatenation ||
-    expr.id() == ID_sva_overlapped_implication ||
-    expr.id() == ID_sva_non_overlapped_implication)
+  else if(expr.id() == ID_sva_sequence_concatenation)
   {
     auto &implication = to_binary_expr(expr);
     std::vector<std::pair<mp_integer, exprt>> result;
@@ -86,12 +83,10 @@ std::vector<std::pair<mp_integer, exprt>> instantiate_sequence(
     // This is the product of the match points on the LHS and RHS
     const auto lhs_match_points =
       instantiate_sequence(implication.lhs(), t, no_timeframes);
+
     for(auto &lhs_match_point : lhs_match_points)
     {
-      // The RHS of the non-overlapped implication starts one timeframe later
-      auto t_rhs = expr.id() == ID_sva_non_overlapped_implication
-                     ? lhs_match_point.first + 1
-                     : lhs_match_point.first;
+      auto t_rhs = lhs_match_point.first;
 
       // Do we exceed the bound? Make it 'true'
       if(t_rhs >= no_timeframes)
@@ -105,20 +100,7 @@ std::vector<std::pair<mp_integer, exprt>> instantiate_sequence(
 
       for(auto &rhs_match_point : rhs_match_points)
       {
-        exprt cond;
-        if(expr.id() == ID_sva_sequence_concatenation)
-        {
-          cond = and_exprt{lhs_match_point.second, rhs_match_point.second};
-        }
-        else if(
-          expr.id() == ID_sva_overlapped_implication ||
-          expr.id() == ID_sva_non_overlapped_implication)
-        {
-          cond = implies_exprt{lhs_match_point.second, rhs_match_point.second};
-        }
-        else
-          PRECONDITION(false);
-
+        auto cond = and_exprt{lhs_match_point.second, rhs_match_point.second};
         result.push_back({rhs_match_point.first, cond});
       }
     }


### PR DESCRIPTION
The sequence implication operators `|->` and `|=>` are property expressions, and not sequence expressions.
    
Furthermore, the implication must hold for _all_ matches of the LHS sequence; a single one is not sufficient.
