### PR TITLE
SMV: test for assignment of set that is too large

### DIFF
--- a/regression/smv/assign/assign_set1.desc
+++ b/regression/smv/assign/assign_set1.desc
@@ -1,0 +1,8 @@
+CORE
+assign_set1.smv
+
+^file .* line 6: Expected expression of type `0..5', but got expression `6', which is of type `6..6'$
+^EXIT=2$
+^SIGNAL=0$
+--
+--

--- a/regression/smv/assign/assign_set1.smv
+++ b/regression/smv/assign/assign_set1.smv
@@ -1,0 +1,6 @@
+MODULE main
+
+VAR x : 0..5;
+
+-- The RHS type is too big
+ASSIGN init(x) := { 1, 6 };


### PR DESCRIPTION
SMV allows assignments of sets to singleton variables, which denotes a nondeterministic choice.  This test checks that cases where the RHS set contains an element that cannot be assigned to the LHS are errored.