### PR TITLE
add (optional) lhs to SVA cycle delay operator

### DIFF
--- a/src/temporal-logic/ltl_sva_to_string.cpp
+++ b/src/temporal-logic/ltl_sva_to_string.cpp
@@ -422,12 +422,16 @@ ltl_sva_to_stringt::rec(const exprt &expr, modet mode)
   else if(expr.id() == ID_sva_cycle_delay_star) // ##[*] something
   {
     PRECONDITION(mode == SVA_SEQUENCE);
-    return suffix("[*]", to_sva_cycle_delay_star_expr(expr), mode);
+    auto new_expr = unary_exprt{
+      ID_sva_cycle_delay_star, to_sva_cycle_delay_star_expr(expr).rhs()};
+    return suffix("[*]", new_expr, mode);
   }
   else if(expr.id() == ID_sva_cycle_delay_plus) // ##[+] something
   {
     PRECONDITION(mode == SVA_SEQUENCE);
-    return suffix("[+]", to_sva_cycle_delay_plus_expr(expr), mode);
+    auto new_expr = unary_exprt{
+      ID_sva_cycle_delay_star, to_sva_cycle_delay_plus_expr(expr).rhs()};
+    return suffix("[+]", new_expr, mode);
   }
   else if(expr.id() == ID_if)
   {

--- a/src/verilog/expr2verilog_class.h
+++ b/src/verilog/expr2verilog_class.h
@@ -16,6 +16,7 @@ class sva_abort_exprt;
 class sva_case_exprt;
 class sva_if_exprt;
 class sva_ranged_predicate_exprt;
+class sva_cycle_delay_exprt;
 class sva_sequence_first_match_exprt;
 class sva_sequence_repetition_exprt;
 
@@ -137,6 +138,9 @@ protected:
 
   resultt convert_sva_binary(const std::string &name, const binary_exprt &);
 
+  resultt
+  convert_sva_cycle_delay(const std::string &symbol, const binary_exprt &);
+
   resultt convert_sva_sequence_repetition(
     const std::string &name,
     const sva_sequence_repetition_exprt &);
@@ -152,7 +156,8 @@ protected:
 
   resultt convert_with(const with_exprt &, verilog_precedencet);
 
-  resultt convert_sva_cycle_delay(const ternary_exprt &, verilog_precedencet);
+  resultt
+  convert_sva_cycle_delay(const sva_cycle_delay_exprt &, verilog_precedencet);
 
   resultt convert_sva_if(const sva_if_exprt &);
 

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2533,10 +2533,16 @@ property_expr_proper:
 	// copy of sequence_expr, to allow and/or to be both sequence_expr and property_expr
 	//
 	| cycle_delay_range sequence_expr %prec "##"
-		{ $$=$1; mto($$, $2); }
+		{ $$=$1;
+		  stack_expr($$).operands().insert(stack_expr($$).operands().begin(), nil_exprt());
+		  mto($$, $2); }
 	// requires sequence_expr on the LHS
 	| property_expr cycle_delay_range sequence_expr %prec "##"
-		{ init($$, ID_sva_sequence_concatenation); mto($$, $1); mto($2, $3); mto($$, $2); }
+		{ init($$, ID_sva_sequence_concatenation);
+		  mto($$, $1);
+		  stack_expr($2).operands().insert(stack_expr($2).operands().begin(), nil_exprt());
+		  mto($2, $3);
+		  mto($$, $2); }
 	// requires sequence_expr on the LHS
 	| '(' property_expr_proper ')' sequence_abbrev
 		{ $$ = $4;
@@ -2636,9 +2642,15 @@ sequence_expr:
 
 sequence_expr_proper:
 	  cycle_delay_range sequence_expr %prec "##"
-		{ $$=$1; mto($$, $2); }
+		{ $$=$1;
+		  stack_expr($$).operands().insert(stack_expr($$).operands().begin(), nil_exprt());
+		  mto($$, $2); }
         | sequence_expr cycle_delay_range sequence_expr %prec "##"
-                { init($$, ID_sva_sequence_concatenation); mto($$, $1); mto($2, $3); mto($$, $2); }
+                { init($$, ID_sva_sequence_concatenation);
+                  mto($$, $1);
+		  stack_expr($2).operands().insert(stack_expr($2).operands().begin(), nil_exprt());
+                  mto($2, $3);
+                  mto($$, $2); }
 	| '(' sequence_expr_proper ')'
 		{ $$ = $2; }
 	| '(' sequence_expr_proper ')' sequence_abbrev

--- a/src/verilog/sva_expr.cpp
+++ b/src/verilog/sva_expr.cpp
@@ -15,18 +15,20 @@ exprt sva_cycle_delay_plus_exprt::lower() const
 {
   // same as ##[1:$]
   return sva_cycle_delay_exprt{
+    lhs(),
     from_integer(1, integer_typet{}),
     exprt{ID_infinity, integer_typet{}},
-    op()};
+    rhs()};
 }
 
 exprt sva_cycle_delay_star_exprt::lower() const
 {
   // same as ##[0:$]
   return sva_cycle_delay_exprt{
+    lhs(),
     from_integer(0, integer_typet{}),
     exprt{ID_infinity, integer_typet{}},
-    op()};
+    rhs()};
 }
 
 exprt sva_case_exprt::lower() const

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -207,6 +207,7 @@ protected:
   [[nodiscard]] exprt convert_unary_sva(unary_exprt);
   [[nodiscard]] exprt convert_binary_sva(binary_exprt);
   [[nodiscard]] exprt convert_ternary_sva(ternary_exprt);
+  [[nodiscard]] exprt convert_other_sva(exprt);
 
   static void set_default_sequence_semantics(exprt &, sva_sequence_semanticst);
 

--- a/unit/temporal-logic/sva_sequence_match.cpp
+++ b/unit/temporal-logic/sva_sequence_match.cpp
@@ -42,8 +42,8 @@ SCENARIO("Generating the matches for an SVA sequence")
     auto p = symbol_exprt{"p", bool_typet{}};
 
     CHECK_THROWS_AS(
-      LTL_sequence_matches(
-        sva_cycle_delay_star_exprt{sva_boolean_exprt{p, sequence_type}}),
+      LTL_sequence_matches(sva_cycle_delay_star_exprt{
+        nil_exprt{}, sva_boolean_exprt{p, sequence_type}}),
       sva_sequence_match_unsupportedt);
   }
 }


### PR DESCRIPTION
The SVA cycle delay operator `##[...]` can have an optional left-hand side operand.  This adds an operand to the expression, which is nil when not used.
