### PR TITLE
SVA: `require_sva_property`

### DIFF
--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -200,6 +200,7 @@ protected:
   }
 
   void require_sva_sequence(const exprt &) const;
+  void require_sva_property(exprt &);
 
   [[nodiscard]] exprt convert_sva_rec(exprt);
   [[nodiscard]] exprt convert_unary_sva(unary_exprt);


### PR DESCRIPTION
This introduces a method to check operands of SVA expressions that are required to be an SVA property.