### PR TITLE
Verilog: test verilog/asic-world-operators/shift.desc works

### DIFF
--- a/regression/verilog/asic-world-operators/shift.desc
+++ b/regression/verilog/asic-world-operators/shift.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 shift.sv
 --module main --bound 0
 ^EXIT=0$
@@ -6,4 +6,3 @@ shift.sv
 --
 ^warning: ignoring
 --
-The test shift_p7 fails.


### PR DESCRIPTION
PR #1277 has moved the failing test case out of this file.