### PR TITLE
Verilog: elaboration per compilation unit

### DIFF
--- a/src/verilog/Makefile
+++ b/src/verilog/Makefile
@@ -6,6 +6,7 @@ SRC = aval_bval_encoding.cpp \
       verilog_bits.cpp \
       verilog_ebmc_language.cpp \
       verilog_elaborate.cpp \
+      verilog_elaborate_compilation_unit.cpp \
       verilog_elaborate_module_instances.cpp \
       verilog_elaborate_type.cpp \
       verilog_expr.cpp \

--- a/src/verilog/verilog_ebmc_language.h
+++ b/src/verilog/verilog_ebmc_language.h
@@ -67,6 +67,7 @@ protected:
 
   std::map<irep_idt, modulet> module_map;
 
+  symbol_tablet elaborate_compilation_units(const parse_treest &);
   transition_systemt typecheck(const parse_treest &, symbol_tablet &&);
   void typecheck_module(modulet &, symbol_tablet &);
 };

--- a/src/verilog/verilog_elaborate_compilation_unit.cpp
+++ b/src/verilog/verilog_elaborate_compilation_unit.cpp
@@ -1,0 +1,33 @@
+/*******************************************************************\
+
+Module: Elaboration of Verilog Compilation Units
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#include "verilog_elaborate_compilation_unit.h"
+
+#include "verilog_typecheck.h"
+
+void verilog_elaborate_compilation_unit(
+  const verilog_parse_treet &parse_tree,
+  symbol_table_baset &symbol_table,
+  message_handlert &message_handler)
+{
+  for(auto &item : parse_tree.items)
+  {
+    if(item.id() == ID_verilog_module || item.id() == ID_verilog_checker)
+    {
+      auto identifier =
+        verilog_module_symbol(to_verilog_module_source(item).base_name());
+      copy_module_source(item, identifier, symbol_table);
+    }
+    else if(item.id() == ID_verilog_package)
+    {
+      auto identifier =
+        verilog_package_identifier(to_verilog_module_source(item).base_name());
+      copy_module_source(item, identifier, symbol_table);
+    }
+  }
+}

--- a/src/verilog/verilog_elaborate_compilation_unit.h
+++ b/src/verilog/verilog_elaborate_compilation_unit.h
@@ -1,0 +1,23 @@
+/*******************************************************************\
+
+Module: Elaboration of Verilog Compilation Units
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_VERILOG_ELABORATE_COMPILATION_UNIT_H
+#define CPROVER_VERILOG_ELABORATE_COMPILATION_UNIT_H
+
+#include <util/message.h>
+#include <util/symbol_table_base.h>
+
+#include "verilog_parse_tree.h"
+
+/// throws ebmc_errort on failure
+void verilog_elaborate_compilation_unit(
+  const verilog_parse_treet &,
+  symbol_table_baset &,
+  message_handlert &);
+
+#endif // CPROVER_VERILOG_ELABORATE_UNIT_H


### PR DESCRIPTION
IEEE 1800 2017 3.12.1 requires compliant tools to compile "compilation units" separately, with a compilation unit scope.

This breaks out a function that elaborates a compilation unit by itself.