### PR TITLE
Verilog: determine top-level module

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # EBMC 5.9
 
+* Verilog: use top-level module for verification, instead of "main"
 * Verilog: fix for four-valued | and &
 * Verilog: fix for typed parameter ports
 * Verilog: fix for the type of implicit nets for continous assignments

--- a/regression/verilog/modules/multiple_top_level_modules.desc
+++ b/regression/verilog/modules/multiple_top_level_modules.desc
@@ -1,0 +1,8 @@
+CORE
+multiple_top_level_modules.v
+
+activate-multi-line-match
+^multiple modules found, please select one:\n  moduleA\n  moduleB$
+^EXIT=1$
+^SIGNAL=0$
+--

--- a/regression/verilog/modules/multiple_top_level_modules.v
+++ b/regression/verilog/modules/multiple_top_level_modules.v
@@ -1,0 +1,5 @@
+module moduleA;
+endmodule
+
+module moduleB;
+endmodule

--- a/regression/verilog/primitive_gates/nand2.desc
+++ b/regression/verilog/primitive_gates/nand2.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
 nand2.sv
-
+--top main
 ^\[main\.nand_ok\] always !main\.nand_in1 == main\.nand_out: PROVED .*$
 ^\[main\.nand_is_reduction_nand\] always ~\&\{ main\.nand_in1 \} == main\.nand_out: PROVED .*$
 ^EXIT=0$

--- a/regression/verilog/primitive_gates/nor2.desc
+++ b/regression/verilog/primitive_gates/nor2.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
 nor2.sv
-
+--top main
 ^\[main\.nor_ok\] always !main\.nor_in1 == main\.nor_out: PROVED .*$
 ^\[main\.nor_is_reduction_nor\] always ~\|\{ main\.nor_in1 \} == main\.nor_out: PROVED .*$
 ^EXIT=0$

--- a/regression/verilog/primitive_gates/xnor1.desc
+++ b/regression/verilog/primitive_gates/xnor1.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
 xnor1.sv
-
+--top main
 ^\[main\.xnor_ok\] always !xor\(xor\(main\.xnor_in1, main\.xnor_in2\), main\.xnor_in3\) == main\.xnor_out: PROVED .*$
 ^\[main\.xnor_fail\] always main\.xnor_in1 == main\.xnor_in2 == main\.xnor_in3 == main\.xnor_out: REFUTED$
 ^\[main\.xnor_is_reduction_xnor\] always ~\^\{ main\.xnor_in1, main\.xnor_in2, main\.xnor_in3 \} == main\.xnor_out: PROVED .*$

--- a/regression/verilog/primitive_gates/xnor2.desc
+++ b/regression/verilog/primitive_gates/xnor2.desc
@@ -1,6 +1,6 @@
 CORE broken-smt-backend
 xnor2.sv
-
+--top main
 ^\[main\.xnor_ok\] always !main\.xnor_in1 == main\.xnor_out: PROVED .*$
 ^\[main\.xnor_is_reduction_xnor\] always ~\^\{ main\.xnor_in1 \} == main\.xnor_out: PROVED .*$
 ^EXIT=0$

--- a/src/verilog/verilog_ebmc_language.h
+++ b/src/verilog/verilog_ebmc_language.h
@@ -49,6 +49,9 @@ protected:
 
   parse_treest parse();
 
+  // base_name of the top-level module
+  irep_idt top_level_module(const parse_treest &) const;
+
   class modulet
   {
   public:


### PR DESCRIPTION
This commit re-implements the logic to determine the top-level module for constructing the model for a given Verilog design, as opposed to using the hard-wired name `main`.
    
1800-2017 23.3.1 gives a definition of "top-level modules" as those modules that are not instantiated.  An implicit instance is created for those.