### PR TITLE
SMV: create module before parsing parameters

### DIFF
--- a/src/smvlang/parser.y
+++ b/src/smvlang/parser.y
@@ -361,14 +361,9 @@ module_name: IDENTIFIER_Token
            | STRING_Token
            ;
 
-module_head: MODULE_Token module_name
-           {
-             new_module($2);
-           }
-           | MODULE_Token module_name '(' module_parameters_opt ')'
-           {
-             new_module($2);
-           }
+module_head: MODULE_Token module_name { new_module($2); }
+           | MODULE_Token module_name { new_module($2); }
+             '(' module_parameters_opt ')'
            ;
 
 module_body: /* optional */


### PR DESCRIPTION
The module data structure needs to be created before parsing the module parameters.