### PR TITLE
SMV: cleanup ports/parameters in parse tree

### DIFF
--- a/src/smvlang/parser.y
+++ b/src/smvlang/parser.y
@@ -360,11 +360,13 @@ module_name: IDENTIFIER_Token
            | STRING_Token
            ;
 
-module_head: MODULE_Token module_name { new_module($2); }
+module_head: MODULE_Token module_name
+           {
+             new_module($2);
+           }
            | MODULE_Token module_name '(' module_parameters_opt ')'
            {
-             auto &module = new_module($2);
-             module.parameters = stack_expr($4);
+             new_module($2);
            }
            ;
 
@@ -579,24 +581,16 @@ var_list   : var_decl
 
 module_parameter: identifier
            {
-             const irep_idt &identifier=stack_expr($1).get(ID_identifier);
+             const irep_idt &identifier=stack_expr($1).id();
              smv_parse_treet::mc_vart &var=PARSER.module->vars[identifier];
              var.var_class=smv_parse_treet::mc_vart::ARGUMENT;
-             PARSER.module->ports.push_back(identifier);
+             PARSER.module->parameters.push_back(identifier);
            }
            ;
 
 module_parameters:
              module_parameter
-           {
-             init($$);
-             mto($$, $1);
-           }
            | module_parameters ',' module_parameter
-           {
-             $$ = $1;
-             mto($$, $3);
-           }
            ;
 
 module_parameters_opt:

--- a/src/smvlang/smv_language.cpp
+++ b/src/smvlang/smv_language.cpp
@@ -136,8 +136,8 @@ void smv_languaget::show_parse(std::ostream &out, message_handlert &)
 
     out << "  PARAMETERS:\n";
 
-    for(auto &parameter : module.parameters.get_sub())
-      out << "    " << parameter.id() << '\n';
+    for(auto &parameter : module.parameters)
+      out << "    " << parameter << '\n';
 
     out << '\n';
 

--- a/src/smvlang/smv_parse_tree.h
+++ b/src/smvlang/smv_parse_tree.h
@@ -37,7 +37,7 @@ public:
   struct modulet
   {
     irep_idt name, base_name;
-    irept parameters;
+    std::list<irep_idt> parameters;
 
     struct itemt
     {
@@ -288,8 +288,6 @@ public:
 
     mc_varst vars;
     enum_sett enum_set;
-
-    std::list<irep_idt> ports;
   };
    
   typedef std::unordered_map<irep_idt, modulet, irep_id_hash> modulest;

--- a/src/smvlang/smv_typecheck.cpp
+++ b/src/smvlang/smv_typecheck.cpp
@@ -169,9 +169,9 @@ void smv_typecheckt::convert_ports(
 {
   irept::subt &ports=dest.add(ID_ports).get_sub();
 
-  ports.reserve(smv_module.ports.size());
+  ports.reserve(smv_module.parameters.size());
 
-  for(const auto &port_name : smv_module.ports)
+  for(const auto &port_name : smv_module.parameters)
   {
     ports.push_back(exprt(ID_symbol));
     ports.back().set(


### PR DESCRIPTION
The parse tree has both a `ports` and a `parameters` member.  This removes the `ports` member, and changes the type of the `parameters` member to a list of identifiers.