### PR TITLE
Verilog: strengthen typing when using `verilog_parameter_overridet`

### DIFF
--- a/src/verilog/verilog_elaborate_module_instances.cpp
+++ b/src/verilog/verilog_elaborate_module_instances.cpp
@@ -185,8 +185,8 @@ void verilog_typecheckt::process_parameter_override(
   for(auto &assignment : module_item.assignments())
   {
     // Copy the lhs/rhs.
-    exprt lhs = to_binary_expr(assignment).lhs();
-    exprt rhs = to_binary_expr(assignment).rhs();
+    exprt lhs = assignment.lhs();
+    exprt rhs = assignment.rhs();
 
     // The lhs is a sequence of module instance names using
     // hierarchical_identifier expressions.

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -2015,18 +2015,20 @@ inline verilog_continuous_assignt &to_verilog_continuous_assign(exprt &expr)
 class verilog_parameter_overridet : public verilog_module_itemt
 {
 public:
+  using assignmentst = std::vector<binary_exprt>;
+
   verilog_parameter_overridet() : verilog_module_itemt(ID_parameter_override)
   {
   }
 
-  exprt::operandst &assignments()
+  assignmentst &assignments()
   {
-    return operands();
+    return (assignmentst &)operands();
   }
 
-  const exprt::operandst &assignments() const
+  const assignmentst &assignments() const
   {
-    return operands();
+    return (const assignmentst &)operands();
   }
 };
 


### PR DESCRIPTION
This strengthens the typing when accessing the assignments in `verilog_parameter_overridet`.