### PR TITLE
Fixup for #1548: pop the scopes that were pushed

### DIFF
--- a/regression/verilog/SVA/property_vs_typedef1.desc
+++ b/regression/verilog/SVA/property_vs_typedef1.desc
@@ -1,7 +1,7 @@
 CORE
 property_vs_typedef1.sv
 
-^EXIT=10$
+^EXIT=0$
 ^SIGNAL=0$
 --
 --

--- a/regression/verilog/SVA/property_vs_typedef1.sv
+++ b/regression/verilog/SVA/property_vs_typedef1.sv
@@ -9,4 +9,7 @@ module main;
     1
   endproperty : some_name
 
+  // some_name is usable as a non-type identifier
+  assert property(some_name);
+
 endmodule

--- a/regression/verilog/SVA/sequence_vs_typedef1.desc
+++ b/regression/verilog/SVA/sequence_vs_typedef1.desc
@@ -1,7 +1,7 @@
 CORE
 sequence_vs_typedef1.sv
 
-^EXIT=10$
+^EXIT=0$
 ^SIGNAL=0$
 --
 --

--- a/regression/verilog/SVA/sequence_vs_typedef1.sv
+++ b/regression/verilog/SVA/sequence_vs_typedef1.sv
@@ -9,4 +9,7 @@ module main;
     1
   endsequence : some_name
 
+  // some_name is usable as a non-type identifier
+  assert property(some_name);
+
 endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2524,6 +2524,7 @@ property_declaration:
 		  auto base_name = stack_expr($2).get(ID_base_name);
 		  stack_expr($$).set(ID_base_name, base_name);
 		  mto($$, $6);
+		  pop_scope();
 		}
         ;
 
@@ -2721,6 +2722,7 @@ sequence_declaration:
 		{ $$=$2;
 		  stack_expr($$).set(ID_base_name, stack_expr($3).get(ID_base_name));
 		  mto($$, $7);
+		  pop_scope();
 		}
 	;
 


### PR DESCRIPTION
This adds the `pop_scope` forgotten in #1548.