### PR TITLE
Verilog: four-valued size casts

### DIFF
--- a/regression/verilog/expressions/signed2.sv
+++ b/regression/verilog/expressions/signed2.sv
@@ -12,7 +12,7 @@ module main;
   // base 8
   pB0: assert final ('so7 == -1);
   pB1: assert final ('so1 == 1);
-  pB2: assert final ('so7x === 'so3777777777x);
+  pB2: assert final ('so7x === 32'so3777777777x);
   pB3: assert final ($bits('so1) == 32);
   pB4: assert final ('so77 == -1);
   pB5: assert final (4'so7 == 7);

--- a/regression/verilog/expressions/size_cast2.desc
+++ b/regression/verilog/expressions/size_cast2.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 size_cast2.sv
 --module main
 ^EXIT=0$
@@ -6,4 +6,3 @@ size_cast2.sv
 --
 ^warning: ignoring
 --
-This is not yet implemented.

--- a/src/verilog/verilog_lowering.cpp
+++ b/src/verilog/verilog_lowering.cpp
@@ -303,7 +303,7 @@ exprt verilog_lowering_cast(typecast_exprt expr)
     return std::move(new_cast);
   }
 
-  if(is_aval_bval(src_type) && dest_type.id() == ID_bool)
+  if(is_aval_bval(src_type))
   {
     // When casting a four-valued scalar to bool,
     // 'true' is defined as a "nonzero known value" (1800-2017 12.4).
@@ -480,7 +480,7 @@ exprt verilog_lowering(exprt expr)
   }
   else if(expr.id() == ID_verilog_explicit_size_cast)
   {
-    return to_verilog_explicit_size_cast_expr(expr).lower();
+    return verilog_lowering(to_verilog_explicit_size_cast_expr(expr).lower());
   }
   else if(
     expr.id() == ID_verilog_streaming_concatenation_left_to_right ||

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -3309,9 +3309,17 @@ exprt verilog_typecheck_exprt::convert_binary_expr(binary_exprt expr)
     {
       expr.type() = signedbv_typet{new_size_int};
     }
+    else if(op_type.id() == ID_verilog_signedbv)
+    {
+      expr.type() = verilog_signedbv_typet{new_size_int};
+    }
     else if(op_type.id() == ID_unsignedbv || op_type.id() == ID_bool)
     {
       expr.type() = unsignedbv_typet{new_size_int};
+    }
+    else if(op_type.id() == ID_verilog_unsignedbv)
+    {
+      expr.type() = verilog_unsignedbv_typet{new_size_int};
     }
     else
     {


### PR DESCRIPTION
This adds support for doing size casts of four-valued data types.