### PR TITLE
fix for no-op assignments during Verilog synthesis

### DIFF
--- a/regression/verilog/synthesis/rf1.desc
+++ b/regression/verilog/synthesis/rf1.desc
@@ -1,9 +1,9 @@
-KNOWNBUG
+CORE
 rf1.sv
 
-^EXIT=0$
+^\[.*\] always 0: REFUTED$
+^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-Results in an assertion violation.


### PR DESCRIPTION
Assignments during Verilog synthesis may be no-op (e.g., out-of-bound). This fix prevents generating an untyped auxiliary variable assignment in this case.

Fixes #1050.