### PR TITLE
Fixup regression test after merging #1115

### DIFF
--- a/regression/smv/expressions/smv_union1.desc
+++ b/regression/smv/expressions/smv_union1.desc
@@ -1,7 +1,7 @@
 CORE broken-smt-backend
 smv_union1.smv
 
-^\[spec1\] x != 3: PROVED \(CT=1\)$
+^\[spec1\] x != 3: PROVED \(CT=0\)$
 ^\[spec2\] x != 2: REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$


### PR DESCRIPTION
It seems that changes between that PR's original base and current main caused the completeness threshold to shrink.