### PR TITLE
Verilog: fix for pretty printing `verilog_identifier_exprt`

### DIFF
--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -1868,7 +1868,7 @@ expr2verilogt::resultt expr2verilogt::convert_rec(const exprt &src)
     return convert_symbol(src);
 
   else if(src.id() == ID_verilog_identifier)
-    return convert_symbol(to_verilog_identifier_expr(src));
+    return convert_verilog_identifier(to_verilog_identifier_expr(src));
 
   else if(src.id()==ID_nondet_symbol)
     return convert_nondet_symbol(src);

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -127,7 +127,6 @@ inline static void new_identifier(YYSTYPE &dest, YYSTYPE &src)
 {
   init(dest, ID_verilog_identifier);
   const auto base_name = stack_expr(src).id();
-  stack_expr(dest).set(ID_identifier, base_name);
   stack_expr(dest).set(ID_base_name, base_name);
 }
 


### PR DESCRIPTION
This fixes the pretty printer for `verilog_identifier_exprt` to use the `base_name` field.  After that, `verilog_identifier` expressions no longer need the `identifier` field.