### PR TITLE
Verilog: add instance names to the current scope

### DIFF
--- a/regression/verilog/modules/instance_vs_typedef2.desc
+++ b/regression/verilog/modules/instance_vs_typedef2.desc
@@ -1,0 +1,7 @@
+CORE
+instance_vs_typedef2.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+--

--- a/regression/verilog/modules/instance_vs_typedef2.sv
+++ b/regression/verilog/modules/instance_vs_typedef2.sv
@@ -1,0 +1,17 @@
+typedef int some_name;
+
+module sub;
+  parameter [7:0] P = 1;
+endmodule
+
+module main;
+
+  // The identifier 'some_name' can be re-used in the module scope.
+  // This works with VCS 2023.03, Questa 2024.3, Xcelium 23.09,
+  // Riviera Pro 2023.04, but fails with Icarus Verilog 12.
+  sub some_name();
+
+  // some_name is no longer a type identifier
+  initial assert($bits(some_name.P) == 8);
+
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3134,7 +3134,9 @@ name_of_gate_instance_opt:
 name_of_gate_instance:
           any_identifier unpacked_dimension_brace
                 { init($$, ID_inst);
-                  stack_expr($$).set(ID_base_name, stack_expr($1).get(ID_base_name));
+                  auto base_name = stack_expr($1).get(ID_base_name);
+                  stack_expr($$).set(ID_base_name, base_name);
+                  PARSER.scopes.add_name(base_name, "", verilog_scopet::MODULE_INSTANCE);
                   if(stack_expr($2).is_not_nil())
                   {
                     auto &range = stack_expr($$).add(ID_range);
@@ -3229,8 +3231,10 @@ name_of_instance:
                 }
         | any_identifier unpacked_dimension_brace
                 { init($$, ID_inst);
-                  stack_expr($$).set(ID_base_name, stack_expr($1).get(ID_base_name));
+                  auto base_name = stack_expr($1).get(ID_base_name);
+                  stack_expr($$).set(ID_base_name, base_name);
                   addswap($$, ID_verilog_instance_array, $2);
+                  PARSER.scopes.add_name(base_name, "", verilog_scopet::MODULE_INSTANCE);
                 }
         ;
 

--- a/src/verilog/verilog_scope.cpp
+++ b/src/verilog/verilog_scope.cpp
@@ -41,19 +41,20 @@ unsigned verilog_scopet::identifier_token() const
   switch(kind)
   {
   // clang-format off
-  case verilog_scopet::GLOBAL:    return TOK_NON_TYPE_IDENTIFIER;
-  case verilog_scopet::FILE:      return TOK_NON_TYPE_IDENTIFIER;
-  case verilog_scopet::PACKAGE:   return TOK_PACKAGE_IDENTIFIER;
-  case verilog_scopet::MODULE:    return TOK_NON_TYPE_IDENTIFIER;
-  case verilog_scopet::CLASS:     return TOK_CLASS_IDENTIFIER;
-  case verilog_scopet::BLOCK:     return TOK_NON_TYPE_IDENTIFIER;
-  case verilog_scopet::ENUM_NAME: return TOK_NON_TYPE_IDENTIFIER;
-  case verilog_scopet::TASK:      return TOK_NON_TYPE_IDENTIFIER;
-  case verilog_scopet::FUNCTION:  return TOK_NON_TYPE_IDENTIFIER;
-  case verilog_scopet::TYPEDEF:   return TOK_TYPE_IDENTIFIER;
-  case verilog_scopet::PROPERTY:  return TOK_NON_TYPE_IDENTIFIER;
-  case verilog_scopet::SEQUENCE:  return TOK_NON_TYPE_IDENTIFIER;
-  case verilog_scopet::OTHER:     return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::GLOBAL:          return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::FILE:            return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::PACKAGE:         return TOK_PACKAGE_IDENTIFIER;
+  case verilog_scopet::MODULE:          return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::CLASS:           return TOK_CLASS_IDENTIFIER;
+  case verilog_scopet::MODULE_INSTANCE: return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::BLOCK:           return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::ENUM_NAME:       return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::TASK:            return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::FUNCTION:        return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::TYPEDEF:         return TOK_TYPE_IDENTIFIER;
+  case verilog_scopet::PROPERTY:        return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::SEQUENCE:        return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::OTHER:           return TOK_NON_TYPE_IDENTIFIER;
     // clang-format on
   }
 

--- a/src/verilog/verilog_scope.h
+++ b/src/verilog/verilog_scope.h
@@ -24,6 +24,7 @@ struct verilog_scopet
     MODULE,
     CLASS,
     ENUM_NAME,
+    MODULE_INSTANCE,
     TASK,
     FUNCTION,
     BLOCK,


### PR DESCRIPTION
This changes the parser to add module instance names to the current scope, so they become usable in case there is a typedef of the same name in a higher scope.