### PR TITLE
extract `verilog_typecheckt::parameterized_module_identifier(...)`

### DIFF
--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -108,6 +108,10 @@ protected:
     const exprt::operandst &parameter_assignment,
     const std::map<irep_idt, exprt> &defparams);
 
+  irep_idt parameterized_module_identifier(
+    const irep_idt &module_identifier,
+    const std::list<exprt> &parameter_values) const;
+
   std::vector<verilog_parameter_declt::declaratort>
   get_parameter_declarators(const verilog_module_sourcet &);
 


### PR DESCRIPTION
This extracts a method that constructs the identifier of a parameterization of a Verilog module.