### PR TITLE
SMV: tests for `next(...)`

### DIFF
--- a/regression/smv/next/next1.desc
+++ b/regression/smv/next/next1.desc
@@ -1,0 +1,8 @@
+CORE
+next1.smv
+--bdd
+^\[.*\] !x: PROVED$
+^\[.*\] AX x: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/smv/next/next1.smv
+++ b/regression/smv/next/next1.smv
@@ -1,0 +1,9 @@
+MODULE main
+
+VAR x : boolean;
+
+INIT !x
+TRANS next(x)
+
+CTLSPEC !x
+CTLSPEC AX x

--- a/regression/smv/next/next2.desc
+++ b/regression/smv/next/next2.desc
@@ -1,0 +1,7 @@
+CORE
+next2.smv
+--bdd
+^\[.*\] AX x <-> !x: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/smv/next/next2.smv
+++ b/regression/smv/next/next2.smv
@@ -1,0 +1,7 @@
+MODULE main
+
+VAR x : boolean;
+
+TRANS next(x)=!x
+
+CTLSPEC (AX x) <-> !x

--- a/regression/smv/next/next3.desc
+++ b/regression/smv/next/next3.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+next3.smv
+--bdd
+^\[.*\] AX x <-> !x: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+The BDD engine gives the wrong answer.

--- a/regression/smv/next/next3.smv
+++ b/regression/smv/next/next3.smv
@@ -1,0 +1,7 @@
+MODULE main
+
+VAR x : boolean;
+
+TRANS next(!x)=x
+
+CTLSPEC (AX x) <-> !x


### PR DESCRIPTION
This adds three tests for SMV `next` expressions.