### PR TITLE
Avoid `sva_sequence_matcht` default constructor

### DIFF
--- a/src/temporal-logic/sva_sequence_match.h
+++ b/src/temporal-logic/sva_sequence_match.h
@@ -16,11 +16,6 @@ Author: Daniel Kroening, dkr@amazon.com
 // sequence expressions.
 struct sva_sequence_matcht
 {
-  // the empty match
-  sva_sequence_matcht()
-  {
-  }
-
   // a match of length 1
   explicit sva_sequence_matcht(exprt __cond) : cond_vector{1, std::move(__cond)}
   {


### PR DESCRIPTION
This replaces uses of the `sva_sequence_matcht` default constructor by uses of the constructor that takes an expression vector as argument.