### PR TITLE
use `netlist_boolbvt` for the property

### DIFF
--- a/regression/ebmc/smv-netlist/always_with_range1.desc
+++ b/regression/ebmc/smv-netlist/always_with_range1.desc
@@ -1,10 +1,10 @@
 CORE
 always_with_range1.sv
 --smv-netlist
-^LTLSPEC node275 & X node363 & X X node451 .*
-^LTLSPEC G node1155$
-^LTLSPEC node1243 & X node1331 & X X node1419 .*
-^LTLSPEC G \(\!node2066 \| X node2097\)$
+^LTLSPEC node275 & X node275 & X X node275 .*
+^LTLSPEC G node275$
+^LTLSPEC node275 & X node275 & X X node275 .*
+^LTLSPEC G \(\!node306 \| X node337\)$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/smv-netlist/cycle_delay2.desc
+++ b/regression/ebmc/smv-netlist/cycle_delay2.desc
@@ -1,7 +1,7 @@
 CORE
 cycle_delay2.sv
 --smv-netlist
-^LTLSPEC X node22 \| X X node25$
+^LTLSPEC X node22 \| X X node22$
 ^EXIT=0$
 ^SIGNAL=0$
 --


### PR DESCRIPTION
This enables sharing common subexpressions in the property, reducing the size of the netlist.