### PR TITLE
Rename declarations() -> declarators()

### DIFF
--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -804,15 +804,15 @@ void verilog_typecheckt::collect_symbols(
   {
     auto &parameter_decl = to_verilog_parameter_decl(module_item);
     collect_symbols(parameter_decl.type());
-    for(auto &decl : parameter_decl.declarations())
-      collect_symbols(parameter_decl.type(), decl);
+    for(auto &declarator : parameter_decl.declarators())
+      collect_symbols(parameter_decl.type(), declarator);
   }
   else if(module_item.id() == ID_local_parameter_decl)
   {
     auto &localparam_decl = to_verilog_local_parameter_decl(module_item);
     collect_symbols(localparam_decl.type());
-    for(auto &decl : localparam_decl.declarations())
-      collect_symbols(localparam_decl.type(), decl);
+    for(auto &declarator : localparam_decl.declarators())
+      collect_symbols(localparam_decl.type(), declarator);
   }
   else if(module_item.id() == ID_decl)
   {

--- a/src/verilog/verilog_expr.cpp
+++ b/src/verilog/verilog_expr.cpp
@@ -146,19 +146,19 @@ static void dependencies_rec(
   else if(module_item.id() == ID_parameter_decl)
   {
     auto &parameter_decl = to_verilog_parameter_decl(module_item);
-    for(auto &decl : parameter_decl.declarations())
+    for(auto &declarator : parameter_decl.declarators())
     {
-      dependencies_rec(decl.type(), dest);
-      dependencies_rec(decl.value(), dest);
+      dependencies_rec(declarator.type(), dest);
+      dependencies_rec(declarator.value(), dest);
     }
   }
   else if(module_item.id() == ID_local_parameter_decl)
   {
     auto &localparam_decl = to_verilog_local_parameter_decl(module_item);
-    for(auto &decl : localparam_decl.declarations())
+    for(auto &declarator : localparam_decl.declarators())
     {
-      dependencies_rec(decl.type(), dest);
-      dependencies_rec(decl.value(), dest);
+      dependencies_rec(declarator.type(), dest);
+      dependencies_rec(declarator.value(), dest);
     }
   }
   else if(module_item.id() == ID_decl)

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -680,6 +680,7 @@ public:
 
 using verilog_declaratorst = std::vector<verilog_declaratort>;
 
+/// a SystemVerilog parameter declaration
 class verilog_parameter_declt : public verilog_module_itemt
 {
 public:
@@ -690,12 +691,12 @@ public:
   using declaratort = verilog_declaratort;
   using declaratorst = verilog_declaratorst;
 
-  const declaratorst &declarations() const
+  const declaratorst &declarators() const
   {
     return (const declaratorst &)operands();
   }
 
-  declaratorst &declarations()
+  declaratorst &declarators()
   {
     return (declaratorst &)operands();
   }
@@ -725,12 +726,12 @@ public:
   using declaratort = verilog_declaratort;
   using declaratorst = verilog_declaratorst;
 
-  const declaratorst &declarations() const
+  const declaratorst &declarators() const
   {
     return (const declaratorst &)operands();
   }
 
-  declaratorst &declarations()
+  declaratorst &declarators()
   {
     return (declaratorst &)operands();
   }

--- a/src/verilog/verilog_parameterize_module.cpp
+++ b/src/verilog/verilog_parameterize_module.cpp
@@ -43,8 +43,8 @@ verilog_typecheckt::get_parameter_declarators(
 
   for(auto &item : module_items)
     if(item.id() == ID_parameter_decl)
-      for(auto &decl : to_verilog_parameter_decl(item).declarations())
-        declarators.push_back(decl);
+      for(auto &declarator : to_verilog_parameter_decl(item).declarators())
+        declarators.push_back(declarator);
 
   return declarators;
 }
@@ -173,7 +173,8 @@ void verilog_typecheckt::set_parameter_values(
   for(auto &module_item : module_items)
     if(module_item.id() == ID_parameter_decl)
     {
-      for(auto &decl : to_verilog_parameter_decl(module_item).declarations())
+      for(auto &declarator :
+          to_verilog_parameter_decl(module_item).declarators())
       {
         if(p_it!=parameter_values.end())
         {
@@ -181,7 +182,7 @@ void verilog_typecheckt::set_parameter_values(
 
           // only overwrite when actually assigned
           if(p_it->is_not_nil())
-            decl.value() = *p_it;
+            declarator.value() = *p_it;
 
           p_it++;
         }


### PR DESCRIPTION
To avoid confusion between declarations and declarators, rename the `declarations()` method on SystemVerilog parameter declarations to `declarators()`.