### PR TITLE
Verilog: type of parameter ports

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # EBMC 5.9
 
+* Verilog: fix for typed parameter ports
 * SystemVerilog: fix for type parameters
 * SMV: word constants
 * SMV: IVAR declarations

--- a/regression/verilog/modules/parameter_ports5.desc
+++ b/regression/verilog/modules/parameter_ports5.desc
@@ -1,7 +1,6 @@
-KNOWNBUG
-parameter_ports5.v
+CORE
+parameter_ports5.sv
 
 ^EXIT=0$
 ^SIGNAL=0$
 --
-The type of the parameter is ignored.

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -989,7 +989,7 @@ verilog_typecheckt::elaborate(const verilog_module_sourcet &module_source)
   // At the top level of the module, include the parameter ports.
   for(auto &declaration : module_source.parameter_port_decls())
     for(auto &declarator : declaration.declarators())
-      collect_symbols(typet(ID_nil), declarator);
+      collect_symbols(declaration.type(), declarator);
 
   // At the top level of the module, include the non-parameter module port
   // module items.


### PR DESCRIPTION
The type checker now applies the type given for a parameter port.