### PR TITLE
CI: download spot from a mirror

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -176,10 +176,11 @@ jobs:
         run: |
           # spot
           SPOT_VERSION=2.14.1
-          wget https://www.lre.epita.fr/repo/debian/stable/libbddx0_${SPOT_VERSION}.0-1_amd64.deb
-          wget https://www.lre.epita.fr/repo/debian/stable/libspotgen0_${SPOT_VERSION}.0-1_amd64.deb
-          wget https://www.lre.epita.fr/repo/debian/stable/libspot0_${SPOT_VERSION}.0-1_amd64.deb
-          wget https://www.lre.epita.fr/repo/debian/stable/spot_${SPOT_VERSION}.0-1_amd64.deb
+          URL=https://download.opensuse.org/repositories/home:/adl/Debian_12/amd64
+          wget ${URL}/libbddx0_${SPOT_VERSION}.0-1_amd64.deb
+          wget ${URL}/libspotgen0_${SPOT_VERSION}.0-1_amd64.deb
+          wget ${URL}/libspot0_${SPOT_VERSION}.0-1_amd64.deb
+          wget ${URL}/spot_${SPOT_VERSION}.0-1_amd64.deb
           sudo dpkg -i libbddx0_${SPOT_VERSION}.0-1_amd64.deb libspotgen0_${SPOT_VERSION}.0-1_amd64.deb libspot0_${SPOT_VERSION}.0-1_amd64.deb spot_${SPOT_VERSION}.0-1_amd64.deb
       - name: Confirm ltl2tgba is available and log the version installed
         run: ltl2tgba --version


### PR DESCRIPTION
This switches the download URL to a mirror, in the hope that it will work without further intervention.