### PR TITLE
Verilog: packages are elaborated in compilation order

### DIFF
--- a/regression/verilog/packages/package3.desc
+++ b/regression/verilog/packages/package3.desc
@@ -1,0 +1,7 @@
+CORE
+package3.sv
+
+^file .* line 8: syntax error, unexpected ::, expecting ';' or ',' before '::'$
+^EXIT=1$
+^SIGNAL=0$
+--

--- a/regression/verilog/packages/package3.sv
+++ b/regression/verilog/packages/package3.sv
@@ -1,0 +1,14 @@
+// IEEE 1800 2017 26.3 Referencing data in packages
+// "The compilation of a package shall precede the compilation of
+// scopes in which the package is imported."
+
+// Hence, the below is an error
+
+module top;
+  int x = P::my_value;
+endmodule
+
+package P;
+  parameter my_value = 123;
+endpackage
+

--- a/src/verilog/verilog_ebmc_language.cpp
+++ b/src/verilog/verilog_ebmc_language.cpp
@@ -418,9 +418,11 @@ symbol_tablet verilog_ebmc_languaget::elaborate_compilation_units(
 {
   symbol_tablet symbol_table;
 
+  const bool warn_implicit_nets = cmdline.isset("warn-implicit-nets");
+
   for(auto &parse_tree : parse_trees)
     verilog_elaborate_compilation_unit(
-      parse_tree, symbol_table, message_handler);
+      parse_tree, warn_implicit_nets, symbol_table, message_handler);
 
   return symbol_table;
 }

--- a/src/verilog/verilog_elaborate_compilation_unit.cpp
+++ b/src/verilog/verilog_elaborate_compilation_unit.cpp
@@ -8,10 +8,13 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include "verilog_elaborate_compilation_unit.h"
 
+#include <ebmc/ebmc_error.h>
+
 #include "verilog_typecheck.h"
 
 void verilog_elaborate_compilation_unit(
   const verilog_parse_treet &parse_tree,
+  bool warn_implicit_nets,
   symbol_table_baset &symbol_table,
   message_handlert &message_handler)
 {
@@ -25,9 +28,31 @@ void verilog_elaborate_compilation_unit(
     }
     else if(item.id() == ID_verilog_package)
     {
+      // IEEE 1800 2017 26.3 Referencing data in packages
+      // "The compilation of a package shall precede the compilation of
+      // scopes in which the package is imported."
+      // We hence elaborate packages in their given order.
+
+      messaget log{message_handler};
+
+      // copy source
       auto identifier =
         verilog_package_identifier(to_verilog_module_source(item).base_name());
       copy_module_source(item, identifier, symbol_table);
+
+      // type check the package
+      log.status() << "Type-checking " << identifier << messaget::eom;
+
+      if(verilog_typecheck(
+           symbol_table,
+           identifier,
+           parse_tree.standard,
+           warn_implicit_nets,
+           message_handler))
+      {
+        log.error() << "CONVERSION ERROR" << messaget::eom;
+        throw ebmc_errort{}.with_exit_code(2);
+      }
     }
   }
 }

--- a/src/verilog/verilog_elaborate_compilation_unit.h
+++ b/src/verilog/verilog_elaborate_compilation_unit.h
@@ -17,6 +17,7 @@ Author: Daniel Kroening, dkr@amazon.com
 /// throws ebmc_errort on failure
 void verilog_elaborate_compilation_unit(
   const verilog_parse_treet &,
+  bool warn_implicit_nets,
   symbol_table_baset &,
   message_handlert &);
 

--- a/src/verilog/verilog_parse_tree.cpp
+++ b/src/verilog/verilog_parse_tree.cpp
@@ -67,11 +67,6 @@ void verilog_parse_treet::modules_provided(
       module_set.insert(id2string(
         verilog_module_symbol(to_verilog_module_source(item).base_name())));
     }
-    else if(item.id() == ID_verilog_package)
-    {
-      module_set.insert(id2string(verilog_package_identifier(
-        to_verilog_module_source(item).base_name())));
-    }
   }
 }
 

--- a/src/verilog/verilog_parse_tree.h
+++ b/src/verilog/verilog_parse_tree.h
@@ -70,6 +70,7 @@ public:
     std::swap(parse_tree.standard, standard);
   }
 
+  // returns the set of modules (not: packages) provided
   void modules_provided(
     std::set<std::string> &module_set) const;
 


### PR DESCRIPTION
This changes the type checking of packages to be done in the order given in the compilation unit.

IEEE 1800 2017 26.3 Referencing data in packages:  "The compilation of a package shall precede the compilation of scopes in which the package is imported."

Hence, there is no need to re-order the elaboration to support use that is out-of-order.