### PR TITLE
netlist: split up `convert_trans_to_netlistt::map_vars`

### DIFF
--- a/src/trans-netlist/var_map.cpp
+++ b/src/trans-netlist/var_map.cpp
@@ -208,6 +208,35 @@ std::vector<var_mapt::mapt::const_iterator> var_mapt::sorted() const
 
 /*******************************************************************\
 
+Function: var_mapt::sorted
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+std::vector<var_mapt::mapt::iterator> var_mapt::sorted()
+{
+  using iteratort = mapt::iterator;
+  std::vector<iteratort> iterators;
+  iterators.reserve(map.size());
+
+  for(auto it = map.begin(); it != map.end(); it++)
+    iterators.push_back(it);
+
+  std::sort(
+    iterators.begin(),
+    iterators.end(),
+    [](iteratort a, iteratort b) { return a->first.compare(b->first) < 0; });
+
+  return iterators;
+}
+
+/*******************************************************************\
+
 Function: var_mapt::output
 
   Inputs:

--- a/src/trans-netlist/var_map.h
+++ b/src/trans-netlist/var_map.h
@@ -130,6 +130,7 @@ public:
   }
 
   std::vector<mapt::const_iterator> sorted() const;
+  std::vector<mapt::iterator> sorted();
 };
  
 #endif


### PR DESCRIPTION
This splits `convert_trans_to_netlistt::map_vars` into two pieces: one that identifies the variables to be put into the var_map, and one that allocates net-list nodes for those variables.