### PR TITLE
SystemVerilog: enums in compilation-unit scope

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 * cast properties given with -p to Boolean if need be
 * SystemVerilog: timeunits and timeprecision
 * SystemVerilog: recursive module definitions
+* SystemVerilog: enums in compilation-unit scope
 * SystemVerilog: typdefs in compilation-unit scope
 
 # EBMC 5.9

--- a/regression/verilog/enums/compilation_unit_enum1.desc
+++ b/regression/verilog/enums/compilation_unit_enum1.desc
@@ -1,13 +1,12 @@
-KNOWNBUG
+CORE
 compilation_unit_enum1.sv
 --bound 3 --numbered-trace
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main\.p1\] always main\.my_light != $unit.YELLOW2: REFUTED$
-^main\.my_light@0 = $unit\.RED$
-^main\.my_light@1 = $unit\.YELLOW1$
-^main\.my_light@2 = $unit\.GREEN$
-^main\.my_light@3 = $unit\.YELLOW2$
+^\[main\.p1\] always main\.my_light != \$unit.YELLOW2: REFUTED$
+^main\.my_light@0 = \$unit\.RED$
+^main\.my_light@1 = \$unit\.YELLOW1$
+^main\.my_light@2 = \$unit\.GREEN$
+^main\.my_light@3 = \$unit\.YELLOW2$
 --
 --
-The enum symbol is not added to the right scope.

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1790,6 +1790,9 @@ void verilog_typecheckt::typecheck_decl(const verilog_declt &decl)
   if(decl_class == ID_typedef)
   {
     collect_symbols(decl);
+
+    for(auto identifier : symbols_added)
+      elaborate_symbol_rec(identifier);
   }
   else
     PRECONDITION(false);


### PR DESCRIPTION
This fixes enums that are defined in the compilation-unit scope.