### PR TITLE
pretty-printing SMV for binary CTL operators

### DIFF
--- a/regression/ebmc/BDD/AU1.desc
+++ b/regression/ebmc/BDD/AU1.desc
@@ -1,8 +1,8 @@
 CORE
 AU1.smv
 --bdd
-^\[spec1\] x >= 1 AU x = 0: REFUTED$
-^\[spec2\] x >= 1 AU x = 10: PROVED$
+^\[spec1\] A \[x >= 1 U x = 0\]: REFUTED$
+^\[spec2\] A \[x >= 1 U x = 10\]: PROVED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/src/smvlang/expr2smv_class.h
+++ b/src/smvlang/expr2smv_class.h
@@ -95,6 +95,8 @@ protected:
     const std::string &symbol,
     precedencet);
 
+  resultt convert_binary_ctl(const binary_exprt &, const std::string &symbol);
+
   resultt convert_binary_associative(
     const exprt &src,
     const std::string &symbol,

--- a/src/smvlang/parser.y
+++ b/src/smvlang/parser.y
@@ -807,14 +807,16 @@ basic_expr : constant
            | EF_Token  basic_expr                 { init($$, ID_EF);  mto($$, $2); }
            | EG_Token  basic_expr                 { init($$, ID_EG);  mto($$, $2); }
            | A_Token '[' basic_expr U_Token basic_expr ']' { binary($$, $3, ID_AU, $5); }
-           | A_Token '[' basic_expr R_Token basic_expr ']' { binary($$, $3, ID_AR, $5); }
            | E_Token '[' basic_expr U_Token basic_expr ']' { binary($$, $3, ID_EU, $5); }
+           /* AR and ER are not part of the NuSMV grammar */
+           | A_Token '[' basic_expr R_Token basic_expr ']' { binary($$, $3, ID_AR, $5); }
            | E_Token '[' basic_expr R_Token basic_expr ']' { binary($$, $3, ID_ER, $5); }
            /* LTL */
            | F_Token  basic_expr                  { init($$, ID_F);  mto($$, $2); }
            | G_Token  basic_expr                  { init($$, ID_G);  mto($$, $2); }
            | X_Token  basic_expr                  { init($$, ID_X);  mto($$, $2); }
            | basic_expr U_Token basic_expr        { binary($$, $1, ID_U, $3); }
+           /* R is not part of the NuSMV grammar */
            | basic_expr R_Token basic_expr        { binary($$, $1, ID_R, $3); }
            | basic_expr V_Token basic_expr        { binary($$, $1, ID_R, $3); }
            /* LTL PAST */

--- a/unit/smvlang/expr2smv.cpp
+++ b/unit/smvlang/expr2smv.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, Amazon, dkr@amazon.com
 #include <util/symbol_table.h>
 
 #include <smvlang/expr2smv.h>
+#include <temporal-logic/ctl.h>
 #include <testing-utils/use_catch.h>
 
 SCENARIO("Generating SMV expression strings")
@@ -34,5 +35,11 @@ SCENARIO("Generating SMV expression strings")
     auto n = [t](mp_integer i) { return from_integer(i, t); };
     auto expr = plus_exprt{n(3), plus_exprt{n(4), n(2)}};
     REQUIRE(expr2smv(expr, empty_ns) == "3 + 4 + 2");
+  }
+
+  GIVEN("A binary CTL operator")
+  {
+    auto expr = AU_exprt{true_exprt(), false_exprt()};
+    REQUIRE(expr2smv(expr, empty_ns) == "A [TRUE U FALSE]");
   }
 }


### PR DESCRIPTION
Instead of printing `a AU b`, output `A[a U b]`, as expected by NuSMV.