### PR TITLE
Update COMPILING.md to new file path and change name

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -28,8 +28,8 @@ Compiling
    make -C lib/cbmc/src minisat2-download
    ```
 
-4. Build EBMC:
+4. Build HW-CBMC:
    ```
    make -C src
    ```
-   This also builds the CBMC submodule. The binary will be in src/ebmc/ebmc.
+   This also builds the CBMC submodule. The hw-cbmc binary will be in src/hw-cbmc/hw-cbmc.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About
 =======
 
-EBMC is a free, open-source formal verification tool for hardware designs.
+HW-CBMC (formerly EBMC) is a free, open-source formal verification tool for hardware designs.
 It can read Verilog 2005, SystemVerilog 2017, NuSMV and netlists (given in
 ISCAS89 format).  Properties can be given in LTL or a fragment of
 SystemVerilog Assertions.  It includes both bounded and (despite its name)
@@ -38,10 +38,10 @@ module main(input clk, x, y);
 endmodule
 ```
 
-We can then invoke the BMC engine in EBMC as follows:
+We can then invoke the BMC engine in HW-CBMC as follows:
 
-`$ ebmc main.sv --top main --bound 3`
+`$ hw-cbmc main.sv --top main --bound 3`
 
 This sets the unwinding bound to `3` and the top-level module to `main`.
 
-For more information see [EBMC Manual](http://www.cprover.org/ebmc/manual/).
+For more information see [HW-CBMC Manual](http://www.cprover.org/ebmc/manual/).


### PR DESCRIPTION
At some point the name appears to have changed from EBMC to HW-CBMC? 

The PR changes the name in the readme and compiling.md files (which I guess you might not actually want to do?), and also changes the file path and binary name to match those in the repo.