### PR TITLE
SVA-to-Buechi: sequence repetition operators

### DIFF
--- a/regression/ebmc-spot/sva-buechi/sequence_repetition4.desc
+++ b/regression/ebmc-spot/sva-buechi/sequence_repetition4.desc
@@ -1,0 +1,10 @@
+CORE
+../../verilog/SVA/sequence_repetition4.sv
+--buechi --bound 10
+^\[main\.p0\] \(main\.x == 0 ##1 main\.x == 1\) \[\*2\]: PROVED up to bound \d+$
+^\[main\.p1\] \(main\.x == 0 ##1 main\.x == 1 ##1 main\.x == 0\) \[\*2\]: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/ebmc-spot/sva-buechi/sequence_repetition5.desc
+++ b/regression/ebmc-spot/sva-buechi/sequence_repetition5.desc
@@ -1,0 +1,10 @@
+CORE
+../../verilog/SVA/sequence_repetition5.sv
+--buechi --bound 20
+^\[.*\] main\.pulse ##1 \!main\.pulse \[\*1:9\] ##1 main.pulse: PROVED up to bound 20$
+^\[.*\] main\.pulse ##1 \!main\.pulse \[\*1:8\] ##1 main.pulse: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/ebmc-spot/sva-buechi/sequence_repetition6.desc
+++ b/regression/ebmc-spot/sva-buechi/sequence_repetition6.desc
@@ -1,8 +1,0 @@
-CORE
-../../verilog/SVA/sequence_repetition6.sv
---buechi
-^file .* line 4: sequence required, but got property$
-^EXIT=2$
-^SIGNAL=0$
---
---

--- a/regression/ebmc-spot/sva-buechi/sequence_repetition7.desc
+++ b/regression/ebmc-spot/sva-buechi/sequence_repetition7.desc
@@ -1,0 +1,10 @@
+CORE
+../../verilog/SVA/sequence_repetition7.sv
+--buechi --bound 20
+^\[.*\] \(main\.a ##1 main\.b\) \[\*5\]: PROVED up to bound 20$
+^\[.*\] \(\!main\.b ##1 \!main\.a\) \[\*5\]: PROVED up to bound 20$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/src/verilog/sva_expr.h
+++ b/src/verilog/sva_expr.h
@@ -1456,25 +1456,35 @@ public:
   /// op[*0] is a special case, denoting the empty match
   bool is_empty_match() const
   {
-    return !is_range() && repetitions_given() && op1().is_zero();
+    return is_singleton() && op1().is_zero();
   }
 
   // The number of repetitions must be a constant after elaboration.
   const constant_exprt &repetitions() const
   {
-    PRECONDITION(repetitions_given() && !is_range());
+    PRECONDITION(is_singleton());
     return static_cast<const constant_exprt &>(op1());
   }
 
   constant_exprt &repetitions()
   {
-    PRECONDITION(repetitions_given() && !is_range());
+    PRECONDITION(is_singleton());
     return static_cast<constant_exprt &>(op1());
   }
 
   bool is_range() const
   {
     return op2().is_not_nil();
+  }
+
+  bool is_bounded_range() const
+  {
+    return op2().is_not_nil() && op2().id() != ID_infinity;
+  }
+
+  bool is_singleton() const
+  {
+    return op1().is_not_nil() && op2().is_nil();
   }
 
   bool is_unbounded() const
@@ -1496,13 +1506,13 @@ public:
 
   const constant_exprt &to() const
   {
-    PRECONDITION(is_range() && !is_unbounded());
+    PRECONDITION(is_bounded_range());
     return static_cast<const constant_exprt &>(op2());
   }
 
   constant_exprt &to()
   {
-    PRECONDITION(is_range() && !is_unbounded());
+    PRECONDITION(is_bounded_range());
     return static_cast<constant_exprt &>(op2());
   }
 


### PR DESCRIPTION
This adds conversion for `[*...]`, `[=...]`, `[->...]`, `[+]` to the SVA-to-Buechi translation.