### PR TITLE
KNOWNBUG test for parameter without default value

### DIFF
--- a/regression/verilog/modules/parameter_without_default1.desc
+++ b/regression/verilog/modules/parameter_without_default1.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+parameter_without_default1.sv
+
+^EXIT=2$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This does not parse.

--- a/regression/verilog/modules/parameter_without_default1.sv
+++ b/regression/verilog/modules/parameter_without_default1.sv
@@ -1,0 +1,11 @@
+// P has no default value; allowed by 1800-2017 6.20.1
+module my_module #(P);
+
+endmodule
+
+module main;
+
+  // error: didn't give value for P
+  my_module m1();
+
+endmodule


### PR DESCRIPTION
SystemVerilog 1800-2017 allows module parameter ports without default value.