### PR TITLE
SVA: fix for `admits_empty` for sequence repetition operators

### DIFF
--- a/src/temporal-logic/rewrite_sva_sequence.cpp
+++ b/src/temporal-logic/rewrite_sva_sequence.cpp
@@ -79,7 +79,12 @@ bool admits_empty(const exprt &expr)
     // admits_empty(r[*0]) = 1
     // admits_empty(r[*1:$]) = admits_empty(r)
     auto &repetition_expr = to_sva_sequence_repetition_star_expr(expr);
-    if(repetition_expr.is_range())
+    if(!repetition_expr.repetitions_given())
+    {
+      // s[*], same as s[0:$]
+      return true;
+    }
+    else if(repetition_expr.is_range())
     {
       if(repetition_expr.from().is_zero())
         return true;
@@ -88,6 +93,9 @@ bool admits_empty(const exprt &expr)
     }
     else // singleton
     {
+      DATA_INVARIANT(
+        repetition_expr.is_singleton(),
+        "repetition must be singleton if not range");
       if(repetition_expr.repetitions().is_zero())
         return true;
       else

--- a/src/verilog/sva_expr.h
+++ b/src/verilog/sva_expr.h
@@ -1164,6 +1164,14 @@ public:
   {
   }
 
+  sva_cycle_delay_exprt(exprt lhs, constant_exprt cycles, exprt rhs)
+    : exprt{
+        ID_sva_cycle_delay,
+        verilog_sva_sequence_typet{},
+        {std::move(lhs), std::move(cycles), nil_exprt{}, std::move(rhs)}}
+  {
+  }
+
   sva_cycle_delay_exprt(constant_exprt cycles, exprt rhs)
     : exprt{
         ID_sva_cycle_delay,

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -7,6 +7,7 @@ SRC = unit_tests.cpp
 SRC += smvlang/expr2smv.cpp \
        temporal-logic/hoa.cpp \
        temporal-logic/ltl_sva_to_string.cpp \
+       temporal-logic/rewrite_sva_sequence.cpp \
        temporal-logic/sva_sequence_match.cpp \
        temporal-logic/sva_to_ltl.cpp \
        temporal-logic/nnf.cpp \

--- a/unit/temporal-logic/rewrite_sva_sequence.cpp
+++ b/unit/temporal-logic/rewrite_sva_sequence.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************\
+
+Module: Rewrite SVA Sequences
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#include <util/arith_tools.h>
+#include <util/mathematical_types.h>
+
+#include <temporal-logic/rewrite_sva_sequence.h>
+#include <testing-utils/use_catch.h>
+#include <verilog/sva_expr.h>
+
+SCENARIO("Checking whether an SVA sequence admits an empty match")
+{
+  auto p = sva_boolean_exprt{
+    symbol_exprt{"p", bool_typet{}}, verilog_sva_sequence_typet{}};
+  auto q = sva_boolean_exprt{
+    symbol_exprt{"q", bool_typet{}}, verilog_sva_sequence_typet{}};
+
+  GIVEN("A boolean formula")
+  {
+    REQUIRE(admits_empty(p) == false);
+  }
+
+  GIVEN("p ##0 q")
+  {
+    auto seq = sva_cycle_delay_exprt{p, from_integer(0, natural_typet{}), q};
+    REQUIRE(admits_empty(seq) == false);
+  }
+
+  GIVEN("p[+]")
+  {
+    auto seq = sva_sequence_repetition_plus_exprt{p}.lower();
+    REQUIRE(admits_empty(seq) == false);
+  }
+
+  GIVEN("p[*]")
+  {
+    auto seq = sva_sequence_repetition_star_exprt{p};
+    REQUIRE(admits_empty(seq) == true);
+  }
+}


### PR DESCRIPTION
This adds the case `s[*]` to the `admits_empty` implementation.

Closes #1651