### PR TITLE
Verilog: add type parameters to scope

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # EBMC 5.9
 
+* SystemVerilog: fix for type parameters
 * SMV: word constants
 * SMV: IVAR declarations
 * SMV: bit selection operator

--- a/regression/verilog/modules/type_parameters1.desc
+++ b/regression/verilog/modules/type_parameters1.desc
@@ -1,8 +1,8 @@
 CORE
 type_parameters1.sv
 
-^\[main\.p1\] always \$bits\(main\.T1\) == 1: PROVED .*$
-^\[main\.p2\] always \$bits\(main\.T2\) == 32: PROVED .*$
+^\[main\.p1\] always \$bits\(bool\) == 1: PROVED .*$
+^\[main\.p2\] always \$bits\(\[31:0\]\) == 32: PROVED .*$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/type_parameters2.desc
+++ b/regression/verilog/modules/type_parameters2.desc
@@ -1,0 +1,7 @@
+CORE
+type_parameters2.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/modules/type_parameters2.sv
+++ b/regression/verilog/modules/type_parameters2.sv
@@ -1,0 +1,9 @@
+module main;
+
+  parameter type T1 = bit [31:0];
+
+  T1 some_data;
+
+  initial assert ($bits(some_data) == 32);
+
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2031,7 +2031,11 @@ type_assignment: param_identifier '=' data_type
 		  auto base_name = stack_expr($1).id();
 		  stack_expr($$).set(ID_identifier, base_name);
 		  stack_expr($$).set(ID_base_name, base_name);
-		  addswap($$, ID_type, $3); }
+		  addswap($$, ID_type, $3);
+
+		  // add to the scope as a type name
+		  PARSER.scopes.add_name(base_name, "", verilog_scopet::TYPEDEF);
+		}
         ;
 
 data_type_or_implicit:


### PR DESCRIPTION
Type parameters are now added to the scope, and hence usable as types.