### PR TITLE
Verilog: allow `genvar` declaration in initialization of `generate for`

### DIFF
--- a/regression/verilog/generate/gen_for_variable_declaration.desc
+++ b/regression/verilog/generate/gen_for_variable_declaration.desc
@@ -1,10 +1,8 @@
-KNOWNBUG
+CORE
 gen_for_variable_declaration.sv
 
 ^EXIT=10$
 ^SIGNAL=0$
-^no properties
+^no properties$
 --
 -- 
-Does not recognize declaration of genvar inside generate-for header
-

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3328,6 +3328,13 @@ genvar_expression: constant_expression;
 genvar_initialization:
           genvar_identifier '=' constant_expression
                 { init($$, ID_generate_assign); mto($$, $1); mto($$, $3); }
+        | TOK_GENVAR genvar_identifier '=' constant_expression
+                { init($$, ID_verilog_generate_decl);
+                  PARSER.scopes.add_name(stack_expr($2).get(ID_base_name), "", verilog_scopet::OTHER);
+                  stack_expr($2).id(ID_declarator);
+                  addswap($2, ID_value, $4);
+                  mto($$, $2);
+                }
         ;
 
 genvar_iteration:

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -938,9 +938,7 @@ verilog_typecheckt::elaborate_level(const module_itemst &module_items)
     {
       // elaborate_generate_item calls elaborate_level
       // recursively.
-      auto generated_items = elaborate_generate_item(module_item);
-      result.insert(
-        result.end(), generated_items.begin(), generated_items.end());
+      elaborate_generate_item(module_item, result);
     }
     else
       result.push_back(module_item);

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -17,14 +17,28 @@ Author: Daniel Kroening, kroening@kroening.com
 class verilog_identifier_exprt : public nullary_exprt
 {
 public:
+  explicit verilog_identifier_exprt(const irep_idt _base_name)
+    : nullary_exprt{ID_verilog_identifier, typet{}}
+  {
+    base_name(_base_name);
+  }
+
   const irep_idt &base_name() const
   {
     return get(ID_base_name);
   }
 
-  void identifier(irep_idt _base_name)
+  void base_name(irep_idt _base_name)
   {
     set(ID_base_name, _base_name);
+  }
+
+  /// Add the source location from \p location, if it is non-nil.
+  verilog_identifier_exprt &&with_source_location(source_locationt location) &&
+  {
+    if(location.is_not_nil())
+      add_source_location() = std::move(location);
+    return std::move(*this);
   }
 };
 
@@ -485,6 +499,13 @@ public:
     return result;
   }
 
+  // helper to generate a verilog_identifier expression
+  verilog_identifier_exprt verilog_identifier_expr() const
+  {
+    return verilog_identifier_exprt{base_name()}.with_source_location(
+      source_location());
+  }
+
   // Helper to merge the declarator's unpacked array type
   // with the declaration type.
   typet merged_type(const typet &declaration_type) const;
@@ -680,9 +701,9 @@ public:
   {
   }
 
-  const verilog_generate_assignt &init() const
+  const verilog_module_itemt &init() const
   {
-    return static_cast<const verilog_generate_assignt &>(op0());
+    return static_cast<const verilog_module_itemt &>(op0());
   }
 
   const exprt &cond() const

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -222,7 +222,8 @@ protected:
   void elaborate_generate_block(
     const verilog_generate_blockt &,
     module_itemst &dest);
-  module_itemst elaborate_generate_item(const verilog_module_itemt &);
+  [[nodiscard]] module_itemst
+  elaborate_generate_item(const verilog_module_itemt &);
   void
   elaborate_generate_item(const verilog_module_itemt &src, module_itemst &dest);
   void elaborate_generate_if(const verilog_generate_ift &, module_itemst &dest);
@@ -231,7 +232,8 @@ protected:
   void elaborate_generate_decl(const verilog_generate_declt &, module_itemst &);
   void
   elaborate_generate_for(const verilog_generate_fort &, module_itemst &dest);
-  exprt generate_for_loop_index(const exprt &initialization_statement) const;
+  exprt
+  generate_for_loop_index(const verilog_module_itemt &initialization) const;
 
   // generate state
   typedef std::map<irep_idt, mp_integer> genvarst;


### PR DESCRIPTION
The Verilog front-end now allows declarations of `genvar` variables in the initialisation section of generate for loops.