### PR TITLE
Verilog: strengthen typing in `verilog_synthesist::instantiate_ports`

### DIFF
--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -316,7 +316,7 @@ protected:
 
   void instantiate_ports(
     const irep_idt &instance,
-    const exprt &inst,
+    const verilog_instt::instancet &inst,
     const symbolt &,
     const replace_mapt &,
     transt &);


### PR DESCRIPTION
This replaces the use of `exprt` in `verilog_synthesist::instantiate_ports` by a stronger type.