### PR TITLE
Verilog: `elsif

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 # EBMC 5.7
 
+* Verilog: `elsif preprocessor directive
+
 # EBMC 5.6
 
 * SystemVerilog: [*] and [+] SVA operators

--- a/regression/verilog/preprocessor/elsif1.desc
+++ b/regression/verilog/preprocessor/elsif1.desc
@@ -1,8 +1,10 @@
-KNOWNBUG
+CORE
 elsif1.v
-
+--preprocess
+^IFDEF$
 ^EXIT=0$
 ^SIGNAL=0$
 --
+^ELSIF$
 --
 The elsif directive is not implemented.

--- a/regression/verilog/preprocessor/elsif2.desc
+++ b/regression/verilog/preprocessor/elsif2.desc
@@ -1,0 +1,9 @@
+CORE
+elsif2.v
+--preprocess
+^ELSIF$
+^EXIT=0$
+^SIGNAL=0$
+--
+^IFDEF$
+--

--- a/regression/verilog/preprocessor/elsif2.v
+++ b/regression/verilog/preprocessor/elsif2.v
@@ -1,6 +1,5 @@
-`define X 1
+`define Y 1
 `ifdef X
-IFDEF
 `elsif Y
 ELSIF
 `endif

--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -551,6 +551,37 @@ void verilog_preprocessort::directive()
     conditional.else_part=true;
     condition=conditional.get_cond();
   }
+  else if(text == "elsif")
+  {
+    if(conditionals.empty())
+      throw verilog_preprocessor_errort() << "`elsif without `ifdef/`ifndef";
+
+    // skip whitespace
+    tokenizer().skip_ws();
+
+    // we expect an identifier
+    const auto identifier_token = tokenizer().next_token();
+
+    if(!identifier_token.is_identifier())
+      throw verilog_preprocessor_errort()
+        << "expecting an identifier after `elsif";
+
+    auto &identifier = identifier_token.text;
+
+    tokenizer().skip_until_eol();
+
+    bool defined = defines.find(identifier) != defines.end();
+
+    conditionalt &conditional = conditionals.back();
+
+    if(conditional.else_part)
+    {
+      throw verilog_preprocessor_errort() << "`elsif after `else";
+    }
+
+    conditional.condition = defined;
+    condition = conditional.get_cond();
+  }
   else if(text=="endif")
   {
     if(conditionals.empty())


### PR DESCRIPTION
This adds the `elsif preprocessor directive to the Verilog preprocessor.