### PR TITLE
Verilog: fix for function and task grammar

### DIFF
--- a/regression/verilog/functioncall/function_with_multiple_statements.desc
+++ b/regression/verilog/functioncall/function_with_multiple_statements.desc
@@ -1,0 +1,8 @@
+CORE
+function_with_multiple_statements.sv
+
+^\[.*\] always main\.foo\(\) == 123: PROVED .*$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/functioncall/function_with_multiple_statements.sv
+++ b/regression/verilog/functioncall/function_with_multiple_statements.sv
@@ -1,0 +1,12 @@
+module main;
+
+  function [31:0] foo;
+    // SystemVerilog allows multiple statements per body
+    reg [31:0] x;
+    x = 123;
+    foo = x;
+  endfunction;
+
+  assert final (foo() == 123);
+
+endmodule

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -633,7 +633,8 @@ void verilog_typecheckt::collect_symbols(
   for(auto &sub_decl : decl.declarations())
     collect_symbols(sub_decl);
 
-  collect_symbols(decl.body());
+  for(auto &statement : decl.body().statements())
+    collect_symbols(statement);
 
   function_or_task_name = "";
 }

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -1131,14 +1131,30 @@ public:
     return (const declarationst &)(find(ID_verilog_declarations).get_sub());
   }
 
-  verilog_statementt &body()
+  class bodyt : public exprt
   {
-    return static_cast<verilog_statementt &>(add(ID_body));
+  public:
+    using statementst = std::vector<verilog_statementt>;
+
+    statementst &statements()
+    {
+      return (statementst &)(operands());
+    }
+
+    const statementst &statements() const
+    {
+      return (const statementst &)(operands());
+    }
+  };
+
+  bodyt &body()
+  {
+    return static_cast<bodyt &>(add(ID_body));
   }
 
-  const verilog_statementt &body() const
+  const bodyt &body() const
   {
-    return static_cast<const verilog_statementt &>(find(ID_body));
+    return static_cast<const bodyt &>(find(ID_body));
   }
 };
 

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -463,7 +463,8 @@ exprt verilog_synthesist::expand_function_call(
     synth_statement(assignment);
   }
 
-  synth_statement(to_verilog_statement(symbol.value));
+  for(auto &statement : symbol.value.operands())
+    synth_statement(to_verilog_statement(statement));
 
   // replace function call by return value symbol
   const symbolt &return_symbol=
@@ -3139,7 +3140,8 @@ void verilog_synthesist::synth_function_call_or_task_enable(
       }
     }
 
-    synth_statement(to_verilog_statement(symbol.value));
+    for(auto &statement : symbol.value.operands())
+      synth_statement(to_verilog_statement(statement));
 
     // do assignments to output parameters
     for(unsigned i=0; i<parameters.size(); i++)

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -304,7 +304,8 @@ void verilog_typecheckt::convert_function_or_task(
   for(auto &inner_decl : decl.declarations())
     convert_decl(inner_decl);
 
-  convert_statement(decl.body());
+  for(auto &statement : decl.body().statements())
+    convert_statement(statement);
 
   function_or_task_name="";
   
@@ -348,8 +349,9 @@ exprt verilog_typecheckt::elaborate_constant_function_call(
   for(auto &inner_decl : decl.declarations())
     convert_decl(inner_decl);
 
-  convert_statement(decl.body());
-  
+  for(auto &statement : decl.body().statements())
+    convert_statement(statement);
+
   const code_typet &code_type=
     to_code_type(function_symbol.type);
 
@@ -387,7 +389,8 @@ exprt verilog_typecheckt::elaborate_constant_function_call(
   }
 
   // interpret it
-  verilog_interpreter(decl.body());
+  for(auto &statement : decl.body().statements())
+    verilog_interpreter(statement);
 
   function_or_task_name="";
   


### PR DESCRIPTION
This aligns the grammar for `function_body_declaration` and `task_declaration`
with 1800-2017, allowing multiple statements without `begin` ... `end`.
