### PR TITLE
Verilog: split parse tree copy and type checking

### DIFF
--- a/src/verilog/verilog_ebmc_language.h
+++ b/src/verilog/verilog_ebmc_language.h
@@ -48,6 +48,8 @@ protected:
 
   parse_treest parse();
 
+  void copy_parse_tree(const parse_treet &, symbol_tablet &);
+
   // base_name of the top-level module
   irep_idt top_level_module(const parse_treest &) const;
 
@@ -65,7 +67,7 @@ protected:
 
   std::map<irep_idt, modulet> module_map;
 
-  transition_systemt typecheck(const parse_treest &);
+  transition_systemt typecheck(const parse_treest &, symbol_tablet &&);
   void typecheck_module(modulet &, symbol_tablet &);
 };
 

--- a/src/verilog/verilog_language.cpp
+++ b/src/verilog/verilog_language.cpp
@@ -173,27 +173,7 @@ bool verilog_languaget::typecheck(
   const std::string &module,
   message_handlert &message_handler)
 {
-  if(module=="") return false;
-
-  if(verilog_typecheck(
-       parse_tree, symbol_table, module, warn_implicit_nets, message_handler))
-    return true;
-
-  messaget message(message_handler);
-  message.debug() << "Synthesis " << module << messaget::eom;
-
-  if(verilog_synthesis(
-       symbol_table,
-       module,
-       parse_tree.standard,
-       ignore_initial,
-       initial_zero,
-       message_handler))
-  {
-    return true;
-  }
-
-  return false;
+  return true;
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -2057,32 +2057,17 @@ Function: verilog_typecheck
 \*******************************************************************/
 
 bool verilog_typecheck(
-  const verilog_parse_treet &parse_tree,
   symbol_table_baset &symbol_table,
   const irep_idt &module_identifier,
+  verilog_standardt standard,
   bool warn_implicit_nets,
   message_handlert &message_handler)
 {
-  verilog_parse_treet::item_mapt::const_iterator it =
-    parse_tree.item_map.find(id2string(verilog_item_key(module_identifier)));
-
-  if(it == parse_tree.item_map.end())
-  {
-    messaget message(message_handler);
-    message.error() << "module `" << module_identifier << "' not found"
-                    << messaget::eom;
-    return true;
-  }
-
-  auto &new_symbol =
-    copy_module_source(*it->second, module_identifier, symbol_table);
+  auto symbol = symbol_table.get_writeable(module_identifier);
+  CHECK_RETURN(symbol != nullptr);
 
   verilog_typecheckt verilog_typecheck(
-    parse_tree.standard,
-    warn_implicit_nets,
-    new_symbol,
-    symbol_table,
-    message_handler);
+    standard, warn_implicit_nets, *symbol, symbol_table, message_handler);
 
   return verilog_typecheck.typecheck_main();
 }

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -20,23 +20,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "verilog_typecheck_expr.h"
 
 bool verilog_typecheck(
-  const verilog_parse_treet &parse_tree,
   symbol_table_baset &,
   const irep_idt &module_identifier,
+  verilog_standardt,
   bool warn_implicit_nets,
   message_handlert &message_handler);
-
-bool verilog_typecheck(
-  symbol_table_baset &,
-  const irep_idt &module_identifier,
-  const exprt::operandst &parameters,
-  message_handlert &message_handler);
-
-bool verilog_typecheck(
-  symbol_table_baset &,
-  const verilog_packaget &verilog_package,
-  verilog_standardt,
-  message_handlert &);
 
 /// copies the source of the given Verilog module or package
 /// into the symbol table


### PR DESCRIPTION
This splits up the Verilog type checking into a separate phase that copies the parse tree and the type checking itself.