### PR TITLE
Verilog: Move shift tests

### DIFF
--- a/regression/verilog/asic-world-operators/shift.sv
+++ b/regression/verilog/asic-world-operators/shift.sv
@@ -3,19 +3,13 @@ module main(input[31:0] in1, in2, in3);
   // follows
   // http://www.asic-world.com/verilog/operators2.html
 
-  // logical shift
+  // logical left shift
   always assert shift_p1:  4'b1001 << 1 === 4'b0010;
   always assert shift_p2:  4'b10x1 << 1 === 4'b0x10;
   always assert shift_p3:  4'b10z1 << 1 === 4'b0z10;
+  // right shift
   always assert shift_p4:  4'b1001 >> 1 === 4'b0100;
   always assert shift_p5:  4'b10x1 >> 1 === 4'b010x;
   always assert shift_p6:  4'b10z1 >> 1 === 4'b010z;
-  always assert shift_p7:  4'b1111 << 1 === 5'b11110;
-  always assert shift_p8:  1 << 6 === 64;
-
-  // arithmetic shift
-  always assert shift_p9:  -1 >>> 1 === -1;
-  always assert shift_p10:   1 >>> 1 === 0;
-  always assert shift_p11: -2 >>> 1 === -1;
 
 endmodule

--- a/regression/verilog/expressions/shl4.desc
+++ b/regression/verilog/expressions/shl4.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+shl4.sv
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This gives the wrong answer.

--- a/regression/verilog/expressions/shl4.sv
+++ b/regression/verilog/expressions/shl4.sv
@@ -1,0 +1,6 @@
+module main;
+
+  assert final (4'b1111 << 1 === 5'b11110);
+  assert final (1 << 6 === 64);
+
+endmodule

--- a/regression/verilog/expressions/shr4.desc
+++ b/regression/verilog/expressions/shr4.desc
@@ -1,0 +1,8 @@
+CORE
+shr4.sv
+--bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/expressions/shr4.sv
+++ b/regression/verilog/expressions/shr4.sv
@@ -1,0 +1,8 @@
+module main;
+
+  // arithmetic shift
+  assert final (-1 >>> 1 === -1);
+  assert final (1 >>> 1 === 0);
+  assert final (-2 >>> 1 === -1);
+
+endmodule


### PR DESCRIPTION
This moves tests out of asic-world-operators/shift.sv to match the website.