### PR TITLE
`cmdlinet` in `ebmc_languaget` can be const

### DIFF
--- a/src/ebmc/ebmc_language.h
+++ b/src/ebmc/ebmc_language.h
@@ -23,7 +23,7 @@ class ebmc_languaget
 {
 public:
   // constructor / destructor
-  ebmc_languaget(cmdlinet &_cmdline, message_handlert &_message_handler)
+  ebmc_languaget(const cmdlinet &_cmdline, message_handlert &_message_handler)
     : cmdline(_cmdline), message_handler(_message_handler)
   {
   }
@@ -32,10 +32,11 @@ public:
 
   /// Produce the transition system, and return it;
   /// returns {} when diagnostic output was produced instead.
-  virtual std::optional<transition_systemt> transition_system() = 0;
+  [[nodiscard]] virtual std::optional<transition_systemt>
+  transition_system() = 0;
 
 protected:
-  cmdlinet &cmdline;
+  const cmdlinet &cmdline;
   message_handlert &message_handler;
 };
 

--- a/src/smvlang/smv_ebmc_language.h
+++ b/src/smvlang/smv_ebmc_language.h
@@ -19,7 +19,9 @@ class smv_parse_treet;
 class smv_ebmc_languaget : public ebmc_languaget
 {
 public:
-  smv_ebmc_languaget(cmdlinet &_cmdline, message_handlert &_message_handler)
+  smv_ebmc_languaget(
+    const cmdlinet &_cmdline,
+    message_handlert &_message_handler)
     : ebmc_languaget(_cmdline, _message_handler)
   {
   }


### PR DESCRIPTION
It is unlikely that a language will want to modify the command line; hence, pass a const reference.