### PR TITLE
BMC: fix encoding of SVA sequence `and`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * SystemVerilog: unbased unsigned literals '0, '1, 'x, 'z
 * SystemVerilog: first_match
 * SystemVerilog: bugfix for |-> and |=>
+* SystemVerilog: bugfix for SVA sequence and
 * Verilog: 'dx, 'dz
 * SMV: LTL V operator, xnor operator
 * SMV: word types and operators

--- a/regression/verilog/SVA/sequence_and3.desc
+++ b/regression/verilog/SVA/sequence_and3.desc
@@ -1,11 +1,11 @@
 CORE
 sequence_and3.sv
 
-^\[.*\] \(\(1 or \(##2 1\)\) and 1\) \|-> main\.x == 2: PROVED up to bound 5$
-^\[.*\] \(1 and \(1 or \(##2 1\)\)\) \|-> main\.x == 2: PROVED up to bound 5$
+^\[.*\] \(\(1 or \(##2 1\)\) and 1\) \|-> main\.x == 2: REFUTED$
+^\[.*\] \(1 and \(1 or \(##2 1\)\)\) \|-> main\.x == 2: REFUTED$
 ^\[.*\] \(\(1 or \(##2 1\)\) and 1\) \|-> main\.x == 0 \|\| main\.x == 2: PROVED up to bound 5$
 ^\[.*\] \(1 and \(1 or \(##2 1\)\)\) \|-> main\.x == 0 \|\| main\.x == 2: PROVED up to bound 5$
-^EXIT=0$
+^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring


### PR DESCRIPTION
This fixes the case in which either the LHS or RHS (or both) of an SVA sequence `and` expression may have multiple matches.  In this case, the cross-product of the LHS/RHS matches must be considered, as opposed to the conjunction of the LHS/RHS matches.