### PR TITLE
SMV: convert typecast expressions

### DIFF
--- a/src/smvlang/expr2smv.cpp
+++ b/src/smvlang/expr2smv.cpp
@@ -584,6 +584,11 @@ expr2smvt::resultt expr2smvt::convert_rec(const exprt &src)
     return convert_binary(to_binary_expr(src), ">>", precedencet::SHIFT);
   }
 
+  else if(src.id() == ID_typecast)
+  {
+    return convert_rec(to_typecast_expr(src).op());
+  }
+
   else // no SMV language expression for internal representation
     return convert_norep(src);
 }


### PR DESCRIPTION
The conversion of SMV IR to text now skips over the typecast expressions generated by the type checker.