### PR TITLE
SMV netlists: declare variables for the nondeterministic nodes

### DIFF
--- a/regression/ebmc/smv-netlist/nondet1.desc
+++ b/regression/ebmc/smv-netlist/nondet1.desc
@@ -1,0 +1,8 @@
+CORE
+nondet1.smv
+--smv-netlist
+^VAR nondet: boolean;$
+^ASSIGN next\(smv\.main\.var\.data\):=nondet;$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv-netlist/nondet1.smv
+++ b/regression/ebmc/smv-netlist/nondet1.smv
@@ -1,0 +1,13 @@
+MODULE main
+
+VAR data : boolean;
+
+-- our encoding of 'case' uses nondeterministic choice
+ASSIGN next(data) :=
+  case
+    data: FALSE;
+    TRUE: TRUE;
+  esac;
+
+-- should pass
+LTLSPEC G (data <-> ! X data)

--- a/src/trans-netlist/smv_netlist.cpp
+++ b/src/trans-netlist/smv_netlist.cpp
@@ -168,6 +168,26 @@ void smv_netlist(const netlistt &netlist, std::ostream &out)
   }
 
   out << '\n';
+  out << "-- Nondeterministic nodes" << '\n';
+  out << '\n';
+
+  for(auto var_it : sorted_var_map)
+  {
+    const var_mapt::vart &var = var_it->second;
+
+    for(std::size_t i = 0; i < var.bits.size(); i++)
+    {
+      if(var.is_nondet())
+      {
+        out << "VAR " << id2smv(var_it->first);
+        if(var.bits.size() != 1)
+          out << "[" << i << "]";
+        out << ": boolean;" << '\n';
+      }
+    }
+  }
+
+  out << '\n';
   out << "-- AND Nodes" << '\n';
   out << '\n';
 


### PR DESCRIPTION
This adds the missing declarations for nondeterministic nodes in netlists to the SMV output.