### PR TITLE
move `cnf_gate_and`

### DIFF
--- a/src/trans-netlist/unwind_netlist.cpp
+++ b/src/trans-netlist/unwind_netlist.cpp
@@ -21,6 +21,40 @@ Author: Daniel Kroening, kroening@kroening.com
 
 /*******************************************************************\
 
+Function: cnf_gate_and
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+// This is a copy of cnft::gate_and, which is protected.
+inline void cnf_gate_and(cnft &cnf, literalt a, literalt b, literalt o)
+{
+  // a*b=c <==> (a + o')( b + o')(a'+b'+o)
+  bvt lits(2);
+
+  lits[0] = pos(a);
+  lits[1] = neg(o);
+  cnf.lcnf(lits);
+
+  lits[0] = pos(b);
+  lits[1] = neg(o);
+  cnf.lcnf(lits);
+
+  lits.clear();
+  lits.reserve(3);
+  lits.push_back(neg(a));
+  lits.push_back(neg(b));
+  lits.push_back(pos(o));
+  cnf.lcnf(lits);
+}
+
+/*******************************************************************\
+
 Function: unwind
 
   Inputs:

--- a/src/util/ebmc_util.h
+++ b/src/util/ebmc_util.h
@@ -25,24 +25,4 @@ inline bool to_integer_non_constant(const exprt &expr, mp_integer &int_value)
   return to_integer(to_constant_expr(expr), int_value);
 }
 
-inline void cnf_gate_and(cnft &cnf, literalt a, literalt b, literalt o) {
-  // a*b=c <==> (a + o')( b + o')(a'+b'+o)
-  bvt lits(2);
-
-  lits[0] = pos(a);
-  lits[1] = neg(o);
-  cnf.lcnf(lits);
-
-  lits[0] = pos(b);
-  lits[1] = neg(o);
-  cnf.lcnf(lits);
-
-  lits.clear();
-  lits.reserve(3);
-  lits.push_back(neg(a));
-  lits.push_back(neg(b));
-  lits.push_back(pos(o));
-  cnf.lcnf(lits);
-}
-
 #endif // HW_CBMC_UTIL_EBMC_UTIL_H


### PR DESCRIPTION
The `cnf_gate_and` function has one user; this moves the implementation from a global header file to that user.