### PR TITLE
Verilog: use `non_type_identifier` for module and checker identifiers

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -647,7 +647,8 @@ module_identifier_with_scope:
           module_identifier
           {
             $$ = $1;
-            push_scope(stack_expr($1).id(), ".", verilog_scopet::MODULE);
+            auto base_name = stack_expr($1).get(ID_base_name);
+            push_scope(base_name, ".", verilog_scopet::MODULE);
           }
         ;
 
@@ -3152,7 +3153,8 @@ name_of_gate_instance:
 module_instantiation:
           module_identifier parameter_value_assignment_opt hierarchical_instance_brace ';'
                 { init($$, ID_inst);
-                  addswap($$, ID_module, $1);
+                  auto base_name = stack_expr($1).get(ID_base_name);
+                  stack_expr($$).set(ID_module, base_name);
                   addswap($$, ID_parameter_assignments, $2);
                   swapop($$, $3); }
         ;
@@ -4765,7 +4767,7 @@ instance_identifier: TOK_NON_TYPE_IDENTIFIER;
 
 interface_identifier: TOK_NON_TYPE_IDENTIFIER;
 
-module_identifier: TOK_NON_TYPE_IDENTIFIER;
+module_identifier: non_type_identifier;
 
 topmodule_identifier: TOK_NON_TYPE_IDENTIFIER;
 
@@ -4776,7 +4778,7 @@ endmodule_identifier_opt:
 
 clocking_identifier: TOK_NON_TYPE_IDENTIFIER;
 
-checker_identifier: TOK_NON_TYPE_IDENTIFIER;
+checker_identifier: non_type_identifier;
 
 net_identifier: identifier;
 

--- a/src/verilog/verilog_parse_tree.cpp
+++ b/src/verilog/verilog_parse_tree.cpp
@@ -33,7 +33,7 @@ exprt verilog_parse_treet::create_module(
      ports.get_sub().front().is_nil())
     ports.clear();
 
-  verilog_module_sourcet new_module{name.id()};
+  verilog_module_sourcet new_module{name.get(ID_base_name)};
 
   new_module.add(ID_verilog_parameter_port_decls) =
     std::move(parameter_port_decls);


### PR DESCRIPTION
This replaces the direct use of a terminal for the module and checker identifiers by the `non_type_identifier` nonterminal.