### PR TITLE
SVA's `[->x:y]` and `[=x:y]`

### DIFF
--- a/regression/verilog/SVA/cover_sequence4.desc
+++ b/regression/verilog/SVA/cover_sequence4.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 cover_sequence4.sv
 --bound 3
 ^\[main\.p0\] cover \(1 \[=10\]\): REFUTED up to bound 3$
@@ -9,4 +9,3 @@ cover_sequence4.sv
 --
 ^warning: ignoring
 --
-Implementation of [=x:y] is missing.

--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -608,7 +608,7 @@ expr2verilogt::resultt expr2verilogt::convert_sva_binary(
 
 /*******************************************************************\
 
-Function: expr2verilogt::convert_sva_sequence_consecutive_repetition
+Function: expr2verilogt::convert_sva_sequence_repetition
 
   Inputs:
 
@@ -622,20 +622,22 @@ expr2verilogt::resultt expr2verilogt::convert_sva_sequence_repetition(
   const std::string &name,
   const sva_sequence_repetition_exprt &expr)
 {
-  auto op = convert_rec(expr.op());
-  if(op.p == verilog_precedencet::MIN)
-    op.s = "(" + op.s + ")";
+  auto op_rec = convert_rec(expr.op());
 
-  std::string dest = op.s + " [" + name;
+  if(op_rec.p == verilog_precedencet::MIN)
+    op_rec.s = "(" + op_rec.s + ")";
+
+  std::string dest = op_rec.s + " [" + name;
 
   if(expr.is_range())
   {
     dest += convert_rec(expr.from()).s;
+    dest += ':';
 
     if(expr.is_unbounded())
-      dest += ":$";
+      dest += '$';
     else
-      dest += ":" + convert_rec(expr.to()).s;
+      dest += convert_rec(expr.to()).s;
   }
   else
     dest += convert_rec(expr.repetitions()).s;

--- a/src/verilog/expr2verilog_class.h
+++ b/src/verilog/expr2verilog_class.h
@@ -16,8 +16,8 @@ class sva_abort_exprt;
 class sva_case_exprt;
 class sva_if_exprt;
 class sva_ranged_predicate_exprt;
-class sva_sequence_repetition_exprt;
 class sva_sequence_first_match_exprt;
+class sva_sequence_repetition_exprt;
 
 // Precedences (higher means binds more strongly).
 // Follows Table 11-2 in IEEE 1800-2017.

--- a/src/verilog/verilog_typecheck_sva.cpp
+++ b/src/verilog/verilog_typecheck_sva.cpp
@@ -352,6 +352,9 @@ exprt verilog_typecheck_exprt::convert_ternary_sva(ternary_exprt expr)
 
     expr.op1() = from_integer(n, integer_typet{});
 
+    if(expr.op2().is_not_nil())
+      convert_expr(expr.op2());
+
     expr.type() = verilog_sva_sequence_typet{};
 
     return std::move(expr);


### PR DESCRIPTION
Both the goto repetition operator and the non-consecutive repetition operator can either take a singleton number of repetition or a range.

This adds support for the range case.