### PR TITLE
Verilog: add genvars to the scope

### DIFF
--- a/regression/verilog/generate/genvar-vs-typedef1.desc
+++ b/regression/verilog/generate/genvar-vs-typedef1.desc
@@ -1,0 +1,6 @@
+CORE
+genvar-vs-typedef1.sv
+
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/verilog/generate/genvar-vs-typedef1.sv
+++ b/regression/verilog/generate/genvar-vs-typedef1.sv
@@ -1,0 +1,12 @@
+module main;
+
+  typedef int some_identifier;
+
+  generate
+    if(1) begin : some_block_label
+      genvar some_identifier;
+      for(some_identifier = 0; some_identifier < 10; some_identifier++);
+    end
+  endgenerate
+
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1938,13 +1938,17 @@ delay_value:
 // A.2.3 Declaration lists
 
 list_of_genvar_identifiers:
-          genvar_identifier
+          // must be any_identifier to allow re-use of typedef identifiers
+          any_identifier
                 { init($$);
+                  PARSER.scopes.add_name(stack_expr($1).get(ID_base_name), "", verilog_scopet::OTHER);
                   stack_expr($1).id(ID_declarator);
                   mto($$, $1);
                 }
-        | list_of_genvar_identifiers ',' genvar_identifier
+          // must be any_identifier to allow re-use of typedef identifiers
+        | list_of_genvar_identifiers ',' any_identifier
                 { $$=$1;
+                  PARSER.scopes.add_name(stack_expr($3).get(ID_base_name), "", verilog_scopet::OTHER);
                   stack_expr($3).id(ID_declarator);
                   mto($$, $3);
                 }


### PR DESCRIPTION
This adds `genvar` declaration identifiers to the scope, enabling re-use of `typedef` identifiers.