### PR TITLE
Verilog: split up verilog_typecheck_exprt::convert_symbol

### DIFF
--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -174,6 +174,7 @@ protected:
 protected:
   [[nodiscard]] exprt convert_expr_rec(exprt expr);
   [[nodiscard]] exprt convert_constant(constant_exprt);
+  [[nodiscard]] const symbolt *resolve(const symbol_exprt &);
   [[nodiscard]] exprt
   convert_symbol(symbol_exprt, const std::optional<typet> &implicit_net_type);
   [[nodiscard]] exprt


### PR DESCRIPTION
This splits up `verilog_typecheck_exprt::convert_symbol` into two parts; one for doing the name resolution, and one for constructing the resulting expression.