### PR TITLE
SVA: `[*]`, `[+]` and `[*x:y]` require sequence arguments

### DIFF
--- a/regression/verilog/SVA/sequence_repetition6.desc
+++ b/regression/verilog/SVA/sequence_repetition6.desc
@@ -1,0 +1,8 @@
+CORE
+sequence_repetition6.sv
+
+^file .* line 4: sequence required$
+^EXIT=2$
+^SIGNAL=0$
+--
+--

--- a/regression/verilog/SVA/sequence_repetition6.sv
+++ b/regression/verilog/SVA/sequence_repetition6.sv
@@ -1,0 +1,6 @@
+module main(input clk);
+
+  // Sequence repetition requires a sequence argument.
+  assert property ((s_nexttime 1)[*]);
+
+endmodule


### PR DESCRIPTION
This adds a check to the typechecker to enforce that the SVA sequence repetition operators are given sequence arguments.