### PR TITLE
Verilog: typedefs in compilation-unit scope

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 * cast properties given with -p to Boolean if need be
 * SystemVerilog: recursive module definitions
+* SystemVerilog: typdefs in compilation-unit scope
 
 # EBMC 5.9
 

--- a/regression/verilog/typedef/global_typedef.desc
+++ b/regression/verilog/typedef/global_typedef.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 global_typedef.sv
 
 ^EXIT=0$
@@ -6,4 +6,3 @@ global_typedef.sv
 --
 ^warning: ignoring
 --
-Global typedefs must be added to the symbol table.

--- a/regression/verilog/typedef/global_typedef.sv
+++ b/regression/verilog/typedef/global_typedef.sv
@@ -1,6 +1,5 @@
 // The VIS model checker accepts global-scoped typedefs as an extension of
-// Verilog. These are at the top-level scope, which is not permitted by
-// SystemVerilog.  It is not clear whether these are file-local or not.
+// Verilog.  In SystemVerilog, these are in the compilation-unit scope.
 
 typedef bit [31:0] some_word_type;
 

--- a/src/verilog/verilog_elaborate_compilation_unit.cpp
+++ b/src/verilog/verilog_elaborate_compilation_unit.cpp
@@ -54,5 +54,13 @@ void verilog_elaborate_compilation_unit(
         throw ebmc_errort{}.with_exit_code(2);
       }
     }
+    else if(item.id() == ID_decl)
+    {
+      // compilation-unit scoped nets, variables, typedefs, functions,
+      // tasks, parameters
+      verilog_typecheckt verilog_typecheck(
+        parse_tree.standard, warn_implicit_nets, symbol_table, message_handler);
+      verilog_typecheck.typecheck_decl(to_verilog_decl(item));
+    }
   }
 }

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1761,6 +1761,32 @@ void verilog_typecheckt::typecheck_design_element(symbolt &symbol)
 
   // store the module expression in symbol.value
   symbol.value = std::move(verilog_module_expr);
+
+  module_identifier = irep_idt{};
+}
+
+/*******************************************************************\
+
+Function: verilog_typecheckt::typecheck_decl
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void verilog_typecheckt::typecheck_decl(const verilog_declt &decl)
+{
+  auto decl_class = decl.get_class();
+
+  if(decl_class == ID_typedef)
+  {
+    collect_symbols(decl);
+  }
+  else
+    PRECONDITION(false);
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -70,6 +70,10 @@ public:
   // checkers, packages, primitives, and configurations)
   void typecheck_design_element(symbolt &);
 
+  // type checking for compilation-unit scoped nets, variables,
+  // typedefs, functions, tasks, parameters
+  void typecheck_decl(const verilog_declt &);
+
 protected:
   const namespacet ns;
 

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -53,12 +53,17 @@ verilog_typecheck_exprt::hierarchical_identifier(irep_idt base_name) const
   const std::string named_block =
     named_blocks.empty() ? std::string() : id2string(named_blocks.back());
 
-  if(function_or_task_name.empty())
+  if(!function_or_task_name.empty())
+    return id2string(function_or_task_name) + "." + named_block +
+           id2string(base_name);
+  else if(!module_identifier.empty())
     return id2string(module_identifier) + "." + named_block +
            id2string(base_name);
   else
-    return id2string(function_or_task_name) + "." + named_block +
-           id2string(base_name);
+  {
+    // not in a function/task, not in a module/checker/package etc.
+    return "Verilog::$unit." + id2string(base_name);
+  }
 }
 
 /*******************************************************************\
@@ -1309,6 +1314,12 @@ const symbolt *verilog_typecheck_exprt::resolve(const irep_idt base_name)
     id2string(module_identifier) + "." + id2string(base_name);
 
   const symbolt *symbol;
+  if(!ns.lookup(full_identifier, symbol))
+    return symbol; // found!
+
+  // compilation-unit scope?
+  full_identifier = "Verilog::$unit." + id2string(base_name);
+
   if(!ns.lookup(full_identifier, symbol))
     return symbol; // found!
 


### PR DESCRIPTION
This adds typedefs that are in the compilation-unit scope.

Fixes #1505
