### PR TITLE
SMV: test for LTL property with 'or'

### DIFF
--- a/regression/smv/LTL/smv_ltlspec_or1.desc
+++ b/regression/smv/LTL/smv_ltlspec_or1.desc
@@ -1,0 +1,8 @@
+CORE
+smv_ltlspec_or1.smv
+--bound 10
+^\[spec1\] F !x \| G x: PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/smv/LTL/smv_ltlspec_or1.smv
+++ b/regression/smv/LTL/smv_ltlspec_or1.smv
@@ -1,0 +1,5 @@
+MODULE main
+
+VAR x : boolean;
+
+LTLSPEC (F !x) | G x


### PR DESCRIPTION
This adds a test for an LTL property with a top-level 'or'.