### PR TITLE
SMV: add a lowering pass

### DIFF
--- a/regression/smv/word/extend1.desc
+++ b/regression/smv/word/extend1.desc
@@ -1,6 +1,8 @@
-KNOWNBUG
+CORE
 extend1.smv
 
+^\[p0\] extend\(0ud1_1, 7\) = 0ud8_1: PROVED$
+^\[p1\] extend\(-0sd1_1, 7\) = -0sd8_1: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/smv/word/extend1.smv
+++ b/regression/smv/word/extend1.smv
@@ -1,4 +1,4 @@
 MODULE main
 
-SPEC extend(uwconst(1, 1), 7) = uwconst(1, 8)
-SPEC extend(swconst(-1, 1), 7) = swconst(-1, 8)
+SPEC NAME p0 := extend(uwconst(1, 1), 7) = uwconst(1, 8)
+SPEC NAME p1 := extend(swconst(-1, 1), 7) = swconst(-1, 8)

--- a/regression/smv/word/resize1.desc
+++ b/regression/smv/word/resize1.desc
@@ -1,6 +1,8 @@
-KNOWNBUG
+CORE
 resize1.smv
 
+^\[p0\] resize\(0ud1_1, 8\) = 0ud8_1: PROVED$
+^\[p1\] resize\(-0sd1_1, 1\) = -0sd1_1: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/smv/word/resize1.smv
+++ b/regression/smv/word/resize1.smv
@@ -1,4 +1,4 @@
 MODULE main
 
-SPEC resize(uwconst(1, 1), 8) = uwconst(1, 8)
-SPEC resize(swconst(123, 1), 1) = swconst(-1, 1)
+SPEC NAME p0 := resize(uwconst(1, 1), 8) = uwconst(1, 8)
+SPEC NAME p1 := resize(swconst(123, 1), 1) = swconst(-1, 1)

--- a/regression/smv/word/signed1.desc
+++ b/regression/smv/word/signed1.desc
@@ -1,6 +1,7 @@
-KNOWNBUG
+CORE
 signed1.smv
 
+^\[p0\] signed\(0ud1_1\) = -0sd1_1: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/smv/word/signed1.smv
+++ b/regression/smv/word/signed1.smv
@@ -1,3 +1,3 @@
 MODULE main
 
-SPEC signed(uwconst(1, 1)) = swconst(-1, 1)
+SPEC NAME p0 := signed(uwconst(1, 1)) = swconst(-1, 1)

--- a/regression/smv/word/unsigned1.desc
+++ b/regression/smv/word/unsigned1.desc
@@ -1,6 +1,7 @@
-KNOWNBUG
+CORE
 unsigned1.smv
 
+^\[p0\] unsigned\(-0sd1_1\) = 0ud1_1: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/smv/word/unsigned1.smv
+++ b/regression/smv/word/unsigned1.smv
@@ -1,3 +1,3 @@
 MODULE main
 
-SPEC unsigned(swconst(-1, 1)) = uwconst(1, 1)
+SPEC NAME p0 := unsigned(swconst(-1, 1)) = uwconst(1, 1)

--- a/src/smvlang/expr2smv.cpp
+++ b/src/smvlang/expr2smv.cpp
@@ -124,6 +124,43 @@ expr2smvt::resultt expr2smvt::convert_binary(
 
 /*******************************************************************\
 
+Function: expr2smvt::convert_function_application
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+expr2smvt::resultt expr2smvt::convert_function_application(
+  const std::string &symbol,
+  const exprt &src)
+{
+  bool first = true;
+
+  std::string dest = symbol + '(';
+
+  for(auto &op : src.operands())
+  {
+    if(first)
+      first = false;
+    else
+    {
+      dest += ',';
+      dest += ' ';
+    }
+
+    auto op_rec = convert_rec(op);
+    dest += op_rec.s;
+  }
+
+  return {precedencet::MAX, dest + ')'};
+}
+
+/*******************************************************************\
+
 Function: expr2smvt::convert_rtctl
 
   Inputs:
@@ -583,6 +620,18 @@ expr2smvt::resultt expr2smvt::convert_rec(const exprt &src)
   {
     return convert_binary(to_binary_expr(src), ">>", precedencet::SHIFT);
   }
+
+  else if(src.id() == ID_smv_extend)
+    return convert_function_application("extend", src);
+
+  else if(src.id() == ID_smv_resize)
+    return convert_function_application("resize", src);
+
+  else if(src.id() == ID_smv_signed_cast)
+    return convert_function_application("signed", src);
+
+  else if(src.id() == ID_smv_unsigned_cast)
+    return convert_function_application("unsigned", src);
 
   else if(src.id() == ID_typecast)
   {

--- a/src/smvlang/expr2smv_class.h
+++ b/src/smvlang/expr2smv_class.h
@@ -116,6 +116,9 @@ protected:
 
   resultt convert_cond(const exprt &);
 
+  resultt
+  convert_function_application(const std::string &symbol, const exprt &);
+
   resultt convert_norep(const exprt &);
 };
 


### PR DESCRIPTION
We currently expect that our solver backends support all expressions generated by the SMV-front-end as-is.

To avoid introducing additional, redundant expressions, this adds a lowering pass to the SMV type checker.

The lowering pass lowers SMV extend expressions to typecast expressions.