### PR TITLE
SMV: `integer_number` nonterminal

### DIFF
--- a/src/smvlang/parser.y
+++ b/src/smvlang/parser.y
@@ -697,7 +697,9 @@ boolean_constant:
            }
            ;
 
-integer_constant:
+integer_constant: integer_number;
+
+integer_number:
              NUMBER_Token
            {
              init($$, ID_constant);
@@ -849,11 +851,11 @@ basic_expr : constant
            }
            ;
 
-bound      : '[' NUMBER_Token ',' NUMBER_Token ']'
+bound      : '[' integer_number ',' integer_number ']'
            { init($$); mto($$, $2); mto($$, $4); }
            ;
 
-range      : NUMBER_Token DOTDOT_Token NUMBER_Token
+range      : integer_number DOTDOT_Token integer_number
            { init($$); mto($$, $1); mto($$, $3); }
            ;
 


### PR DESCRIPTION
This adds the `integer_number` nonterminal rule, to match the NuSMV 2.7 manual.