### PR TITLE
SystemVerilog: allow assignment of new to any class type

### DIFF
--- a/regression/verilog/class/new1.desc
+++ b/regression/verilog/class/new1.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE
 new1.sv
 
-^EXIT=0$
+^EXIT=10$
 ^SIGNAL=0$
 --
 --
-The class is not yet recognized as a type.

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -269,6 +269,15 @@ void verilog_typecheck_exprt::assignment_conversion(
     }
   }
 
+  if(rhs.type().id() == ID_verilog_new)
+  {
+    if(lhs_type.id() == ID_verilog_class_type)
+    {
+      rhs = typecast_exprt{rhs, lhs_type};
+      return;
+    }
+  }
+
   // "The size of the left-hand side of an assignment forms
   // the context for the right-hand expression."
 


### PR DESCRIPTION
The `new` expression has no self-determined type; this allows assignment to any class type.