### PR TITLE
SMV: conversion for extractbits operator

### DIFF
--- a/regression/ebmc/smv-word-level/verilog4.desc
+++ b/regression/ebmc/smv-word-level/verilog4.desc
@@ -1,0 +1,7 @@
+CORE
+verilog4.sv
+--smv-word-level
+^LTLSPEC X X extend\(main\.x\[31:1\], 1\) = unsigned\(0sd32_1\)$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv-word-level/verilog4.sv
+++ b/regression/ebmc/smv-word-level/verilog4.sv
@@ -1,0 +1,12 @@
+module main(input clk);
+
+  reg [31:0] x;
+
+  initial x = 0;
+
+  always @(posedge clk)
+    x = x + 1;
+
+  initial assert property (nexttime[2] x[31:1] == 1);
+
+endmodule

--- a/src/smvlang/expr2smv_class.h
+++ b/src/smvlang/expr2smv_class.h
@@ -10,6 +10,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #define CPROVER_SMV_EXPR2SMV_CLASS_H
 
 #include <util/arith_tools.h>
+#include <util/bitvector_expr.h>
 #include <util/bitvector_types.h>
 #include <util/namespace.h>
 #include <util/std_expr.h>
@@ -110,6 +111,8 @@ protected:
 
   resultt
   convert_unary(const unary_exprt &, const std::string &symbol, precedencet);
+
+  resultt convert_extractbits(const extractbits_exprt &);
 
   resultt convert_index(const index_exprt &, precedencet);
 


### PR DESCRIPTION
This adds conversion for the IR `extractbits` operator to SMV for the case when the low index is an integer constant.