### PR TITLE
Verilog: assignment to 1-bit LHSs require truncation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 * Verilog: fix for four-valued | and &
 * Verilog: fix for typed parameter ports
 * Verilog: fix for the type of implicit nets for continous assignments
+* Verilog: fix for assignments to 1-bit types
 * SystemVerilog: fix for type parameters
 * SystemVerilog: type parameter ports
 * SMV: word constants

--- a/regression/verilog/nets/wire_with_assignment1.desc
+++ b/regression/verilog/nets/wire_with_assignment1.desc
@@ -1,0 +1,7 @@
+CORE
+wire_with_assignment1.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/nets/wire_with_assignment1.sv
+++ b/regression/verilog/nets/wire_with_assignment1.sv
@@ -1,0 +1,12 @@
+module main;
+
+  wire x = 2'b10; // truncated
+  initial #1 assert($bits(x) == 1 && x == 0);
+
+  wire [1:0] y = 3'b101; // truncated
+  initial #1 assert($bits(y) == 2 && y == 1);
+
+  wire signed z = 3'sb100; // truncated
+  initial #1 assert($bits(z) == 1 && z == 0);
+
+endmodule

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -311,10 +311,18 @@ void verilog_typecheck_exprt::assignment_conversion(
     else
       downwards_type_propagation(rhs, lhs_type);
   }
-  else
+  else if(lhs_width == rhs_width)
   {
-    // no need to enlarge
+    // size stays the same -- this is a reinterpret cast
     rhs = typecast_exprt::conditional_cast(rhs, lhs_type);
+  }
+  else // lhs_width < rhs_width
+  {
+    // we shrink -- this is truncation
+    if(lhs_type.id() == ID_bool)
+      rhs = extractbit_exprt{rhs, from_integer(0, integer_typet{})};
+    else
+      rhs = typecast_exprt{rhs, lhs_type};
   }
 }
 


### PR DESCRIPTION
We use bool to encode 1-bit values; when assigning to variables or nets of this type, use truncation, not type casting.