### PR TITLE
Verilog: fix integral vs. bit vector terminology

### DIFF
--- a/regression/verilog/expressions/concatenation5.desc
+++ b/regression/verilog/expressions/concatenation5.desc
@@ -1,7 +1,7 @@
 CORE
 concatenation5.v
 
-^file .* line 4: operand 1.1 must be integral$
+^file .* line 4: operand 1.1 must have a bit vector type$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/equality3.desc
+++ b/regression/verilog/expressions/equality3.desc
@@ -1,6 +1,7 @@
 CORE
 equality3.v
 
+^file .* line 4: the case equality operator does not allow real or shortreal$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/mod2.desc
+++ b/regression/verilog/expressions/mod2.desc
@@ -1,7 +1,7 @@
 CORE
 mod2.v
 
-^file .* line 4: operand 1\.1 must be integral$
+^file .* line 4: operand 1\.1 must have a bit vector type$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/reduction2.desc
+++ b/regression/verilog/expressions/reduction2.desc
@@ -1,7 +1,7 @@
 CORE
 reduction2.v
 
-^file .* line 4: operand 1\.1 must be integral$
+^file .* line 4: operand 1\.1 must have a bit vector type$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/replication3.desc
+++ b/regression/verilog/expressions/replication3.desc
@@ -1,7 +1,7 @@
 CORE
 replication3.v
 
-^file .* line 3: operand 1\.1 must be integral$
+^file .* line 3: operand 1\.1 must have a bit vector type$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/shr2.desc
+++ b/regression/verilog/expressions/shr2.desc
@@ -1,7 +1,7 @@
 CORE
 shr2.v
 
-^file .* line 4: operand 1\.1 must be integral$
+^file .* line 4: operand 1\.1 must have a bit vector type$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/streaming_concatenation2.desc
+++ b/regression/verilog/expressions/streaming_concatenation2.desc
@@ -1,7 +1,7 @@
 CORE
 streaming_concatenation2.sv
 
-^file .* line 4: operand 1\.1 must be integral$
+^file .* line 4: operand 1\.1 must have a bit vector type$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/wildcard_equality2.desc
+++ b/regression/verilog/expressions/wildcard_equality2.desc
@@ -1,7 +1,7 @@
 CORE
-wildcard_equality2.v
+wildcard_equality2.sv
 
-^file .* line 4: operand 1\.1 must be integral$
+^file .* line 4: operand 1\.1 must have a bit vector type$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/wildcard_equality2.sv
+++ b/regression/verilog/expressions/wildcard_equality2.sv
@@ -1,6 +1,6 @@
 module main;
 
   // ==? only takes integral types
-  wire x = 1.1 === 1.2;
+  wire x = 1.1 ==? 1.2;
 
 endmodule

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -196,7 +196,7 @@ protected:
   void tc_binary_expr(const exprt &expr, exprt &op0, exprt &op1);
   void convert_relation(binary_exprt &);
   void no_bool_ops(exprt &);
-  void must_be_integral(const exprt &);
+  void must_be_bit_vector(exprt &);
 
   // SVA
   void convert_sva(exprt &expr)


### PR DESCRIPTION
This changes the naming of methods and error messages.  The term 'integral' includes non-integer types, e.g., time variables.  Many operators require operands that are integral but exclude time variables.  The standard calls these "bit vector types".