### PR TITLE
`SVA_to_LTL` now throws exception

### DIFF
--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -475,11 +475,15 @@ std::optional<exprt> bdd_enginet::property_supported(const exprt &expr)
   if(is_SVA(expr))
   {
     // We can map some SVA to LTL. In turn, some of that can be mapped to CTL.
-    auto ltl_opt = SVA_to_LTL(expr);
-    if(ltl_opt.has_value())
-      return property_supported(ltl_opt.value());
-    else
+    try
+    {
+      auto ltl = SVA_to_LTL(expr);
+      return property_supported(ltl);
+    }
+    catch(sva_to_ltl_unsupportedt)
+    {
       return {};
+    }
   }
 
   return {};

--- a/src/ebmc/output_smv_word_level.cpp
+++ b/src/ebmc/output_smv_word_level.cpp
@@ -192,11 +192,16 @@ static void smv_properties(
     else if(is_SVA(property.normalized_expr))
     {
       // we can turn some SVA properties into LTL
-      auto ltl_opt = SVA_to_LTL(property.normalized_expr);
-      if(ltl_opt.has_value())
-        out << "LTLSPEC " << expr2smv(ltl_opt.value(), ns);
-      else
-        out << "-- " << property.identifier << ": SVA not converted\n";
+      try
+      {
+        auto ltl = SVA_to_LTL(property.normalized_expr);
+        out << "LTLSPEC " << expr2smv(ltl, ns);
+      }
+      catch(sva_to_ltl_unsupportedt error)
+      {
+        out << "-- " << property.identifier << ": SVA " << error.expr.id()
+            << " not converted\n";
+      }
     }
     else
       out << "-- " << property.identifier << ": not converted\n";

--- a/src/temporal-logic/sva_to_ltl.h
+++ b/src/temporal-logic/sva_to_ltl.h
@@ -11,8 +11,18 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include <util/expr.h>
 
+class sva_to_ltl_unsupportedt
+{
+public:
+  explicit sva_to_ltl_unsupportedt(exprt __expr) : expr(std::move(__expr))
+  {
+  }
+
+  exprt expr;
+};
+
 /// If possible, this maps an SVA expression to an equivalent LTL
-/// expression, or otherwise returns {}.
-std::optional<exprt> SVA_to_LTL(exprt);
+/// expression, or otherwise throws \ref sva_to_ltl_unsupportedt.
+exprt SVA_to_LTL(exprt);
 
 #endif

--- a/src/trans-netlist/instantiate_netlist.cpp
+++ b/src/trans-netlist/instantiate_netlist.cpp
@@ -179,11 +179,15 @@ std::optional<exprt> netlist_property(
     else if(is_SVA_operator(expr))
     {
       // Try to turn into LTL
-      auto LTL_opt = SVA_to_LTL(expr);
-      if(LTL_opt.has_value())
-        return netlist_property(solver, var_map, *LTL_opt, ns, message_handler);
-      else
+      try
+      {
+        auto LTL = SVA_to_LTL(expr);
+        return netlist_property(solver, var_map, LTL, ns, message_handler);
+      }
+      catch(sva_to_ltl_unsupportedt)
+      {
         return {};
+      }
     }
     else
       return {};

--- a/src/trans-netlist/trans_to_netlist.cpp
+++ b/src/trans-netlist/trans_to_netlist.cpp
@@ -391,11 +391,15 @@ convert_trans_to_netlistt::convert_property(const exprt &expr)
     else if(is_SVA_operator(expr))
     {
       // Try to turn into LTL
-      auto LTL_opt = SVA_to_LTL(expr);
-      if(LTL_opt.has_value())
-        return convert_property(*LTL_opt);
-      else
+      try
+      {
+        auto LTL = SVA_to_LTL(expr);
+        return convert_property(LTL);
+      }
+      catch(sva_to_ltl_unsupportedt)
+      {
         return {};
+      }
     }
     else
       return {};


### PR DESCRIPTION
`SVA_to_LTL(expr)` now throws an exception when given an expression that does not map to LTL.  The exception includes a subexpression that is not convertible.