### PR TITLE
AIGs: add check for dependency order

### DIFF
--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -966,6 +966,7 @@ void bdd_enginet::build_BDDs()
     // A node is either an 'and' or a variable/nondet
     if(n.is_and())
     {
+      // This relies on the dependency ordering of the AIG
       BDD a=aig2bdd(n.a, BDDs);
       BDD b=aig2bdd(n.b, BDDs);
     
@@ -1051,4 +1052,3 @@ property_checker_resultt bdd_engine(
 {
   return bdd_enginet{cmdline, transition_system, properties, message_handler}();
 }
-

--- a/src/ebmc/netlist.cpp
+++ b/src/ebmc/netlist.cpp
@@ -30,5 +30,8 @@ netlistt make_netlist(
     netlist,
     message_handler);
 
+  // check that the AIG is in dependency order
+  netlist.check_ordering();
+
   return netlist;
 }

--- a/src/trans-netlist/aig.cpp
+++ b/src/trans-netlist/aig.cpp
@@ -110,3 +110,16 @@ std::ostream &operator<<(std::ostream &out, const aigt &aig) {
   aig.print(out);
   return out;
 }
+
+void aigt::check_ordering() const
+{
+  for(std::size_t node_index = 0; node_index < nodes.size(); node_index++)
+  {
+    auto &node = nodes[node_index];
+    if(node.is_and())
+    {
+      DATA_INVARIANT(node.a.var_no() < node_index, "aig topsort failure");
+      DATA_INVARIANT(node.b.var_no() < node_index, "aig topsort failure");
+    }
+  }
+}

--- a/src/trans-netlist/aig.h
+++ b/src/trans-netlist/aig.h
@@ -56,6 +56,9 @@ public:
 
   typedef aig_nodet nodet;
   typedef std::vector<nodet> nodest;
+
+  // The nodes are expected to be in dependency order,
+  // see check_ordering().
   nodest nodes;
 
   void clear() { nodes.clear(); }
@@ -90,6 +93,10 @@ public:
 
   std::string label(nodest::size_type v) const;
   std::string dot_label(nodest::size_type v) const;
+
+  /// Check that the nodes are in topological order,
+  /// otherwise fails a DATA_INVARIANT.
+  void check_ordering() const;
 };
 
 std::ostream &operator<<(std::ostream &, const aigt &);


### PR DESCRIPTION
The AIG data structure maintains the invariant that the nodes are in dependency order, i.e., nodes may only depend on earlier nodes.  This adds a method for checking this property.