### PR TITLE
SMV netlists: output in-state constraints

### DIFF
--- a/regression/ebmc/smv-netlist/invar1.desc
+++ b/regression/ebmc/smv-netlist/invar1.desc
@@ -1,0 +1,9 @@
+CORE
+invar1.smv
+--smv-netlist
+^VAR smv\.main\.var\.x: boolean;$
+^INVAR smv\.main\.var\.x$
+^CTLSPEC AG smv\.main\.var\.x$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv-netlist/invar1.smv
+++ b/regression/ebmc/smv-netlist/invar1.smv
@@ -1,0 +1,7 @@
+MODULE main
+
+VAR x : boolean;
+
+INVAR x
+
+SPEC AG x

--- a/src/trans-netlist/smv_netlist.cpp
+++ b/src/trans-netlist/smv_netlist.cpp
@@ -224,6 +224,20 @@ void smv_netlist(const netlistt &netlist, std::ostream &out)
   }
 
   out << '\n';
+  out << "-- in-state constraints" << '\n';
+  out << '\n';
+
+  for(auto &constraint_l : netlist.constraints)
+  {
+    if(!constraint_l.is_true())
+    {
+      out << "INVAR ";
+      print_smv(netlist, out, constraint_l);
+      out << '\n';
+    }
+  }
+
+  out << '\n';
   out << "-- TRANS" << '\n';
   out << '\n';
 


### PR DESCRIPTION
The SMV netlist output now includes in-state constraints.