### PR TITLE
Verilog: avoid `verilog_languaget` for parsing/preprocessing

### DIFF
--- a/src/verilog/verilog_ebmc_language.h
+++ b/src/verilog/verilog_ebmc_language.h
@@ -14,7 +14,11 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include <ebmc/ebmc_language.h>
 
+#include <filesystem>
+#include <iosfwd>
+
 class verilog_parse_treet;
+class ebmc_language_filest;
 
 class verilog_ebmc_languaget : public ebmc_languaget
 {
@@ -28,6 +32,15 @@ public:
 
   // produce the transition system, and return it
   std::optional<transition_systemt> transition_system() override;
+
+protected:
+  void preprocess(const std::filesystem::path &, std::ostream &);
+  void preprocess();
+  verilog_parse_treet parse(const std::filesystem::path &);
+  void show_parse(const std::filesystem::path &);
+  void show_parse();
+  void parse(const std::filesystem::path &, ebmc_language_filest &);
+  void parse(ebmc_language_filest &);
 };
 
 #endif // EBMC_VERILOG_LANGUAGE_H


### PR DESCRIPTION
This replaces the implementation of preprocessing and parsing in `verilog_ebmc_languaget` by a direct invocation of the Verilog preprocessor and parser.