### PR TITLE
Verilog: type checker can now have multiple entry points

### DIFF
--- a/src/verilog/verilog_elaborate_module_instances.cpp
+++ b/src/verilog/verilog_elaborate_module_instances.cpp
@@ -114,7 +114,7 @@ void verilog_typecheckt::elaborate_inst(
   {
     throw errort().with_location(op.source_location())
       << "duplicate definition of identifier `" << symbol.base_name
-      << "' in module `" << module_symbol.base_name << '\'';
+      << "' in module `" << module_symbol().base_name << '\'';
   }
 }
 

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -2431,7 +2431,8 @@ to_verilog_restrict_statement(verilog_statementt &statement)
   return static_cast<verilog_restrict_statementt &>(statement);
 }
 
-// modules, primitives, programs, interfaces, classes, packages
+// base class for design elements (modules, programs, interfaces,
+// checkers, packages, primitives, configs)
 class verilog_item_containert : public irept
 {
 public:

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -50,7 +50,7 @@ Function: verilog_typecheckt::check_module_ports
 void verilog_typecheckt::check_module_ports(
   const verilog_module_sourcet::port_listt &module_ports)
 {
-  auto &ports = to_module_type(module_symbol.type).ports();
+  auto &ports = to_module_type(module_symbol().type).ports();
   ports.clear();
   ports.reserve(module_ports.size());
   std::map<irep_idt, unsigned> port_names;
@@ -71,7 +71,7 @@ void verilog_typecheckt::check_module_ports(
     if(base_name.empty())
     {
       throw errort().with_location(decl.source_location())
-        << "empty port name (module " << module_symbol.base_name << ')';
+        << "empty port name (module " << module_symbol().base_name << ')';
     }
 
     if(port_names.find(base_name) != port_names.end())
@@ -387,7 +387,7 @@ void verilog_typecheckt::interface_block(
     {
       throw errort().with_location(statement.source_location())
         << "duplicate definition of identifier `" << symbol.base_name
-        << "' in module `" << module_symbol.base_name << '\'';
+        << "' in module `" << module_symbol().base_name << '\'';
     }
 
     enter_named_block(base_name);

--- a/src/verilog/verilog_parameterize_module.cpp
+++ b/src/verilog/verilog_parameterize_module.cpp
@@ -315,10 +315,9 @@ irep_idt verilog_typecheckt::parameterize_module(
   // recursive call
 
   verilog_typecheckt verilog_typecheck(
-    standard, false, *new_symbol, symbol_table, get_message_handler());
+    standard, warn_implicit_nets, symbol_table, get_message_handler());
 
-  if(verilog_typecheck.typecheck_main())
-    throw 0;
+  verilog_typecheck.typecheck_design_element(*new_symbol);
 
   return new_module_identifier;
 }

--- a/src/verilog/verilog_symbol_table.cpp
+++ b/src/verilog/verilog_symbol_table.cpp
@@ -8,6 +8,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "verilog_symbol_table.h"
 
+#include <ebmc/ebmc_error.h>
+
 /*******************************************************************\
 
 Function: verilog_symbol_tablet::symbol_table_lookup
@@ -25,7 +27,7 @@ symbolt &verilog_symbol_tablet::symbol_table_lookup(const irep_idt &identifier)
   auto it=symbol_table.get_writeable(identifier);
 
   if(it==nullptr)
-    throw "symbol "+id2string(identifier)+" not found";
+    throw ebmc_errort{} << "symbol " << identifier << " not found";
 
   return *it;
 }

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -53,7 +53,6 @@ public:
   verilog_typecheckt(
     verilog_standardt _standard,
     bool warn_implicit_nets,
-    symbolt &_module_symbol,
     symbol_table_baset &_symbol_table,
     message_handlert &_message_handler)
     : verilog_typecheck_exprt(
@@ -63,15 +62,23 @@ public:
         _message_handler),
       verilog_symbol_tablet(_symbol_table),
       ns(_symbol_table),
-      module_symbol(_module_symbol),
       assertion_counter(0)
   {}
 
-  void typecheck() override;
+  // type checking for all "item containers", which includes
+  // all "design elements" (modules, programs, interfaces,
+  // checkers, packages, primitives, and configurations)
+  void typecheck_design_element(symbolt &);
 
 protected:
   const namespacet ns;
-  symbolt &module_symbol;
+
+  // look up the module symbol
+  symbolt &module_symbol()
+  {
+    PRECONDITION(!module_identifier.empty());
+    return symbol_table_lookup(module_identifier);
+  }
 
   // Parameters.
   // defparam assignments. Map from module instance names


### PR DESCRIPTION
This refactors the Verilog type checker to enable multiple entry points, to allow type checking items that are not module symbols (e.g., compilation-unit scoped declarations).