### PR TITLE
Verilog: construct `show_modulest` from parse trees

### DIFF
--- a/src/verilog/verilog_ebmc_language.h
+++ b/src/verilog/verilog_ebmc_language.h
@@ -35,17 +35,16 @@ public:
   // produce the transition system, and return it
   std::optional<transition_systemt> transition_system() override;
 
+  /// a Verilog parse tree forest
+  using parse_treet = verilog_parse_treet;
+  using parse_treest = std::list<parse_treet>;
+
 protected:
   void preprocess(const std::filesystem::path &, std::ostream &);
   void preprocess();
   verilog_parse_treet parse(const std::filesystem::path &);
   void show_parse(const std::filesystem::path &);
   void show_parse();
-
-  using parse_treet = verilog_parse_treet;
-
-  /// a Verilog parse tree forest
-  using parse_treest = std::list<parse_treet>;
 
   parse_treest parse();
 


### PR DESCRIPTION
The list of modules for `--show-modules` is now constructed directly from the parse tree forest, as opposed to going via the type checker and symbol table.