### PR TITLE
Verilog: strengthen typing when using module type

### DIFF
--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -326,8 +326,7 @@ protected:
   void replace_symbols(const irep_idt &target, exprt &dest);
 
   void instantiate_port(
-    bool is_output,
-    const symbol_exprt &port,
+    const module_typet::portt &,
     const exprt &value,
     const replace_mapt &,
     const source_locationt &,

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -39,10 +39,9 @@ Function: verilog_typecheckt::typecheck_port_connection
 
 void verilog_typecheckt::typecheck_port_connection(
   exprt &op,
-  const exprt &port)
+  const module_typet::portt &port)
 {
-  const symbolt &symbol=
-    ns.lookup(port.get(ID_identifier));
+  const symbolt &symbol = ns.lookup(port.identifier());
 
   if(!symbol.is_input && !symbol.is_output)
   {
@@ -101,7 +100,7 @@ void verilog_typecheckt::typecheck_port_connections(
   else
     range = convert_range(range_expr);
 
-  const irept::subt &ports=symbol.type.find(ID_ports).get_sub();
+  const auto &ports = to_module_type(symbol.type).ports();
 
   // no connection is one connection that is nil
   if(inst.connections().size() == 1 && inst.connections().front().is_nil())
@@ -148,10 +147,9 @@ void verilog_typecheckt::typecheck_port_connections(
       {
         if(port.get(ID_identifier) == identifier)
         {
-          auto &p_expr = static_cast<const exprt &>(port);
           found=true;
-          typecheck_port_connection(value, p_expr);
-          named_port_connection.port().type() = p_expr.type();
+          typecheck_port_connection(value, port);
+          named_port_connection.port().type() = port.type();
           break;
         }
       }
@@ -174,12 +172,11 @@ void verilog_typecheckt::typecheck_port_connections(
         << " but got " << inst.connections().size();
     }
 
-    irept::subt::const_iterator p_it=
-      ports.begin();
+    auto p_it = ports.begin();
 
     for(auto &connection : inst.connections())
     {
-      typecheck_port_connection(connection, (exprt &)*p_it);
+      typecheck_port_connection(connection, *p_it);
       p_it++;
     }
   }

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -202,9 +202,7 @@ protected:
 
   void typecheck_builtin_port_connections(verilog_inst_baset::instancet &);
 
-  void typecheck_port_connection(
-    exprt &op,
-    const exprt &port);
+  void typecheck_port_connection(exprt &op, const module_typet::portt &);
 
   bool replace_symbols(const replace_mapt &what, exprt &dest);
   void replace_symbols(const std::string &target, exprt &dest);

--- a/src/verilog/verilog_types.h
+++ b/src/verilog/verilog_types.h
@@ -141,7 +141,108 @@ public:
   inline module_typet():typet(ID_module)
   {
   }
+
+  class portt : public irept
+  {
+  public:
+    portt(irep_idt _identifier, typet _type, bool _input, bool _output)
+      : irept(ID_symbol)
+    {
+      type() = std::move(_type);
+      identifier(_identifier);
+      input(_input);
+      output(_output);
+    }
+
+    typet &type()
+    {
+      return static_cast<typet &>(add(ID_type));
+    }
+
+    const typet &type() const
+    {
+      return static_cast<const typet &>(find(ID_type));
+    }
+
+    irep_idt identifier() const
+    {
+      return get(ID_identifier);
+    }
+
+    void identifier(irep_idt _identifier)
+    {
+      set(ID_identifier, _identifier);
+    }
+
+    bool output() const
+    {
+      return get_bool(ID_output);
+    }
+
+    void output(bool _output)
+    {
+      set(ID_output, _output);
+    }
+
+    bool input() const
+    {
+      return get_bool(ID_input);
+    }
+
+    void input(bool _input)
+    {
+      set(ID_input, _input);
+    }
+  };
+
+  using portst = std::vector<portt>;
+
+  portst &ports()
+  {
+    return (portst &)(add(ID_ports).get_sub());
+  }
+
+  const portst &ports() const
+  {
+    return (const portst &)(find(ID_ports).get_sub());
+  }
+
+  using port_mapt = std::unordered_map<irep_idt, portt, irep_id_hash>;
+
+  port_mapt port_map() const
+  {
+    port_mapt result;
+    auto &ports = this->ports();
+    for(auto &port : ports)
+      result.emplace(port.identifier(), port);
+    return result;
+  }
 };
+
+/*! \brief Cast a generic typet to a \ref module_typet
+ *
+ * This is an unchecked conversion. \a type must be known to be \ref
+ * module_typet.
+ *
+ * \param type Source type
+ * \return Object of type \ref module_typet
+ *
+ * \ingroup gr_std_types
+*/
+inline const module_typet &to_module_type(const typet &type)
+{
+  PRECONDITION(type.id() == ID_module);
+  return static_cast<const module_typet &>(type);
+}
+
+/*! \copydoc to_module_type(const typet &)
+ * \ingroup gr_std_types
+*/
+inline module_typet &to_module_type(typet &type)
+{
+  PRECONDITION(type.id() == ID_module);
+  return static_cast<module_typet &>(type);
+}
 
 class verilog_genvar_typet : public typet
 {


### PR DESCRIPTION
This adds the `ports()` member functions to the `module_typet` class, avoiding direct access to the components of the irep.