### PR TITLE
Verilog: constant folding for `$onehot` and `$onehot0`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 * Verilog: `elsif preprocessor directive
 * Verilog: fix for named generate blocks
+* Verilog: $onehot and $onehot0 are now elaboration-time constant
 * LTL/SVA to Buechi with --buechi
 
 # EBMC 5.6

--- a/regression/verilog/system-functions/onehot1.desc
+++ b/regression/verilog/system-functions/onehot1.desc
@@ -1,0 +1,13 @@
+CORE
+onehot1.sv
+--module main
+^\[main\.pA0\] always \$onehot\(8\) == 1: PROVED .*$
+^\[main\.pA1\] always \$onehot\(10\) == 0: PROVED .*$
+^\[main\.pA2\] always \$onehot\(247\) == 0: PROVED .*$
+^\[main\.pB0\] always \$onehot0\(8\) == 0: PROVED .*$
+^\[main\.pB1\] always \$onehot0\(10\) == 0: PROVED .*$
+^\[main\.pB2\] always \$onehot0\(247\) == 1: PROVED .*$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/system-functions/onehot1.sv
+++ b/regression/verilog/system-functions/onehot1.sv
@@ -1,0 +1,15 @@
+module main;
+
+  pA0: assert final ($onehot(8'b00001000)==1);
+  pA1: assert final ($onehot(8'b00001010)==0);
+  pA2: assert final ($onehot(8'b11110111)==0);
+
+  pB0: assert final ($onehot0(8'b00001000)==0);
+  pB1: assert final ($onehot0(8'b00001010)==0);
+  pB2: assert final ($onehot0(8'b11110111)==1);
+
+  // $onehot and $onehot0 yield elaboration-time constants
+  parameter Q1 = $onehot(3'b101);
+  parameter P1 = $onehot0(3'b101);
+
+endmodule


### PR DESCRIPTION
`$onehot` and `$onehot0` are now elaboration-time constant.
