### PR TITLE
SMV: precedence of `!` vs `::`

### DIFF
--- a/regression/smv/word/bitwise_not2.desc
+++ b/regression/smv/word/bitwise_not2.desc
@@ -1,0 +1,11 @@
+CORE
+bitwise_not2.smv
+
+^\[spec1\] \(!\(0ud1_1 :: 0ud1_1\)\) = 0ud2_1: REFUTED$
+^\[spec2\] \(!0ud1_1\) :: 0ud1_1 = 0ud2_1: PROVED .*$
+^\[spec3\] \(!\(0ud1_1 :: 0ud1_1\)\) = 0ud2_1: REFUTED$
+^\[spec4\] !\(0ud1_1 :: 0ud1_1 = 0ud2_1\): PROVED .*$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/smv/word/bitwise_not2.smv
+++ b/regression/smv/word/bitwise_not2.smv
@@ -1,0 +1,9 @@
+MODULE main
+
+-- The precedence of ! vs :: determines the outcome.
+SPEC (!(0b_1 :: 0b_1)) = 0b_01 -- fails
+SPEC (!0b_1) :: 0b_1 = 0b_01 -- passes
+SPEC (!0b_1 :: 0b_1) = 0b_01 -- passes
+
+-- The precedence of ! vs = determines the outcome.
+SPEC !0b_1 :: 0b_1 = 0b_01 -- passes

--- a/src/smvlang/expr2smv.cpp
+++ b/src/smvlang/expr2smv.cpp
@@ -199,9 +199,14 @@ expr2smvt::resultt expr2smvt::convert_binary_associative(
 
     auto op_rec = convert_rec(*it);
 
+    // Special case for bitwise negation (!) vs :: (concatenation).
+    // We always add the parentheses since the precedence has
+    // changed between CMU SMV and NuSMV.
+
     // clang-format off
     bool use_parentheses =
         src.id() == it->id() ? false
+      : src.id() == ID_concatenation && it->id() == ID_bitnot ? true
       : precedence >= op_rec.p;
     // clang-format on
 
@@ -476,6 +481,7 @@ expr2smvt::resultt expr2smvt::convert_unary(
   bool parentheses =
       op.operands().size() == 1 ? false
     : src.id() == ID_not && !op.operands().empty() ? true
+    : op.id() == ID_concatenation ? true
     : precedence >= op_rec.p;
   // clang-format on
 
@@ -959,7 +965,7 @@ expr2smvt::resultt expr2smvt::convert_rec(const exprt &src)
   else if(src.id() == ID_concatenation)
   {
     return convert_binary_associative(
-      to_binary_expr(src), "::", precedencet::CONCAT);
+      to_concatenation_expr(src), "::", precedencet::CONCAT);
   }
 
   else if(src.id() == ID_shl)


### PR DESCRIPTION
This adds more parentheses to the SMV output, given that the relative precedence of `!`  (negation, bitwise negation) and `::` (concatenation) has changed from CMU SMV to NuSMV.