### PR TITLE
SMV: extract code for duplicate identifiers

### DIFF
--- a/regression/smv/define/define2.desc
+++ b/regression/smv/define/define2.desc
@@ -1,7 +1,7 @@
 CORE
 define2.smv
 
-^file .* line 6: variable `x' already declared.*$
+^file .* line 6: identifier x already used as variable$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/smv/define/define3.desc
+++ b/regression/smv/define/define3.desc
@@ -1,7 +1,7 @@
 CORE
 define3.smv
 
-^file .* line 6: variable x already declared, at file .* line 3$
+^file .* line 6: identifier x already used as define$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/smv/enums/name_collision1.desc
+++ b/regression/smv/enums/name_collision1.desc
@@ -1,9 +1,9 @@
-KNOWNBUG
+CORE
 name_collision1.smv
 
-^EXIT=0$
+^file .* line 6: identifier red already used as enum$
+^EXIT=2$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-This crashes.

--- a/regression/smv/enums/name_collision2.desc
+++ b/regression/smv/enums/name_collision2.desc
@@ -1,7 +1,7 @@
 CORE
 name_collision2.smv
 
-^file .* line 8: enum red already declared, at file .* line 3$
+^file .* line 8: identifier red already used as variable$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/smv/enums/name_collision3.desc
+++ b/regression/smv/enums/name_collision3.desc
@@ -1,9 +1,9 @@
-KNOWNBUG
+CORE
 name_collision3.smv
 
-^EXIT=0$
+^file .* line 8: identifier red already used as enum$
+^EXIT=2$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-This crashes.

--- a/regression/smv/var/already_declared1.desc
+++ b/regression/smv/var/already_declared1.desc
@@ -1,7 +1,7 @@
 CORE
 already_declared1.smv
 
-^file .* line 6: variable x already declared, at file .* line 3$
+^file .* line 6: identifier x already used as variable$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/smv/var/already_declared2.desc
+++ b/regression/smv/var/already_declared2.desc
@@ -1,7 +1,7 @@
 CORE
 already_declared2.smv
 
-^file .* line 6: variable x already declared, at file .* line 3$
+^file .* line 6: identifier x already used as define$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/smv/var/already_declared3.desc
+++ b/regression/smv/var/already_declared3.desc
@@ -1,7 +1,7 @@
 CORE
 already_declared3.smv
 
-^file .* line 8: variable x already declared, at file .* line 5$
+^file .* line 8: identifier x already used as variable$
 ^EXIT=2$
 ^SIGNAL=0$
 --


### PR DESCRIPTION
This extracts the code that checks for re-use of parameter/define/enum identifiers into a separate method.