### PR TITLE
Verilog: allow typedefs as sequence/property identifiers

### DIFF
--- a/regression/verilog/SVA/property_vs_typedef1.desc
+++ b/regression/verilog/SVA/property_vs_typedef1.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE
 property_vs_typedef1.sv
 
 ^EXIT=10$
 ^SIGNAL=0$
 --
 --
-This fails to parse.

--- a/regression/verilog/SVA/sequence_vs_typedef1.desc
+++ b/regression/verilog/SVA/sequence_vs_typedef1.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE
 sequence_vs_typedef1.sv
 
 ^EXIT=10$
 ^SIGNAL=0$
 --
 --
-This fails to parse.

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2515,11 +2515,11 @@ assertion_item_declaration:
 	;
 
 property_declaration:
-          TOK_PROPERTY property_identifier property_port_list_paren_opt ';'
+          TOK_PROPERTY any_identifier property_port_list_paren_opt ';'
           property_spec semicolon_opt
           TOK_ENDPROPERTY property_identifier_opt
 		{ init($$, ID_verilog_property_declaration);
-		  stack_expr($$).set(ID_base_name, stack_expr($2).id());
+		  stack_expr($$).set(ID_base_name, stack_expr($2).get(ID_base_name));
 		  mto($$, $5); }
         ;
 
@@ -2707,11 +2707,11 @@ property_case_item:
 
 sequence_declaration:
 	  "sequence" { init($$, ID_verilog_sequence_declaration); }
-	  sequence_identifier sequence_port_list_opt ';'
+	  any_identifier sequence_port_list_opt ';'
 	  sequence_expr semicolon_opt
 	  "endsequence" sequence_identifier_opt
 		{ $$=$2;
-		  stack_expr($$).set(ID_base_name, stack_expr($3).id());
+		  stack_expr($$).set(ID_base_name, stack_expr($3).get(ID_base_name));
 		  mto($$, $6);
 		}
 	;


### PR DESCRIPTION
This changes the Verilog grammar to allow typedef identifiers to be reused as sequence and property identifiers.