### PR TITLE
Verilog: use `verilog_identifier_exprt` for port names

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3222,6 +3222,7 @@ named_port_connection:
 	  // are typedefs in the local scope.
 	  '.' any_identifier '(' expression_opt ')'
 		{ init($$, ID_named_port_connection);
+		  stack_expr($2).id(ID_verilog_identifier);
 		  mto($$, $2);
 		  mto($$, $4); }
 	;

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -134,15 +134,16 @@ void verilog_typecheckt::typecheck_port_connections(
 
       exprt &value = named_port_connection.value();
       const irep_idt &base_name =
-        to_symbol_expr(named_port_connection.port()).get_identifier();
+        to_verilog_identifier_expr(named_port_connection.port()).base_name();
 
       bool found=false;
 
       std::string full_identifier =
         id2string(symbol.module) + "." + id2string(base_name);
 
-      to_symbol_expr(named_port_connection.port())
-        .set_identifier(full_identifier);
+      named_port_connection.port() =
+        symbol_exprt{full_identifier, typet{}}.with_source_location(
+          named_port_connection.port());
 
       if(assigned_ports.find(base_name) != assigned_ports.end())
       {


### PR DESCRIPTION
Port names in named port connections are always simple identifiers, hence use `verilog_identifier_exprt`.