### PR TITLE
Use `verilog_identifier_exprt`

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -112,7 +112,7 @@ inline static void init(YYSTYPE &expr, const irep_idt &id)
 
 /*******************************************************************\
 
-Function: new_symbol
+Function: new_identifier
 
   Inputs:
 
@@ -123,9 +123,9 @@ Function: new_symbol
 
 \*******************************************************************/
 
-inline static void new_symbol(YYSTYPE &dest, YYSTYPE &src)
+inline static void new_identifier(YYSTYPE &dest, YYSTYPE &src)
 {
-  init(dest, ID_symbol);
+  init(dest, ID_verilog_identifier);
   const auto base_name = stack_expr(src).id();
   stack_expr(dest).set(ID_identifier, base_name);
   stack_expr(dest).set(ID_base_name, base_name);
@@ -3719,7 +3719,7 @@ function_statement: statement
 	;
 
 system_task_name: TOK_SYSIDENT
-                { new_symbol($$, $1); stack_expr($$).id(ID_verilog_identifier); }
+                { new_identifier($$, $1); }
         ;
 
 // System Verilog standard 1800-2017
@@ -4648,12 +4648,12 @@ attr_name: identifier
 // in a higher scope.
 any_identifier:
 	  TOK_TYPE_IDENTIFIER
-		{ new_symbol($$, $1); }
+		{ new_identifier($$, $1); }
 	| non_type_identifier
 	;
 
 non_type_identifier: TOK_NON_TYPE_IDENTIFIER
-		{ new_symbol($$, $1); }
+		{ new_identifier($$, $1); }
 	;
 
 block_identifier: TOK_NON_TYPE_IDENTIFIER;
@@ -4769,7 +4769,6 @@ hierarchical_identifier:
         | hierarchical_identifier '.' identifier
 		{ init($$, ID_hierarchical_identifier);
 		  stack_expr($$).reserve_operands(2);
-		  stack_expr($3).id(ID_verilog_identifier);
 		  mto($$, $1);
 		  mto($$, $3);
 		}

--- a/src/verilog/verilog_generate.cpp
+++ b/src/verilog/verilog_generate.cpp
@@ -170,13 +170,14 @@ void verilog_typecheckt::elaborate_generate_assign(
   const verilog_generate_assignt &statement,
   module_itemst &dest)
 {
-  if(statement.lhs().id() != ID_symbol)
+  if(statement.lhs().id() != ID_verilog_identifier)
   {
     throw errort().with_location(statement.lhs().source_location())
       << "expected symbol on left hand side of assignment";
   }
 
-  const irep_idt &identifier = to_symbol_expr(statement.lhs()).get_identifier();
+  const irep_idt &identifier =
+    to_verilog_identifier_expr(statement.lhs()).base_name();
 
   genvarst::iterator it=genvars.find(identifier);
   

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -60,11 +60,12 @@ void verilog_typecheckt::typecheck_port_connection(
   {
     // IEEE 1800 2017 6.10 allows implicit declarations of nets when
     // used in a port connection.
-    if(op.id() == ID_symbol)
+    if(op.id() == ID_verilog_identifier)
     {
       // The type of the implicit net is _not_ the type of the port,
       // but an "implicit scalar net of default net type".
-      op = convert_symbol(to_symbol_expr(op), bool_typet{});
+      op = convert_verilog_identifier(
+        to_verilog_identifier_expr(op), bool_typet{});
     }
     else
     {
@@ -233,11 +234,12 @@ void verilog_typecheckt::typecheck_builtin_port_connections(
   {
     // IEEE 1800 2017 6.10 allows implicit declarations of nets when
     // used in a port connection.
-    if(connection.id() == ID_symbol)
+    if(connection.id() == ID_verilog_identifier)
     {
       // The type of the implicit net is _not_ the type of the port,
       // but an "implicit scalar net of default net type".
-      connection = convert_symbol(to_symbol_expr(connection), bool_typet{});
+      connection = convert_verilog_identifier(
+        to_verilog_identifier_expr(connection), bool_typet{});
     }
     else
     {
@@ -845,8 +847,9 @@ void verilog_typecheckt::convert_continuous_assign(
     // from the RHS, and hence, we convert that first.
     convert_expr(rhs);
 
-    if(lhs.id() == ID_symbol)
-      lhs = convert_symbol(to_symbol_expr(lhs), rhs.type());
+    if(lhs.id() == ID_verilog_identifier)
+      lhs =
+        convert_verilog_identifier(to_verilog_identifier_expr(lhs), rhs.type());
     else
       convert_expr(lhs);
 
@@ -877,7 +880,8 @@ void verilog_typecheckt::convert_function_call_or_task_enable(
   }
   else
   {
-    irep_idt base_name = to_symbol_expr(statement.function()).get_identifier();
+    irep_idt base_name =
+      to_verilog_identifier_expr(statement.function()).base_name();
 
     // look it up
     const irep_idt full_identifier =
@@ -914,8 +918,8 @@ void verilog_typecheckt::convert_function_call_or_task_enable(
       assignment_conversion(arguments[i], parameter_types[i].type());
     }
 
-    statement.function().type() = symbol->type;
-    statement.function().set(ID_identifier, symbol->name);
+    statement.function() =
+      symbol->symbol_expr().with_source_location(statement.function());
   }
 }
 

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -174,9 +174,10 @@ protected:
 protected:
   [[nodiscard]] exprt convert_expr_rec(exprt expr);
   [[nodiscard]] exprt convert_constant(constant_exprt);
-  [[nodiscard]] const symbolt *resolve(const symbol_exprt &);
-  [[nodiscard]] exprt
-  convert_symbol(symbol_exprt, const std::optional<typet> &implicit_net_type);
+  [[nodiscard]] const symbolt *resolve(const verilog_identifier_exprt &);
+  [[nodiscard]] exprt convert_verilog_identifier(
+    verilog_identifier_exprt,
+    const std::optional<typet> &implicit_net_type);
   [[nodiscard]] exprt
     convert_hierarchical_identifier(class hierarchical_identifier_exprt);
   [[nodiscard]] exprt convert_nullary_expr(nullary_exprt);


### PR DESCRIPTION
This replaces the remaining uses of `symbol_exprt` for simple identifiers in the Verilog parse tree by `verilog_identifier_exprt`.