### PR TITLE
Verilog: parameter assignments use base name

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2015,7 +2015,6 @@ list_of_param_assignments:
 param_assignment: param_identifier '=' constant_param_expression
 		{ init($$, ID_parameter);
 		  auto base_name = stack_expr($1).id();
-		  stack_expr($$).set(ID_identifier, base_name);
 		  stack_expr($$).set(ID_base_name, base_name);
 		  addswap($$, ID_value, $3); }
         ;
@@ -2030,7 +2029,6 @@ list_of_type_assignments:
 type_assignment: param_identifier '=' data_type
 		{ init($$, ID_parameter);
 		  auto base_name = stack_expr($1).id();
-		  stack_expr($$).set(ID_identifier, base_name);
 		  stack_expr($$).set(ID_base_name, base_name);
 		  stack_expr($$).set(ID_value, type_exprt{stack_type($3)});
 		  stack_expr($$).type() = typet{ID_type};

--- a/src/verilog/verilog_parameterize_module.cpp
+++ b/src/verilog/verilog_parameterize_module.cpp
@@ -120,8 +120,8 @@ std::list<exprt> verilog_typecheckt::get_parameter_values(
       }
 
       // Is there a defparam that overrides this parameter?
-      auto &identifier = decl.identifier();
-      auto def_param_it = instance_defparams.find(identifier);
+      auto &base_name = decl.base_name();
+      auto def_param_it = instance_defparams.find(base_name);
       if(def_param_it != instance_defparams.end())
         value = def_param_it->second;
 

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -962,14 +962,14 @@ void verilog_typecheckt::convert_parameter_override(
 
     auto module_instance =
       to_symbol_expr(hierarchical_identifier.module()).get_identifier();
-    auto parameter_name = hierarchical_identifier.item().get_identifier();
+    auto parameter_base_name = hierarchical_identifier.item().get_identifier();
 
     // The rhs must be a constant at this point.
     auto rhs_value =
       from_integer(convert_integer_constant_expression(rhs), integer_typet());
 
-    // store the assignment
-    defparams[module_instance][parameter_name] = rhs_value;
+    // store the assignment.
+    defparams[module_instance][parameter_base_name] = rhs_value;
   }
 }
 


### PR DESCRIPTION
Parameter assignments generated by the parser use a base name, not a fully qualified identifier.