### PR TITLE
Verilog: extend test for unary minus and Boolean negation

### DIFF
--- a/regression/verilog/expressions/negation1.sv
+++ b/regression/verilog/expressions/negation1.sv
@@ -8,4 +8,7 @@ module main;
   property06: assert final (!2'bxx===1'bx);
   property07: assert final (!1'bz===1'bx);
 
+  // expression type contexts do not pass through !
+  initial assert(!(1'b1 + 1'b1) == 1);
+
 endmodule

--- a/regression/verilog/expressions/unary_minus1.sv
+++ b/regression/verilog/expressions/unary_minus1.sv
@@ -3,4 +3,7 @@ module main;
   // Any arithmetic with x or z returns x.
   initial assert(-32'bz === 32'hxxxx_xxxx);
 
+  // Downwards type propagation passes through unary minus.
+  initial assert(-(1'sb1 + 1'sb1) == 2);
+
 endmodule


### PR DESCRIPTION
This extends two tests to check that

a) the downwards expression context passes through unary minus.

b) the downwards expression context does not pass through Boolean negation.