### PR TITLE
Verilog: make power3 test work

### DIFF
--- a/regression/verilog/expressions/power3.desc
+++ b/regression/verilog/expressions/power3.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE broken-smt-backend
 power3.sv
 
 ^EXIT=0$
@@ -6,4 +6,3 @@ power3.sv
 --
 ^warning: ignoring
 --
-The result is wrong.

--- a/regression/verilog/expressions/power3.sv
+++ b/regression/verilog/expressions/power3.sv
@@ -1,9 +1,9 @@
 module main;
 
   // Any arithmetic with x or z returns x.
-  initial assert('bx ** 1 === 'x);
-  initial assert('bz ** 1 === 'x);
-  initial assert(1 ** 'bx === 'x);
-  initial assert(1 ** 'bz === 'x);
+  initial assert('bx ** 1 === 32'hxxxx_xxxx);
+  initial assert('bz ** 1 === 32'hxxxx_xxxx);
+  initial assert(1 ** 'bx === 32'hxxxx_xxxx);
+  initial assert(1 ** 'bz === 32'hxxxx_xxxx);
 
 endmodule


### PR DESCRIPTION
The test power3.desc uses `'x`, which doesn't work right now.  The test works when replacing `'x` by a sized literal.