### PR TITLE
BMC: looping constraint must consider all inputs

### DIFF
--- a/regression/ebmc/SVA-LTL/lasso1-show-formula.desc
+++ b/regression/ebmc/SVA-LTL/lasso1-show-formula.desc
@@ -3,6 +3,6 @@ lasso1.sv
 --bound 1 --show-formula
 ^EXIT=0$
 ^SIGNAL=0$
-^\(\d+\) lasso::1-back-to-0 ⇔ \(.*counter@1 = .*counter@0 ∧ .*clock@1 ⇔ .*clock@0\)$
+^\(\d+\) lasso::1-back-to-0 ⇔ \(.*clock@1 ⇔ .*clock@0 ∧ .*counter@1 = .*counter@0\)$
 --
 --

--- a/regression/smv/LTL/smv_ltlspec_F5.desc
+++ b/regression/smv/LTL/smv_ltlspec_F5.desc
@@ -1,10 +1,10 @@
-KNOWNBUG
+CORE
 smv_ltlspec_F5.smv
---bound 3 --numbered-trace
+--bound 1 --numbered-trace
 ^\[spec1\] F \(!some_input \& X !some_input\): REFUTED$
+^Counterexample with 2 states:$
 ^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-The BMC engine gives the wrong answer.

--- a/regression/smv/LTL/smv_ltlspec_F5.smv
+++ b/regression/smv/LTL/smv_ltlspec_F5.smv
@@ -3,5 +3,5 @@ MODULE main
 VAR some_input : boolean;
 
 -- Expected to fail
--- The shortest loop is FALSE, FALSE
+-- The shortest loop is FALSE, FALSE or TRUE, TRUE
 LTLSPEC F (!some_input & X !some_input)

--- a/regression/smv/LTL/smv_ltlspec_F7.desc
+++ b/regression/smv/LTL/smv_ltlspec_F7.desc
@@ -1,0 +1,8 @@
+CORE
+smv_ltlspec_F7.smv
+--bound 1 --show-formula
+^\(1\) lasso::1-back-to-0 ⇔ \(smv::main::var::some_input@1 = smv::main::var::some_input@0\)$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/smv/LTL/smv_ltlspec_F7.smv
+++ b/regression/smv/LTL/smv_ltlspec_F7.smv
@@ -1,0 +1,6 @@
+MODULE main
+
+VAR some_input : 1..3;
+
+-- Expected to fail
+LTLSPEC F (some_input >= 2)


### PR DESCRIPTION
The SMV top-level `main` module does not have explicit inputs or output.  This change adds all inputs to the list of variables that are compared when creating the lasso condition.