### PR TITLE
BDD engine: only look for atomic propositions in supported properties

### DIFF
--- a/src/temporal-logic/Makefile
+++ b/src/temporal-logic/Makefile
@@ -1,4 +1,6 @@
-SRC = nnf.cpp \
+SRC = ctl.cpp \
+      ltl.cpp \
+      nnf.cpp \
       normalize_property.cpp \
       temporal_logic.cpp \
       trivial_sva.cpp \

--- a/src/temporal-logic/ctl.cpp
+++ b/src/temporal-logic/ctl.cpp
@@ -1,0 +1,16 @@
+/*******************************************************************\
+
+Module: CTL
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#include "ctl.h"
+
+#include "temporal_logic.h"
+
+bool is_AGp(const exprt &expr)
+{
+  return expr.id() == ID_AG && !has_temporal_operator(to_AG_expr(expr).op());
+}

--- a/src/temporal-logic/ltl.cpp
+++ b/src/temporal-logic/ltl.cpp
@@ -1,0 +1,22 @@
+/*******************************************************************\
+
+Module: LTL
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#include "ltl.h"
+
+#include "temporal_logic.h"
+
+bool is_Gp(const exprt &expr)
+{
+  return expr.id() == ID_G && !has_temporal_operator(to_G_expr(expr).op());
+}
+
+bool is_GFp(const exprt &expr)
+{
+  return expr.id() == ID_G && to_G_expr(expr).op().id() == ID_F &&
+         !has_temporal_operator(to_F_expr(to_G_expr(expr).op()).op());
+}

--- a/src/temporal-logic/temporal_logic.h
+++ b/src/temporal-logic/temporal_logic.h
@@ -25,6 +25,9 @@ bool is_exists_path(const exprt &);
 /// Returns true iff the given expression is a CTL formula
 bool is_CTL(const exprt &);
 
+/// Returns true iff the given expression is AGp
+bool is_AGp(const exprt &);
+
 /// Returns true iff the given expression has a CTL operator
 /// as its root
 bool is_CTL_operator(const exprt &);
@@ -41,6 +44,12 @@ bool has_RTCTL_operator(const exprt &);
 
 /// Returns true iff the given expression is an LTL formula
 bool is_LTL(const exprt &);
+
+/// Returns true iff the given expression is Gp
+bool is_Gp(const exprt &);
+
+/// Returns true iff the given expression is GFp
+bool is_GFp(const exprt &);
 
 /// Returns true iff the given expression is an LTL past formula
 bool is_LTL_past(const exprt &);


### PR DESCRIPTION
The BDD engine is changed to avoid searching unsupported properties for atomic propositions.