### PR TITLE
copy language_file.cpp and language_file.h from CBMC

### DIFF
--- a/src/ebmc/Makefile
+++ b/src/ebmc/Makefile
@@ -12,6 +12,7 @@ SRC = \
       diatest.cpp \
       dimacs_writer.cpp \
       ebmc_base.cpp \
+      ebmc_language_file.cpp \
       ebmc_languages.cpp \
       ebmc_parse_options.cpp \
       ebmc_properties.cpp \

--- a/src/ebmc/ebmc_language_file.cpp
+++ b/src/ebmc/ebmc_language_file.cpp
@@ -1,0 +1,298 @@
+/*******************************************************************\
+
+Module:
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#include "ebmc_language_file.h"
+
+#include <util/message.h>
+
+#include <langapi/language.h>
+
+#include <fstream>
+
+ebmc_language_filet::ebmc_language_filet(const ebmc_language_filet &rhs)
+  : modules(rhs.modules),
+    language(rhs.language == nullptr ? nullptr : rhs.language->new_language()),
+    filename(rhs.filename)
+{
+}
+
+/// To avoid compiler errors, the complete definition of a pointed-to type must
+/// be visible at the point at which the unique_ptr destructor is created.  In
+/// this case, the pointed-to type is forward-declared, so we have to place the
+/// destructor in the source file, where the full definition is availible.
+ebmc_language_filet::~ebmc_language_filet() = default;
+
+ebmc_language_filet::ebmc_language_filet(const std::string &filename)
+  : filename(filename)
+{
+}
+
+void ebmc_language_filet::get_modules()
+{
+  language->modules_provided(modules);
+}
+
+void ebmc_language_filet::convert_lazy_method(
+  const irep_idt &id,
+  symbol_table_baset &symbol_table,
+  message_handlert &message_handler)
+{
+  language->convert_lazy_method(id, symbol_table, message_handler);
+}
+
+void ebmc_language_filest::show_parse(
+  std::ostream &out,
+  message_handlert &message_handler)
+{
+  for(const auto &file : file_map)
+    file.second.language->show_parse(out, message_handler);
+}
+
+bool ebmc_language_filest::parse(message_handlert &message_handler)
+{
+  messaget log(message_handler);
+
+  for(auto &file : file_map)
+  {
+    // open file
+
+    std::ifstream infile(file.first);
+
+    if(!infile)
+    {
+      log.error() << "Failed to open " << file.first << messaget::eom;
+      return true;
+    }
+
+    // parse it
+
+    languaget &language = *(file.second.language);
+
+    if(language.parse(infile, file.first, message_handler))
+    {
+      log.error() << "Parsing of " << file.first << " failed" << messaget::eom;
+      return true;
+    }
+
+    // what is provided?
+
+    file.second.get_modules();
+  }
+
+  return false;
+}
+
+bool ebmc_language_filest::typecheck(
+  symbol_table_baset &symbol_table,
+  const bool keep_file_local,
+  message_handlert &message_handler)
+{
+  // typecheck interfaces
+
+  for(auto &file : file_map)
+  {
+    if(file.second.language->interfaces(symbol_table, message_handler))
+      return true;
+  }
+
+  // build module map
+
+  unsigned collision_counter = 0;
+
+  for(auto &file : file_map)
+  {
+    const ebmc_language_filet::modulest &modules = file.second.modules;
+
+    for(ebmc_language_filet::modulest::const_iterator mo_it = modules.begin();
+        mo_it != modules.end();
+        mo_it++)
+    {
+      // these may collide, and then get renamed
+      std::string module_name = *mo_it;
+
+      while(module_map.find(module_name) != module_map.end())
+      {
+        module_name = *mo_it + "#" + std::to_string(collision_counter);
+        collision_counter++;
+      }
+
+      ebmc_language_modulet module;
+      module.file = &file.second;
+      module.name = module_name;
+      module_map.insert(
+        std::pair<std::string, ebmc_language_modulet>(module.name, module));
+    }
+  }
+
+  // typecheck files
+
+  for(auto &file : file_map)
+  {
+    if(file.second.modules.empty())
+    {
+      if(file.second.language->can_keep_file_local())
+      {
+        if(file.second.language->typecheck(
+             symbol_table, "", message_handler, keep_file_local))
+          return true;
+      }
+      else
+      {
+        if(file.second.language->typecheck(symbol_table, "", message_handler))
+          return true;
+      }
+      // register lazy methods.
+      // TODO: learn about modules and generalise this
+      // to module-providing languages if required.
+      std::unordered_set<irep_idt> lazy_method_ids;
+      file.second.language->methods_provided(lazy_method_ids);
+      for(const auto &id : lazy_method_ids)
+        lazy_method_map[id] = &file.second;
+    }
+  }
+
+  // typecheck modules
+
+  for(auto &module : module_map)
+  {
+    if(typecheck_module(
+         symbol_table, module.second, keep_file_local, message_handler))
+      return true;
+  }
+
+  return false;
+}
+
+bool ebmc_language_filest::generate_support_functions(
+  symbol_table_baset &symbol_table,
+  message_handlert &message_handler)
+{
+  std::set<std::string> languages;
+
+  for(auto &file : file_map)
+  {
+    if(languages.insert(file.second.language->id()).second)
+      if(file.second.language->generate_support_functions(
+           symbol_table, message_handler))
+        return true;
+  }
+
+  return false;
+}
+
+bool ebmc_language_filest::final(symbol_table_baset &symbol_table)
+{
+  std::set<std::string> languages;
+
+  for(auto &file : file_map)
+  {
+    if(languages.insert(file.second.language->id()).second)
+      if(file.second.language->final(symbol_table))
+        return true;
+  }
+
+  return false;
+}
+
+bool ebmc_language_filest::interfaces(
+  symbol_table_baset &symbol_table,
+  message_handlert &message_handler)
+{
+  for(auto &file : file_map)
+  {
+    if(file.second.language->interfaces(symbol_table, message_handler))
+      return true;
+  }
+
+  return false;
+}
+
+bool ebmc_language_filest::typecheck_module(
+  symbol_table_baset &symbol_table,
+  const std::string &module,
+  const bool keep_file_local,
+  message_handlert &message_handler)
+{
+  // check module map
+
+  module_mapt::iterator it = module_map.find(module);
+
+  if(it == module_map.end())
+  {
+    messaget log(message_handler);
+    log.error() << "found no file that provides module " << module
+                << messaget::eom;
+    return true;
+  }
+
+  return typecheck_module(
+    symbol_table, it->second, keep_file_local, message_handler);
+}
+
+bool ebmc_language_filest::typecheck_module(
+  symbol_table_baset &symbol_table,
+  ebmc_language_modulet &module,
+  const bool keep_file_local,
+  message_handlert &message_handler)
+{
+  // already typechecked?
+
+  if(module.type_checked)
+    return false;
+
+  messaget log(message_handler);
+
+  // already in progress?
+
+  if(module.in_progress)
+  {
+    log.error() << "circular dependency in " << module.name << messaget::eom;
+    return true;
+  }
+
+  module.in_progress = true;
+
+  // first get dependencies of current module
+
+  std::set<std::string> dependency_set;
+
+  module.file->language->dependencies(module.name, dependency_set);
+
+  for(std::set<std::string>::const_iterator it = dependency_set.begin();
+      it != dependency_set.end();
+      it++)
+  {
+    module.in_progress =
+      !typecheck_module(symbol_table, *it, keep_file_local, message_handler);
+    if(module.in_progress == false)
+      return true;
+  }
+
+  // type check it
+
+  log.status() << "Type-checking " << module.name << messaget::eom;
+
+  if(module.file->language->can_keep_file_local())
+  {
+    module.in_progress = !module.file->language->typecheck(
+      symbol_table, module.name, message_handler, keep_file_local);
+  }
+  else
+  {
+    module.in_progress = !module.file->language->typecheck(
+      symbol_table, module.name, message_handler);
+  }
+
+  if(!module.in_progress)
+    return true;
+
+  module.type_checked = true;
+  module.in_progress = false;
+
+  return false;
+}

--- a/src/ebmc/ebmc_language_file.h
+++ b/src/ebmc/ebmc_language_file.h
@@ -1,0 +1,169 @@
+/*******************************************************************\
+
+Module:
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_LANGAPI_LANGUAGE_FILE_H
+#define CPROVER_LANGAPI_LANGUAGE_FILE_H
+
+#include <util/symbol_table_base.h>
+
+#include <iosfwd>
+#include <map>
+#include <memory> // unique_ptr
+#include <set>
+#include <string>
+#include <unordered_set>
+
+class message_handlert;
+class ebmc_language_filet;
+class languaget;
+
+class ebmc_language_modulet final
+{
+public:
+  std::string name;
+  bool type_checked, in_progress;
+  ebmc_language_filet *file;
+
+  ebmc_language_modulet()
+    : type_checked(false), in_progress(false), file(nullptr)
+  {
+  }
+};
+
+class ebmc_language_filet final
+{
+public:
+  typedef std::set<std::string> modulest;
+  modulest modules;
+
+  std::unique_ptr<languaget> language;
+  std::string filename;
+
+  void get_modules();
+
+  void convert_lazy_method(
+    const irep_idt &id,
+    symbol_table_baset &symbol_table,
+    message_handlert &message_handler);
+
+  explicit ebmc_language_filet(const std::string &filename);
+  ebmc_language_filet(const ebmc_language_filet &rhs);
+
+  ~ebmc_language_filet();
+};
+
+class ebmc_language_filest
+{
+private:
+  typedef std::map<std::string, ebmc_language_filet> file_mapt;
+  file_mapt file_map;
+
+  typedef std::map<std::string, ebmc_language_modulet> module_mapt;
+  module_mapt module_map;
+
+  // Contains pointers into file_map!
+  // This is safe-ish as long as this is std::map.
+  typedef std::map<irep_idt, ebmc_language_filet *> lazy_method_mapt;
+  lazy_method_mapt lazy_method_map;
+
+public:
+  ebmc_language_filet &add_file(const std::string &filename)
+  {
+    ebmc_language_filet language_file(filename);
+    return file_map.emplace(filename, std::move(language_file)).first->second;
+  }
+
+  void remove_file(const std::string &filename)
+  {
+    // Clear relevant entries from lazy_method_map
+    ebmc_language_filet *language_file = &file_map.at(filename);
+    std::unordered_set<irep_idt> files_methods;
+    for(auto const &method : lazy_method_map)
+    {
+      if(method.second == language_file)
+        files_methods.insert(method.first);
+    }
+    for(const irep_idt &method_name : files_methods)
+      lazy_method_map.erase(method_name);
+
+    file_map.erase(filename);
+  }
+
+  void clear_files()
+  {
+    lazy_method_map.clear();
+    file_map.clear();
+  }
+
+  bool parse(message_handlert &message_handler);
+
+  void show_parse(std::ostream &out, message_handlert &message_handler);
+
+  bool generate_support_functions(
+    symbol_table_baset &symbol_table,
+    message_handlert &message_handler);
+
+  bool
+
+  typecheck(
+    symbol_table_baset &symbol_table,
+    const bool keep_file_local,
+    message_handlert &message_handler);
+  bool
+  typecheck(symbol_table_baset &symbol_table, message_handlert &message_handler)
+  {
+    return typecheck(symbol_table, false, message_handler);
+  }
+
+  bool final(symbol_table_baset &symbol_table);
+
+  bool interfaces(
+    symbol_table_baset &symbol_table,
+    message_handlert &message_handler);
+
+  // The method must have been added to the symbol table and registered
+  // in lazy_method_map (currently always in language_filest::typecheck)
+  // for this to be legal.
+  void convert_lazy_method(
+    const irep_idt &id,
+    symbol_table_baset &symbol_table,
+    message_handlert &message_handler)
+  {
+    PRECONDITION(symbol_table.has_symbol(id));
+    lazy_method_mapt::iterator it = lazy_method_map.find(id);
+    if(it != lazy_method_map.end())
+      it->second->convert_lazy_method(id, symbol_table, message_handler);
+  }
+
+  bool can_convert_lazy_method(const irep_idt &id) const
+  {
+    return lazy_method_map.count(id) != 0;
+  }
+
+  void clear()
+  {
+    file_map.clear();
+    module_map.clear();
+    lazy_method_map.clear();
+  }
+
+protected:
+  bool typecheck_module(
+    symbol_table_baset &symbol_table,
+    ebmc_language_modulet &module,
+    const bool keep_file_local,
+    message_handlert &message_handler);
+
+  bool typecheck_module(
+    symbol_table_baset &symbol_table,
+    const std::string &module,
+    const bool keep_file_local,
+    message_handlert &message_handler);
+};
+
+#endif // CPROVER_UTIL_LANGUAGE_FILE_H

--- a/src/ebmc/transition_system.cpp
+++ b/src/ebmc/transition_system.cpp
@@ -17,7 +17,6 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <util/unicode.h>
 
 #include <langapi/language.h>
-#include <langapi/language_file.h>
 #include <langapi/language_util.h>
 #include <langapi/mode.h>
 #include <trans-word-level/show_module_hierarchy.h>
@@ -25,6 +24,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <verilog/verilog_types.h>
 
 #include "ebmc_error.h"
+#include "ebmc_language_file.h"
 #include "ebmc_version.h"
 #include "output_file.h"
 
@@ -132,7 +132,7 @@ int preprocess(const cmdlinet &cmdline, message_handlert &message_handler)
 static bool parse(
   const cmdlinet &cmdline,
   const std::string &filename,
-  language_filest &language_files,
+  ebmc_language_filest &language_files,
   message_handlert &message_handler)
 {
   messaget message(message_handler);
@@ -200,7 +200,7 @@ static bool parse(
 
 bool parse(
   const cmdlinet &cmdline,
-  language_filest &language_files,
+  ebmc_language_filest &language_files,
   message_handlert &message_handler)
 {
   for(unsigned i = 0; i < cmdline.args.size(); i++)
@@ -261,7 +261,7 @@ int get_transition_system(
   //
   // parsing
   //
-  language_filest language_files;
+  ebmc_language_filest language_files;
 
   if(parse(cmdline, language_files, message_handler))
     return 1;


### PR DESCRIPTION
The logic implemented in CBMC's `language_filest` class typechecks modules starting from the leaves of the dependency tree.  This is an ill-fit for both SMV and Verilog, which expect elaboration and type checking to start from the root (or "main") module.

This copies the file that contains the `langauge_filet` and `language_filest` classes in order to make this change locally.