### PR TITLE
SMV: `smv_cases_exprt`

### DIFF
--- a/src/smvlang/smv_expr.cpp
+++ b/src/smvlang/smv_expr.cpp
@@ -26,3 +26,23 @@ smv_extend_exprt::smv_extend_exprt(exprt __op, std::size_t __size, typet __type)
       std::move(__type)}
 {
 }
+
+cond_exprt smv_cases_exprt::lower() const
+{
+  auto &cases = this->cases();
+
+  exprt::operandst cond_ops;
+  cond_ops.reserve(cases.size() * 2);
+
+  for(auto &case_expr : cases)
+  {
+    DATA_INVARIANT(
+      case_expr.operands().size() == 2, "case expected to have two operands");
+    cond_ops.push_back(case_expr.condition());
+    cond_ops.push_back(case_expr.value());
+  }
+
+  auto cond_expr = cond_exprt{cond_ops, type()};
+  cond_expr.add_source_location() = source_location();
+  return cond_expr;
+}

--- a/src/smvlang/smv_expr.h
+++ b/src/smvlang/smv_expr.h
@@ -493,4 +493,71 @@ inline smv_range_exprt &to_smv_range_expr(exprt &expr)
   return static_cast<smv_range_exprt &>(expr);
 }
 
+/// SMV's case ... esac expression
+class smv_cases_exprt : public multi_ary_exprt
+{
+public:
+  smv_cases_exprt() : multi_ary_exprt{ID_smv_cases, {}, typet{}}
+  {
+  }
+
+  class caset : public binary_exprt
+  {
+  public:
+    caset(exprt _condition, exprt _value)
+      : binary_exprt{std::move(_condition), ID_case, std::move(_value), typet{}}
+    {
+    }
+
+    const exprt &condition() const
+    {
+      return op0();
+    }
+
+    exprt &condition()
+    {
+      return op0();
+    }
+
+    const exprt &value() const
+    {
+      return op1();
+    }
+
+    exprt &value()
+    {
+      return op1();
+    }
+  };
+
+  using casest = std::vector<caset>;
+
+  const casest &cases() const
+  {
+    return (const casest &)(operands());
+  }
+
+  casest &cases()
+  {
+    return (casest &)(operands());
+  }
+
+  /// a lowering to a cond_exprt
+  cond_exprt lower() const;
+};
+
+inline const smv_cases_exprt &to_smv_cases_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_smv_cases);
+  smv_cases_exprt::check(expr, validation_modet::INVARIANT);
+  return static_cast<const smv_cases_exprt &>(expr);
+}
+
+inline smv_cases_exprt &to_smv_cases_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_smv_cases);
+  smv_cases_exprt::check(expr, validation_modet::INVARIANT);
+  return static_cast<smv_cases_exprt &>(expr);
+}
+
 #endif // CPROVER_SMV_EXPR_H

--- a/src/smvlang/smv_typecheck.cpp
+++ b/src/smvlang/smv_typecheck.cpp
@@ -2187,32 +2187,16 @@ void smv_typecheckt::convert(exprt &expr)
   }
   else if(expr.id() == ID_smv_cases) // cases
   {
-    if(expr.operands().size()<1)
+    auto &cases_expr = to_smv_cases_expr(expr);
+
+    if(cases_expr.cases().empty())
     {
-      throw errort().with_location(expr.find_source_location())
-        << "Expected at least one operand for " << expr.id() << " expression";
+      throw errort().with_location(cases_expr.source_location())
+        << "Expected at least one case for cases expression";
     }
 
-    exprt tmp;
-    tmp.operands().swap(expr.operands());
-    expr.reserve_operands(tmp.operands().size()*2);
-
-    for(auto &op : tmp.operands())
-    {
-      if(op.operands().size() != 2)
-      {
-        throw errort().with_location(op.find_source_location())
-          << "case expected to have two operands";
-      }
-
-      exprt &condition = to_binary_expr(op).op0();
-      exprt &value = to_binary_expr(op).op1();
-
-      expr.add_to_operands(std::move(condition));
-      expr.add_to_operands(std::move(value));
-    }
-
-    expr.id(ID_cond);
+    // rewrite into a 'cond' expression
+    expr = cases_expr.lower();
   }
 }
 


### PR DESCRIPTION
This adds a class for the existing SMV `case` ..  `esac` expression generated by the front-end.