### PR TITLE
`LTL_sequence_matches` now throws `sva_sequence_match_unsupportedt`

### DIFF
--- a/src/temporal-logic/sva_sequence_match.cpp
+++ b/src/temporal-logic/sva_sequence_match.cpp
@@ -64,9 +64,6 @@ std::vector<sva_sequence_matcht> LTL_sequence_matches(const exprt &sequence)
     auto matches_lhs = LTL_sequence_matches(concatenation.lhs());
     auto matches_rhs = LTL_sequence_matches(concatenation.rhs());
 
-    if(matches_lhs.empty() || matches_rhs.empty())
-      return {};
-
     std::vector<sva_sequence_matcht> result;
 
     // cross product
@@ -86,9 +83,6 @@ std::vector<sva_sequence_matcht> LTL_sequence_matches(const exprt &sequence)
     auto &repetition = to_sva_sequence_repetition_star_expr(sequence);
     auto matches_op = LTL_sequence_matches(repetition.op());
 
-    if(matches_op.empty())
-      return {};
-
     std::vector<sva_sequence_matcht> result;
 
     if(repetition.repetitions_given())
@@ -97,7 +91,7 @@ std::vector<sva_sequence_matcht> LTL_sequence_matches(const exprt &sequence)
       {
         if(repetition.is_unbounded()) // [*n:$]
         {
-          return {}; // no support
+          throw sva_sequence_match_unsupportedt{sequence}; // no support
         }
         else // [*n:m]
         {
@@ -118,7 +112,7 @@ std::vector<sva_sequence_matcht> LTL_sequence_matches(const exprt &sequence)
       }
     }
     else         // [*]
-      return {}; // no support
+      throw sva_sequence_match_unsupportedt{sequence}; // no support
 
     return result;
   }
@@ -127,9 +121,6 @@ std::vector<sva_sequence_matcht> LTL_sequence_matches(const exprt &sequence)
     auto &delay = to_sva_cycle_delay_expr(sequence);
     auto matches = LTL_sequence_matches(delay.op());
     auto from_int = numeric_cast_v<mp_integer>(delay.from());
-
-    if(matches.empty())
-      return {};
 
     if(!delay.is_range())
     {
@@ -143,7 +134,7 @@ std::vector<sva_sequence_matcht> LTL_sequence_matches(const exprt &sequence)
     }
     else if(delay.is_unbounded())
     {
-      return {}; // can't encode
+      throw sva_sequence_match_unsupportedt{sequence}; // can't encode
     }
     else
     {
@@ -174,9 +165,6 @@ std::vector<sva_sequence_matcht> LTL_sequence_matches(const exprt &sequence)
     auto &and_expr = to_sva_and_expr(sequence);
     auto matches_lhs = LTL_sequence_matches(and_expr.lhs());
     auto matches_rhs = LTL_sequence_matches(and_expr.rhs());
-
-    if(matches_lhs.empty() || matches_rhs.empty())
-      return {};
 
     std::vector<sva_sequence_matcht> result;
 
@@ -214,7 +202,7 @@ std::vector<sva_sequence_matcht> LTL_sequence_matches(const exprt &sequence)
     {
       auto op_matches = LTL_sequence_matches(op);
       if(op_matches.empty())
-        return {}; // not supported
+        throw sva_sequence_match_unsupportedt{sequence}; // not supported
       for(auto &match : op_matches)
         result.push_back(std::move(match));
     }
@@ -223,6 +211,6 @@ std::vector<sva_sequence_matcht> LTL_sequence_matches(const exprt &sequence)
   }
   else
   {
-    return {}; // unsupported
+    throw sva_sequence_match_unsupportedt{sequence}; // not supported
   }
 }

--- a/src/temporal-logic/sva_sequence_match.h
+++ b/src/temporal-logic/sva_sequence_match.h
@@ -26,6 +26,12 @@ struct sva_sequence_matcht
   {
   }
 
+  // a match with given sequence of conditions
+  explicit sva_sequence_matcht(std::vector<exprt> __cond_vector)
+    : cond_vector(std::move(__cond_vector))
+  {
+  }
+
   std::vector<exprt> cond_vector;
 
   std::size_t length()
@@ -40,9 +46,26 @@ struct sva_sequence_matcht
 
   // generate true ##1 ... ##1 true with length n
   static sva_sequence_matcht true_match(const mp_integer &n);
+
+  bool operator==(const sva_sequence_matcht &other) const
+  {
+    return cond_vector == other.cond_vector;
+  }
 };
 
-// the set of potential matches for the given sequence expression
+class sva_sequence_match_unsupportedt
+{
+public:
+  explicit sva_sequence_match_unsupportedt(exprt __expr)
+    : expr(std::move(__expr))
+  {
+  }
+
+  exprt expr;
+};
+
+/// The set of potential matches for the given sequence expression.
+/// Throws sva_sequence_match_unsupportedt when given sequence that cannot be translated.
 std::vector<sva_sequence_matcht> LTL_sequence_matches(const exprt &);
 
 #endif // CPROVER_TEMPORAL_LOGICS_SVA_SEQUENCE_MATCH_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -6,6 +6,7 @@ SRC = unit_tests.cpp
 # Test source files
 SRC += smvlang/expr2smv.cpp \
        temporal-logic/ltl_sva_to_string.cpp \
+       temporal-logic/sva_sequence_match.cpp \
        temporal-logic/nnf.cpp \
        # Empty last line
 

--- a/unit/temporal-logic/sva_sequence_match.cpp
+++ b/unit/temporal-logic/sva_sequence_match.cpp
@@ -1,0 +1,49 @@
+/*******************************************************************\
+
+Module: SVA Sequence Matches
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#include <util/arith_tools.h>
+#include <util/mathematical_types.h>
+
+#include <temporal-logic/sva_sequence_match.h>
+#include <testing-utils/use_catch.h>
+#include <verilog/sva_expr.h>
+
+SCENARIO("Generating the matches for an SVA sequence")
+{
+  const auto sequence_type = verilog_sva_sequence_typet{};
+
+  GIVEN("A boolean formula")
+  {
+    auto p = symbol_exprt{"p", bool_typet{}};
+
+    REQUIRE(
+      LTL_sequence_matches(sva_boolean_exprt{p, sequence_type}) ==
+      std::vector<sva_sequence_matcht>{sva_sequence_matcht{p}});
+  }
+
+  GIVEN("##1 p")
+  {
+    auto p = symbol_exprt{"p", bool_typet{}};
+    auto one = from_integer(1, integer_typet{});
+
+    REQUIRE(
+      LTL_sequence_matches(
+        sva_cycle_delay_exprt{one, sva_boolean_exprt{p, sequence_type}}) ==
+      std::vector<sva_sequence_matcht>{sva_sequence_matcht{{true_exprt{}, p}}});
+  }
+
+  GIVEN("##[*] p")
+  {
+    auto p = symbol_exprt{"p", bool_typet{}};
+
+    CHECK_THROWS_AS(
+      LTL_sequence_matches(
+        sva_cycle_delay_star_exprt{sva_boolean_exprt{p, sequence_type}}),
+      sva_sequence_match_unsupportedt);
+  }
+}


### PR DESCRIPTION
This allows reporting the sequence expression that is unsupported.