### PR TITLE
Fix display of code changes in clang-format CI action

### DIFF
--- a/.github/workflows/syntax-checks.yaml
+++ b/.github/workflows/syntax-checks.yaml
@@ -45,7 +45,7 @@ jobs:
 
           # Do the checking. "eval" is used so that quotes (as inserted into $EXCLUDES
           # above) are not interpreted as parts of file names.
-          git-clang-format-15 --binary clang-format-15 $MERGE_BASE
+          git-clang-format-15 --binary clang-format-15 $MERGE_BASE || true
           git diff > formatted.diff
           if [[ -s formatted.diff ]] ; then
             echo 'Formatting error! The following diff shows the required changes'


### PR DESCRIPTION
Versions of `git-clang-format` later than 11 issue exit code 1 when changes were made to the source code. Although our CI job ended with a non-zero exit code as expected, it terminated early than wanted so that the differences are not printed to the log.

See https://github.com/diffblue/hw-cbmc/actions/runs/14080967185/job/39433628824?pr=1036 for an example of such a failure.