### PR TITLE
CI: change Spot download URL

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -199,7 +199,7 @@ jobs:
         run: |
           # spot
           SPOT_VERSION=2.14.3.16
-          URL=https://download.opensuse.org/repositories/home:/adl/Debian_12/amd64
+          URL=https://www.lre.epita.fr/repo/debian/stable/
           wget ${URL}/libbddx0_${SPOT_VERSION}-1_amd64.deb
           wget ${URL}/libspotgen0_${SPOT_VERSION}-1_amd64.deb
           wget ${URL}/libspot0_${SPOT_VERSION}-1_amd64.deb


### PR DESCRIPTION
This changes the URL where the Spot binaries are downloaded to www.lre.epita.fr.

The currently used mirror redirects to another mirror, where the files are missing.