### PR TITLE
SMV: check for cases of disallowed `next`

### DIFF
--- a/regression/smv/CTL/smv_ctlspec3.desc
+++ b/regression/smv/CTL/smv_ctlspec3.desc
@@ -1,7 +1,7 @@
-KNOWNBUG
+CORE
 smv_ctlspec3.smv
 
-^file .* line 5: next\(...\) is not allowed here$
+^file .* line 8: next\(...\) is not allowed here$
 ^EXIT=2$
 ^SIGNAL=0$
 --


### PR DESCRIPTION
This adds checks for additional cases where `next(...)` is not allowed.