### PR TITLE
SystemVerilog: `for` with variable declaration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * SystemVerilog: type parameter ports
 * SystemVerilog: fix for checkers with multiple ports
 * SystemVerilog: for loops with multiple initializations
+* SystemVerilog: for loops with variable declarations
 * SMV: word constants
 * SMV: IVAR declarations
 * SMV: bit selection operator

--- a/regression/verilog/for/for_variable_declaration.desc
+++ b/regression/verilog/for/for_variable_declaration.desc
@@ -1,10 +1,8 @@
-KNOWNBUG
+CORE
 for_variable_declaration.sv
 
+^no properties$
 ^EXIT=10$
 ^SIGNAL=0$
-^no properties
 --
 --
-Declaration of loop index in for-loop header is not recognized
-

--- a/regression/verilog/for/for_variable_declaration.sv
+++ b/regression/verilog/for/for_variable_declaration.sv
@@ -1,16 +1,11 @@
 module main;
 
+  logic [1:0] some_logic;
 
-logic [1:0] some_logic;
-
-
-always_comb begin
-    for (int i=0; i<2; i++) begin     // i cannot be defined in the loop header
-        some_logic[i] <= 1'b0;
+  always_comb begin
+    for (int i=0; i<2; i++) begin
+      some_logic[i] <= 1'b0;
     end
-end
+  end
 
 endmodule
-
-
-

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -4045,6 +4045,35 @@ for_initialization:
                   for(auto &assignment : assignments)
                     assignment.id(ID_verilog_blocking_assign);
                 }
+        | for_variable_declaration_brace
+        ;
+
+for_variable_declaration_brace:
+          for_variable_declaration
+                { init($$); mto($$, $1); }
+        | for_variable_declaration_brace ',' for_variable_declaration
+                { $$ = $1; mto($$, $3); }
+        ;
+
+for_variable_declaration:
+          data_type variable_identifier '=' expression
+                { // these create a scope -- unlike for loops without declaration
+                  init($$, ID_decl);
+                  stack_expr($$).set(ID_class, ID_var);
+                  addswap($$, ID_type, $1);
+                  stack_expr($2).id(ID_declarator);
+                  addswap($2, ID_value, $4);
+                  mto($$, $2);
+                }
+        | TOK_VAR data_type variable_identifier '=' expression
+                { // these create a scope -- unlike for loops without declaration
+                  init($$, ID_decl);
+                  stack_expr($$).set(ID_class, ID_var);
+                  addswap($$, ID_type, $2);
+                  stack_expr($3).id(ID_declarator);
+                  addswap($3, ID_value, $5);
+                  mto($$, $3);
+                }
         ;
 
 for_step: for_step_assignment

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -726,7 +726,12 @@ void verilog_typecheckt::collect_symbols(const verilog_statementt &statement)
   }
   else if(statement.id() == ID_for)
   {
-    collect_symbols(to_verilog_for(statement).body());
+    auto &for_statement = to_verilog_for(statement);
+
+    for(auto &init_statement : for_statement.initialization())
+      collect_symbols(init_statement);
+
+    collect_symbols(for_statement.body());
   }
   else if(statement.id() == ID_forever)
   {


### PR DESCRIPTION
This adds the 1800-2017 grammar rules for `for_initialization`, allowing `for` loops with variable declarations.