### PR TITLE
Fixup for test oracle in #1575

### DIFF
--- a/regression/ebmc/smv-netlist/array_assignment.desc
+++ b/regression/ebmc/smv-netlist/array_assignment.desc
@@ -5,6 +5,7 @@ array_assignment.sv
 ^EXIT=0$
 ^SIGNAL=0$
 --
+nondet
 --
 Outputs an SMV with an undeclared nondet. When declaring the nondet, nuXmv falsifies the property depsite it being correct.
 


### PR DESCRIPTION
This avoids a KNOWNBUG CI failure on
`regression/ebmc/smv-netlist/array_assignment.desc`.