### PR TITLE
additional test for SMV netlist output with nondet node

### DIFF
--- a/regression/ebmc/smv-netlist/nondet2.desc
+++ b/regression/ebmc/smv-netlist/nondet2.desc
@@ -1,0 +1,8 @@
+CORE
+nondet2.sv
+--smv-netlist
+^VAR nondet: boolean;$
+^LTLSPEC G nondet$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv-netlist/nondet2.sv
+++ b/regression/ebmc/smv-netlist/nondet2.sv
@@ -1,0 +1,8 @@
+module main;
+
+  wire some_data = $ND(1'b0, 1'b1);
+
+  // should fail
+  assert property (some_data);
+
+endmodule


### PR DESCRIPTION
This adds a test that uses Verilog's `$ND` to create a nondet node in the netlist.