### PR TITLE
SVA: `require_sva_sequence`

### DIFF
--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -199,7 +199,7 @@ protected:
     expr = convert_sva_rec(std::move(expr));
   }
 
-  void require_sva_sequence(const exprt &) const;
+  void require_sva_sequence(exprt &);
   void require_sva_property(exprt &);
 
   [[nodiscard]] exprt convert_sva_rec(exprt);


### PR DESCRIPTION
This adds missing calls to `require_sva_sequence` in the SVA type checker. The method changes the type of the argument to Boolean when necessary, to match the behavior of `require_sva_property`.