### PR TITLE
Verilog: fix Pacakge typo

### DIFF
--- a/regression/verilog/packages/package1.desc
+++ b/regression/verilog/packages/package1.desc
@@ -1,7 +1,7 @@
 CORE
 package1.sv
 --show-parse
-^Pacakge: my_pkg$
+^Package: my_pkg$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/verilog/verilog_expr.cpp
+++ b/src/verilog/verilog_expr.cpp
@@ -272,7 +272,7 @@ void verilog_checkert::show(std::ostream &out) const
 
 void verilog_packaget::show(std::ostream &out) const
 {
-  out << "Pacakge: " << base_name() << '\n';
+  out << "Package: " << base_name() << '\n';
 
   out << "  Items:\n";
 


### PR DESCRIPTION
This fixes a typo int the Verilog parse tree output.