### PR TITLE
SMV: use hex when the source constant has been given in hex

### DIFF
--- a/regression/ebmc/smv-word-level/constants1.desc
+++ b/regression/ebmc/smv-word-level/constants1.desc
@@ -1,0 +1,8 @@
+CORE
+constants1.sv
+--smv-word-level
+^INVAR main\.w1 = 0uh32_12345678$
+^INVAR main\.w2 = 0ud32_12345678$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv-word-level/constants1.sv
+++ b/regression/ebmc/smv-word-level/constants1.sv
@@ -1,0 +1,6 @@
+module main;
+
+  wire [31:0] w1 = 32'h12345678;
+  wire [31:0] w2 = 32'd12345678;
+
+endmodule

--- a/src/smvlang/expr2smv.cpp
+++ b/src/smvlang/expr2smv.cpp
@@ -721,6 +721,19 @@ expr2smvt::resultt expr2smvt::convert_constant(const constant_exprt &src)
 {
   const typet &type = src.type();
 
+  auto use_hex = [](const exprt &src)
+  {
+    auto verilog_value = id2string(src.get("#verilog_value"));
+    auto tick_pos = verilog_value.find('\'');
+    if(tick_pos != std::string::npos)
+    {
+      auto base_char = std::string(verilog_value, tick_pos + 1, 1);
+      return base_char == "h" || base_char == "H";
+    }
+    else
+      return false;
+  };
+
   std::string dest;
 
   if(type.id()==ID_bool)
@@ -743,8 +756,17 @@ expr2smvt::resultt expr2smvt::convert_constant(const constant_exprt &src)
     auto minus = value_int < 0 ? "-" : "";
     auto sign_specifier = type.id() == ID_signedbv ? 's' : 'u';
     auto word_width = to_bitvector_type(type).width();
-    dest = minus + std::string("0") + sign_specifier + 'd' +
-           std::to_string(word_width) + '_' + integer2string(value_abs);
+
+    if(use_hex(src))
+    {
+      dest = minus + std::string("0") + sign_specifier + 'h' +
+             std::to_string(word_width) + '_' + integer2string(value_abs, 16);
+    }
+    else
+    {
+      dest = minus + std::string("0") + sign_specifier + 'd' +
+             std::to_string(word_width) + '_' + integer2string(value_abs);
+    }
   }
   else if(type.id() == ID_bv)
   {


### PR DESCRIPTION
The SMV pretty printer now uses base 16 when the original constant was given using Verilog's base 16 syntax.