### PR TITLE
Verilog: split out elaboration of module instances

### DIFF
--- a/src/verilog/Makefile
+++ b/src/verilog/Makefile
@@ -6,6 +6,7 @@ SRC = aval_bval_encoding.cpp \
       verilog_bits.cpp \
       verilog_ebmc_language.cpp \
       verilog_elaborate.cpp \
+      verilog_elaborate_module_instances.cpp \
       verilog_elaborate_type.cpp \
       verilog_expr.cpp \
       verilog_generate.cpp \

--- a/src/verilog/verilog_elaborate_module_instances.cpp
+++ b/src/verilog/verilog_elaborate_module_instances.cpp
@@ -1,0 +1,132 @@
+/*******************************************************************\
+
+Module: Verilog Elaboration
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#include "verilog_typecheck.h"
+
+/*******************************************************************\
+
+Function: verilog_typecheckt::elaborate_inst
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void verilog_typecheckt::elaborate_inst(
+  const verilog_inst_baset &inst_module_item)
+{
+  for(auto &instance : inst_module_item.instances())
+    elaborate_inst(inst_module_item, instance);
+}
+
+/*******************************************************************\
+
+Function: verilog_typecheckt::elaborate_inst
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void verilog_typecheckt::elaborate_inst(
+  const verilog_inst_baset &statement,
+  const verilog_instt::instancet &op)
+{
+  if(op.instance_array().is_not_nil())
+  {
+    throw errort().with_location(op.source_location())
+      << "no support for instance arrays";
+  }
+
+  bool primitive = statement.id() == ID_inst_builtin;
+  const exprt &range_expr = static_cast<const exprt &>(op.find(ID_range));
+
+  ranget range;
+
+  if(range_expr.is_nil() || range_expr.id().empty())
+    range = ranget{0, 0};
+  else
+    range = convert_range(range_expr);
+
+  irep_idt instantiated_module_identifier =
+    verilog_module_symbol(id2string(statement.get(ID_module)));
+
+  // add symbol for the module instance
+  symbolt symbol;
+
+  symbol.mode = mode;
+  symbol.base_name = op.base_name();
+  symbol.type =
+    typet(primitive ? ID_primitive_module_instance : ID_module_instance);
+  symbol.module = module_identifier;
+  symbol.name = hierarchical_identifier(symbol.base_name);
+  symbol.pretty_name = strip_verilog_prefix(symbol.name);
+  symbol.value.set(ID_module, instantiated_module_identifier);
+
+  if(symbol_table.add(symbol))
+  {
+    throw errort().with_location(op.source_location())
+      << "duplicate definition of identifier `" << symbol.base_name
+      << "' in module `" << module_symbol.base_name << '\'';
+  }
+}
+
+/*******************************************************************\
+
+Function: verilog_typecheckt::elaboate_module_instances
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void verilog_typecheckt::elaborate_module_instances(
+  const verilog_module_itemt &module_item)
+{
+  if(module_item.id() == ID_inst)
+  {
+    elaborate_inst(to_verilog_inst(module_item));
+  }
+  else if(module_item.id() == ID_inst_builtin)
+  {
+    elaborate_inst(to_verilog_inst_builtin(module_item));
+  }
+  else if(module_item.id() == ID_generate_block)
+  {
+    auto &generate_block = to_verilog_generate_block(module_item);
+
+    // These introduce scope, much like a named block statement.
+    bool is_named = generate_block.is_named();
+
+    if(is_named)
+    {
+      irep_idt base_name = generate_block.base_name();
+      enter_named_block(base_name);
+    }
+
+    for(auto &item : generate_block.module_items())
+      elaborate_module_instances(item);
+
+    if(is_named)
+      named_blocks.pop_back();
+  }
+  else if(module_item.id() == ID_set_genvars)
+  {
+    elaborate_module_instances(
+      to_verilog_set_genvars(module_item).module_item());
+  }
+}

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -144,79 +144,6 @@ void verilog_typecheckt::check_module_ports(
 
 /*******************************************************************\
 
-Function: verilog_typecheckt::convert_inst
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-void verilog_typecheckt::interface_inst(
-  const verilog_inst_baset &inst_module_item)
-{
-  for(auto &instance : inst_module_item.instances())
-    interface_inst(inst_module_item, instance);
-}
-
-/*******************************************************************\
-
-Function: verilog_typecheckt::interface_inst
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-void verilog_typecheckt::interface_inst(
-  const verilog_inst_baset &statement,
-  const verilog_instt::instancet &op)
-{
-  if(op.instance_array().is_not_nil())
-  {
-    throw errort().with_location(op.source_location())
-      << "no support for instance arrays";
-  }
-
-  bool primitive=statement.id()==ID_inst_builtin;
-  const exprt &range_expr = static_cast<const exprt &>(op.find(ID_range));
-
-  ranget range;
-
-  if(range_expr.is_nil() || range_expr.id().empty())
-    range = ranget{0, 0};
-  else
-    range = convert_range(range_expr);
-
-  irep_idt instantiated_module_identifier =
-    verilog_module_symbol(id2string(statement.get(ID_module)));
-
-  // add symbol for the module instance
-  symbolt symbol;
-
-  symbol.mode=mode;
-  symbol.base_name = op.base_name();
-  symbol.type=typet(primitive?ID_primitive_module_instance:ID_module_instance);
-  symbol.module=module_identifier;
-  symbol.name = hierarchical_identifier(symbol.base_name);
-  symbol.pretty_name=strip_verilog_prefix(symbol.name);
-  symbol.value.set(ID_module, instantiated_module_identifier);
-
-  if(symbol_table.add(symbol))
-  {
-    throw errort().with_location(op.source_location())
-      << "duplicate definition of identifier `" << symbol.base_name
-      << "' in module `" << module_symbol.base_name << '\'';
-  }
-}
-
-/*******************************************************************\
-
 Function: verilog_typecheckt::interface_generate_block
 
   Inputs:
@@ -279,9 +206,11 @@ void verilog_typecheckt::interface_module_item(
     // already done by elaborate_parameters
   }
   else if(module_item.id() == ID_inst)
-    interface_inst(to_verilog_inst(module_item));
+  {
+  }
   else if(module_item.id() == ID_inst_builtin)
-    interface_inst(to_verilog_inst_builtin(module_item));
+  {
+  }
   else if(
     module_item.id() == ID_verilog_always ||
     module_item.id() == ID_verilog_always_comb ||

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1982,6 +1982,10 @@ void verilog_typecheckt::typecheck()
   // generate constructs, and add the symbols to the symbol table.
   auto verilog_module_expr = elaborate(module_source);
 
+  // elaborate the module instances
+  for(auto &module_item : verilog_module_expr.module_items())
+    elaborate_module_instances(module_item);
+
   // Create symbols for the functions, tasks, registers/variables and wires.
   for(auto &module_item : verilog_module_expr.module_items())
     interface_module_item(module_item);

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -102,6 +102,13 @@ protected:
   std::set<irep_idt> let_symbols;
 
   // instances
+  void elaborate_inst(const verilog_inst_baset &);
+
+  void
+  elaborate_inst(const verilog_inst_baset &, const verilog_instt::instancet &);
+
+  void elaborate_module_instances(const verilog_module_itemt &);
+
   irep_idt parameterize_module(
     const source_locationt &location,
     const irep_idt &module_identifier,
@@ -127,10 +134,6 @@ protected:
   // interfaces
   void module_interface(const verilog_module_sourcet &);
   void check_module_ports(const verilog_module_sourcet::port_listt &);
-  void interface_inst(const verilog_inst_baset &);
-  void interface_inst(
-    const verilog_inst_baset &,
-    const verilog_instt::instancet &op);
   void interface_module_item(const class verilog_module_itemt &);
   void interface_block(const class verilog_blockt &);
   void interface_generate_block(const class verilog_generate_blockt &);


### PR DESCRIPTION
This moves the methods that create the symbols for module instances into a separate file.