### PR TITLE
SystemVerilog: allow typedefs as port names in named port connections

### DIFF
--- a/regression/verilog/modules/port_connection1.desc
+++ b/regression/verilog/modules/port_connection1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 port_connection1.sv
 
 ^EXIT=0$
@@ -6,4 +6,3 @@ port_connection1.sv
 --
 ^warning: ignoring
 --
-This does not parse.

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3218,10 +3218,12 @@ named_port_connection_brace:
 	;
 
 named_port_connection:
-	  '.' port_identifier '(' expression_opt ')'
+	  // This needs to be 'any_identifier' to allow identifiers that
+	  // are typedefs in the local scope.
+	  '.' any_identifier '(' expression_opt ')'
 		{ init($$, ID_named_port_connection);
-                  mto($$, $2);
-                  mto($$, $4); }
+		  mto($$, $2);
+		  mto($$, $4); }
 	;
 
 // System Verilog standard 1800-2017
@@ -4644,7 +4646,8 @@ attr_name: identifier
 // even if they are already used for a different kind of identifier
 // in a higher scope.
 any_identifier:
-	  type_identifier
+	  TOK_TYPE_IDENTIFIER
+		{ new_symbol($$, $1); }
 	| non_type_identifier
 	;
 


### PR DESCRIPTION
This allows the use of identifiers that are typedefs in the local scope as the name of the port in a named port connection.