### PR TITLE
Verilog: introduce `verilog_function_callt::is_system_function_call()`

### DIFF
--- a/src/verilog/verilog_expr.cpp
+++ b/src/verilog/verilog_expr.cpp
@@ -50,11 +50,20 @@ typet verilog_declaratort::merged_type(const typet &declaration_type) const
   return result;
 }
 
+static bool is_system_function_identifier(const exprt &function)
+{
+  return function.id() == ID_symbol &&
+         has_prefix(id2string(to_symbol_expr(function).get_identifier()), "$");
+}
+
 bool function_call_exprt::is_system_function_call() const
 {
-  return function().id() == ID_symbol &&
-         has_prefix(
-           id2string(to_symbol_expr(function()).get_identifier()), "$");
+  return is_system_function_identifier(function());
+}
+
+bool verilog_function_callt::is_system_function_call() const
+{
+  return is_system_function_identifier(function());
 }
 
 void verilog_module_sourcet::show(std::ostream &out) const

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -1413,6 +1413,7 @@ inline verilog_ift &to_verilog_if(exprt &expr)
   return static_cast<verilog_ift &>(expr);
 }
 
+/// task or function enable
 class verilog_function_callt:public verilog_statementt
 {
 public:
@@ -1430,7 +1431,9 @@ public:
   {
     return op0();
   }
-  
+
+  bool is_system_function_call() const;
+
   exprt::operandst &arguments()
   {
     return op1().operands();

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -869,17 +869,14 @@ Function: verilog_typecheckt::convert_function_call_or_task_enable
 void verilog_typecheckt::convert_function_call_or_task_enable(
   verilog_function_callt &statement)
 {
-  irep_idt base_name=
-    to_symbol_expr(statement.function()).get_identifier();
-
-  // We ignore everyting that starts with a '$',
-  // e.g., $display etc
-
-  if(!base_name.empty() && base_name[0]=='$')
+  if(statement.is_system_function_call())
   {
+    // we ignore all of these
   }
   else
   {
+    irep_idt base_name = to_symbol_expr(statement.function()).get_identifier();
+
     // look it up
     const irep_idt full_identifier =
       id2string(module_identifier) + "." + id2string(base_name);


### PR DESCRIPTION
To remove the duplication of the logic that detects system function/task identifiers, introduce a method that identifies system task/function call statements.