### PR TITLE
netlists can now track properties with arbitrary shapes

### DIFF
--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, daniel.kroening@inf.ethz.ch
 #include <ebmc/liveness_to_safety.h>
 #include <ebmc/transition_system.h>
 #include <solvers/bdd/miniBDD/miniBDD.h>
+#include <solvers/prop/literal_expr.h>
 #include <solvers/sat/satcheck.h>
 #include <temporal-logic/ctl.h>
 #include <temporal-logic/ltl.h>
@@ -1057,7 +1058,14 @@ void bdd_enginet::build_BDDs()
         // find the netlist property
         auto netlist_property = netlist.properties.find(property.identifier);
         CHECK_RETURN(netlist_property != netlist.properties.end());
-        auto l = std::get<netlistt::Gpt>(netlist_property->second).p;
+        DATA_INVARIANT(
+          netlist_property->second.id() == ID_sva_always,
+          "assumed property must be sva_always");
+        auto &p = to_sva_always_expr(netlist_property->second).op();
+        DATA_INVARIANT(
+          p.id() == ID_literal,
+          "assumed property must be sva_assume sva_assert literal");
+        auto l = to_literal_expr(p).get_literal();
         constraints_BDDs.push_back(aig2bdd(l, BDDs));
       }
     }

--- a/src/temporal-logic/temporal_logic.cpp
+++ b/src/temporal-logic/temporal_logic.cpp
@@ -10,6 +10,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/expr_util.h>
 
+#include <verilog/sva_expr.h>
+
 bool is_temporal_operator(const exprt &expr)
 {
   return is_CTL_operator(expr) || is_LTL_operator(expr) ||
@@ -135,4 +137,18 @@ bool is_SVA(const exprt &expr)
   { return is_temporal_operator(expr) && !is_SVA_operator(expr); };
 
   return !has_subexpr(expr, non_SVA_operator);
+}
+
+bool is_SVA_always_p(const exprt &expr)
+{
+  return expr.id() == ID_sva_always &&
+         !has_temporal_operator(to_sva_always_expr(expr).op());
+}
+
+bool is_SVA_always_s_eventually_p(const exprt &expr)
+{
+  return expr.id() == ID_sva_always &&
+         to_sva_always_expr(expr).op().id() == ID_sva_s_eventually &&
+         !has_temporal_operator(
+           to_sva_s_eventually_expr(to_sva_always_expr(expr).op()).op());
 }

--- a/src/temporal-logic/temporal_logic.h
+++ b/src/temporal-logic/temporal_logic.h
@@ -71,4 +71,10 @@ bool is_SVA_operator(const exprt &);
 /// Returns true iff the given expression is an SVA expression
 bool is_SVA(const exprt &);
 
+/// Returns true iff the given expression is always p
+bool is_SVA_always_p(const exprt &);
+
+/// Returns true iff the given expression is always s_eventually p
+bool is_SVA_always_s_eventually_p(const exprt &);
+
 #endif

--- a/src/trans-netlist/instantiate_netlist.h
+++ b/src/trans-netlist/instantiate_netlist.h
@@ -30,7 +30,14 @@ literalt instantiate_convert(
   const exprt &expr,
   const namespacet &,
   message_handlert &);
-  
+
+std::optional<exprt> netlist_property(
+  propt &solver,
+  const var_mapt &var_map,
+  const exprt &expr,
+  const namespacet &,
+  message_handlert &);
+
 void instantiate_convert(
   propt &solver,
   const var_mapt &var_map,

--- a/src/trans-netlist/netlist.h
+++ b/src/trans-netlist/netlist.h
@@ -9,6 +9,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_TRANS_NETLIST_H
 #define CPROVER_TRANS_NETLIST_H
 
+#include <util/expr.h>
+
 #include "aig.h"
 #include "var_map.h"
 
@@ -53,29 +55,15 @@ public:
   bvt initial;
   bvt transition;
 
-  struct Gpt
-  {
-    literalt p;
-  };
-
-  struct GFpt
-  {
-    literalt p;
-  };
-
-  struct not_translatedt
-  {
-  };
-
-  using propertyt = std::variant<Gpt, GFpt, not_translatedt>;
-
-  // map from property ID to property netlist nodes
-  using propertiest = std::map<irep_idt, propertyt>;
+  // Map from property ID to a netlist property,
+  // which uses literal_exprt.
+  using propertiest = std::map<irep_idt, exprt>;
   propertiest properties;
 
 protected:
   static std::string id2smv(const irep_idt &id);
-  void print_smv(std::ostream &out, literalt l) const;
+  void print_smv(std::ostream &, literalt) const;
+  void print_smv(std::ostream &, const exprt &) const;
 };
 
 #endif

--- a/src/trans-netlist/unwind_netlist.h
+++ b/src/trans-netlist/unwind_netlist.h
@@ -36,6 +36,6 @@ void unwind(
 bool netlist_bmc_supports_property(const class exprt &);
 
 // unwind a netlist property
-bvt unwind_property(const netlistt::propertyt &, const bmc_mapt &);
+bvt unwind_property(const exprt &, const bmc_mapt &);
 
 #endif


### PR DESCRIPTION
The netlist data structure can store properties to check about the netlist.

This replaces the std::variant data structure for storing properties for a
few special cases of temporal logic formulas by an encoding using
expressions over `literal_exprt`.