### PR TITLE
SMV: `TRUE`/`FALSE` are keywords

### DIFF
--- a/src/smvlang/smv_typecheck.cpp
+++ b/src/smvlang/smv_typecheck.cpp
@@ -1720,11 +1720,7 @@ void smv_typecheckt::convert(exprt &expr, expr_modet expr_mode)
   {
     const std::string &identifier=expr.get_string(ID_identifier);
 
-    if(identifier=="TRUE")
-      expr=true_exprt();
-    else if(identifier=="FALSE")
-      expr=false_exprt();
-    else if(identifier.find("::")==std::string::npos)
+    if(identifier.find("::") == std::string::npos)
     {
       std::string id=module+"::var::"+identifier;
 


### PR DESCRIPTION
The SMV scanner generates separate tokens for the `TRUE`/`FALSE` keywords; hence, there is no need to recognise these as special identifiers in the type checker.