### PR TITLE
Fixup for version field in Homebrew formula

### DIFF
--- a/.github/workflows/ebmc-release.yaml
+++ b/.github/workflows/ebmc-release.yaml
@@ -348,7 +348,7 @@ jobs:
             url "https://github.com/diffblue/hw-cbmc.git",
               tag: "ebmc-${{ env.EBMC_VERSION }}",
               revision: "${{ github.sha }}"
-            version "ebmc-${{ env.EBMC_VERSION }}"
+            version "${{ env.EBMC_VERSION }}"
             license "BSD-3-Clause"
 
             uses_from_macos "flex" => :build


### PR DESCRIPTION
Fixup for #1618 -- the version field should read `5.9`, not `ebmc-5.9`.