### PR TITLE
Verilog: use `instance_array` for width of primitive gates

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3126,12 +3126,7 @@ name_of_gate_instance:
 	  TOK_NON_TYPE_IDENTIFIER unpacked_dimension_brace
 	        { init($$, ID_inst);
 	          addswap($$, ID_base_name, $1);
-	          if(stack_expr($2).is_not_nil())
-	          {
-	            auto &range = stack_expr($$).add(ID_range);
-	            range = stack_expr($2).find(ID_range);
-	            range.id(ID_range);
-	          }
+	          addswap($$, ID_verilog_instance_array, $2);
 	        }
 	;
 

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -904,6 +904,11 @@ public:
               connections.front().id() == ID_verilog_wildcard_port_connection);
     }
 
+    bool has_instance_array() const
+    {
+      return instance_array().is_not_nil();
+    }
+
     const typet &instance_array() const
     {
       return static_cast<const typet &>(find(ID_verilog_instance_array));

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -177,21 +177,16 @@ void verilog_typecheckt::interface_inst(
   const verilog_inst_baset &statement,
   const verilog_instt::instancet &op)
 {
-  if(op.instance_array().is_not_nil())
+  bool primitive = statement.id() == ID_inst_builtin;
+
+  if(op.has_instance_array() && !primitive)
   {
     throw errort().with_location(op.source_location())
       << "no support for instance arrays";
   }
 
-  bool primitive=statement.id()==ID_inst_builtin;
-  const exprt &range_expr = static_cast<const exprt &>(op.find(ID_range));
-
-  ranget range;
-
-  if(range_expr.is_nil() || range_expr.id().empty())
-    range = ranget{0, 0};
-  else
-    range = convert_range(range_expr);
+  if(op.has_instance_array())
+    (void)elaborate_type(op.instance_array());
 
   irep_idt instantiated_module_identifier =
     verilog_module_symbol(id2string(statement.get(ID_module)));


### PR DESCRIPTION
This switches the `range` annotation on primitive gates to the unpacked array as required by 1800-2017.