### PR TITLE
Verilog: fix for port direction of output register ports

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # EBMC 5.8
 
 * SystemVerilog: cover sequence
+* Verilog: semantic fix for output register ports
 
 # EBMC 5.7
 

--- a/regression/verilog/modules/ports9.desc
+++ b/regression/verilog/modules/ports9.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 ports9.sv
 --bound 1
 ^EXIT=0$
@@ -6,4 +6,3 @@ ports9.sv
 --
 ^warning: ignoring
 --
-This gives the wrong answer.

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -108,6 +108,10 @@ void verilog_typecheckt::check_module_ports(
       else
         direction = ID_inout;
     }
+    else if(direction == ID_output_register)
+    {
+      direction = ID_output;
+    }
 
     ports.emplace_back(identifier, port_symbol->type, direction);
 


### PR DESCRIPTION
Output register ports are now recognised as outputs.  Fixes a regression introduced by #1271.

Closes #635.