### PR TITLE
CI: tie the AIGER tools to rel-1.9.20 for hwmcc08 benchmarking

### DIFF
--- a/benchmarking/hwmcc08.sh
+++ b/benchmarking/hwmcc08.sh
@@ -3,8 +3,8 @@
 # This runs ebmc in BMC mode on the HWMCC08 benchmarks.
 
 if [ ! -e aiger/. ] ; then
-  echo Downloading and building the AIGER tools
-  git clone https://github.com/arminbiere/aiger
+  echo Downloading and building the AIGER tools at version 1.9.20
+  git clone -b rel-1.9.20 https://github.com/arminbiere/aiger
   (cd aiger ; ./configure.sh ; make aigtosmv )
 fi
 


### PR DESCRIPTION
To stabilise CI, tie the AIGER tools to the version with tag rel-1.9.20.