### PR TITLE
SVA: test for sequence concatenation with 0 delay

### DIFF
--- a/regression/verilog/SVA/sequence4.sv
+++ b/regression/verilog/SVA/sequence4.sv
@@ -11,4 +11,6 @@ module main;
   // sequence concatenation
   initial p0: assert property (x == 0 ##1 x == 1 ##1 x == 2);
 
+  initial p1: assert property (x == 0 ##0 x == 0 ##1 x == 1);
+
 endmodule


### PR DESCRIPTION
This extends an existing test with the case of a sequence concatenation delay 0.