### PR TITLE
BMC: SVA sequence `within`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * SystemVerilog: unbased unsigned literals '0, '1, 'x, 'z
 * SystemVerilog: first_match
 * SystemVerilog: [->n] and [=n]
+* SystemVerilog: within
 * SystemVerilog: bugfix for |-> and |=>
 * SystemVerilog: bugfix for SVA sequence and
 * Verilog: 'dx, 'dz

--- a/regression/verilog/SVA/sequence_within1.desc
+++ b/regression/verilog/SVA/sequence_within1.desc
@@ -1,7 +1,11 @@
 CORE
 sequence_within1.sv
---bound 5
-^\[.*\] main\.x == 0 within main\.x == 1: FAILURE: property not supported by BMC engine$
+--bound 20
+^\[main\.p0\] main\.x == 0 within main\.x == 1: REFUTED$
+^\[main\.p1\] main\.x == 0 within \(##10 1\): PROVED up to bound 20$
+^\[main\.p2\] main\.x == 5 within \(##10 1\): PROVED up to bound 20$
+^\[main\.p3\] main\.x == 10 within \(##10 1\): PROVED up to bound 20$
+^\[main\.p4\] main\.x == 11 within \(##10 1\): REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/sequence_within1.sv
+++ b/regression/verilog/SVA/sequence_within1.sv
@@ -1,10 +1,23 @@
 module main(input clk);
 
-  reg [31:0] x = 0;
+  reg [7:0] x = 0;
 
   always @(posedge clk)
     x<=x+1;
 
+  // fails, no rhs match
   initial p0: assert property (x == 0 within x == 1);
+
+  // passes, lhs match at beginning of rhs match
+  initial p1: assert property (x == 0 within ##10 1);
+
+  // passes, lhs match in the middle of rhs match
+  initial p2: assert property (x == 5 within ##10 1);
+
+  // passes, lhs match at the end of rhs match
+  initial p3: assert property (x == 10 within ##10 1);
+
+  // fails, lhs match just beyond the rhs match
+  initial p4: assert property (x == 11 within ##10 1);
 
 endmodule

--- a/src/trans-word-level/property.cpp
+++ b/src/trans-word-level/property.cpp
@@ -111,10 +111,6 @@ Function: bmc_supports_SVA_property
 
 bool bmc_supports_SVA_property(const exprt &expr)
 {
-  // sva_sequence_within is not supported yet
-  if(has_subexpr(expr, ID_sva_sequence_within))
-    return false;
-
   return true;
 }
 

--- a/src/verilog/sva_expr.h
+++ b/src/verilog/sva_expr.h
@@ -1500,6 +1500,35 @@ to_sva_sequence_intersect_expr(exprt &expr)
   return static_cast<sva_sequence_intersect_exprt &>(expr);
 }
 
+class sva_sequence_within_exprt : public binary_exprt
+{
+public:
+  sva_sequence_within_exprt(exprt op0, exprt op1)
+    : binary_exprt(
+        std::move(op0),
+        ID_sva_sequence_within,
+        std::move(op1),
+        verilog_sva_sequence_typet{})
+  {
+  }
+};
+
+static inline const sva_sequence_within_exprt &
+to_sva_sequence_within_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_sva_sequence_within);
+  sva_sequence_within_exprt::check(expr, validation_modet::INVARIANT);
+  return static_cast<const sva_sequence_within_exprt &>(expr);
+}
+
+static inline sva_sequence_within_exprt &
+to_sva_sequence_within_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_sva_sequence_within);
+  sva_sequence_within_exprt::check(expr, validation_modet::INVARIANT);
+  return static_cast<sva_sequence_within_exprt &>(expr);
+}
+
 class sva_sequence_throughout_exprt : public binary_exprt
 {
 public:

--- a/src/verilog/verilog_typecheck_sva.cpp
+++ b/src/verilog/verilog_typecheck_sva.cpp
@@ -239,7 +239,6 @@ exprt verilog_typecheck_exprt::convert_binary_sva(binary_exprt expr)
 
     convert_sva(expr.rhs());
     require_sva_sequence(expr.rhs());
-    expr.type() = bool_typet{};
 
     expr.type() = verilog_sva_sequence_typet{};
 


### PR DESCRIPTION
This implements the SVA sequence `within` operator in the word-level BMC backend.