### PR TITLE
aval/bval encoding for shifts

### DIFF
--- a/regression/verilog/expressions/shl3.desc
+++ b/regression/verilog/expressions/shl3.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 shl3.sv
 --bound 0
 ^EXIT=0$
@@ -6,4 +6,3 @@ shl3.sv
 --
 ^warning: ignoring
 --
-aval/bval encoding is missing.

--- a/regression/verilog/expressions/shr3.desc
+++ b/regression/verilog/expressions/shr3.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 shr3.sv
 --bound 0
 ^EXIT=0$
@@ -6,4 +6,3 @@ shr3.sv
 --
 ^warning: ignoring
 --
-aval/bval encoding is missing.

--- a/src/verilog/aval_bval_encoding.h
+++ b/src/verilog/aval_bval_encoding.h
@@ -63,5 +63,7 @@ exprt aval_bval(const verilog_iff_exprt &);
 exprt aval_bval(const verilog_implies_exprt &);
 /// lowering for typecasts
 exprt aval_bval(const typecast_exprt &);
+/// lowering for shifts
+exprt aval_bval(const shift_exprt &);
 
 #endif

--- a/src/verilog/verilog_lowering.cpp
+++ b/src/verilog/verilog_lowering.cpp
@@ -608,6 +608,13 @@ exprt verilog_lowering(exprt expr)
 
     return expr;
   }
+  else if(expr.id() == ID_lshr || expr.id() == ID_ashr || expr.id() == ID_shl)
+  {
+    if(is_four_valued(expr.type()))
+      return aval_bval(to_shift_expr(expr));
+    else
+      return expr;
+  }
   else
     return expr; // leave as is
 


### PR DESCRIPTION
This adds an aval/bval encoding for four-valued shift expressions to the Verilog frontend.