### PR TITLE
SMV: rename `STRING_Token`, `QSTRING_Token` and `QUOTE_Token`

### DIFF
--- a/regression/smv/syntax-errors/syntax1.desc
+++ b/regression/smv/syntax-errors/syntax1.desc
@@ -1,7 +1,7 @@
 CORE
 syntax1.smv
 
-^file .* line 3: syntax error, unexpected VAR, expecting string or "'" before 'VAR'$
+^file .* line 3: syntax error, unexpected VAR, expecting identifier or quoted string before 'VAR'$
 ^EXIT=1$
 ^SIGNAL=0$
 --

--- a/regression/smv/syntax-errors/syntax3.desc
+++ b/regression/smv/syntax-errors/syntax3.desc
@@ -1,7 +1,7 @@
 CORE
 syntax3.smv
 
-^file .* line 3: syntax error, unexpected string, expecting number before 'not_a_number'$
+^file .* line 3: syntax error, unexpected identifier, expecting number before 'not_a_number'$
 ^EXIT=1$
 ^SIGNAL=0$
 --

--- a/src/smvlang/scanner.l
+++ b/src/smvlang/scanner.l
@@ -176,12 +176,12 @@ void newlocation(YYSTYPE &x)
 [\$A-Za-z_][A-Za-z0-9_\$#-]*	{
                   newstack(yysmvlval);
                   stack_expr(yysmvlval).id(yytext);
-		  return STRING_Token;
+		  return IDENTIFIER_Token;
 		}
 \\[A-Za-z0-9_\$#-]*	{
                   newstack(yysmvlval);
                   stack_expr(yysmvlval).id(yytext);
-		  return QSTRING_Token;
+		  return QIDENTIFIER_Token;
 		}
 [0-9][0-9]*	{
                   newstack(yysmvlval);
@@ -192,7 +192,7 @@ void newlocation(YYSTYPE &x)
                   newstack(yysmvlval);
                   std::string tmp(yytext);
                   stack_expr(yysmvlval).id(std::string(tmp, 1, tmp.size()-2));
-                  return QUOTE_Token;
+                  return STRING_Token;
                 }
 
 "?"		return IF_Token;


### PR DESCRIPTION
This renames the token identifiers used for SMV identifiers to better match the NuSMV manual.