### PR TITLE
BDD engine: extend `--show-bdds` output

### DIFF
--- a/regression/ebmc/BDD/show_bdds1.desc
+++ b/regression/ebmc/BDD/show_bdds1.desc
@@ -1,0 +1,9 @@
+CORE
+just_p.smv
+--show-bdds
+activate-multi-line-match
+^Properties:\nspec1:\nsmv::main::var::some_var\[0\]\n\nspec2:\n!smv::main::var::some_var\[0\]\n$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -227,15 +227,46 @@ property_checker_resultt bdd_enginet::operator()()
     {
       mgr.DumpTable(std::cout);
       std::cout << '\n';
-      
-      std::cout << "Atomic propositions:\n";
-      for(const auto & a : atomic_propositions)
-      {
-        std::cout << '`' << format(a.first) << "' -> "
-                  << a.second.bdd.node_number() << '\n';
-      }
 
+      std::cout << "Variables:\n";
+      for(const auto &[id, var] : vars)
+      {
+        std::cout << id << " <-> " << cubes(var.current_bdd);
+        std::cout << "next(" << id << ") <-> " << cubes(var.next_bdd);
+      }
       std::cout << '\n';
+
+      std::cout << "Initial states:\n";
+      for(const auto &bdd : initial_BDDs)
+        std::cout << cubes(bdd) << '\n';
+
+      std::cout << "In-state constraints:\n";
+      for(const auto &bdd : constraints_BDDs)
+        std::cout << cubes(bdd) << '\n';
+
+      std::cout << "Transition relation:\n";
+      for(const auto &bdd : transition_BDDs)
+        std::cout << cubes(bdd) << '\n';
+
+      std::cout << "Atomic propositions:\n";
+      for(const auto &a : atomic_propositions)
+        std::cout << '`' << format(a.first) << "':\n"
+                  << cubes(a.second.bdd) << '\n';
+
+      std::cout << "Properties:\n";
+      for(const auto &property : properties.properties)
+      {
+        if(
+          property.is_disabled() || property.is_assumed() ||
+          property.is_failure())
+        {
+        }
+        else
+        {
+          auto result = CTL(property.normalized_expr);
+          std::cout << property.name << ":\n" << cubes(result) << '\n';
+        }
+      }
 
       return property_checker_resultt::success();
     }


### PR DESCRIPTION
This adds a debugging facility to the BDD engine.

The `--show-bdds` output in bdd_engine is extended to include sections for initial states, transition relation, atomic propositions, and properties, printed in DNF.