### PR TITLE
SMV: catch variables that have the same identifier as a parameter

### DIFF
--- a/regression/smv/define/define9.desc
+++ b/regression/smv/define/define9.desc
@@ -1,0 +1,8 @@
+CORE
+define9.smv
+
+^file .* line 4: identifier x already used as a parameter$
+^EXIT=2$
+^SIGNAL=0$
+--
+--

--- a/regression/smv/define/define9.smv
+++ b/regression/smv/define/define9.smv
@@ -1,0 +1,10 @@
+MODULE some-module(x)
+
+-- x is already declared as a parameter
+DEFINE x := 123;
+
+INIT x = 123
+
+MODULE main
+
+VAR instance : some-module(124);

--- a/regression/smv/var/already_declared4.desc
+++ b/regression/smv/var/already_declared4.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE
 already_declared4.smv
 
 ^EXIT=2$
 ^SIGNAL=0$
 --
 --
-This should be errored.


### PR DESCRIPTION
This errors variable and enum declarations that use the same identifier as a previously defined module parameter.