### PR TITLE
tautology checker now only considers properties with unknown state

### DIFF
--- a/regression/ebmc/engine-heuristic/given_property1.desc
+++ b/regression/ebmc/engine-heuristic/given_property1.desc
@@ -1,6 +1,6 @@
-KNOWNBUG
+CORE
 given_property1.sv
-
+--property main.p0
 ^\[main\.p0\] 0: REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/src/ebmc/tautology_check.cpp
+++ b/src/ebmc/tautology_check.cpp
@@ -74,9 +74,13 @@ property_checker_resultt tautology_check(
 
   for(auto &property : result.properties)
   {
-    if(is_tautology(property.normalized_expr, solver_factory, message_handler))
+    if(property.is_unknown())
     {
-      property.proved("tautology");
+      if(is_tautology(
+           property.normalized_expr, solver_factory, message_handler))
+      {
+        property.proved("tautology");
+      }
     }
   }
 


### PR DESCRIPTION
The tautology checker should only be applied to properties that are still unknown.