### PR TITLE
KNOWNBUGs for loop index declaration and SMV conversion

### DIFF
--- a/regression/ebmc/smv-netlist/array_assignment.desc
+++ b/regression/ebmc/smv-netlist/array_assignment.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+array_assignment.sv
+--reset rst --smv-netlist 
+
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Outputs an SMV with an undeclared nondet. When declaring the nondet, nuXmv falsifies the property depsite it being correct.
+

--- a/regression/ebmc/smv-netlist/array_assignment.sv
+++ b/regression/ebmc/smv-netlist/array_assignment.sv
@@ -1,0 +1,12 @@
+module main(input clk, input rst);
+
+logic data [1:0];
+
+always_ff @(posedge clk) begin
+    data[1] <= 1'b1;
+end
+
+assert property(@(posedge clk) disable iff (rst) data[1]);
+
+endmodule
+

--- a/regression/ebmc/smv-netlist/assignment.desc
+++ b/regression/ebmc/smv-netlist/assignment.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+assignment.sv
+--smv-netlist
+^EXIT=0$
+^SIGNAL=0$
+--
+^LTLSPEC G TRUE$
+--
+Outputs "LTLSPEC G TRUE" despite the property being incorrect.
+

--- a/regression/ebmc/smv-netlist/assignment.sv
+++ b/regression/ebmc/smv-netlist/assignment.sv
@@ -1,0 +1,16 @@
+module main(some_input);
+
+input wire [1:0]  some_input;
+logic  [1:0]      data;
+
+
+assign data[0] = some_input[0];
+assign data[1] = some_input[1] & ~data[0];
+
+   
+
+assert property( !data[1]);
+
+   
+endmodule 
+

--- a/regression/verilog/for/for_variable_declaration.desc
+++ b/regression/verilog/for/for_variable_declaration.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+for_variable_declaration.sv
+
+^EXIT=10$
+^SIGNAL=0$
+^no properties
+--
+--
+Declaration of loop index in for-loop header is not recognized
+

--- a/regression/verilog/for/for_variable_declaration.sv
+++ b/regression/verilog/for/for_variable_declaration.sv
@@ -1,0 +1,16 @@
+module main;
+
+
+logic [1:0] some_logic;
+
+
+always_comb begin
+    for (int i=0; i<2; i++) begin     // i cannot be defined in the loop header
+        some_logic[i] <= 1'b0;
+    end
+end
+
+endmodule
+
+
+

--- a/regression/verilog/generate/gen_for_variable_declaration.desc
+++ b/regression/verilog/generate/gen_for_variable_declaration.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+gen_for_variable_declaration.sv
+
+^EXIT=10$
+^SIGNAL=0$
+^no properties
+--
+-- 
+Does not recognize declaration of genvar inside generate-for header
+

--- a/regression/verilog/generate/gen_for_variable_declaration.sv
+++ b/regression/verilog/generate/gen_for_variable_declaration.sv
@@ -1,0 +1,12 @@
+module main;
+
+
+generate 
+    for (genvar i=0; i<2; i++) begin     // i cannot be defined in the loop header
+        logic some_logic;
+    end
+endgenerate
+
+endmodule
+
+


### PR DESCRIPTION
This PR adds three testcases covering:
1. Loop variable declaration in a for-loop header
2. Genvar declaration in a generate-for header
3. A case where using --smv-netlist together with --buechi produces an SMV that, when translated to AIG, yields a provable property