### PR TITLE
extract `var_mapt::record_as_nondet`

### DIFF
--- a/src/trans-netlist/trans_to_netlist.cpp
+++ b/src/trans-netlist/trans_to_netlist.cpp
@@ -391,14 +391,7 @@ void convert_trans_to_netlistt::operator()(
         dest.var_map.reverse_map.find(n);
       
       if(it==dest.var_map.reverse_map.end())
-      {
-        bv_varidt varid{"nondet", dest.var_map.nondets.size()};
-        var_mapt::vart &var=dest.var_map.map[varid.id];
-        var.add_bit().current=literalt(n, false);
-        var.vartype=var_mapt::vart::vartypet::NONDET;
-        dest.var_map.reverse_map.emplace(n, varid);
-        dest.var_map.nondets.insert(n);
-      }
+        dest.var_map.record_as_nondet(n);
     }
   }
 }

--- a/src/trans-netlist/var_map.cpp
+++ b/src/trans-netlist/var_map.cpp
@@ -13,6 +13,28 @@ Author: Daniel Kroening, kroening@kroening.com
 
 /*******************************************************************\
 
+Function: var_mapt::record_as_nondet
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void var_mapt::record_as_nondet(literalt::var_not var_no)
+{
+  bv_varidt varid{"nondet", nondets.size()};
+  var_mapt::vart &var = map[varid.id];
+  var.add_bit().current = literalt(var_no, false);
+  var.vartype = var_mapt::vart::vartypet::NONDET;
+  reverse_map.emplace(var_no, varid);
+  nondets.insert(var_no);
+}
+
+/*******************************************************************\
+
 Function: var_mapt::add
 
   Inputs:

--- a/src/trans-netlist/var_map.h
+++ b/src/trans-netlist/var_map.h
@@ -55,7 +55,10 @@ public:
     {
     }
   };
-  
+
+  /// record variable given by its number as nondet
+  void record_as_nondet(literalt::var_not);
+
   void add(const irep_idt &id, unsigned bit_nr, const vart &var);
   
   void build_reverse_map();


### PR DESCRIPTION
This extracts the code that records a variable given by its number as nondet in the variable map.