### PR TITLE
Verilog: separate path for downwards type progatation

### DIFF
--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -66,6 +66,7 @@ protected:
   void make_boolean(exprt &expr);
 
   void propagate_type(exprt &expr, const typet &type);
+  void downwards_type_propagation(exprt &, const typet &);
 
   [[nodiscard]] typet elaborate_type(const typet &);
   typet elaborate_package_scope_typedef(const verilog_package_scope_typet &);


### PR DESCRIPTION
This splits up the logic for downwards type progatation used for expression evaluation and for the RHS of assignments, given that they differ in behavior.