### PR TITLE
SystemVerilog: multiple assignments for `for` initialization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * SystemVerilog: fix for type parameters
 * SystemVerilog: type parameter ports
 * SystemVerilog: fix for checkers with multiple ports
+* SystemVerilog: for loops with multiple initializations
 * SMV: word constants
 * SMV: IVAR declarations
 * SMV: bit selection operator

--- a/regression/verilog/for/multiple_init.desc
+++ b/regression/verilog/for/multiple_init.desc
@@ -1,0 +1,8 @@
+CORE
+multiple_init.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/for/multiple_init.sv
+++ b/regression/verilog/for/multiple_init.sv
@@ -1,0 +1,11 @@
+module main;
+
+  initial begin
+    int i, j;
+    for(i = 0, j = 1; i < 10; i++) begin
+    end
+    assert(i==10);
+    assert(j==1);
+  end
+
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3565,6 +3565,13 @@ list_of_net_assignments:
                 { $$=$1;    mto($$, $3); }
         ;
 
+list_of_variable_assignments:
+          variable_assignment
+                { init($$); mto($$, $1); }
+        | list_of_variable_assignments ',' variable_assignment
+                { $$=$1;    mto($$, $3); }
+        ;
+
 net_assignment: net_lvalue '=' expression
                 { init($$, ID_equal); mto($$, $1); mto($$, $3); }
         ;
@@ -4019,7 +4026,14 @@ loop_statement:
                 { init($$, ID_for); mto($$, $3); mto($$, $5); mto($$, $7); mto($$, $9); }
         ;
 
-for_initialization: blocking_assignment
+for_initialization:
+          list_of_variable_assignments
+                { // Turn the variable_assignments into statements
+                  // by changing the id to ID_verilog_blocking_assign
+                  auto &assignments = stack_expr($1).operands();
+                  for(auto &assignment : assignments)
+                    assignment.id(ID_verilog_blocking_assign);
+                }
         ;
 
 for_step: for_step_assignment

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -1601,15 +1601,17 @@ public:
   {
     operands().resize(4);
   }
-  
-  verilog_statementt &initialization()
+
+  using statementst = std::vector<verilog_statementt>;
+
+  statementst &initialization()
   {
-    return static_cast<verilog_statementt &>(op0());
+    return (statementst &)(op0().operands());
   }
 
-  const verilog_statementt &initialization() const
+  const statementst &initialization() const
   {
-    return static_cast<const verilog_statementt &>(op0());
+    return (const statementst &)(op0().operands());
   }
   
   exprt &condition()

--- a/src/verilog/verilog_interpreter.cpp
+++ b/src/verilog/verilog_interpreter.cpp
@@ -58,8 +58,9 @@ void verilog_typecheckt::verilog_interpreter(
   {
     const verilog_fort &verilog_for=to_verilog_for(statement);
 
-    verilog_interpreter(verilog_for.initialization());
-    
+    for(auto &init : verilog_for.initialization())
+      verilog_interpreter(init);
+
     while(true)
     {
       exprt cond = elaborate_constant_expression(verilog_for.condition());

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -2921,7 +2921,8 @@ void verilog_synthesist::synth_for(const verilog_fort &statement)
       << "for expected to have four operands";
   }
 
-  synth_statement(statement.initialization());
+  for(auto &init : statement.initialization())
+    synth_statement(init);
 
   while(true)
   {

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1391,7 +1391,8 @@ void verilog_typecheckt::convert_for(verilog_fort &statement)
       << "for expected to have four operands";
   }
 
-  convert_statement(statement.initialization());
+  for(auto &init : statement.initialization())
+    convert_statement(init);
 
   exprt &condition=statement.condition();
   convert_expr(condition);


### PR DESCRIPTION
1800-2017 allows multiple assignments in the initialization part of `for` loops.