### PR TITLE
AIG generation: ignore Verilog named blocks

### DIFF
--- a/src/trans-netlist/trans_to_netlist.cpp
+++ b/src/trans-netlist/trans_to_netlist.cpp
@@ -229,6 +229,10 @@ void convert_trans_to_netlistt::map_vars(
     {
       return; // ignore modules
     }
+    else if(symbol.type.id() == ID_named_block)
+    {
+      return; // ignore Verilog named blocks
+    }
     else if(symbol.is_type)
       return; // ignore types
     else if (symbol.is_input)


### PR DESCRIPTION
Verilog named blocks do not need to be allocated AIG nodes.