### PR TITLE
Verilog: casts from real to int

### DIFF
--- a/regression/verilog/expressions/cast_from_real2.desc
+++ b/regression/verilog/expressions/cast_from_real2.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 cast_from_real2.sv
 
 ^EXIT=0$
@@ -6,4 +6,3 @@ cast_from_real2.sv
 --
 ^warning: ignoring
 --
-The implicit cast is currently not allowed.

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -2123,6 +2123,14 @@ void verilog_typecheck_exprt::implicit_typecast(
       expr = typecast_exprt{expr, dest_type};
       return;
     }
+    else if(
+      dest_type.id() == ID_bool || dest_type.id() == ID_signedbv ||
+      dest_type.id() == ID_unsignedbv)
+    {
+      // Cast from float to int -- the rounding mode is added during lowering.
+      expr = typecast_exprt{expr, dest_type};
+      return;
+    }
   }
   else if(src_type.id() == ID_verilog_null)
   {


### PR DESCRIPTION
This adds implicit casts from real to integer types.