### PR TITLE
Verilog: fix grammar for gate instances

### DIFF
--- a/regression/verilog/nets/implicit2.sv
+++ b/regression/verilog/nets/implicit2.sv
@@ -3,7 +3,7 @@ module main;
   // Implicit nets are allowed in the port connection list of a module.
   // The type of the implicit net is _not_ the type of the port,
   // but an "implicit scalar net of default net type".
-  and [3:0] (O, A, B);
+  and my_instance[3:0] (O, A, B);
 
   always assert final (O == (A & B));
   always assert final ($bits(O) == 1);

--- a/regression/verilog/nets/implicit6.sv
+++ b/regression/verilog/nets/implicit6.sv
@@ -5,7 +5,7 @@ module main;
   // Implicit nets are allowed in the port connection list of a module.
   // The type of the implicit net is _not_ the type of the port,
   // but an "implicit scalar net of default net type".
-  and [P:0] (O, A, B);
+  and my_instance[P:0] (O, A, B);
 
   assert final ($bits(O) == 1);
 

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3108,20 +3108,31 @@ gate_instance_brace:
 	;
 
 gate_instance:
-	  name_of_gate_instance_opt range_opt '(' list_of_module_connections_opt ')'
-		{ init($$, ID_inst); addswap($$, ID_base_name, $1);
-                  swapop($$, $4);
-                  addswap($$, ID_range, $2);
+	  name_of_gate_instance_opt '(' list_of_module_connections_opt ')'
+		{ $$ = $1;
+                  swapop($$, $3);
                 }
 	;
 
 name_of_gate_instance_opt:
 	  /* Optional */ 
-	        { init($$, "$_&#ANON" + PARSER.get_next_id()); }
+	        { init($$, ID_inst);
+	          stack_expr($$).set(ID_base_name, "$_&#ANON" + PARSER.get_next_id()); }
 	| name_of_gate_instance
 	;
 
-name_of_gate_instance: TOK_NON_TYPE_IDENTIFIER;
+name_of_gate_instance:
+	  TOK_NON_TYPE_IDENTIFIER unpacked_dimension_brace
+	        { init($$, ID_inst);
+	          addswap($$, ID_base_name, $1);
+	          if(stack_expr($2).is_not_nil())
+	          {
+	            auto &range = stack_expr($$).add(ID_range);
+	            range = stack_expr($2).find(ID_range);
+	            range.id(ID_range);
+	          }
+	        }
+	;
 
 // System Verilog standard 1800-2017
 // A.4.1.1 Module instantiation


### PR DESCRIPTION
This changes the grammar for gate instances to match 1800-2017.