### PR TITLE
mark three Verilog tests as passing with Z3

### DIFF
--- a/regression/verilog/primitive_gates/nand4.desc
+++ b/regression/verilog/primitive_gates/nand4.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 nand4.sv
 
 ^EXIT=0$

--- a/regression/verilog/primitive_gates/nor4.desc
+++ b/regression/verilog/primitive_gates/nor4.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 nor4.sv
 
 ^EXIT=0$

--- a/regression/verilog/primitive_gates/xnor4.desc
+++ b/regression/verilog/primitive_gates/xnor4.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 xnor4.sv
 
 ^\[main\.xnor_x1_ok\] always ~\(main\.xnor_in1 \^ main\.xnor_in2 \^ main.xnor_in3\) == main.xnor_out: PROVED .*$


### PR DESCRIPTION
Three Verilog tests marked as broken-smt-backend do indeed pass.