### PR TITLE
SMV: move collection of enums from parser to type checker

### DIFF
--- a/src/smvlang/Makefile
+++ b/src/smvlang/Makefile
@@ -1,5 +1,6 @@
 SRC = smv_ebmc_language.cpp \
       smv_expr.cpp \
+      smv_index.cpp \
       smv_language.cpp \
       smv_parser.cpp \
       smv_typecheck.cpp \

--- a/src/smvlang/parser.y
+++ b/src/smvlang/parser.y
@@ -148,7 +148,6 @@ static smv_parse_treet::modulet &new_module(YYSTYPE &location, YYSTYPE &module_n
   const auto identifier=smv_module_symbol(base_name);
   PARSER.parse_tree.module_list.push_back(smv_parse_treet::modulet{});
   auto &module=PARSER.parse_tree.module_list.back();
-  PARSER.parse_tree.module_map[base_name] = --PARSER.parse_tree.module_list.end();
   module.identifier = identifier;
   module.base_name = base_name;
   module.source_location = stack_expr(location).source_location();
@@ -632,7 +631,6 @@ enumeration_type_body: enum_element
 enum_element: IDENTIFIER_Token
            {
              $$=$1;
-             PARSER.parse_tree.enum_set.insert(stack_expr($1).id_string());
              PARSER.module->add_enum(
                smv_identifier_exprt{stack_expr($1).id(), PARSER.source_location()});
            }

--- a/src/smvlang/smv_index.cpp
+++ b/src/smvlang/smv_index.cpp
@@ -1,0 +1,36 @@
+/*******************************************************************\
+
+Module: SMV Parse Tree Index
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#include "smv_index.h"
+
+#include "smv_expr.h"
+
+smv_indext::smv_indext(smv_parse_treet &parse_tree)
+{
+  // module map
+  for(auto module_it = parse_tree.module_list.begin();
+      module_it != parse_tree.module_list.end();
+      module_it++)
+  {
+    module_map[module_it->base_name] = module_it;
+  }
+
+  // enums
+  for(const auto &module : parse_tree.module_list)
+  {
+    for(const auto &element : module.elements)
+    {
+      if(element.is_enum())
+      {
+        const auto &identifier_expr = to_smv_identifier_expr(element.expr);
+        irep_idt base_name = identifier_expr.identifier();
+        enum_names.insert(base_name);
+      }
+    }
+  }
+}

--- a/src/smvlang/smv_index.h
+++ b/src/smvlang/smv_index.h
@@ -1,0 +1,32 @@
+/*******************************************************************\
+
+Module: SMV Parse Tree Index
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_SMV_INDEX_H
+#define CPROVER_SMV_INDEX_H
+
+#include "smv_parse_tree.h"
+
+#include <set>
+
+class smv_indext
+{
+public:
+  smv_indext() = default;
+  explicit smv_indext(smv_parse_treet &);
+
+  using module_listt = smv_parse_treet::module_listt;
+
+  // map from module base names into the module list
+  using module_mapt =
+    std::unordered_map<irep_idt, module_listt::iterator, irep_id_hash>;
+  module_mapt module_map;
+
+  std::set<irep_idt> enum_names;
+};
+
+#endif // CPROVER_SMV_INDEX_H

--- a/src/smvlang/smv_language.cpp
+++ b/src/smvlang/smv_language.cpp
@@ -62,20 +62,6 @@ void smv_languaget::dependencies(
   const std::string &module, 
   std::set<std::string> &module_set)
 {
-  auto m_it = smv_parse_tree.module_map.find(smv_module_base_name(module));
-
-  if(m_it == smv_parse_tree.module_map.end())
-    return;
-
-  const smv_parse_treet::modulet &smv_module = *m_it->second;
-
-  for(auto &element : smv_module.elements)
-    if(element.is_var() && element.expr.type().id() == ID_smv_module_instance)
-    {
-      auto base_name =
-        to_smv_module_instance_type(element.expr.type()).base_name();
-      module_set.insert(id2string(smv_module_symbol(base_name)));
-    }
 }
 
 /*******************************************************************\

--- a/src/smvlang/smv_parse_tree.cpp
+++ b/src/smvlang/smv_parse_tree.cpp
@@ -29,8 +29,6 @@ Function: smv_parse_treet::swap
 void smv_parse_treet::swap(smv_parse_treet &smv_parse_tree)
 {
   smv_parse_tree.module_list.swap(module_list);
-  smv_parse_tree.module_map.swap(module_map);
-  smv_parse_tree.enum_set.swap(enum_set);
 }
 
 /*******************************************************************\
@@ -47,7 +45,6 @@ Function: smv_parse_treet::clear
 
 void smv_parse_treet::clear()
 {
-  module_map.clear();
   module_list.clear();
 }
 

--- a/src/smvlang/smv_parse_tree.h
+++ b/src/smvlang/smv_parse_tree.h
@@ -25,8 +25,6 @@ public:
   // don't copy, contains pointers
   smv_parse_treet(const smv_parse_treet &) = delete;
 
-  typedef std::unordered_set<irep_idt, irep_id_hash> enum_sett;
-
   struct modulet
   {
     source_locationt source_location;
@@ -314,14 +312,6 @@ public:
 
   using module_listt = std::list<modulet>;
   module_listt module_list;
-
-  // map from module base names into the module list
-  using module_mapt =
-    std::unordered_map<irep_idt, module_listt::iterator, irep_id_hash>;
-  module_mapt module_map;
-
-  // enums are global
-  enum_sett enum_set;
 
   void swap(smv_parse_treet &);
   void clear();

--- a/src/smvlang/smv_typecheck.cpp
+++ b/src/smvlang/smv_typecheck.cpp
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "expr2smv.h"
 #include "smv_expr.h"
+#include "smv_index.h"
 #include "smv_range.h"
 #include "smv_types.h"
 
@@ -81,6 +82,7 @@ public:
 protected:
   smv_parse_treet &smv_parse_tree;
   symbol_table_baset &symbol_table;
+  smv_indext index;
   const std::string &module_identifier;
   bool do_spec;
 
@@ -297,9 +299,9 @@ void smv_typecheckt::instantiate(
   const source_locationt &location)
 {
   // Find the module
-  auto module_it = smv_parse_tree.module_map.find(module_base_name);
+  auto module_it = index.module_map.find(module_base_name);
 
-  if(module_it == smv_parse_tree.module_map.end())
+  if(module_it == index.module_map.end())
   {
     throw errort().with_location(location)
       << "submodule `" << module_base_name << "' not found";
@@ -346,9 +348,7 @@ void smv_typecheckt::instantiate(
             // It's a parameter
             expr = parameter_it->second;
           }
-          else if(
-            smv_parse_tree.enum_set.find(identifier) !=
-            smv_parse_tree.enum_set.end())
+          else if(index.enum_names.find(identifier) != index.enum_names.end())
           {
             // It's an enum, leave as is
           }
@@ -1934,8 +1934,7 @@ void smv_typecheckt::convert(exprt &expr)
       identifier.find("::") == std::string::npos, "conversion is done once");
 
     // enum or variable?
-    if(
-      smv_parse_tree.enum_set.find(identifier) == smv_parse_tree.enum_set.end())
+    if(index.enum_names.find(identifier) == index.enum_names.end())
     {
       std::string id = module_identifier + "::var::" + identifier;
 
@@ -2728,14 +2727,17 @@ void smv_typecheckt::typecheck()
   if(module_identifier != "smv::main")
     return;
 
+  // build the index
+  index = smv_indext{smv_parse_tree};
+
   // check all modules for duplicate identifiers
   for(auto &module : smv_parse_tree.module_list)
     variable_checks(module);
 
   auto module_base_name = smv_module_base_name(module_identifier);
-  auto it = smv_parse_tree.module_map.find(module_base_name);
+  auto it = index.module_map.find(module_base_name);
 
-  if(it == smv_parse_tree.module_map.end())
+  if(it == index.module_map.end())
   {
     throw errort() << "failed to find module " << module_base_name;
   }


### PR DESCRIPTION
This moves the construction of the module map and the collection of enum names from the SMV parser to the SMV type checker, using a new data structure named `smv_indext`.