### PR TITLE
smv-netlist: use expr2smv for property

### DIFF
--- a/regression/ebmc/smv-netlist/smv1.desc
+++ b/regression/ebmc/smv-netlist/smv1.desc
@@ -1,0 +1,10 @@
+CORE
+smv1.smv
+--smv-netlist
+^MODULE main$
+^VAR smv\.main\.var\.x: boolean;$
+^ASSIGN next\(smv\.main\.var\.x\):=\!smv\.main\.var\.x;$
+^INIT !smv\.main\.var\.x$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv-netlist/smv1.smv
+++ b/regression/ebmc/smv-netlist/smv1.smv
@@ -1,0 +1,9 @@
+MODULE main
+
+VAR x: boolean;
+
+ASSIGN next(x):=!x;
+ASSIGN init(x):=FALSE;
+
+LTLSPEC G F x
+

--- a/regression/ebmc/smv-netlist/verilog1.desc
+++ b/regression/ebmc/smv-netlist/verilog1.desc
@@ -1,0 +1,11 @@
+CORE
+verilog1.sv
+--smv-netlist
+^MODULE main$
+^VAR Verilog\.main\.x: boolean;$
+^ASSIGN next\(Verilog\.main\.x\):=\!Verilog\.main\.x;$
+^INIT !Verilog\.main\.x$
+^LTLSPEC G F Verilog\.main\.x$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv-netlist/verilog1.sv
+++ b/regression/ebmc/smv-netlist/verilog1.sv
@@ -1,0 +1,12 @@
+module main(input clk);
+
+  reg x;
+
+  initial x = 0;
+
+  always @(posedge clk)
+    x = !x;
+
+  always assert property (always s_eventually x);
+
+endmodule

--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -1054,12 +1054,10 @@ void bdd_enginet::build_BDDs()
         auto netlist_property = netlist.properties.find(property.identifier);
         CHECK_RETURN(netlist_property != netlist.properties.end());
         DATA_INVARIANT(
-          netlist_property->second.id() == ID_sva_always,
-          "assumed property must be sva_always");
-        auto &p = to_sva_always_expr(netlist_property->second).op();
+          netlist_property->second.id() == ID_G, "assumed property must be G");
+        auto &p = to_G_expr(netlist_property->second).op();
         DATA_INVARIANT(
-          p.id() == ID_literal,
-          "assumed property must be sva_assume sva_assert literal");
+          p.id() == ID_literal, "assumed property must be G literal");
         auto l = to_literal_expr(p).get_literal();
         constraints_BDDs.push_back(aig2bdd(l, BDDs));
       }

--- a/src/trans-netlist/instantiate_netlist.cpp
+++ b/src/trans-netlist/instantiate_netlist.cpp
@@ -311,20 +311,10 @@ std::optional<exprt> netlist_property(
     }
     else if(is_SVA_operator(expr))
     {
-      if(expr.id() == ID_sva_always || expr.id() == ID_sva_assume)
-      {
-        auto copy = expr;
-        auto &op = to_unary_expr(copy).op();
-        auto op_opt =
-          netlist_property(solver, var_map, op, ns, message_handler);
-        if(op_opt.has_value())
-        {
-          op = op_opt.value();
-          return copy;
-        }
-        else
-          return {};
-      }
+      // Try to turn into LTL
+      auto LTL_opt = SVA_to_LTL(expr);
+      if(LTL_opt.has_value())
+        return netlist_property(solver, var_map, *LTL_opt, ns, message_handler);
       else
         return {};
     }

--- a/src/trans-netlist/smv_netlist.cpp
+++ b/src/trans-netlist/smv_netlist.cpp
@@ -20,7 +20,7 @@ std::string id2smv(const irep_idt &id)
 {
   std::string result;
 
-  for(unsigned i = 0; i < id.size(); i++)
+  for(std::size_t i = 0; i < id.size(); i++)
   {
     const bool first = i == 0;
     char ch = id[i];
@@ -60,7 +60,7 @@ void print_smv(const netlistt &netlist, std::ostream &out, literalt a)
     return;
   }
 
-  unsigned node_nr = a.var_no();
+  std::size_t node_nr = a.var_no();
   DATA_INVARIANT(node_nr < netlist.number_of_nodes(), "node_nr in range");
 
   if(a.sign())
@@ -115,17 +115,15 @@ void smv_netlist(const netlistt &netlist, std::ostream &out)
 
   auto &var_map = netlist.var_map;
 
-  for(var_mapt::mapt::const_iterator it = var_map.map.begin();
-      it != var_map.map.end();
-      it++)
+  for(auto &var_it : var_map.map)
   {
-    const var_mapt::vart &var = it->second;
+    const var_mapt::vart &var = var_it.second;
 
-    for(unsigned i = 0; i < var.bits.size(); i++)
+    for(std::size_t i = 0; i < var.bits.size(); i++)
     {
       if(var.is_latch())
       {
-        out << "VAR " << id2smv(it->first);
+        out << "VAR " << id2smv(var_it.first);
         if(var.bits.size() != 1)
           out << "[" << i << "]";
         out << ": boolean;" << '\n';
@@ -137,17 +135,15 @@ void smv_netlist(const netlistt &netlist, std::ostream &out)
   out << "-- Inputs" << '\n';
   out << '\n';
 
-  for(var_mapt::mapt::const_iterator it = var_map.map.begin();
-      it != var_map.map.end();
-      it++)
+  for(auto &var_it : var_map.map)
   {
-    const var_mapt::vart &var = it->second;
+    const var_mapt::vart &var = var_it.second;
 
-    for(unsigned i = 0; i < var.bits.size(); i++)
+    for(std::size_t i = 0; i < var.bits.size(); i++)
     {
       if(var.is_input())
       {
-        out << "VAR " << id2smv(it->first);
+        out << "VAR " << id2smv(var_it.first);
         if(var.bits.size() != 1)
           out << "[" << i << "]";
         out << ": boolean;" << '\n';
@@ -161,7 +157,7 @@ void smv_netlist(const netlistt &netlist, std::ostream &out)
 
   auto &nodes = netlist.nodes;
 
-  for(unsigned node_nr = 0; node_nr < nodes.size(); node_nr++)
+  for(std::size_t node_nr = 0; node_nr < nodes.size(); node_nr++)
   {
     const aig_nodet &node = nodes[node_nr];
 
@@ -179,17 +175,15 @@ void smv_netlist(const netlistt &netlist, std::ostream &out)
   out << "-- Next state functions" << '\n';
   out << '\n';
 
-  for(var_mapt::mapt::const_iterator it = var_map.map.begin();
-      it != var_map.map.end();
-      it++)
+  for(auto &var_it : var_map.map)
   {
-    const var_mapt::vart &var = it->second;
+    const var_mapt::vart &var = var_it.second;
 
-    for(unsigned i = 0; i < var.bits.size(); i++)
+    for(std::size_t i = 0; i < var.bits.size(); i++)
     {
       if(var.is_latch())
       {
-        out << "ASSIGN next(" << id2smv(it->first);
+        out << "ASSIGN next(" << id2smv(var_it.first);
         if(var.bits.size() != 1)
           out << "[" << i << "]";
         out << "):=";


### PR DESCRIPTION
The SMV to netlist conversion now uses expr2smv for outputting the property, which enables outputting full LTL or CTL.