### PR TITLE
Verilog: helper methods for port connections

### DIFF
--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -854,6 +854,18 @@ public:
       return operands();
     }
 
+    bool positional_port_connections() const
+    {
+      return !named_port_connections();
+    }
+
+    bool named_port_connections() const
+    {
+      auto &connections = this->connections();
+      return connections.empty() ||
+             connections.front().id() == ID_named_port_connection;
+    }
+
   protected:
     using exprt::operands;
   };

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -1419,7 +1419,7 @@ void verilog_synthesist::instantiate_ports(
 
   // named port connection?
 
-  if(inst.connections().front().id() == ID_named_port_connection)
+  if(inst.named_port_connections())
   {
     const irept::subt &ports = symbol.type.find(ID_ports).get_sub();
 

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -110,9 +110,7 @@ void verilog_typecheckt::typecheck_port_connections(
   }
 
   // named port connection?
-  if(
-    inst.connections().empty() ||
-    inst.connections().front().id() == ID_named_port_connection)
+  if(inst.named_port_connections())
   {
     // We don't require that all ports are connected.
   


### PR DESCRIPTION
Port connections of a module instance can be named or positional.  This adds two helper methods to distinguish these two cases.