### PR TITLE
SMV: extract check for LTL/CTL operators

### DIFF
--- a/regression/smv/define/define_with_CTL.desc
+++ b/regression/smv/define/define_with_CTL.desc
@@ -1,0 +1,8 @@
+CORE
+define_with_CTL.smv
+
+^file .* line 4: CTL operator not permitted here$
+^EXIT=2$
+^SIGNAL=0$
+--
+--

--- a/regression/smv/define/define_with_CTL.smv
+++ b/regression/smv/define/define_with_CTL.smv
@@ -1,0 +1,10 @@
+MODULE main
+
+-- no temporal operators in DEFINEs
+DEFINE property := AG x=2;
+
+VAR x : 1..4;
+ASSIGN init(x) := 2;
+ASSIGN next(x) := x;
+
+CTLSPEC property


### PR DESCRIPTION
This moves the check for LTL/CTL operators into a separate method.