### PR TITLE
SMV: properties must not contain `next(...)`

### DIFF
--- a/regression/smv/CTL/smv_ctlspec2.desc
+++ b/regression/smv/CTL/smv_ctlspec2.desc
@@ -1,0 +1,7 @@
+CORE
+smv_ctlspec2.smv
+
+^file .* line 6: next\(...\) is not allowed here$
+^EXIT=2$
+^SIGNAL=0$
+--

--- a/regression/smv/CTL/smv_ctlspec2.smv
+++ b/regression/smv/CTL/smv_ctlspec2.smv
@@ -1,0 +1,6 @@
+MODULE main
+
+VAR x : boolean;
+
+-- error, next(...) is not allowed
+SPEC AG next(x)

--- a/regression/smv/CTL/smv_ctlspec3.desc
+++ b/regression/smv/CTL/smv_ctlspec3.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+smv_ctlspec3.smv
+
+^file .* line 5: next\(...\) is not allowed here$
+^EXIT=2$
+^SIGNAL=0$
+--

--- a/regression/smv/CTL/smv_ctlspec3.smv
+++ b/regression/smv/CTL/smv_ctlspec3.smv
@@ -1,0 +1,8 @@
+MODULE main
+
+VAR x : boolean;
+
+DEFINE y := next(x);
+
+-- error, next(...) is not allowed
+SPEC AG y

--- a/regression/smv/LTL/smv_ltlspec7.desc
+++ b/regression/smv/LTL/smv_ltlspec7.desc
@@ -1,0 +1,7 @@
+CORE
+smv_ltlspec7.smv
+
+^file .* line 6: next\(...\) is not allowed here$
+^EXIT=2$
+^SIGNAL=0$
+--

--- a/regression/smv/LTL/smv_ltlspec7.smv
+++ b/regression/smv/LTL/smv_ltlspec7.smv
@@ -1,0 +1,6 @@
+MODULE main
+
+VAR x : boolean;
+
+-- error, next(...) is not allowed
+LTLSPEC G next(x)

--- a/src/smvlang/smv_typecheck.cpp
+++ b/src/smvlang/smv_typecheck.cpp
@@ -642,6 +642,11 @@ void smv_typecheckt::typecheck_expr_rec(exprt &expr, modet mode)
   if(expr.id()==ID_symbol || 
      expr.id()==ID_next_symbol)
   {
+    // next_symbol is only allowed in TRANS mode
+    if(expr.id() == ID_next_symbol && mode != TRANS && mode != OTHER)
+      throw errort().with_location(expr.find_source_location())
+        << "next(...) is not allowed here";
+
     const irep_idt &identifier=expr.get(ID_identifier);
     bool next=expr.id()==ID_next_symbol;
     

--- a/src/trans-word-level/instantiate_word_level.h
+++ b/src/trans-word-level/instantiate_word_level.h
@@ -12,12 +12,16 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/mp_arith.h>
 #include <util/std_expr.h>
 
+// Instantiate a expression in the given time frame.
+// May contain next_symbol, but must not contain any temporal operators.
 exprt instantiate(
   const exprt &expr,
   const mp_integer &current,
   const mp_integer &no_timeframes);
 
-std::pair<mp_integer, exprt> instantiate_property(
+// Instantiate an atomic state predicate in the given time frame.
+// Must not contain next_symbol or any temporal operators.
+exprt instantiate_property(
   const exprt &,
   const mp_integer &current,
   const mp_integer &no_timeframes);
@@ -25,6 +29,7 @@ std::pair<mp_integer, exprt> instantiate_property(
 std::string
 timeframe_identifier(const mp_integer &timeframe, const irep_idt &identifier);
 
+// Instantiate a symbol in the given time frame.
 symbol_exprt timeframe_symbol(const mp_integer &timeframe, symbol_exprt);
 
 #endif

--- a/src/trans-word-level/property.cpp
+++ b/src/trans-word-level/property.cpp
@@ -517,8 +517,7 @@ static obligationst property_obligations_rec(
   {
     // we rely on NNF
     auto &if_expr = to_if_expr(property_expr);
-    auto cond =
-      instantiate_property(if_expr.cond(), current, no_timeframes).second;
+    auto cond = instantiate_property(if_expr.cond(), current, no_timeframes);
     auto obligations_true =
       property_obligations_rec(if_expr.true_case(), current, no_timeframes)
         .conjunction();
@@ -577,7 +576,7 @@ static obligationst property_obligations_rec(
     {
       // state formula
       return obligationst{
-        instantiate_property(property_expr, current, no_timeframes)};
+        current, instantiate_property(property_expr, current, no_timeframes)};
     }
   }
   else if(property_expr.id() == ID_sva_implies)
@@ -721,7 +720,7 @@ static obligationst property_obligations_rec(
   else
   {
     return obligationst{
-      instantiate_property(property_expr, current, no_timeframes)};
+      current, instantiate_property(property_expr, current, no_timeframes)};
   }
 }
 

--- a/src/trans-word-level/sequence.cpp
+++ b/src/trans-word-level/sequence.cpp
@@ -456,7 +456,7 @@ sequence_matchest instantiate_sequence(
     // a state predicate
     auto &predicate = to_sva_boolean_expr(expr).op();
     auto instantiated = instantiate_property(predicate, t, no_timeframes);
-    return {{instantiated.first, instantiated.second}};
+    return {{t, instantiated}};
   }
   else
   {


### PR DESCRIPTION
This adds a check to the SMV type checker that prohibits the use of `next(...)` inside temporal-logic properties.  This matches the behavior of NuSMV.