### PR TITLE
Verilog: use value field for type parameter declarators

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2032,7 +2032,8 @@ type_assignment: param_identifier '=' data_type
 		  auto base_name = stack_expr($1).id();
 		  stack_expr($$).set(ID_identifier, base_name);
 		  stack_expr($$).set(ID_base_name, base_name);
-		  addswap($$, ID_type, $3);
+		  stack_expr($$).set(ID_value, type_exprt{stack_type($3)});
+		  stack_expr($$).type() = typet{ID_type};
 
 		  // add to the scope as a type name
 		  PARSER.scopes.add_name(base_name, "", verilog_scopet::TYPEDEF);

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -102,7 +102,8 @@ void verilog_typecheckt::collect_symbols(
   if(type.id() == ID_type)
   {
     // much like a typedef
-    auto symbol_type = to_be_elaborated_typet{declarator.type()};
+    auto symbol_type =
+      to_be_elaborated_typet{to_type_expr(declarator.value()).type()};
 
     type_symbolt symbol{full_identifier, symbol_type, mode};
 


### PR DESCRIPTION
The type in a type parameter assignment is now stored in the value field of the parameter declarator.