### PR TITLE
KNOWNBUG test for nondeterministic definition of variable

### DIFF
--- a/regression/smv/assign/assign_set2.desc
+++ b/regression/smv/assign/assign_set2.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+assign_set2.smv
+--bdd
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This does not type check.

--- a/regression/smv/assign/assign_set2.smv
+++ b/regression/smv/assign/assign_set2.smv
@@ -1,0 +1,9 @@
+MODULE main
+
+VAR x : 0..6;
+
+-- this is a nondeterministic choice
+ASSIGN x := { 1, 4 };
+
+SPEC AG x != 2
+SPEC EX x = 1


### PR DESCRIPTION
NuSMV allows `ASSIGN var := { ... }`, which is errored by the type checker.