### PR TITLE
KNOWNBUG tests for sets

### DIFF
--- a/regression/smv/expressions/case1.desc
+++ b/regression/smv/expressions/case1.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+case1.smv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This does not type check.

--- a/regression/smv/expressions/case1.smv
+++ b/regression/smv/expressions/case1.smv
@@ -1,0 +1,9 @@
+MODULE main
+
+VAR x : 1..10;
+
+SPEC !(4 in
+  case
+    x=1:  { 2, 3 };
+    TRUE: 1;
+  esac)

--- a/regression/smv/expressions/range1.desc
+++ b/regression/smv/expressions/range1.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+range1.smv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This does not parse.

--- a/regression/smv/expressions/range1.smv
+++ b/regression/smv/expressions/range1.smv
@@ -1,0 +1,5 @@
+MODULE main
+
+-- a .. b denots an integer range
+SPEC 2 in 1..3
+SPEC !(4 in 1..3)

--- a/regression/smv/expressions/smv_if3.desc
+++ b/regression/smv/expressions/smv_if3.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+smv_if3.smv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This does not type check.

--- a/regression/smv/expressions/smv_if3.smv
+++ b/regression/smv/expressions/smv_if3.smv
@@ -1,0 +1,6 @@
+MODULE main
+
+VAR x : 1..10;
+
+-- if allows sets
+SPEC !(4 in (x=1 ? { 2, 3 } : 1))


### PR DESCRIPTION
Both SMV `case` and `?:` accept sets as operands.