### PR TITLE
Verilog: strengthen type of `tc_binary_expr` method

### DIFF
--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -2727,15 +2727,9 @@ Function: verilog_typecheck_exprt::tc_binary_expr
 
 \*******************************************************************/
 
-void verilog_typecheck_exprt::tc_binary_expr(exprt &expr)
+void verilog_typecheck_exprt::tc_binary_expr(binary_exprt &expr)
 {
-  if(expr.operands().size()!=2)
-  {
-    throw errort().with_location(expr.source_location())
-      << "operator " << expr.id_string() << " takes two operands";
-  }
-
-  tc_binary_expr(expr, to_binary_expr(expr).op0(), to_binary_expr(expr).op1());
+  tc_binary_expr(expr, expr.op0(), expr.op1());
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -191,7 +191,7 @@ protected:
   [[nodiscard]] exprt convert_power_expr(power_exprt);
   [[nodiscard]] exprt convert_shl_expr(shl_exprt);
   void implicit_typecast(exprt &, const typet &type);
-  void tc_binary_expr(exprt &);
+  void tc_binary_expr(binary_exprt &);
   void tc_binary_expr(const exprt &expr, exprt &op0, exprt &op1);
   void convert_relation(binary_exprt &);
   void no_bool_ops(exprt &);


### PR DESCRIPTION
This avoids the need for a runtime check.