### PR TITLE
SystemVerilog: `++`/`--` for generate `for`

### DIFF
--- a/regression/verilog/generate/generate-for4.desc
+++ b/regression/verilog/generate/generate-for4.desc
@@ -1,0 +1,6 @@
+CORE
+generate-for4.sv
+--bound 1
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/verilog/generate/generate-for4.sv
+++ b/regression/verilog/generate/generate-for4.sv
@@ -1,0 +1,14 @@
+module main;
+
+  wire [15:0] some_wire;
+
+  generate
+    genvar i;
+    for (i = 0; i <= 15; ++i)
+      assign some_wire[i] = (i%2) == 0;
+  endgenerate
+
+  // should pass
+  always assert property1: some_wire == 'b0101_0101_0101_0101;
+
+endmodule

--- a/regression/verilog/generate/generate-for5.desc
+++ b/regression/verilog/generate/generate-for5.desc
@@ -1,0 +1,6 @@
+CORE
+generate-for5.sv
+--bound 1
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/verilog/generate/generate-for5.sv
+++ b/regression/verilog/generate/generate-for5.sv
@@ -1,0 +1,14 @@
+module main;
+
+  wire [15:0] some_wire;
+
+  generate
+    genvar i;
+    for (i = 16; i != 0; i--)
+      assign some_wire[i - 1] = ((i-1)%2) == 0;
+  endgenerate
+
+  // should pass
+  always assert property1: some_wire == 'b0101_0101_0101_0101;
+
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3123,8 +3123,8 @@ generate_item_brace:
 
 loop_generate_construct:
 	  TOK_FOR '(' genvar_initialization ';'
-	              constant_expression ';'
-                      genvar_initialization ')'
+	              genvar_expression ';'
+                      genvar_iteration ')'
           generate_block
 		{ init($$, ID_generate_for);
 		  stack_expr($$).reserve_operands(4);
@@ -3135,9 +3135,20 @@ loop_generate_construct:
 		}
         ;
 
+genvar_expression: constant_expression;
+
 genvar_initialization:
 	  genvar_identifier '=' constant_expression
 	  	{ init($$, ID_generate_assign); mto($$, $1); mto($$, $3); }
+	;
+
+genvar_iteration:
+	  genvar_identifier assignment_operator genvar_expression
+		{ init($$, ID_generate_assign); mto($$, $1); mto($$, $3); }
+	| inc_or_dec_operator genvar_identifier
+		{ $$ = $1; mto($$, $2); }
+	| genvar_identifier inc_or_dec_operator
+		{ $$ = $2; mto($$, $1); }
 	;
 
 conditional_generate_construct:
@@ -4440,6 +4451,11 @@ unary_operator:
 	| TOK_CARETTILDE   { init($$, ID_reduction_xnor); }
 	| TOK_TILDECARET   { init($$, ID_reduction_xnor); }
         ;
+
+inc_or_dec_operator:
+	  TOK_PLUSPLUS     { init($$, ID_preincrement); }
+	| TOK_MINUSMINUS   { init($$, ID_predecrement); }
+	;
 
 // System Verilog standard 1800-2017
 // A.8.7 Numbers

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -408,6 +408,12 @@ inline verilog_module_itemt &to_verilog_module_item(irept &irep)
 class verilog_generate_assignt : public verilog_module_itemt
 {
 public:
+  verilog_generate_assignt(exprt __lhs, exprt __rhs)
+    : verilog_module_itemt{ID_generate_assign}
+  {
+    add_to_operands(std::move(__lhs), std::move(__rhs));
+  }
+
   const exprt &lhs() const
   {
     return op0();
@@ -562,9 +568,10 @@ public:
     return op1();
   }
 
-  const verilog_generate_assignt &increment() const
+  // assignment, ++, --
+  const verilog_module_itemt &iteration() const
   {
-    return static_cast<const verilog_generate_assignt &>(op2());
+    return static_cast<const verilog_module_itemt &>(op2());
   }
 
   const verilog_module_itemt &body() const


### PR DESCRIPTION
SystemVerilog generate `for` allows both pre- and post-increment and -decrement.