### PR TITLE
Verilog: add sequence/property identifiers to scope

### DIFF
--- a/regression/verilog/SVA/property_vs_typedef1.sv
+++ b/regression/verilog/SVA/property_vs_typedef1.sv
@@ -7,6 +7,6 @@ module main;
   // Riviera Pro 2023.04.
   property some_name;
     1
-  endproperty
+  endproperty : some_name
 
 endmodule

--- a/regression/verilog/SVA/sequence_vs_typedef1.sv
+++ b/regression/verilog/SVA/sequence_vs_typedef1.sv
@@ -7,6 +7,6 @@ module main;
   // Riviera Pro 2023.04.
   sequence some_name;
     1
-  endsequence
+  endsequence : some_name
 
 endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2514,12 +2514,17 @@ assertion_item_declaration:
 	;
 
 property_declaration:
-          TOK_PROPERTY any_identifier property_port_list_paren_opt ';'
+	  TOK_PROPERTY any_identifier
+		{ auto base_name = stack_expr($2).get(ID_base_name);
+		  push_scope(base_name, ".", verilog_scopet::PROPERTY); }
+          property_port_list_paren_opt ';'
           property_spec semicolon_opt
           TOK_ENDPROPERTY property_identifier_opt
 		{ init($$, ID_verilog_property_declaration);
-		  stack_expr($$).set(ID_base_name, stack_expr($2).get(ID_base_name));
-		  mto($$, $5); }
+		  auto base_name = stack_expr($2).get(ID_base_name);
+		  stack_expr($$).set(ID_base_name, base_name);
+		  mto($$, $6);
+		}
         ;
 
 property_identifier_opt:
@@ -2706,12 +2711,16 @@ property_case_item:
 
 sequence_declaration:
 	  "sequence" { init($$, ID_verilog_sequence_declaration); }
-	  any_identifier sequence_port_list_opt ';'
+	  any_identifier
+		{ auto base_name = stack_expr($3).get(ID_base_name);
+		  push_scope(base_name, ".", verilog_scopet::SEQUENCE);
+		}
+	  sequence_port_list_opt ';'
 	  sequence_expr semicolon_opt
 	  "endsequence" sequence_identifier_opt
 		{ $$=$2;
 		  stack_expr($$).set(ID_base_name, stack_expr($3).get(ID_base_name));
-		  mto($$, $6);
+		  mto($$, $7);
 		}
 	;
 

--- a/src/verilog/verilog_scope.cpp
+++ b/src/verilog/verilog_scope.cpp
@@ -51,6 +51,8 @@ unsigned verilog_scopet::identifier_token() const
   case verilog_scopet::TASK:      return TOK_NON_TYPE_IDENTIFIER;
   case verilog_scopet::FUNCTION:  return TOK_NON_TYPE_IDENTIFIER;
   case verilog_scopet::TYPEDEF:   return TOK_TYPE_IDENTIFIER;
+  case verilog_scopet::PROPERTY:  return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::SEQUENCE:  return TOK_NON_TYPE_IDENTIFIER;
   case verilog_scopet::OTHER:     return TOK_NON_TYPE_IDENTIFIER;
     // clang-format on
   }

--- a/src/verilog/verilog_scope.h
+++ b/src/verilog/verilog_scope.h
@@ -28,6 +28,8 @@ struct verilog_scopet
     FUNCTION,
     BLOCK,
     TYPEDEF,
+    PROPERTY,
+    SEQUENCE,
     OTHER
   };
 


### PR DESCRIPTION
This changes the Verilog grammar to add sequence and property identifiers to the scope, to enable reusing typedef identifiers.