### PR TITLE
BMC: `sequence_matcht`

### DIFF
--- a/src/trans-word-level/instantiate_word_level.cpp
+++ b/src/trans-word-level/instantiate_word_level.cpp
@@ -123,15 +123,15 @@ wl_instantiatet::instantiate_rec(exprt expr, const mp_integer &t) const
   {
     // sequence expressions -- these may have multiple potential
     // match points, and evaluate to true if any of them matches
-    const auto match_points = instantiate_sequence(expr, t, no_timeframes);
+    const auto matches = instantiate_sequence(expr, t, no_timeframes);
     exprt::operandst disjuncts;
-    disjuncts.reserve(match_points.size());
+    disjuncts.reserve(matches.size());
     mp_integer max = t;
 
-    for(auto &match_point : match_points)
+    for(auto &match : matches)
     {
-      disjuncts.push_back(match_point.second);
-      max = std::max(max, match_point.first);
+      disjuncts.push_back(match.condition);
+      max = std::max(max, match.end_time);
     }
 
     return {max, disjunction(disjuncts)};

--- a/src/trans-word-level/sequence.h
+++ b/src/trans-word-level/sequence.h
@@ -12,9 +12,25 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/expr.h>
 #include <util/mp_arith.h>
 
+/// A match for an SVA sequence.
+class sequence_matcht
+{
+public:
+  sequence_matcht(mp_integer __end_time, exprt __condition)
+    : end_time(std::move(__end_time)), condition(std::move(__condition))
+  {
+  }
+
+  mp_integer end_time;
+  exprt condition;
+};
+
+/// A set of matches of an SVA sequence.
+using sequence_matchest = std::vector<sequence_matcht>;
+
 /// Returns a list of match points and matching conditions
 /// for the given sequence expression starting at time t
-[[nodiscard]] std::vector<std::pair<mp_integer, exprt>> instantiate_sequence(
+[[nodiscard]] sequence_matchest instantiate_sequence(
   exprt expr,
   const mp_integer &t,
   const mp_integer &no_timeframes);


### PR DESCRIPTION
This introduces a class `sequence_matcht`, with members named `end_time` and `condition`, to replace an `std::pair<,>` with the same data.

This also introduces the type `sequence_matchest` to denote a vector of sequence matches.