### PR TITLE
SMV: =, !=, <, >, <=, >= do not allow set types

### DIFF
--- a/regression/smv/expressions/equality1.desc
+++ b/regression/smv/expressions/equality1.desc
@@ -1,0 +1,7 @@
+CORE
+equality1.smv
+
+^file .* line 4: operator = does not allow set types$
+^EXIT=2$
+^SIGNAL=0$
+--

--- a/regression/smv/expressions/equality1.smv
+++ b/regression/smv/expressions/equality1.smv
@@ -1,0 +1,4 @@
+MODULE main
+
+-- SMV does not allow equality on set types
+SPEC { 1, 2 } = { 1, 2 };

--- a/src/smvlang/smv_typecheck.cpp
+++ b/src/smvlang/smv_typecheck.cpp
@@ -893,6 +893,11 @@ void smv_typecheckt::typecheck_expr_rec(exprt &expr, modet mode, bool next)
 
     typet op_type = type_union(op0.type(), op1.type(), expr.source_location());
 
+    // no set types
+    if(op_type.id() == ID_smv_set)
+      throw errort{}.with_location(expr.source_location())
+        << "operator " << expr.id() << " does not allow set types";
+
     convert_expr_to(op0, op_type);
     convert_expr_to(op1, op_type);
 


### PR DESCRIPTION
NuSMV does not allow the application of `=`, `!=`, `<`, `>`, `<=`, `>=` to set typed operands.