### PR TITLE
 Verilog: fix for bit select on boolean argument

### DIFF
--- a/regression/verilog/expressions/index-constant1.desc
+++ b/regression/verilog/expressions/index-constant1.desc
@@ -1,0 +1,8 @@
+CORE
+index-constant1.sv
+
+^\[.*\] .* PROVED .*$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/expressions/index-constant1.sv
+++ b/regression/verilog/expressions/index-constant1.sv
@@ -1,0 +1,11 @@
+module main;
+
+  // index expressions yield constants
+  parameter p = 'b1010;
+  parameter q = p[3];
+  parameter r = p[0];
+
+  assert final (q == 1);
+  assert final (r == 0);
+
+endmodule

--- a/regression/verilog/expressions/index-constant2.desc
+++ b/regression/verilog/expressions/index-constant2.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 index-constant2.sv
 
 ^\[.*\] .* PROVED .*$

--- a/regression/verilog/expressions/index-constant2.desc
+++ b/regression/verilog/expressions/index-constant2.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+index-constant2.sv
+
+^\[.*\] .* PROVED .*$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/expressions/index-constant2.sv
+++ b/regression/verilog/expressions/index-constant2.sv
@@ -1,0 +1,9 @@
+module main;
+
+  // index expressions yield constants
+  parameter p = (1>0); // boolean
+  parameter q = p[0];
+
+  assert final (q == 1);
+
+endmodule

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -2738,6 +2738,9 @@ exprt verilog_typecheck_exprt::convert_bit_select_expr(binary_exprt expr)
   }
   else
   {
+    // extractbit works on bit vectors only
+    no_bool_ops(expr);
+
     auto width = get_width(op0.type());
     auto offset = op0.type().get_int(ID_C_offset);
 


### PR DESCRIPTION
Our `extractbit` IR expression requires a bit-vector argument.  This change converts booleans to bit-vectors when used as vector argument for a Verilog bit select expression.