### PR TITLE
SMV: use explicit stack for type checking DEFINEs

### DIFF
--- a/regression/smv/define/deep_define.desc
+++ b/regression/smv/define/deep_define.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE broken-smt-backend
 deep_define.smv
 
 ^EXIT=0$
 ^SIGNAL=0$
 --
 --
-This segfaults.


### PR DESCRIPTION
This replaces the recursion for type checking DEFINEs by an explicit `std::stack`.  This prevents stack overflow when given deep definition chains.

This is an alternative to #234 that does not require the construction of an explicit graph.

Closes #17