### PR TITLE
optional lableling for AIG nodes

### DIFF
--- a/src/trans-netlist/aig.h
+++ b/src/trans-netlist/aig.h
@@ -61,7 +61,15 @@ public:
   // see check_ordering().
   nodest nodes;
 
-  void clear() { nodes.clear(); }
+  // An (optional) labeling, mapping labels to nodes or their negation.
+  using labelingt = std::map<std::string, literalt>;
+  labelingt labeling;
+
+  void clear()
+  {
+    nodes.clear();
+    labeling.clear();
+  }
 
   const aig_nodet &get_node(literalt l) const { return nodes[l.var_no()]; }
 
@@ -77,7 +85,14 @@ public:
     return {narrow_cast<literalt::var_not>(nodes.size() - 1), false};
   }
 
-  literalt new_and_node(literalt a, literalt b) {
+  // label a node
+  void label(literalt l, const std::string &label)
+  {
+    labeling[label] = l;
+  }
+
+  literalt new_and_node(literalt a, literalt b)
+  {
     PRECONDITION(a.var_no() < number_of_nodes());
     PRECONDITION(b.var_no() < number_of_nodes());
     nodes.emplace_back(a, b);
@@ -86,19 +101,25 @@ public:
 
   bool empty() const { return nodes.empty(); }
 
-  void print(std::ostream &out) const;
-  void print(std::ostream &out, literalt a) const;
-  void output_dot_node(std::ostream &out, nodest::size_type v) const;
-  void output_dot_edge(std::ostream &out, nodest::size_type v,
-                       literalt l) const;
-  void output_dot(std::ostream &out) const;
-
-  std::string label(nodest::size_type v) const;
-  std::string dot_label(nodest::size_type v) const;
+  void print(std::ostream &) const;
+  void output_dot(std::ostream &) const;
 
   /// Check that the nodes are in topological order,
   /// otherwise fails a DATA_INVARIANT.
   void check_ordering() const;
+
+protected:
+  using reverse_labelingt = std::map<literalt::var_not, std::string>;
+  reverse_labelingt reverse_labeling() const;
+
+  std::string label(literalt::var_not, const reverse_labelingt &) const;
+
+  void print(std::ostream &out, const reverse_labelingt &, literalt) const;
+  void output_dot_node(
+    std::ostream &out,
+    const reverse_labelingt &,
+    literalt::var_not) const;
+  void output_dot_edge(std::ostream &out, literalt::var_not, literalt l) const;
 };
 
 std::ostream &operator<<(std::ostream &, const aigt &);

--- a/src/trans-netlist/netlist.cpp
+++ b/src/trans-netlist/netlist.cpp
@@ -29,6 +29,8 @@ void netlistt::print(std::ostream &out) const
 {
   var_map.output(out);
 
+  auto reverse_labeling = this->reverse_labeling();
+
   out << '\n';
   out << "Next state functions:" << '\n';
 
@@ -45,7 +47,7 @@ void netlistt::print(std::ostream &out) const
         if(var.bits.size()!=1) out << "[" << i << "]";
         out << ")=";
 
-        print(out, var.bits[i].next);
+        print(out, reverse_labeling, var.bits[i].next);
 
         out << '\n';
       }
@@ -59,7 +61,7 @@ void netlistt::print(std::ostream &out) const
   for(auto &c : initial)
   {
     out << "  ";
-    print(out, c);
+    print(out, reverse_labeling, c);
     out << '\n';
   }
 
@@ -70,7 +72,7 @@ void netlistt::print(std::ostream &out) const
   for(auto &c : constraints)
   {
     out << "  ";
-    print(out, c);
+    print(out, reverse_labeling, c);
     out << '\n';
   }
 
@@ -81,7 +83,7 @@ void netlistt::print(std::ostream &out) const
   for(auto &c : transition)
   {
     out << "  ";
-    print(out, c);
+    print(out, reverse_labeling, c);
     out << '\n';
   }
   

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -11,6 +11,7 @@ SRC += smvlang/expr2smv.cpp \
        temporal-logic/sva_to_ltl.cpp \
        temporal-logic/nnf.cpp \
        temporal-logic/trivial_sva.cpp \
+       trans-netlist/aig.cpp \
        verilog/typename.cpp \
        # Empty last line
 
@@ -25,6 +26,7 @@ CXXFLAGS += -D'LOCAL_IREP_IDS=<hw_cbmc_irep_ids.h>'
 
 OBJ += ../src/smvlang/smvlang$(LIBEXT) \
        ../src/temporal-logic/temporal-logic$(LIBEXT) \
+       ../src/trans-netlist/trans-netlist$(LIBEXT) \
        ../src/verilog/verilog$(LIBEXT)
 
 cprover.dir:

--- a/unit/trans-netlist/aig.cpp
+++ b/unit/trans-netlist/aig.cpp
@@ -1,0 +1,191 @@
+/*******************************************************************\
+
+Module: AIG Unit Tests
+
+Author: Daniel Kroening, Amazon, dkr@amazon.com
+
+\*******************************************************************/
+
+#include <testing-utils/use_catch.h>
+#include <trans-netlist/aig.h>
+
+#include <sstream>
+
+static std::string print_aig(const aigt &aig)
+{
+  std::ostringstream oss;
+  aig.print(oss);
+  return oss.str();
+}
+
+static std::string aig_to_dot(const aigt &aig)
+{
+  std::ostringstream oss;
+  aig.output_dot(oss);
+  return oss.str();
+}
+
+SCENARIO("aigt output without labels")
+{
+  GIVEN("An AIG with two input nodes")
+  {
+    aigt aig;
+    (void)aig.new_var_node();
+    (void)aig.new_var_node();
+
+    THEN("print outputs the nodes with numeric identifiers")
+    {
+      REQUIRE(print_aig(aig) == "n0 = 0\nn1 = 1\n");
+    }
+
+    THEN("output_dot outputs the nodes with numeric identifiers")
+    {
+      REQUIRE(
+        aig_to_dot(aig) ==
+        "TRUE [label=\"TRUE\", shape=box]\n"
+        "0 [label=\"0\",shape=box]\n"
+        "1 [label=\"1\",shape=box]\n");
+    }
+  }
+
+  GIVEN("An AIG with an AND node")
+  {
+    aigt aig;
+    auto lit0 = aig.new_var_node();
+    auto lit1 = aig.new_var_node();
+    (void)aig.new_and_node(lit0, lit1);
+
+    THEN("print outputs the AND as a conjunction")
+    {
+      REQUIRE(print_aig(aig) == "n0 = 0\nn1 = 1\nn2 = 0 & 1\n");
+    }
+
+    THEN("output_dot outputs the AND node and edges")
+    {
+      REQUIRE(
+        aig_to_dot(aig) ==
+        "TRUE [label=\"TRUE\", shape=box]\n"
+        "0 [label=\"0\",shape=box]\n"
+        "1 [label=\"1\",shape=box]\n"
+        "2 [label=\"2\"]\n"
+        "0 -> 2\n"
+        "1 -> 2\n");
+    }
+  }
+
+  GIVEN("An AIG with negated inputs to AND")
+  {
+    aigt aig;
+    auto lit0 = aig.new_var_node();
+    auto lit1 = aig.new_var_node();
+    (void)aig.new_and_node(!lit0, lit1);
+
+    THEN("print outputs the negation")
+    {
+      REQUIRE(print_aig(aig) == "n0 = 0\nn1 = 1\nn2 = !(0) & 1\n");
+    }
+
+    THEN("output_dot shows negated edge with odiamond arrowhead")
+    {
+      REQUIRE(
+        aig_to_dot(aig) ==
+        "TRUE [label=\"TRUE\", shape=box]\n"
+        "0 [label=\"0\",shape=box]\n"
+        "1 [label=\"1\",shape=box]\n"
+        "2 [label=\"2\"]\n"
+        "0 -> 2 [arrowhead=odiamond]\n"
+        "1 -> 2\n");
+    }
+  }
+}
+
+SCENARIO("aigt output with labels")
+{
+  GIVEN("An AIG with labeled input nodes")
+  {
+    aigt aig;
+    auto lit0 = aig.new_var_node();
+    auto lit1 = aig.new_var_node();
+    aig.label(lit0, "a");
+    aig.label(lit1, "b");
+
+    THEN("print outputs the nodes with labels")
+    {
+      REQUIRE(print_aig(aig) == "n0 = a\nn1 = b\n");
+    }
+
+    THEN("output_dot outputs the nodes with labels")
+    {
+      REQUIRE(
+        aig_to_dot(aig) ==
+        "TRUE [label=\"TRUE\", shape=box]\n"
+        "0 [label=\"a\",shape=box]\n"
+        "1 [label=\"b\",shape=box]\n");
+    }
+  }
+
+  GIVEN("An AIG with labeled AND node")
+  {
+    aigt aig;
+    auto lit0 = aig.new_var_node();
+    auto lit1 = aig.new_var_node();
+    auto lit2 = aig.new_and_node(lit0, lit1);
+    aig.label(lit0, "a");
+    aig.label(lit1, "b");
+    aig.label(lit2, "c");
+
+    THEN("print outputs the AND with labels")
+    {
+      REQUIRE(print_aig(aig) == "n0 = a\nn1 = b\nn2 = a & b\n");
+    }
+
+    THEN("output_dot outputs the AND node with label")
+    {
+      REQUIRE(
+        aig_to_dot(aig) ==
+        "TRUE [label=\"TRUE\", shape=box]\n"
+        "0 [label=\"a\",shape=box]\n"
+        "1 [label=\"b\",shape=box]\n"
+        "2 [label=\"c\"]\n"
+        "0 -> 2\n"
+        "1 -> 2\n");
+    }
+  }
+
+  GIVEN("An AIG with negated labeled literal")
+  {
+    aigt aig;
+    auto lit0 = aig.new_var_node();
+    aig.label(!lit0, "not_a");
+
+    THEN("print outputs the negated label with !")
+    {
+      REQUIRE(print_aig(aig) == "n0 = !not_a\n");
+    }
+
+    THEN("output_dot shows the negated label")
+    {
+      REQUIRE(
+        aig_to_dot(aig) ==
+        "TRUE [label=\"TRUE\", shape=box]\n"
+        "0 [label=\"!not_a\",shape=box]\n");
+    }
+  }
+
+  GIVEN("An AIG with multiple labels on the same node")
+  {
+    aigt aig;
+    auto lit0 = aig.new_var_node();
+    aig.label(lit0, "x");
+    aig.label(lit0, "y");
+
+    THEN("output_dot combines labels with comma")
+    {
+      auto dot = aig_to_dot(aig);
+      REQUIRE(
+        dot ==
+        "TRUE [label=\"TRUE\", shape=box]\n"
+        "0 [label=\"x,y\",shape=box]\n");
+    }
+  }
+}


### PR DESCRIPTION
This adds an option to label AIG nodes with strings, for better readability of AIG outputs.