### PR TITLE
SMV: test for bitwise NOT

### DIFF
--- a/regression/smv/word/bitwise_not1.desc
+++ b/regression/smv/word/bitwise_not1.desc
@@ -1,0 +1,10 @@
+CORE
+bitwise_not1.smv
+
+^\[spec1\] !\(0ud2_1 = 0ud2_3\): PROVED.*$
+^\[spec2\] \(!0ud2_1\) = 0ud2_3: REFUTED.*$
+^\[spec3\] !\(0ud2_1 = 0ud2_3\): PROVED.*$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/smv/word/bitwise_not1.smv
+++ b/regression/smv/word/bitwise_not1.smv
@@ -1,0 +1,6 @@
+MODULE main
+
+-- The precedence of ! vs = determines the outcome.
+SPEC !(0b_01 = 0b_11) -- passes
+SPEC (!0b_01) = 0b_11 -- fails
+SPEC !0b_01 = 0b_11   -- passes


### PR DESCRIPTION
This adds a test that exposes the relative precedence of `!` vs `=`.