### PR TITLE
Verilog: typed parameters are assignment-like contexts

### DIFF
--- a/regression/verilog/modules/localparam3.v
+++ b/regression/verilog/modules/localparam3.v
@@ -3,7 +3,11 @@ module main;
   localparam [7:0] foo = 1;
   parameter [7:0] bar = 2;
 
+  // Parameters with type are "assignment contexts"
+  localparam [7:0] baz = 1'b1 + 1'b1;
+
   always assert property1: $bits(foo) == 8;
   always assert property2: $bits(bar) == 8;
+  always assert property3: baz == 2;
 
 endmodule

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -1026,11 +1026,11 @@ void verilog_typecheckt::elaborate_symbol_rec(irep_idt identifier)
       {
         convert_expr(symbol.value);
 
+        // Convert to the given type. These are assignment contexts.
+        assignment_conversion(symbol.value, symbol.type);
+
         if(!is_let)
           symbol.value = elaborate_constant_expression_check(symbol.value);
-
-        // Cast to the given type.
-        propagate_type(symbol.value, symbol.type);
       }
     }
   }


### PR DESCRIPTION
IEEE 1800-2017 10.8 states that parameter assignments with a type are assignment-like contexts.  Hence, use `assignment_conversion(...)`.