### PR TITLE
Verilog: allow typedefs as enums

### DIFF
--- a/regression/verilog/enums/enum_vs_typedef1.desc
+++ b/regression/verilog/enums/enum_vs_typedef1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 enum_vs_typedef1.sv
 
 ^EXIT=10$

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1679,10 +1679,10 @@ enum_name_value_opt:
 	;
 
 enum_name_declaration:
-	  TOK_NON_TYPE_IDENTIFIER enum_name_value_opt
+	  any_identifier enum_name_value_opt
 	  {
 	    init($$);
-	    auto &scope = PARSER.scopes.add_name(stack_expr($1).id(), "", verilog_scopet::ENUM_NAME);
+	    auto &scope = PARSER.scopes.add_name(stack_expr($1).get(ID_base_name), "", verilog_scopet::ENUM_NAME);
 	    stack_expr($$).set(ID_base_name, scope.base_name());
 	    stack_expr($$).set(ID_verilog_scope_prefix, scope.parent->prefix);
 	    stack_expr($$).add(ID_value).swap(stack_expr($2));


### PR DESCRIPTION
This changes the Verilog grammar to allow typedef identifiers to be reused as enum identifiers.