### PR TITLE
SVA: parentheses around the arguments of `##`

### DIFF
--- a/regression/ebmc-spot/sva-buechi/sequence_repetition5.desc
+++ b/regression/ebmc-spot/sva-buechi/sequence_repetition5.desc
@@ -1,8 +1,8 @@
 CORE
 ../../verilog/SVA/sequence_repetition5.sv
 --buechi --bound 20
-^\[.*\] main\.pulse ##1 \!main\.pulse \[\*1:9\] ##1 main.pulse: PROVED up to bound 20$
-^\[.*\] main\.pulse ##1 \!main\.pulse \[\*1:8\] ##1 main.pulse: REFUTED$
+^\[.*\] main\.pulse ##1 \(\!main\.pulse \[\*1:9\]\) ##1 main.pulse: PROVED up to bound 20$
+^\[.*\] main\.pulse ##1 \(\!main\.pulse \[\*1:8\]\) ##1 main.pulse: REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/empty_sequence1.desc
+++ b/regression/verilog/SVA/empty_sequence1.desc
@@ -2,7 +2,7 @@ CORE
 empty_sequence1.sv
 --bound 5
 ^\[main\.p0\] 1 \[\*0\]: REFUTED$
-^\[main\.p1\] 1 \[\*0\] ##1 main\.x == 0: REFUTED$
+^\[main\.p1\] \(1 \[\*0\]\) ##1 main\.x == 0: REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/sequence_repetition5.desc
+++ b/regression/verilog/SVA/sequence_repetition5.desc
@@ -1,8 +1,8 @@
 CORE
 sequence_repetition5.sv
 --bound 20
-^\[.*\] main\.pulse ##1 \!main\.pulse \[\*1:9\] ##1 main.pulse: PROVED up to bound 20$
-^\[.*\] main\.pulse ##1 \!main\.pulse \[\*1:8\] ##1 main.pulse: REFUTED$
+^\[.*\] main\.pulse ##1 \(\!main\.pulse \[\*1:9\]\) ##1 main.pulse: PROVED up to bound 20$
+^\[.*\] main\.pulse ##1 \(\!main\.pulse \[\*1:8\]\) ##1 main.pulse: REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/src/verilog/expr2verilog_class.h
+++ b/src/verilog/expr2verilog_class.h
@@ -156,13 +156,11 @@ protected:
 
   resultt convert_with(const with_exprt &, verilog_precedencet);
 
-  resultt
-  convert_sva_cycle_delay(const sva_cycle_delay_exprt &, verilog_precedencet);
+  resultt convert_sva_cycle_delay(const sva_cycle_delay_exprt &);
 
   resultt convert_sva_if(const sva_if_exprt &);
 
-  resultt
-  convert_sva_sequence_concatenation(const binary_exprt &, verilog_precedencet);
+  resultt convert_sva_sequence_concatenation(const binary_exprt &);
 
   resultt
   convert_sva_sequence_first_match(const sva_sequence_first_match_exprt &);


### PR DESCRIPTION
This adds parentheses around the arguments of SVA `##` to avoid ambiguity.