### PR TITLE
Extend shl4 test

### DIFF
--- a/regression/verilog/expressions/shl4.sv
+++ b/regression/verilog/expressions/shl4.sv
@@ -1,6 +1,12 @@
 module main;
 
+  // The arguments of === are adjusted to the maximum of the
+  // self-determined widths of the lhs and rhs.
+  // Hence, 4'b1111 << 1 is equal both to 4'b1110 and 5'b11110.
+  assert final (4'b1111 << 1 === 4'b1110);
   assert final (4'b1111 << 1 === 5'b11110);
-  assert final (1 << 6 === 64);
+
+  assert final (1'b1 << 6 === 64);
+  assert final (1'b1 << 6 === 1'b0);
 
 endmodule


### PR DESCRIPTION
The operands of relational expressions are given an evaluation context with the max width of both operands.

Hence, an expression can be equal to two different values.