### PR TITLE
Verilog: modernise signature of `verilog_synthesist::assignment_rec`

### DIFF
--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -222,10 +222,7 @@ protected:
 
   void assignment_rec(const exprt &lhs, const exprt &rhs, bool blocking);
 
-  void assignment_rec(
-    const exprt &lhs,
-    exprt &rhs,
-    exprt &new_value);
+  exprt assignment_rec(const exprt &lhs, const exprt &rhs);
 
   const symbolt &assignment_symbol(const exprt &lhs);
 


### PR DESCRIPTION
This replaces a return-by reference and a swap by an explicit return value in the signature of the method `verilog_synthesist::assignment_rec(...)`.