### PR TITLE
SVA: `[->n]` and `[=n]`

### DIFF
--- a/src/trans-word-level/property.cpp
+++ b/src/trans-word-level/property.cpp
@@ -115,14 +115,6 @@ bool bmc_supports_SVA_property(const exprt &expr)
   if(has_subexpr(expr, ID_sva_sequence_within))
     return false;
 
-  // sva_sequence_non_consecutive_repetition is not supported yet
-  if(has_subexpr(expr, ID_sva_sequence_non_consecutive_repetition))
-    return false;
-
-  // sva_sequence_goto_repetition is not supported yet
-  if(has_subexpr(expr, ID_sva_sequence_goto_repetition))
-    return false;
-
   return true;
 }
 

--- a/src/trans-word-level/sequence.cpp
+++ b/src/trans-word-level/sequence.cpp
@@ -272,6 +272,50 @@ std::vector<std::pair<mp_integer, exprt>> instantiate_sequence(
 
     return result;
   }
+  else if(expr.id() == ID_sva_sequence_goto_repetition)
+  {
+    auto &op = to_sva_sequence_goto_repetition_expr(expr).op();
+    auto repetitions = numeric_cast_v<mp_integer>(
+      to_sva_sequence_goto_repetition_expr(expr).repetitions());
+
+    std::vector<std::pair<mp_integer, exprt>> result;
+
+    for(mp_integer u = t; u < no_timeframes; ++u)
+    {
+      // match of op in timeframe u?
+      auto rec_u = instantiate_sequence(op, u, no_timeframes);
+
+      // We have a match for op[->n] if
+      // a) we have a match of op in timeframe u and
+      // b) n=1 or we have a match for [=n-1] in timeframe u-1
+    }
+
+    return result;
+  }
+  else if(expr.id() == ID_sva_sequence_non_consecutive_repetition)
+  {
+    auto &op = to_sva_sequence_non_consecutive_repetition_expr(expr).op();
+    auto repetitions = numeric_cast_v<mp_integer>(
+      to_sva_sequence_non_consecutive_repetition_expr(expr).repetitions());
+
+    std::vector<std::pair<mp_integer, exprt>> result;
+
+    for(mp_integer u = t; u < no_timeframes; ++u)
+    {
+      // match of op in timeframe u?
+      auto rec_u = instantiate_sequence(op, u, no_timeframes);
+
+      // We have a match for op[=n]:
+      // 1. If
+      //    a. there is a match of op in timeframe u and
+      //    b. n=1 or we have a match for [=n-1] in timeframe u-1; or
+      // 2. If
+      //    a. there is no match of op in timeframe u and
+      //    b. op[=n] in timeframe u-1
+    }
+
+    return result;
+  }
   else
   {
     // not a sequence, evaluate as state predicate

--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -1856,7 +1856,8 @@ expr2verilogt::resultt expr2verilogt::convert_rec(const exprt &src)
 
   else if(src.id() == ID_sva_sequence_non_consecutive_repetition)
     return precedence = verilog_precedencet::MIN,
-           convert_sva_binary_repetition("[=", to_binary_expr(src));
+           convert_sva_binary_repetition(
+             "[=", to_sva_sequence_non_consecutive_repetition_expr(src));
   // not sure about precedence
 
   else if(src.id() == ID_sva_sequence_consecutive_repetition)
@@ -1865,7 +1866,8 @@ expr2verilogt::resultt expr2verilogt::convert_rec(const exprt &src)
 
   else if(src.id() == ID_sva_sequence_goto_repetition)
     return precedence = verilog_precedencet::MIN,
-           convert_sva_binary_repetition("[->", to_binary_expr(src));
+           convert_sva_binary_repetition(
+             "[->", to_sva_sequence_goto_repetition_expr(src));
   // not sure about precedence
 
   else if(src.id() == ID_sva_ranged_always)

--- a/src/verilog/sva_expr.h
+++ b/src/verilog/sva_expr.h
@@ -1318,6 +1318,117 @@ to_sva_sequence_consecutive_repetition_expr(exprt &expr)
   return static_cast<sva_sequence_consecutive_repetition_exprt &>(expr);
 }
 
+class sva_sequence_goto_repetition_exprt : public binary_exprt
+{
+public:
+  sva_sequence_goto_repetition_exprt(exprt __op, constant_exprt __repetitions)
+    : binary_exprt{
+        std::move(__op),
+        ID_sva_sequence_goto_repetition,
+        std::move(__repetitions),
+        bool_typet{}}
+  {
+  }
+
+  const exprt &op() const
+  {
+    return op0();
+  }
+
+  exprt &op()
+  {
+    return op0();
+  }
+
+  // The number of repetitions must be a constant after elaboration.
+  const constant_exprt &repetitions() const
+  {
+    return static_cast<const constant_exprt &>(op1());
+  }
+
+  constant_exprt &repetitions()
+  {
+    return static_cast<constant_exprt &>(op1());
+  }
+
+protected:
+  using binary_exprt::op0;
+  using binary_exprt::op1;
+};
+
+inline const sva_sequence_goto_repetition_exprt &
+to_sva_sequence_goto_repetition_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_sva_sequence_goto_repetition);
+  sva_sequence_goto_repetition_exprt::check(expr);
+  return static_cast<const sva_sequence_goto_repetition_exprt &>(expr);
+}
+
+inline sva_sequence_goto_repetition_exprt &
+to_sva_sequence_goto_repetition_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_sva_sequence_goto_repetition);
+  sva_sequence_goto_repetition_exprt::check(expr);
+  return static_cast<sva_sequence_goto_repetition_exprt &>(expr);
+}
+
+class sva_sequence_non_consecutive_repetition_exprt : public binary_exprt
+{
+public:
+  sva_sequence_non_consecutive_repetition_exprt(
+    exprt __op,
+    constant_exprt __repetitions)
+    : binary_exprt{
+        std::move(__op),
+        ID_sva_sequence_non_consecutive_repetition,
+        std::move(__repetitions),
+        bool_typet{}}
+  {
+  }
+
+  const exprt &op() const
+  {
+    return op0();
+  }
+
+  exprt &op()
+  {
+    return op0();
+  }
+
+  // The number of repetitions must be a constant after elaboration.
+  const constant_exprt &repetitions() const
+  {
+    return static_cast<const constant_exprt &>(op1());
+  }
+
+  constant_exprt &repetitions()
+  {
+    return static_cast<constant_exprt &>(op1());
+  }
+
+protected:
+  using binary_exprt::op0;
+  using binary_exprt::op1;
+};
+
+inline const sva_sequence_non_consecutive_repetition_exprt &
+to_sva_sequence_non_consecutive_repetition_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_sva_sequence_non_consecutive_repetition);
+  sva_sequence_non_consecutive_repetition_exprt::check(expr);
+  return static_cast<const sva_sequence_non_consecutive_repetition_exprt &>(
+    expr);
+}
+
+inline sva_sequence_non_consecutive_repetition_exprt &
+to_sva_sequence_non_consecutive_repetition_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_sva_sequence_non_consecutive_repetition);
+  sva_sequence_non_consecutive_repetition_exprt::check(expr);
+  return static_cast<sva_sequence_non_consecutive_repetition_exprt &>(expr);
+}
+
 class sva_sequence_intersect_exprt : public binary_exprt
 {
 public:


### PR DESCRIPTION
This adds SVA's goto repetition and SVA's nonconsecutive repetition to the BMC backend.