### PR TITLE
word-level BMC: precondition for timeframe

### DIFF
--- a/src/trans-word-level/sequence.cpp
+++ b/src/trans-word-level/sequence.cpp
@@ -82,6 +82,8 @@ sequence_matchest instantiate_sequence(
   const mp_integer &t,
   const mp_integer &no_timeframes)
 {
+  PRECONDITION(t < no_timeframes);
+
   if(expr.id() == ID_sva_cycle_delay) // ##[1:2] something
   {
     auto &sva_cycle_delay_expr = to_sva_cycle_delay_expr(expr);


### PR DESCRIPTION
This adds a `PRECONDITION` on the starting timeframe to the word-level SVA sequence encoding.