### PR TITLE
k-induction: remove redundant call to liveness_to_safety

### DIFF
--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -140,7 +140,7 @@ Function: k_induction
 
 property_checker_resultt k_induction(
   const cmdlinet &cmdline,
-  transition_systemt &transition_system,
+  const transition_systemt &transition_system,
   ebmc_propertiest &properties,
   message_handlert &message_handler)
 {
@@ -157,10 +157,6 @@ property_checker_resultt k_induction(
 
   if(properties.properties.empty())
     throw ebmc_errort() << "no properties";
-
-  // liveness to safety translation, if requested
-  if(cmdline.isset("liveness-to-safety"))
-    liveness_to_safety(transition_system, properties);
 
   // Are there any properties suitable for k-induction?
   // Fail early if not.

--- a/src/ebmc/k_induction.h
+++ b/src/ebmc/k_induction.h
@@ -20,7 +20,7 @@ class ebmc_propertiest;
 
 [[nodiscard]] property_checker_resultt k_induction(
   const cmdlinet &,
-  transition_systemt &,
+  const transition_systemt &,
   ebmc_propertiest &,
   message_handlert &);
 


### PR DESCRIPTION
`liveness_to_safety` is already done in `ebmc_parse_options`, hence, there's no need to call it again in `k_induction`.