### PR TITLE
Buechi: identify special cases where reachability is sufficient

### DIFF
--- a/regression/ebmc-spot/sva-buechi/initial2.desc
+++ b/regression/ebmc-spot/sva-buechi/initial2.desc
@@ -1,8 +1,8 @@
 CORE
 ../../verilog/SVA/initial2.sv
 --buechi --module main
-^\[main\.assert\.1\] main\.counter == 1: PROVED up to bound \d+$
-^\[main\.assert\.2\] main\.counter == 2: PROVED up to bound \d+$
+^\[main\.assert\.1\] main\.counter == 1: PROVED \(1-induction\)$
+^\[main\.assert\.2\] main\.counter == 2: PROVED \(1-induction\)$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc-spot/sva-buechi/static_final1.desc
+++ b/regression/ebmc-spot/sva-buechi/static_final1.desc
@@ -1,7 +1,7 @@
 CORE
 ../../verilog/SVA/static_final1.sv
 --buechi
-^\[full_adder\.p0\] always \{ full_adder\.carry, full_adder\.sum \} == \{ 1'b0, full_adder\.a \} \+ full_adder\.b \+ full_adder\.c: PROVED up to bound \d+$
+^\[full_adder\.p0\] always \{ full_adder\.carry, full_adder\.sum \} == \{ 1'b0, full_adder\.a \} \+ full_adder\.b \+ full_adder\.c: PROVED \(1-induction\)$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/ebmc/instrument_buechi.cpp
+++ b/src/ebmc/instrument_buechi.cpp
@@ -68,18 +68,30 @@ void instrument_buechi(
     // by the Buechi acceptance condition.
     exprt::operandst property_conjuncts;
 
+    bool have_liveness = false, have_safety = false;
+
     if(!buechi.liveness_signal.is_false())
     {
       // Note that we have negated the property,
       // so this is the negation of the Buechi acceptance condition.
       property_conjuncts.push_back(
         F_exprt{G_exprt{not_exprt{buechi.liveness_signal}}});
+      have_liveness = true;
     }
 
     if(!buechi.error_signal.is_true())
     {
       property_conjuncts.push_back(G_exprt{not_exprt{buechi.error_signal}});
+      have_safety = true;
     }
+
+    if(have_liveness && have_safety)
+      message.debug() << "Buechi automaton has liveness and safety components"
+                      << messaget::eom;
+    else if(have_liveness)
+      message.debug() << "Buechi automaton is liveness only" << messaget::eom;
+    else if(have_safety)
+      message.debug() << "Buechi automaton is safety only" << messaget::eom;
 
     property.normalized_expr = conjunction(property_conjuncts);
 


### PR DESCRIPTION
This adds treatment for the special case where all nonaccepting states of the Buechi automaton have an unconditional self-loop.

In this case, when these nonaccepting states is reached, the trace cannot be extended to an accepting trace, and will hence be rejected.

Hence, in this case, the Buechi acceptance condition is unnecessary, and a simple reachability property is sufficient.