### PR TITLE
Fix for lowering for expressions given as named properties

### DIFF
--- a/regression/verilog/property/named_property3.desc
+++ b/regression/verilog/property/named_property3.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+named_property3.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The expression in the named property is not lowered.

--- a/regression/verilog/property/named_property3.desc
+++ b/regression/verilog/property/named_property3.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 named_property3.sv
 
 ^EXIT=0$
@@ -6,4 +6,3 @@ named_property3.sv
 --
 ^warning: ignoring
 --
-The expression in the named property is not lowered.

--- a/regression/verilog/property/named_property3.sv
+++ b/regression/verilog/property/named_property3.sv
@@ -3,6 +3,7 @@ module main;
   wire [31:0] x = 'b10010001;
 
   property with_index;
+    // the index expression requires lowering
     x[7:4] == 'b1001
   endproperty
 

--- a/regression/verilog/property/named_property3.sv
+++ b/regression/verilog/property/named_property3.sv
@@ -1,0 +1,11 @@
+module main;
+
+  wire [31:0] x = 'b10010001;
+
+  property with_index;
+    x[7:4] == 'b1001
+  endproperty
+
+  assert property (with_index);
+
+endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -90,8 +90,11 @@ exprt verilog_synthesist::synth_expr_rec(exprt expr, symbol_statet symbol_state)
       // substitute
       assert(symbol.value.is_not_nil());
 
+      // These aren't lowered yet
+      auto lowered = verilog_lowering(symbol.value);
+
       // recursive call
-      return synth_expr_rec(symbol.value, symbol_state);
+      return synth_expr_rec(lowered, symbol_state);
     }
     else
     {


### PR DESCRIPTION
This adds the missing lowering for expressions given as named properties.