### PR TITLE
Verilog: remove constant folding during downwards type propagation

### DIFF
--- a/regression/ebmc/smv-word-level/verilog1.desc
+++ b/regression/ebmc/smv-word-level/verilog1.desc
@@ -4,7 +4,7 @@ verilog1.sv
 ^MODULE main$
 ^VAR x : unsigned word\[32\];$
 ^INIT main\.x = 0ud32_0$
-^INVAR Verilog::main\.x_aux0 = main\.x \+ 0ud32_1$
+^INVAR Verilog::main\.x_aux0 = main\.x \+ unsigned\(0sd32_1\)$
 ^TRANS next\(main\.x\) = Verilog::main\.x_aux0$
 ^LTLSPEC F main\.x = unsigned\(0sd32_10\)$
 ^EXIT=0$

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -322,9 +322,6 @@ void verilog_typecheck_exprt::downwards_type_propagation(
   }
 
   // Just cast the expression, leave any operands as they are.
-
-  bool is_constant = expr.is_constant();
-
   if(
     (expr.type().id() == ID_signedbv ||
      expr.type().id() == ID_verilog_signedbv) &&
@@ -340,10 +337,6 @@ void verilog_typecheck_exprt::downwards_type_propagation(
   {
     expr = typecast_exprt{expr, type};
   }
-
-  // fold constants
-  if(is_constant)
-    expr = verilog_simplifier(expr, ns);
 }
 
 /*******************************************************************\


### PR DESCRIPTION
This removes the constant folding during towards type propagation in the Verilog frontend, as this is premature optimisation.