### PR TITLE
SMV netlists: use `TRUE`/`FALSE` instead of `1`/`0`

### DIFF
--- a/regression/ebmc/smv-netlist/s_until1.desc
+++ b/regression/ebmc/smv-netlist/s_until1.desc
@@ -2,7 +2,7 @@ CORE
 s_until1.sv
 --smv-netlist
 ^LTLSPEC \(\!node144\) U node151$
-^LTLSPEC \(1\) U node158$
+^LTLSPEC \(TRUE\) U node158$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/trans-netlist/smv_netlist.cpp
+++ b/src/trans-netlist/smv_netlist.cpp
@@ -51,12 +51,12 @@ void print_smv(const netlistt &netlist, std::ostream &out, literalt a)
 {
   if(a == const_literal(false))
   {
-    out << "0";
+    out << "FALSE";
     return;
   }
   else if(a == const_literal(true))
   {
-    out << "1";
+    out << "TRUE";
     return;
   }
 


### PR DESCRIPTION
NuSMV no longer accepts `1`/`0` for `TRUE`/`FALSE`.