### PR TITLE
Verilog: fix for named generate block scopes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # EBMC 5.7
 
 * Verilog: `elsif preprocessor directive
+* Verilog: fix for named generate blocks
 * LTL/SVA to Buechi with --buechi
 
 # EBMC 5.6

--- a/regression/verilog/typedef/typedef2.sv
+++ b/regression/verilog/typedef/typedef2.sv
@@ -23,6 +23,13 @@ module main();
     end
   endtask
 
+  // module item inside a named generate block
+  if (1) begin: some_block
+    typedef logic some_type;
+    some_type some_var;
+   end // checks
+
+  // named procedural block
   always @my_type2_var begin : named_block
     typedef bit my_type5;
     my_type5 my_type5_var;

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3163,9 +3163,12 @@ generate_block:
 	  generate_item
 	| TOK_BEGIN generate_item_brace TOK_END
 		{ init($$, ID_generate_block); swapop($$, $2); }
-	| TOK_BEGIN TOK_COLON generate_block_identifier generate_item_brace TOK_END
-		{ init($$, ID_generate_block);
-		  swapop($$, $4);
+	| TOK_BEGIN TOK_COLON generate_block_identifier
+		{ push_scope(stack_expr($3).id(), ".", verilog_scopet::BLOCK); }
+	  generate_item_brace TOK_END
+		{ pop_scope();
+		  init($$, ID_generate_block);
+		  swapop($$, $5);
 		  stack_expr($$).set(ID_base_name, stack_expr($3).id()); }
 	;
 


### PR DESCRIPTION
Verilog generate blocks may be named, which creates a scope.