### PR TITLE
Verilog: retain type of `null`

### DIFF
--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -1348,6 +1348,10 @@ expr2verilogt::convert_constant(const constant_exprt &src)
     else
       return convert_norep(src);
   }
+  else if(type.id() == ID_verilog_null)
+  {
+    dest = "null";
+  }
   else
     return convert_norep(src);
 

--- a/src/verilog/verilog_lowering.cpp
+++ b/src/verilog/verilog_lowering.cpp
@@ -251,6 +251,16 @@ exprt verilog_lowering_cast(typecast_exprt expr)
   auto &src_type = expr.op().type();
   auto &dest_type = expr.type();
 
+  if(src_type.id() == ID_verilog_null && dest_type.id() == ID_verilog_chandle)
+  {
+    return to_verilog_chandle_type(dest_type).null_expr();
+  }
+
+  if(src_type.id() == ID_verilog_null && dest_type.id() == ID_verilog_event)
+  {
+    return to_verilog_event_type(dest_type).null_expr();
+  }
+
   // float to int
   if(
     (src_type.id() == ID_verilog_real ||

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -2313,11 +2313,8 @@ void verilog_typecheck_exprt::implicit_typecast(
       dest_type.id() == ID_verilog_class_type ||
       dest_type.id() == ID_verilog_event)
     {
-      if(expr.id() == ID_constant)
-      {
-        expr.type() = dest_type;
-        return;
-      }
+      expr = typecast_exprt{expr, dest_type};
+      return;
     }
   }
 


### PR DESCRIPTION
This changes the representation of Verilog's `null`.  Instead of converting the null type to the type expected in the context, an implicit cast is added.