### PR TITLE
Verilog: allow system function calls as module items

### DIFF
--- a/regression/verilog/system-functions/error1.desc
+++ b/regression/verilog/system-functions/error1.desc
@@ -1,9 +1,8 @@
-KNOWNBUG
+CORE
 error1.v
 --module main
-^EXIT=0$
+^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-This doesn't parse.

--- a/regression/verilog/system-functions/error1.v
+++ b/regression/verilog/system-functions/error1.v
@@ -2,7 +2,7 @@ module main;
 
   parameter P = 1;
 
-  if(P!=1)
+  if(P==1)
     $error("something is wrong");
 
 endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1024,6 +1024,9 @@ module_or_generate_item:
 		{ add_attributes($2, $1); $$=$2; }
 	| attribute_instance_brace module_common_item
 		{ add_attributes($2, $1); $$=$2; }
+	// The next rule is not in 1800-2017, but is a vendor extension.
+	| attribute_instance_brace system_tf_call ';'
+		{ add_attributes($2, $1); $$ = $2; }
 	;
 
 module_or_generate_item_declaration:

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -902,6 +902,10 @@ void verilog_typecheckt::collect_symbols(
   {
     collect_symbols(to_verilog_sequence_declaration(module_item));
   }
+  else if(module_item.id() == ID_function_call)
+  {
+    // e.g., $error
+  }
   else
     DATA_INVARIANT(false, "unexpected module item: " + module_item.id_string());
 }

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -335,6 +335,9 @@ void verilog_typecheckt::interface_module_item(
   else if(module_item.id() == ID_verilog_sequence_declaration)
   {
   }
+  else if(module_item.id() == ID_function_call)
+  {
+  }
   else
   {
     DATA_INVARIANT(false, "unexpected module item: " + module_item.id_string());

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -3424,6 +3424,9 @@ void verilog_synthesist::synth_module_item(
   else if(module_item.id() == ID_verilog_sequence_declaration)
   {
   }
+  else if(module_item.id() == ID_function_call)
+  {
+  }
   else
   {
     throw errort().with_location(module_item.source_location())

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1972,6 +1972,9 @@ void verilog_typecheckt::convert_module_item(
   {
     convert_sequence_declaration(to_verilog_sequence_declaration(module_item));
   }
+  else if(module_item.id() == ID_function_call)
+  {
+  }
   else
   {
     throw errort().with_location(module_item.source_location())


### PR DESCRIPTION
This allows system function calls as module items, e.g., to check parameter values and fail with `$error`.