### PR TITLE
Introduce `sva_sequence_repetition_exprt`

### DIFF
--- a/src/verilog/expr2verilog_class.h
+++ b/src/verilog/expr2verilog_class.h
@@ -16,7 +16,7 @@ class sva_abort_exprt;
 class sva_case_exprt;
 class sva_if_exprt;
 class sva_ranged_predicate_exprt;
-class sva_sequence_consecutive_repetition_exprt;
+class sva_sequence_repetition_exprt;
 class sva_sequence_first_match_exprt;
 
 // Precedences (higher means binds more strongly).
@@ -137,11 +137,9 @@ protected:
 
   resultt convert_sva_binary(const std::string &name, const binary_exprt &);
 
-  resultt
-  convert_sva_binary_repetition(const std::string &name, const binary_exprt &);
-
-  resultt convert_sva_sequence_consecutive_repetition(
-    const sva_sequence_consecutive_repetition_exprt &);
+  resultt convert_sva_sequence_repetition(
+    const std::string &name,
+    const sva_sequence_repetition_exprt &);
 
   resultt convert_sva_abort(const std::string &name, const sva_abort_exprt &);
 

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2707,12 +2707,28 @@ consecutive_repetition:
 
 non_consecutive_repetition:
 	  "[=" const_or_range_expression ']'
-		{ init($$, ID_sva_sequence_non_consecutive_repetition); mto($$, $2); }
+		{ init($$, ID_sva_sequence_non_consecutive_repetition);
+		  if(stack_expr($2).id() == ID_sva_cycle_delay)
+		    swapop($$, $2);
+		  else
+		  {
+		    mto($$, $2);
+		    stack_expr($$).add_to_operands(nil_exprt{});
+		  }
+		}
 	;
 
 goto_repetition:
 	  "[->" const_or_range_expression ']'
-		{ init($$, ID_sva_sequence_goto_repetition); mto($$, $2); }
+		{ init($$, ID_sva_sequence_goto_repetition);
+		  if(stack_expr($2).id() == ID_sva_cycle_delay)
+		    swapop($$, $2);
+		  else
+		  {
+		    mto($$, $2);
+		    stack_expr($$).add_to_operands(nil_exprt{});
+		  }
+		}
 	;
 
 cycle_delay_range:

--- a/src/verilog/sva_expr.cpp
+++ b/src/verilog/sva_expr.cpp
@@ -62,10 +62,10 @@ exprt sva_sequence_consecutive_repetition_exprt::lower() const
   PRECONDITION(
     op().type().id() == ID_bool || op().type().id() == ID_verilog_sva_sequence);
 
-  if(to().is_nil())
+  if(!is_range())
   {
     // expand x[*n] into x ##1 x ##1 ...
-    auto n = numeric_cast_v<mp_integer>(to_constant_expr(from()));
+    auto n = numeric_cast_v<mp_integer>(repetitions());
     DATA_INVARIANT(n >= 1, "number of repetitions must be at least one");
 
     exprt result = op();
@@ -84,11 +84,11 @@ exprt sva_sequence_consecutive_repetition_exprt::lower() const
   {
     PRECONDITION(false);
   }
-  else
+  else // bounded range
   {
     // expand x[*a:b] into x[*a] or x[*a+1] or ... or x[*b]
-    auto from_int = numeric_cast_v<mp_integer>(to_constant_expr(from()));
-    auto to_int = numeric_cast_v<mp_integer>(to_constant_expr(to()));
+    auto from_int = numeric_cast_v<mp_integer>(from());
+    auto to_int = numeric_cast_v<mp_integer>(to());
 
     DATA_INVARIANT(from_int >= 1, "number of repetitions must be at least one");
     DATA_INVARIANT(


### PR DESCRIPTION
This introduces `sva_sequence_repetition_exprt` as a base class for the SVA repetition operators `[*...]`, `[=...]`, `[->...]`.