### PR TITLE
Verilog: catch typechecking errors

### DIFF
--- a/src/verilog/verilog_elaborate_compilation_unit.cpp
+++ b/src/verilog/verilog_elaborate_compilation_unit.cpp
@@ -58,9 +58,25 @@ void verilog_elaborate_compilation_unit(
     {
       // compilation-unit scoped nets, variables, typedefs, functions,
       // tasks, parameters
-      verilog_typecheckt verilog_typecheck(
-        parse_tree.standard, warn_implicit_nets, symbol_table, message_handler);
-      verilog_typecheck.typecheck_decl(to_verilog_decl(item));
+      try
+      {
+        verilog_typecheckt verilog_typecheck(
+          parse_tree.standard,
+          warn_implicit_nets,
+          symbol_table,
+          message_handler);
+        verilog_typecheck.typecheck_decl(to_verilog_decl(item));
+      }
+      catch(const typecheckt::errort &error)
+      {
+        if(!error.what().empty())
+        {
+          throw ebmc_errort{}.with_location(error.source_location())
+            << error.what();
+        }
+        else
+          throw ebmc_errort{};
+      }
     }
   }
 }


### PR DESCRIPTION
This catches typechecker errors and re-throws them as `ebmc_errort`.