### PR TITLE
KNOWNBUG test for SMV `in` with set on LHS

### DIFF
--- a/regression/smv/expressions/smv_in1.desc
+++ b/regression/smv/expressions/smv_in1.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+smv_in1.smv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This does not type check.

--- a/regression/smv/expressions/smv_in1.smv
+++ b/regression/smv/expressions/smv_in1.smv
@@ -1,0 +1,5 @@
+MODULE main
+
+-- "in" allows sets on the lhs
+SPEC { 1, 2 } in { 1, 2, 3 }
+SPEC !({ 1, 2, 4 } in { 1, 2, 3 })


### PR DESCRIPTION
The SMV `in` operator accepts sets on the LHS.