### PR TITLE
simple-netlist: allocate next-state nodes for all signals

### DIFF
--- a/regression/ebmc/CLI/reset3.desc
+++ b/regression/ebmc/CLI/reset3.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 reset3.sv
 --reset rst --aig --simple-netlist --bound 5
 ^\[.*\] always \(disable iff \(main\.rst\) main\.data\): PROVED up to bound 5$
@@ -6,4 +6,3 @@ reset3.sv
 ^SIGNAL=0$
 --
 --
-This crashes.

--- a/regression/ebmc/smv-netlist/array_assignment.desc
+++ b/regression/ebmc/smv-netlist/array_assignment.desc
@@ -1,11 +1,9 @@
-KNOWNBUG
+CORE
 array_assignment.sv
---reset rst --smv-netlist 
-
+--reset rst --smv-netlist --simple-netlist
+^ASSIGN next\(Verilog\.main\.data\[0\]\):=nondet\[1\];$
+^ASSIGN next\(Verilog\.main\.data\[1\]\):=nondet\[2\];$
 ^EXIT=0$
 ^SIGNAL=0$
 --
-nondet
 --
-Outputs an SMV with an undeclared nondet. When declaring the nondet, nuXmv falsifies the property depsite it being correct.
-

--- a/regression/ebmc/smv-netlist/assignment.desc
+++ b/regression/ebmc/smv-netlist/assignment.desc
@@ -1,7 +1,7 @@
 CORE
 assignment.sv
 --smv-netlist --simple-netlist
-^LTLSPEC G \(\!nondet\[1\]\)$
+^LTLSPEC G \(\!nondet\[5\]\)$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/trans-netlist/trans_to_netlist_simple.cpp
+++ b/src/trans-netlist/trans_to_netlist_simple.cpp
@@ -123,12 +123,9 @@ void convert_trans_to_netlist_simplet::allocate_nodes(netlistt &dest)
     {
       bit.current = dest.new_var_node();
 
-      if(var.is_latch())
-      {
-        // use an input as AIG node for the next state value
-        bit.next = dest.new_var_node();
-        dest.var_map.record_as_nondet(bit.next.var_no());
-      }
+      // use a primary input as AIG node for the next state value
+      bit.next = dest.new_var_node();
+      dest.var_map.record_as_nondet(bit.next.var_no());
     }
   }
 }

--- a/src/trans-netlist/var_map.cpp
+++ b/src/trans-netlist/var_map.cpp
@@ -293,22 +293,20 @@ void var_mapt::output(std::ostream &out) const
         if(l_c.sign()) out << "!";
         out << l_c.var_no();
       }
-      
-      if(var.vartype==vart::vartypet::LATCH)
-      {
-        out << "->";
-        
-        literalt l_n=var.bits[i].next;
 
-        if(l_n.is_true())
-          out << "true";
-        else if(l_n.is_false())
-          out << "false";
-        else
-        {
-          if(l_n.sign()) out << "!";
-          out << l_n.var_no();
-        }
+      out << "->";
+
+      literalt l_n = var.bits[i].next;
+
+      if(l_n.is_true())
+        out << "true";
+      else if(l_n.is_false())
+        out << "false";
+      else
+      {
+        if(l_n.sign())
+          out << "!";
+        out << l_n.var_no();
       }
        
       out << " ";


### PR DESCRIPTION
This changes the node allocation in the simple netlist translation to allocate next-state nodes for all variable kinds, not just registers.