### PR TITLE
SystemVerilog: fix for checkers with multiple ports

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Verilog: fix for the type of implicit nets for continous assignments
 * SystemVerilog: fix for type parameters
 * SystemVerilog: type parameter ports
+* SystemVerilog: fix for checkers with multiple ports
 * SMV: word constants
 * SMV: IVAR declarations
 * SMV: bit selection operator

--- a/regression/verilog/checker/checker7.desc
+++ b/regression/verilog/checker/checker7.desc
@@ -1,0 +1,7 @@
+CORE
+checker7.sv
+--bound 20
+^\[main\.c\.assert\.1\] always myChecker\.data1 != myChecker\.data2: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/verilog/checker/checker7.sv
+++ b/regression/verilog/checker/checker7.sv
@@ -1,0 +1,9 @@
+checker myChecker(input logic [31:0] data1, input logic [31:0] data2);
+  assert property (data1 != data2);
+endchecker
+
+module main(input clk);
+  reg [31:0] counter = 0;
+  always_ff @(posedge clk) counter++;
+  myChecker c(counter, 10);
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -794,8 +794,8 @@ checker_port_list_opt:
 checker_port_list:
 	  checker_port_item
 		{ init($$); mts($$, $1); }
-	| checker_port_list checker_port_item
-		{ $$ = $1; mts($$, $2); }
+	| checker_port_list ',' checker_port_item
+		{ $$ = $1; mts($$, $3); }
 	;
 
 checker_port_item:


### PR DESCRIPTION
This fixes the grammar for checker declarations with multiple ports.