### PR TITLE
SMV netlist: translate some SVA to LTL

### DIFF
--- a/src/temporal-logic/temporal_logic.h
+++ b/src/temporal-logic/temporal_logic.h
@@ -81,4 +81,8 @@ bool is_SVA_always_s_eventually_p(const exprt &);
 /// returns {} if not possible
 std::optional<exprt> LTL_to_CTL(exprt);
 
+/// If possible, this maps an SVA expression to an equivalent LTL
+/// expression, or otherwise returns {}.
+std::optional<exprt> SVA_to_LTL(exprt);
+
 #endif


### PR DESCRIPTION
Parts of SVA map directly to LTL.  This allows extending the set of formulas converted to LTL when outputting an SMV model.