### PR TITLE
Verilog: use `zero_extend_exprt`

### DIFF
--- a/regression/ebmc/smv-word-level/verilog6.desc
+++ b/regression/ebmc/smv-word-level/verilog6.desc
@@ -1,0 +1,7 @@
+CORE
+verilog6.sv
+--smv-word-level
+^CTLSPEC 0ud8_1 \+ 0ub6_000000 :: -0sd2_1 = 0ud8_4$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv-word-level/verilog6.sv
+++ b/regression/ebmc/smv-word-level/verilog6.sv
@@ -1,0 +1,6 @@
+module main(input clk, input in);
+
+  // The RHS of the addition will be zero-extended
+  initial p1: assert property (8'b1 + 2'sb11 == 8'b100);
+
+endmodule

--- a/src/smvlang/expr2smv_class.h
+++ b/src/smvlang/expr2smv_class.h
@@ -131,6 +131,8 @@ protected:
 
   resultt convert_typecast(const typecast_exprt &);
 
+  resultt convert_zero_extend(const zero_extend_exprt &);
+
   resultt convert_norep(const exprt &);
 };
 

--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -2007,6 +2007,9 @@ expr2verilogt::resultt expr2verilogt::convert_rec(const exprt &src)
     return convert_function(src.id_string(), src);
   }
 
+  else if(src.id() == ID_zero_extend)
+    return convert_rec(to_zero_extend_expr(src).op());
+
   // no VERILOG language expression for internal representation
   return convert_norep(src);
 }

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -302,39 +302,6 @@ void verilog_typecheck_exprt::assignment_conversion(
 
 /*******************************************************************\
 
-Function: zero_extend
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-static exprt zero_extend(const exprt &expr, const typet &type)
-{
-  auto old_width = expr.type().id() == ID_bool ? 1
-                   : expr.type().id() == ID_integer
-                     ? 32
-                     : to_bitvector_type(expr.type()).get_width();
-
-  // first make unsigned
-  typet tmp_type;
-
-  if(type.id() == ID_unsignedbv)
-    tmp_type = unsignedbv_typet{old_width};
-  else if(type.id() == ID_verilog_unsignedbv)
-    tmp_type = verilog_unsignedbv_typet{old_width};
-  else
-    PRECONDITION(false);
-
-  return typecast_exprt::conditional_cast(
-    typecast_exprt::conditional_cast(expr, tmp_type), type);
-}
-
-/*******************************************************************\
-
 Function: verilog_typecheck_exprt::downwards_type_progatation
 
   Inputs:
@@ -411,7 +378,7 @@ void verilog_typecheck_exprt::downwards_type_propagation(
     // "If the operand shall be extended, then it shall be sign-extended only
     // if the propagated type is signed."
     // A typecast from signed to a larger unsigned would sign extend.
-    expr = zero_extend(expr, type);
+    expr = zero_extend_exprt{expr, type};
   }
   else
   {


### PR DESCRIPTION
This replaces a custom encoding via `typecast_exprt` used in the Verilog front-end by `zero_extend_exprt`.