### PR TITLE
Hanoi Omega-Automata INT is 32 bits

### DIFF
--- a/src/temporal-logic/hoa.h
+++ b/src/temporal-logic/hoa.h
@@ -10,8 +10,8 @@ Author: Daniel Kroening, dkr@amazon.com
 #define CPROVER_TEMPORAL_LOGIC_HOA_H
 
 #include <util/irep.h>
-#include <util/mp_arith.h>
 
+#include <cstdint>
 #include <list>
 #include <map>
 #include <string>
@@ -24,12 +24,15 @@ public:
   using headert = std::list<std::pair<std::string, std::list<std::string>>>;
   headert header;
 
+  // A HOA INT is non-negative and less than 2^31
+  using intt = uint32_t;
+
   // body
   using labelt = irept;
   using acc_sigt = std::vector<std::string>;
   struct state_namet
   {
-    mp_integer number;
+    intt number;
     labelt label; // in-state condition
     acc_sigt acc_sig;
     bool is_accepting() const
@@ -40,7 +43,7 @@ public:
   struct edget
   {
     labelt label; // transition condition
-    std::vector<mp_integer> dest_states;
+    std::vector<intt> dest_states;
     acc_sigt acc_sig; // acceptance sets
   };
   using edgest = std::list<edget>;
@@ -61,10 +64,10 @@ public:
     return out;
   }
 
-  mp_integer max_state_number() const;
+  intt max_state_number() const;
 
   // atomic propositions
-  std::map<mp_integer, std::string> ap_map;
+  std::map<intt, std::string> ap_map;
 };
 
 #endif // CPROVER_TEMPORAL_LOGIC_HOA_H

--- a/src/temporal-logic/ltl_to_buechi.cpp
+++ b/src/temporal-logic/ltl_to_buechi.cpp
@@ -178,7 +178,7 @@ ltl_to_buechi(const exprt &property, message_handlert &message_handler)
     // is nonaccepting with an unconditional self-loop.
     std::vector<exprt> error_disjuncts;
 
-    std::map<mp_integer, std::pair<hoat::state_namet, hoat::edgest>> state_map;
+    std::map<hoat::intt, std::pair<hoat::state_namet, hoat::edgest>> state_map;
     for(auto &state : hoa.body)
       state_map[state.first.number] = state;
 


### PR DESCRIPTION
The Hanoi Omega-Automata specification requires that numbers of type INT are nonnegative and less than 2^31.  Hence, `uint32_t` suffices, `mp_integer` is not necessary.