### PR TITLE
Test for SVA empty match and followed-by operator

### DIFF
--- a/regression/ebmc-spot/sva-buechi/followed-by5.bdd.desc
+++ b/regression/ebmc-spot/sva-buechi/followed-by5.bdd.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+followed-by5.sv
+--buechi --bdd
+^\[main\.p0\] \(1 \[\*0\]\) #=# main\.x == 0: PROVED$
+^\[main\.p1\] \(1 \[\*0\]\) #-# 1: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Empty LHS sequences are not implemented.

--- a/regression/ebmc-spot/sva-buechi/followed-by5.bmc.desc
+++ b/regression/ebmc-spot/sva-buechi/followed-by5.bmc.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+followed-by5.sv
+--buechi --bound 2
+^\[main\.p0\] \(1 \[\*0\]\) #=# main\.x == 0: PROVED$
+^\[main\.p1\] \(1 \[\*0\]\) #-# 1: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Empty LHS sequences are not implemented.

--- a/regression/verilog/SVA/followed-by5.bdd.desc
+++ b/regression/verilog/SVA/followed-by5.bdd.desc
@@ -1,0 +1,10 @@
+CORE
+followed-by5.sv
+--bdd
+^\[main\.p0\] \(1 \[\*0\]\) #=# main\.x == 0: PROVED$
+^\[main\.p1\] \(1 \[\*0\]\) #-# 1: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/followed-by5.bmc.desc
+++ b/regression/verilog/SVA/followed-by5.bmc.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+followed-by5.sv
+--bound 2
+^\[main\.p0\] \(1 \[\*0\]\) #=# main\.x == 0: PROVED$
+^\[main\.p1\] \(1 \[\*0\]\) #-# 1: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Empty LHS sequences are not implemented.

--- a/regression/verilog/SVA/followed-by5.sv
+++ b/regression/verilog/SVA/followed-by5.sv
@@ -1,0 +1,17 @@
+module main(input clk);
+
+  reg [31:0] x;
+
+  initial x=0;
+
+  // 0, 1, ...
+  always @(posedge clk)
+    x<=x+1;
+
+  // expected to pass: the rhs is evaluated in time frame 0
+  initial p0: assert property (1[*0] #=# x==0);
+
+  // expected to fail: the lhs is empty, and the rhs overlaps with the lhs
+  initial p1: assert property (1[*0] #-# 1);
+
+endmodule


### PR DESCRIPTION
This adds a test that checks the behavior of an SVA empty match used as the LHS of the two followed-by operators.