### PR TITLE
SVA `[*...]` for sequence operands

### DIFF
--- a/regression/verilog/SVA/sequence_repetition7.desc
+++ b/regression/verilog/SVA/sequence_repetition7.desc
@@ -1,0 +1,10 @@
+CORE
+sequence_repetition7.sv
+--bound 20
+^\[.*\] \(main\.a ##1 main\.b\) \[\*5\]: PROVED up to bound 20$
+^\[.*\] \(\!main\.b ##1 \!main\.a\) \[\*5\]: PROVED up to bound 20$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_repetition7.sv
+++ b/regression/verilog/SVA/sequence_repetition7.sv
@@ -1,0 +1,16 @@
+module main(input clk);
+
+  bit a = 1, b = 0;
+
+  always_ff @(posedge clk) begin
+    a = !a;
+    b = !b;
+  end
+
+  // a b a b ...
+  initial assert property ((a ##1 b)[*5]);
+
+  // !b !a !b !a ...
+  initial assert property ((!b ##1 !a)[*5]);
+
+endmodule

--- a/src/verilog/sva_expr.cpp
+++ b/src/verilog/sva_expr.cpp
@@ -75,11 +75,16 @@ exprt sva_sequence_repetition_star_exprt::lower() const
     return sva_sequence_repetition_star_exprt{
       op(), from_integer(0, integer_typet{}), infinity_exprt{integer_typet{}}};
   }
+  else if(is_empty_match())
+  {
+    // [*0] is a special case, denoting the empty match
+    PRECONDITION(false);
+  }
   else if(!is_range())
   {
     // expand x[*n] into x ##1 x ##1 ...
     auto n = numeric_cast_v<mp_integer>(repetitions());
-    DATA_INVARIANT(n >= 1, "number of repetitions must be at least one");
+    PRECONDITION(n >= 1);
 
     exprt result = op();
 
@@ -103,7 +108,7 @@ exprt sva_sequence_repetition_star_exprt::lower() const
     auto from_int = numeric_cast_v<mp_integer>(from());
     auto to_int = numeric_cast_v<mp_integer>(to());
 
-    DATA_INVARIANT(from_int >= 1, "number of repetitions must be at least one");
+    DATA_INVARIANT(from_int >= 0, "number of repetitions must not be negative");
     DATA_INVARIANT(
       to_int >= from_int, "number of repetitions must be interval");
 

--- a/src/verilog/sva_expr.h
+++ b/src/verilog/sva_expr.h
@@ -1401,6 +1401,12 @@ public:
     return op1().is_not_nil();
   }
 
+  /// op[*0] is a special case, denoting the empty match
+  bool is_empty_match() const
+  {
+    return !is_range() && repetitions_given() && op1().is_zero();
+  }
+
   // The number of repetitions must be a constant after elaboration.
   const constant_exprt &repetitions() const
   {


### PR DESCRIPTION
This implements the SVA operator `op[*x:y]` for the case when op is a sequence.