### PR TITLE
Verilog: test for function ports

### DIFF
--- a/regression/verilog/functioncall/function_ports3.desc
+++ b/regression/verilog/functioncall/function_ports3.desc
@@ -1,0 +1,8 @@
+CORE
+function_ports3.sv
+--module main
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/functioncall/function_ports3.sv
+++ b/regression/verilog/functioncall/function_ports3.sv
@@ -1,0 +1,11 @@
+module main;
+
+  function [7:0] identity(input [7:0] value);
+    identity = value;
+  endfunction
+
+  // function ports are 'assignment-like contexts', 1800-2017 10.8,
+  // and hence, the signed argument is sign extended
+  assert final(identity(1'sb1) == 8'hff);
+
+endmodule


### PR DESCRIPTION
This adds a test for function input ports that demonstrates that function input ports are assignment-like contexts.