### PR TITLE
Verilog: remove redundant case for `ID_power`

### DIFF
--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -3463,9 +3463,7 @@ exprt verilog_typecheck_exprt::convert_binary_expr(binary_exprt expr)
     expr.type() = bool_typet{};
     return std::move(expr);
   }
-  else if(
-    expr.id() == ID_plus || expr.id() == ID_minus || expr.id() == ID_mult ||
-    expr.id() == ID_power)
+  else if(expr.id() == ID_plus || expr.id() == ID_minus || expr.id() == ID_mult)
   {
     for(auto &op : expr.operands())
       convert_expr(op);


### PR DESCRIPTION
The case of `ID_power` is already handled separately; this removes the dead branch.