### PR TITLE
SMV: test for precedence of X vs &

### DIFF
--- a/regression/smv/LTL/smv_ltlspec_X1.desc
+++ b/regression/smv/LTL/smv_ltlspec_X1.desc
@@ -1,0 +1,10 @@
+CORE
+smv_ltlspec_X1.smv
+
+^\[.*\] X x & x: REFUTED$
+^\[.*\] X x & x: REFUTED$
+^\[.*\] X \(x & x\): PROVED \(CT=1\)$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/smv/LTL/smv_ltlspec_X1.smv
+++ b/regression/smv/LTL/smv_ltlspec_X1.smv
@@ -1,0 +1,11 @@
+MODULE main
+
+VAR x : boolean;
+
+ASSIGN next(x) := TRUE;
+       init(x) := FALSE;
+
+-- X binds stronger than &
+LTLSPEC X x & x -- should parse as (X x) & x
+LTLSPEC (X x) & x -- should fail
+LTLSPEC X (x & x) -- should pass


### PR DESCRIPTION
This test checks the relative precedence of `X` vs `&`.