### PR TITLE
SystemVerilog: assignments to type casts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # EBMC 5.10
 
 * cast properties given with -p to Boolean if need be
+* SystemVerilog: assignments to a part-select of a struct
 * SystemVerilog: timeunits and timeprecision
 * SystemVerilog: recursive module definitions
 * SystemVerilog: enums in compilation-unit scope

--- a/regression/verilog/assignments/assignment-to-part-select-of-struct1.desc
+++ b/regression/verilog/assignments/assignment-to-part-select-of-struct1.desc
@@ -1,10 +1,9 @@
-KNOWNBUG
+CORE
 assignment-to-part-select-of-struct1.sv
 --bound 0
 ^EXIT=0$
 ^SIGNAL=0$
-^\[top\.assert\.p1\] always top\.data\[2:0\] == 68'h20000000000000000: PROVED .*$
+^\[top\.assert\.1\] always top\.data == 68'h20000000000000000: PROVED .*$
 --
 ^warning: ignoring
 --
-This crashes.

--- a/regression/verilog/assignments/assignment-to-part-select-of-struct1.sv
+++ b/regression/verilog/assignments/assignment-to-part-select-of-struct1.sv
@@ -8,7 +8,7 @@ module top(output some_type data);
   always_comb begin
     data[63:0] = 0;
     data[127:64] = 2;
-    assert(data[2:0] == 'h2_00000000_00000000);
+    assert(data == 'h2_00000000_00000000);
   end
 
 endmodule

--- a/src/verilog/verilog_lowering.h
+++ b/src/verilog/verilog_lowering.h
@@ -10,9 +10,12 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_VERILOG_LOWERING_H
 
 class exprt;
+class typecast_exprt;
 class typet;
 
 exprt verilog_lowering(exprt);
 typet verilog_lowering(typet);
+
+exprt verilog_lowering_cast(typecast_exprt);
 
 #endif

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -270,6 +270,12 @@ exprt verilog_synthesist::synth_lhs_expr(exprt expr)
     member_expr.struct_op() = synth_lhs_expr(member_expr.struct_op());
     return expr;
   }
+  else if(expr.id() == ID_typecast)
+  {
+    auto &typecast_expr = to_typecast_expr(expr);
+    typecast_expr.op() = synth_lhs_expr(typecast_expr.op());
+    return expr;
+  }
   else
   {
     DATA_INVARIANT_WITH_DIAGNOSTICS(
@@ -855,6 +861,20 @@ exprt verilog_synthesist::assignment_rec(
       throw errort() << "unexpected member lhs: " << lhs_compound.type().id();
     }
   }
+  else if(lhs.id() == ID_typecast)
+  {
+    // The cast is assumed to be a reinterpret cast.
+    // (T)lhs = rhs
+    auto &typecast_expr = to_typecast_expr(lhs);
+
+    // note that the LHS is not yet fully synthesised; we will need to lower
+    // the typecast
+    auto new_rhs = typecast_exprt{rhs, typecast_expr.op().type()};
+
+    auto new_rhs_lowered = verilog_lowering_cast(new_rhs);
+
+    return assignment_rec(typecast_expr.op(), new_rhs_lowered);
+  }
   else
   {
     throw errort() << "unexpected lhs: " << lhs.id();
@@ -1037,6 +1057,10 @@ void verilog_synthesist::assignment_member_rec(
   {
     add_assignment_member(lhs, member, data);
   }
+  else if(lhs.id() == ID_typecast)
+  {
+    add_assignment_member(lhs, member, data);
+  }
   else
   {
     throw errort() << "unexpected lhs: " << lhs.id();
@@ -1172,6 +1196,10 @@ const symbolt &verilog_synthesist::assignment_symbol(const exprt &lhs)
     else if(e->id() == ID_member)
     {
       e = &to_member_expr(*e).struct_op();
+    }
+    else if(e->id() == ID_typecast)
+    {
+      e = &to_typecast_expr(*e).op();
     }
     else
     {

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -629,6 +629,10 @@ void verilog_typecheckt::check_lhs(
     throw errort().with_location(lhs.source_location())
       << "no support for assignment patterns on LHS of an assignment";
   }
+  else if(lhs.id() == ID_typecast)
+  {
+    check_lhs(to_typecast_expr(lhs).op(), vassign);
+  }
   else
   {
     throw errort() << "typechecking: failed to get identifier on LHS "


### PR DESCRIPTION
SystemVerilog allows assignments to implicit conversions, e.g., from vectors to structs.