### PR TITLE
Verilog: add identifier to enum constants in enum type

### DIFF
--- a/regression/verilog/packages/package_enum1.desc
+++ b/regression/verilog/packages/package_enum1.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE
 package_enum1.sv
 
 ^EXIT=0$
 ^SIGNAL=0$
 --
 --
-Support for enums in packages is missing.

--- a/regression/verilog/packages/package_enum1.sv
+++ b/regression/verilog/packages/package_enum1.sv
@@ -6,8 +6,6 @@ endpackage
 
 module main;
 
-  import moo::*;
-
   assert final (moo::GREEN == 1);
 
 endmodule

--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -1281,9 +1281,7 @@ expr2verilogt::convert_constant(const constant_exprt &src)
     // Find the enum name with the matching value.
     for(auto &enum_name : enum_type.enum_names())
     {
-      const auto identifier =
-        "Verilog::" + id2string(enum_name.scope_prefix()) +
-        id2string(enum_name.base_name());
+      const auto identifier = enum_name.identifier();
       auto &enum_symbol = ns.lookup(identifier);
       DATA_INVARIANT(
         enum_symbol.value.id() == ID_constant,

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -200,11 +200,21 @@ void verilog_typecheckt::collect_symbols(const typet &type)
           from_integer(1, integer_typet()), tbd_type));
     }
 
+    // copy the type
+    auto enum_type_copy = enum_type;
+
+    for(auto &enum_name : enum_type_copy.enum_names())
+    {
+      const auto base_name = enum_name.base_name();
+      const auto identifier = hierarchical_identifier(base_name);
+      enum_name.identifier(identifier);
+    }
+
     // Add a symbol for the enum to the symbol table.
     // This allows looking up the enum name identifiers.
     {
       const auto identifier = hierarchical_identifier(enum_type.base_name());
-      type_symbolt enum_type_symbol(identifier, enum_type, mode);
+      type_symbolt enum_type_symbol(identifier, enum_type_copy, mode);
       enum_type_symbol.module = module_identifier;
       enum_type_symbol.is_file_local = true;
       enum_type_symbol.location = enum_type.source_location();

--- a/src/verilog/verilog_types.h
+++ b/src/verilog/verilog_types.h
@@ -504,9 +504,14 @@ public:
       return static_cast<exprt &>(add(ID_value));
     }
 
-    irep_idt scope_prefix() const
+    irep_idt identifier() const
     {
-      return get(ID_verilog_scope_prefix);
+      return get(ID_identifier);
+    }
+
+    void identifier(irep_idt _identifier)
+    {
+      set(ID_identifier, _identifier);
     }
 
     irep_idt base_name() const


### PR DESCRIPTION
This adds a full identifier to the enum constants listed in the enum type.