### PR TITLE
Verilog: extract `verilog_scopet::identifier_token()`

### DIFF
--- a/src/verilog/verilog_scope.cpp
+++ b/src/verilog/verilog_scope.cpp
@@ -36,6 +36,28 @@ void verilog_scopet::print_rec(std::size_t indent, std::ostream &out) const
     scope_it.second.print_rec(indent + 2, out);
 }
 
+unsigned verilog_scopet::identifier_token() const
+{
+  switch(kind)
+  {
+  // clang-format off
+  case verilog_scopet::GLOBAL:    return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::FILE:      return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::PACKAGE:   return TOK_PACKAGE_IDENTIFIER;
+  case verilog_scopet::MODULE:    return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::CLASS:     return TOK_CLASS_IDENTIFIER;
+  case verilog_scopet::BLOCK:     return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::ENUM_NAME: return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::TASK:      return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::FUNCTION:  return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::TYPEDEF:   return TOK_TYPE_IDENTIFIER;
+  case verilog_scopet::OTHER:     return TOK_NON_TYPE_IDENTIFIER;
+    // clang-format on
+  }
+
+  UNREACHABLE;
+}
+
 void verilog_scopest::enter_package_scope(irep_idt base_name)
 {
   // look in the global scope
@@ -55,23 +77,6 @@ unsigned verilog_scopest::identifier_token(irep_idt base_name) const
   }
   else
   {
-    switch(scope->kind)
-    {
-    // clang-format off
-    case verilog_scopet::GLOBAL:    return TOK_NON_TYPE_IDENTIFIER;
-    case verilog_scopet::FILE:      return TOK_NON_TYPE_IDENTIFIER;
-    case verilog_scopet::PACKAGE:   return TOK_PACKAGE_IDENTIFIER;
-    case verilog_scopet::MODULE:    return TOK_NON_TYPE_IDENTIFIER;
-    case verilog_scopet::CLASS:     return TOK_CLASS_IDENTIFIER;
-    case verilog_scopet::BLOCK:     return TOK_NON_TYPE_IDENTIFIER;
-    case verilog_scopet::ENUM_NAME: return TOK_NON_TYPE_IDENTIFIER;
-    case verilog_scopet::TASK:      return TOK_NON_TYPE_IDENTIFIER;
-    case verilog_scopet::FUNCTION:  return TOK_NON_TYPE_IDENTIFIER;
-    case verilog_scopet::TYPEDEF:   return TOK_TYPE_IDENTIFIER;
-    case verilog_scopet::OTHER:     return TOK_NON_TYPE_IDENTIFIER;
-      // clang-format on
-    }
-
-    UNREACHABLE;
+    return scope->identifier_token();
   }
 }

--- a/src/verilog/verilog_scope.h
+++ b/src/verilog/verilog_scope.h
@@ -73,6 +73,9 @@ struct verilog_scopet
   // sub-scopes
   using scope_mapt = std::map<irep_idt, verilog_scopet>;
   scope_mapt scope_map;
+
+  //.the scanner token number
+  unsigned identifier_token() const;
 };
 
 class verilog_scopest


### PR DESCRIPTION
This extracts the code for determining the token kind for an identifier in a Verilog scope into a method of the scope.