### PR TITLE
SMV: split up `DEFINE x` and `ASSIGN x`

### DIFF
--- a/regression/smv/assign/assign_set2.desc
+++ b/regression/smv/assign/assign_set2.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE
 assign_set2.smv
 --bdd
 ^EXIT=0$
 ^SIGNAL=0$
 --
 --
-This does not type check.

--- a/regression/smv/define/define5.desc
+++ b/regression/smv/define/define5.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
+CORE
 define5.smv
 
 ^file .* line 6: variable `x' already defined.*$
-^EXIT=1$
+^EXIT=2$
 ^SIGNAL=0$
 --
 --

--- a/regression/smv/define/define6.desc
+++ b/regression/smv/define/define6.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
+CORE
 define6.smv
 
 ^file .* line 6: variable `x' already defined.*$
-^EXIT=1$
+^EXIT=2$
 ^SIGNAL=0$
 --
 --


### PR DESCRIPTION
This splits up the code paths used for `DEFINE x` and for `ASSIGN x`.  The latter have a given type, and also allow an implicit nondeterministic choice by using a set on the RHS of the assignment.