### PR TITLE
Add a Dockerfile for building and running EBMC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:24.04 AS builder
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install -y --no-install-recommends \
+    g++ \
+    gcc \
+    flex \
+    bison \
+    make \
+    curl \
+    patch
+
+
+COPY . /app/ebmc
+WORKDIR /app/ebmc
+
+# This Dockerfile assumes the submodule lib/cbmc is already checked out.
+RUN make -j$(nproc) -C lib/cbmc/src minisat2-download
+RUN make -j$(nproc) -C src
+
+FROM ubuntu:24.04 AS runner
+COPY --from=builder /app/ebmc/src/ebmc/ebmc /usr/local/bin/
+ENTRYPOINT [ "ebmc" ]


### PR DESCRIPTION
This Dockerfile uses a two-stage build process similar to [CBMC's Dockerfile](https://github.com/diffblue/cbmc/blob/develop/Dockerfile):
the binary is compiled in the first stage and then copied into another container in the second stage.

The build step follows the instructions in `COMPILING.md`,
with the assumption that the submodule `lib/cbmc` has already been checked out locally.