### PR TITLE
SVA: add type to SVA `if` expressions

### DIFF
--- a/regression/verilog/SVA/if1.desc
+++ b/regression/verilog/SVA/if1.desc
@@ -1,8 +1,8 @@
 CORE
 if1.sv
 --bound 2
-^\[main\.p0\] always if\(main\.counter == 0\) nexttime main\.counter == 1: PROVED up to bound 2$
-^\[main\.p1\] always if\(main\.counter == 0\) nexttime main\.counter == 1 else nexttime main\.counter == 3: REFUTED$
+^\[main\.p0\] always \(if\(main\.counter == 0\) nexttime main\.counter == 1\): PROVED up to bound 2$
+^\[main\.p1\] always \(if\(main\.counter == 0\) nexttime main\.counter == 1 else nexttime main\.counter == 3\): REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/src/verilog/verilog_typecheck_sva.cpp
+++ b/src/verilog/verilog_typecheck_sva.cpp
@@ -331,6 +331,9 @@ exprt verilog_typecheck_exprt::convert_ternary_sva(ternary_exprt expr)
       make_boolean(expr.op2());
     }
 
+    // these are always properties
+    expr.type() = bool_typet{};
+
     return std::move(expr);
   }
   else


### PR DESCRIPTION
SVA `if` expressions are property expressions, and hence boolean.