### PR TITLE
SMV: test for module instance as module argument

### DIFF
--- a/regression/smv/modules/module_argument1.desc
+++ b/regression/smv/modules/module_argument1.desc
@@ -1,0 +1,8 @@
+CORE
+module_argument1.smv
+
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/smv/modules/module_argument1.smv
+++ b/regression/smv/modules/module_argument1.smv
@@ -1,0 +1,15 @@
+-- from the NuSMV 2.7 manual
+
+MODULE main
+ VAR
+  a : bar;
+  m : foo(a);
+
+MODULE bar
+ VAR
+  q : boolean;
+  p : boolean;
+
+MODULE foo(c)
+ DEFINE
+  flag := c.q | c.p;


### PR DESCRIPTION
This adds a test from the SMV manual, in which a module instance is passed as argument to another module.