### PR TITLE
SystemVerilog: grammar for assignment patterns on LHS

### DIFF
--- a/regression/verilog/assignments/assignment-pattern-lhs1.desc
+++ b/regression/verilog/assignments/assignment-pattern-lhs1.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
+CORE
 assignment-pattern-lhs1.sv
 
-^EXIT=0$
+^file .* line 9: no support for assignment patterns on LHS of an assignment$
+^EXIT=2$
 ^SIGNAL=0$
 --
 --
-This does not parse.

--- a/regression/verilog/assignments/assignment-pattern-lhs1.sv
+++ b/regression/verilog/assignments/assignment-pattern-lhs1.sv
@@ -1,14 +1,12 @@
 module main;
 
-  typedef struct packed {int a, b;} S;
-  S my_s;
   int x, y;
 
   initial begin
     // Assignment pattern on LHS.
     // Does not parse with Icarus Verilog, VCS, XCelium.
     // Works with Riviera, Questa.
-    '{x, y} = S'{1, 2};
+    '{x, y} = '{1, 2};
 
     assert(x == 1 && y == 2);
   end

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -4549,6 +4549,7 @@ variable_lvalue:
         | '{' variable_concatenation_lvalue_brace '}'
 		{ init($$, ID_concatenation); swapop($$, $2); }
         */
+	| assignment_pattern
 	;
 	
 variable_concatenation_lvalue_brace:

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -760,6 +760,11 @@ void verilog_typecheckt::check_lhs(
   {
     check_lhs(to_member_expr(lhs).struct_op(), vassign);
   }
+  else if(lhs.id() == ID_verilog_assignment_pattern)
+  {
+    throw errort().with_location(lhs.source_location())
+      << "no support for assignment patterns on LHS of an assignment";
+  }
   else
   {
     throw errort() << "typechecking: failed to get identifier on LHS "
@@ -1019,8 +1024,8 @@ void verilog_typecheckt::convert_assign(
 
   convert_expr(lhs);
   convert_expr(rhs);
-  assignment_conversion(rhs, lhs.type());
   check_lhs(lhs, blocking?A_BLOCKING:A_NON_BLOCKING);
+  assignment_conversion(rhs, lhs.type());
 }
 
 /*******************************************************************\


### PR DESCRIPTION
This adds the grammar needed for parsing assignment patterns on the LHS of assignments.  Their use is errored as unsupported in the type checker.