### PR TITLE
Make the counter synthesizable, update comment

### DIFF
--- a/regression/ebmc/ranking-function/counter2.sv
+++ b/regression/ebmc/ranking-function/counter2.sv
@@ -13,5 +13,6 @@ module main(
 
   // expected to pass
   ASSERT_COUNTER_EVENTUALLY_10: assert property (@(posedge clk) disable iff (reset) s_eventually (counter == 10));
+  ASSERT_COUNTER_EVENTUALLY_9: assert property (@(posedge clk) disable iff (reset) s_eventually (counter == 9));
 
 endmodule


### PR DESCRIPTION
- Use nonblocking assignment for counter. Sequential design use nonblocking assignments.
- Add reset and remove initial block as initial block is not synthesizable
- Add counter output port
-  Update comment to count up