### PR TITLE
Verilog: add missing expression precedences

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -581,6 +581,8 @@ int yyverilogerror(const char *error)
 // following System Verilog 1800-2017 Table 11-2.
 // Bison expects these in order of increasing precedence,
 // whereas the table gives them in decreasing order.
+%nonassoc '{'
+%nonassoc '=' "+=" "-=" "*=" "/=" "%=" "&=" "^=" "|=" "<<=" ">>=" "<<<=" ">>>=" ":=" ":/"
 %right "->" "<->"
 %right "?" ":"
 %left "||"


### PR DESCRIPTION
This adds the missing precedences for some Verilog operators.