### PR TITLE
extract `convert_trans_to_netlistt::build_var_map` into separate file

### DIFF
--- a/src/trans-netlist/Makefile
+++ b/src/trans-netlist/Makefile
@@ -2,6 +2,7 @@ SRC = aig.cpp \
       aig_prop.cpp \
       aig_terminals.cpp \
       bmc_map.cpp \
+      build_netlist_var_map.cpp \
       bv_varid.cpp \
       compute_ct.cpp \
       counterexample_netlist.cpp \

--- a/src/trans-netlist/build_netlist_var_map.cpp
+++ b/src/trans-netlist/build_netlist_var_map.cpp
@@ -1,0 +1,81 @@
+/*******************************************************************\
+
+Module: var_map for Netlist
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#include "build_netlist_var_map.h"
+
+#include <util/namespace.h>
+
+#include <solvers/flattening/boolbv_width.h>
+
+var_mapt
+build_netlist_var_map(symbol_table_baset &symbol_table, const irep_idt &module)
+{
+  const namespacet ns{symbol_table};
+  boolbv_widtht boolbv_width(ns);
+  var_mapt var_map;
+
+  auto update_dest_var_map = [&var_map, &boolbv_width](const symbolt &symbol)
+  {
+    var_mapt::vart::vartypet vartype;
+
+    if(symbol.is_property)
+      return; // ignore properties
+    else if(
+      symbol.type.id() == ID_verilog_sva_named_sequence ||
+      symbol.type.id() == ID_verilog_sva_named_property)
+    {
+      return; // ignore sequence/property declarations
+    }
+    else if(
+      symbol.type.id() == ID_natural || symbol.type.id() == ID_integer ||
+      symbol.type.id() == ID_verilog_genvar)
+    {
+      return; // ignore
+    }
+    else if(symbol.type.id() == ID_smv_set)
+    {
+      return; // ignore
+    }
+    else if(
+      symbol.type.id() == ID_module || symbol.type.id() == ID_module_instance ||
+      symbol.type.id() == ID_primitive_module_instance ||
+      symbol.type.id() == ID_smv_module_instance)
+    {
+      return; // ignore modules
+    }
+    else if(symbol.type.id() == ID_named_block)
+    {
+      return; // ignore Verilog named blocks
+    }
+    else if(symbol.is_type)
+      return; // ignore types
+    else if(symbol.is_input)
+      vartype = var_mapt::vart::vartypet::INPUT;
+    else if(symbol.is_state_var)
+      vartype = var_mapt::vart::vartypet::LATCH;
+    else
+      vartype = var_mapt::vart::vartypet::WIRE;
+
+    std::size_t size = boolbv_width(symbol.type);
+
+    if(size == 0)
+      return;
+
+    var_mapt::vart &var = var_map.map[symbol.name];
+    var.vartype = vartype;
+    var.type = symbol.type;
+    var.mode = symbol.mode;
+    var.bits.resize(size);
+  };
+
+  for(const auto &symbol_it : symbol_table.symbols)
+    if(symbol_it.second.module == module)
+      update_dest_var_map(symbol_it.second);
+
+  return var_map;
+}

--- a/src/trans-netlist/build_netlist_var_map.h
+++ b/src/trans-netlist/build_netlist_var_map.h
@@ -1,0 +1,18 @@
+/*******************************************************************\
+
+Module: var_map for Netlist
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_TRANS_NETLIST_BUILD_NETLIST_VAR_MAP_H
+#define CPROVER_TRANS_NETLIST_BUILD_NETLIST_VAR_MAP_H
+
+#include <util/symbol_table_base.h>
+
+#include "var_map.h"
+
+var_mapt build_netlist_var_map(symbol_table_baset &, const irep_idt &module);
+
+#endif

--- a/src/trans-netlist/trans_to_netlist.cpp
+++ b/src/trans-netlist/trans_to_netlist.cpp
@@ -26,6 +26,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <verilog/sva_expr.h>
 
 #include "aig_prop.h"
+#include "build_netlist_var_map.h"
 #include "netlist.h"
 #include "netlist_boolbv.h"
 
@@ -149,8 +150,6 @@ protected:
 
   std::optional<exprt> convert_property(const exprt &);
 
-  var_mapt build_var_map(const irep_idt &module);
-
   void allocate_state_variables(netlistt &);
 };
 
@@ -186,84 +185,6 @@ literalt convert_trans_to_netlistt::new_input()
   bit.current=dest.new_var_node();
   bit.next=const_literal(false); // just to fill it
   return bit.current;
-}
-
-/*******************************************************************\
-
-Function: convert_trans_to_netlistt::build_var_map
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-var_mapt convert_trans_to_netlistt::build_var_map(const irep_idt &module)
-{
-  boolbv_widtht boolbv_width(ns);
-  var_mapt var_map;
-
-  auto update_dest_var_map = [&var_map, &boolbv_width](const symbolt &symbol)
-  {
-    var_mapt::vart::vartypet vartype;
-
-    if (symbol.is_property)
-      return; // ignore properties
-    else if(
-      symbol.type.id() == ID_verilog_sva_named_sequence ||
-      symbol.type.id() == ID_verilog_sva_named_property)
-    {
-      return; // ignore sequence/property declarations
-    }
-    else if(
-      symbol.type.id() == ID_natural || symbol.type.id() == ID_integer ||
-      symbol.type.id() == ID_verilog_genvar)
-    {
-      return; // ignore
-    }
-    else if(symbol.type.id() == ID_smv_set)
-    {
-      return; // ignore
-    }
-    else if(
-      symbol.type.id() == ID_module || symbol.type.id() == ID_module_instance ||
-      symbol.type.id() == ID_primitive_module_instance ||
-      symbol.type.id() == ID_smv_module_instance)
-    {
-      return; // ignore modules
-    }
-    else if(symbol.type.id() == ID_named_block)
-    {
-      return; // ignore Verilog named blocks
-    }
-    else if(symbol.is_type)
-      return; // ignore types
-    else if (symbol.is_input)
-      vartype = var_mapt::vart::vartypet::INPUT;
-    else if (symbol.is_state_var)
-      vartype = var_mapt::vart::vartypet::LATCH;
-    else
-      vartype = var_mapt::vart::vartypet::WIRE;
-
-    std::size_t size = boolbv_width(symbol.type);
-
-    if (size == 0)
-      return;
-
-    var_mapt::vart &var = var_map.map[symbol.name];
-    var.vartype = vartype;
-    var.type = symbol.type;
-    var.mode = symbol.mode;
-    var.bits.resize(size);
-  };
-
-  for(const auto &symbol_it : symbol_table.symbols)
-    if(symbol_it.second.module == module)
-      update_dest_var_map(symbol_it.second);
-
-  return var_map;
 }
 
 /*******************************************************************\
@@ -321,7 +242,7 @@ void convert_trans_to_netlistt::operator()(
   rhs_list.clear();
   constraint_list.clear();
 
-  dest.var_map = build_var_map(module);
+  dest.var_map = build_netlist_var_map(symbol_table, module);
   allocate_state_variables(dest);
 
   // setup lhs_map


### PR DESCRIPTION
This extracts the method `convert_trans_to_netlistt::build_var_map` into a separate function in a separate file.