### PR TITLE
Add `verilog_parse_treet::dependencies(...)`

### DIFF
--- a/src/verilog/verilog_expr.cpp
+++ b/src/verilog/verilog_expr.cpp
@@ -94,9 +94,9 @@ void verilog_module_sourcet::show(std::ostream &out) const
 }
 
 static void
-dependencies_rec(const verilog_module_itemt &, std::vector<irep_idt> &);
+dependencies_rec(const verilog_module_itemt &, std::set<irep_idt> &);
 
-static void dependencies_rec(const exprt &expr, std::vector<irep_idt> &dest)
+static void dependencies_rec(const exprt &expr, std::set<irep_idt> &dest)
 {
   for(const_depth_iteratort it = expr.depth_cbegin(); it != expr.depth_cend();
       ++it)
@@ -104,29 +104,29 @@ static void dependencies_rec(const exprt &expr, std::vector<irep_idt> &dest)
     if(it->id() == ID_verilog_package_scope)
     {
       auto &package_scope_expr = to_verilog_package_scope_expr(*it);
-      dest.push_back(
+      dest.insert(
         verilog_package_identifier(package_scope_expr.package_base_name()));
     }
   }
 }
 
-static void dependencies_rec(const typet &type, std::vector<irep_idt> &dest)
+static void dependencies_rec(const typet &type, std::set<irep_idt> &dest)
 {
   if(type.id() == ID_verilog_package_scope)
   {
     auto &package_scope_type = to_verilog_package_scope_type(type);
-    dest.push_back(
+    dest.insert(
       verilog_package_identifier(package_scope_type.package_base_name()));
   }
 }
 
 static void dependencies_rec(
   const verilog_module_itemt &module_item,
-  std::vector<irep_idt> &dest)
+  std::set<irep_idt> &dest)
 {
   if(module_item.id() == ID_inst)
   {
-    dest.push_back(
+    dest.insert(
       verilog_module_symbol(to_verilog_inst(module_item).get_module()));
   }
   else if(module_item.id() == ID_generate_block)
@@ -149,7 +149,7 @@ static void dependencies_rec(
   {
     for(auto &import_item : module_item.get_sub())
     {
-      dest.push_back(
+      dest.insert(
         verilog_package_identifier(import_item.get(ID_verilog_package)));
     }
   }
@@ -241,9 +241,9 @@ static void dependencies_rec(
   }
 }
 
-std::vector<irep_idt> verilog_item_containert::dependencies() const
+std::set<irep_idt> verilog_item_containert::dependencies() const
 {
-  std::vector<irep_idt> result;
+  std::set<irep_idt> result;
 
   for(auto &item : items())
     dependencies_rec(item, result);

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -11,6 +11,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/std_expr.h>
 
+#include <set>
+
 /// A simple Verilog identifier, unqualified
 class verilog_identifier_exprt : public nullary_exprt
 {
@@ -2387,7 +2389,7 @@ public:
 
   // The identifiers of the modules and packages used
   // (not: the identifiers of the module instances)
-  std::vector<irep_idt> dependencies() const;
+  std::set<irep_idt> dependencies() const;
 };
 
 class verilog_interfacet : public verilog_item_containert

--- a/src/verilog/verilog_language.cpp
+++ b/src/verilog/verilog_language.cpp
@@ -134,18 +134,8 @@ void verilog_languaget::dependencies(
   const std::string &module,
   std::set<std::string> &dependency_set)
 {
-  verilog_parse_treet::item_mapt::const_iterator it =
-    parse_tree.item_map.find(id2string(verilog_item_key(module)));
-
-  if(it != parse_tree.item_map.end())
-  {
-    // dependencies on other Verilog modules or packages
-
-    const auto &item_container = *it->second;
-
-    for(auto &identifier : item_container.dependencies())
-      dependency_set.insert(id2string(identifier));
-  }
+  for(auto identifier : parse_tree.dependencies(module))
+    dependency_set.insert(id2string(identifier));
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_parse_tree.cpp
+++ b/src/verilog/verilog_parse_tree.cpp
@@ -77,6 +77,29 @@ void verilog_parse_treet::modules_provided(
 
 /*******************************************************************\
 
+Function: verilog_parse_treet::dependencies
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+std::set<irep_idt>
+verilog_parse_treet::dependencies(irep_idt item_identifier) const
+{
+  verilog_parse_treet::item_mapt::const_iterator it =
+    item_map.find(id2string(verilog_item_key(item_identifier)));
+
+  CHECK_RETURN(it != item_map.end());
+
+  return it->second->dependencies();
+}
+
+/*******************************************************************\
+
 Function: verilog_parse_treet::build_item_map
 
   Inputs:

--- a/src/verilog/verilog_parse_tree.h
+++ b/src/verilog/verilog_parse_tree.h
@@ -73,6 +73,9 @@ public:
   void modules_provided(
     std::set<std::string> &module_set) const;
 
+  /// get the dependencies of the item given by the identifier
+  std::set<irep_idt> dependencies(irep_idt item_identifier) const;
+
   // An index into the items list.
   // The key is
   //   package::name for packages


### PR DESCRIPTION
This adds a helper that returns the module and package dependencies of a module in a given parse tree with a given identifier.