### PR TITLE
KNOWNBUG test for SMV set-in-a-set

### DIFF
--- a/regression/smv/expressions/smv_set4.desc
+++ b/regression/smv/expressions/smv_set4.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+smv_set4.smv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This yields a type error.

--- a/regression/smv/expressions/smv_set4.smv
+++ b/regression/smv/expressions/smv_set4.smv
@@ -1,0 +1,5 @@
+MODULE main
+
+-- Set expressions can contain other sets,
+-- which is interpreted as their union.
+SPEC 3 in { 1, { 1, 2, 3 } };


### PR DESCRIPTION
SMV allows sets as members of set expressions.  These are interpreted as the union of those sets.