### PR TITLE
SMV word-level output: map identifiers to SMV

### DIFF
--- a/regression/ebmc/smv-word-level/assignment-to-part-select1.desc
+++ b/regression/ebmc/smv-word-level/assignment-to-part-select1.desc
@@ -2,11 +2,11 @@ CORE
 assignment-to-part-select1.sv
 --smv-word-level
 ^MODULE main$
-^INVAR main\.data = Verilog::main\.data_aux2$
-^INVAR Verilog::main\.data_aux2 = \(\(\(\(\(\(\(\(Verilog::main\.data_aux1
-^INVAR Verilog::main\.data_aux1 = \(\(\(\(\(\(\(\(Verilog::main\.data_aux0
-^INVAR Verilog::main\.data_aux0 = \(\(\(\(\(\(\(\(0uh32_10
-^LTLSPEC G main\.data = 0uh32_40302010$
+^INVAR data = data_aux2$
+^INVAR data_aux2 = \(\(\(\(\(\(\(\(data_aux1
+^INVAR data_aux1 = \(\(\(\(\(\(\(\(data_aux0
+^INVAR data_aux0 = \(\(\(\(\(\(\(\(0uh32_10
+^LTLSPEC G data = 0uh32_40302010$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/smv-word-level/constants1.desc
+++ b/regression/ebmc/smv-word-level/constants1.desc
@@ -1,8 +1,8 @@
 CORE
 constants1.sv
 --smv-word-level
-^INVAR main\.w1 = 0uh32_12345678$
-^INVAR main\.w2 = 0ud32_12345678$
+^INVAR w1 = 0uh32_12345678$
+^INVAR w2 = 0ud32_12345678$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/smv-word-level/identifier_syntax1.desc
+++ b/regression/ebmc/smv-word-level/identifier_syntax1.desc
@@ -1,0 +1,14 @@
+CORE
+identifier_syntax1.sv
+--smv-word-level
+^VAR _0 : boolean;$
+^VAR _\$ : boolean;$
+^VAR _# : boolean;$
+^VAR foo_bar : boolean;$
+^VAR foo_bar#2 : boolean;$
+^VAR foo__bar : boolean;$
+^VAR foo_ : boolean;$
+^EXIT=0$
+^SIGNAL=0$
+--
+--

--- a/regression/ebmc/smv-word-level/identifier_syntax1.sv
+++ b/regression/ebmc/smv-word-level/identifier_syntax1.sv
@@ -1,0 +1,20 @@
+module main;
+
+  // SMV identifiers must start with letter or _
+  wire \0 = 1;
+  wire \$ = 1;
+  wire \# = 1;
+
+  // SMV identifiers must not contain +
+  wire \foo+bar = 1;
+
+  // deliberately picked to provoke a collision
+  wire foo_bar = 1;
+
+  // SMV identifiers must not contain two consecutive dots
+  wire \foo..bar = 1;
+
+  // SMV identifiers must not end on a dot
+  wire \foo. = 1;
+
+endmodule

--- a/regression/ebmc/smv-word-level/keywords1.desc
+++ b/regression/ebmc/smv-word-level/keywords1.desc
@@ -4,6 +4,6 @@ keywords1.sv
 ^EXIT=0$
 ^SIGNAL=0$
 --
-INVAR main\.MODULE = 0sd32_0
+INVAR MODULE = 0sd32_0
 --
 The SMV keywords must not be used as identifiers.

--- a/regression/ebmc/smv-word-level/verilog1.desc
+++ b/regression/ebmc/smv-word-level/verilog1.desc
@@ -3,10 +3,10 @@ verilog1.sv
 --smv-word-level
 ^MODULE main$
 ^VAR x : unsigned word\[32\];$
-^INIT main\.x = 0ud32_0$
-^INVAR Verilog::main\.x_aux0 = main\.x \+ unsigned\(0sd32_1\)$
-^TRANS next\(main\.x\) = Verilog::main\.x_aux0$
-^LTLSPEC F main\.x = unsigned\(0sd32_10\)$
+^INIT x = 0ud32_0$
+^INVAR x_aux0 = x \+ unsigned\(0sd32_1\)$
+^TRANS next\(x\) = x_aux0$
+^LTLSPEC F x = unsigned\(0sd32_10\)$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/smv-word-level/verilog2.desc
+++ b/regression/ebmc/smv-word-level/verilog2.desc
@@ -2,18 +2,18 @@ CORE
 verilog2.sv
 --smv-word-level
 ^MODULE main$
-^INVAR main\.sw1 = extend\(signed\(main\.ui\), 24\)$
-^INVAR main\.sw2 = extend\(main\.si, 24\)$
-^INVAR main\.uw1 = extend\(main\.ui, 24\)$
-^INVAR main\.uw2 = unsigned\(extend\(main\.si, 24\)\)$
-^INVAR main\.sn1 = signed\(resize\(main\.ui, 4\)\)$
-^INVAR main\.sn2 = signed\(resize\(unsigned\(main.si\), 4\)\)$
-^INVAR main\.un1 = resize\(main\.ui, 4\)$
-^INVAR main\.un2 = resize\(unsigned\(main\.si\), 4\)$
-^INVAR main\.sb1 = signed\(main\.ui\)$
-^INVAR main\.sb2 = main\.si$
-^INVAR main\.ub1 = main\.ui$
-^INVAR main\.ub2 = unsigned\(main\.si\)$
+^INVAR sw1 = extend\(signed\(ui\), 24\)$
+^INVAR sw2 = extend\(si, 24\)$
+^INVAR uw1 = extend\(ui, 24\)$
+^INVAR uw2 = unsigned\(extend\(si, 24\)\)$
+^INVAR sn1 = signed\(resize\(ui, 4\)\)$
+^INVAR sn2 = signed\(resize\(unsigned\(si\), 4\)\)$
+^INVAR un1 = resize\(ui, 4\)$
+^INVAR un2 = resize\(unsigned\(si\), 4\)$
+^INVAR sb1 = signed\(ui\)$
+^INVAR sb2 = si$
+^INVAR ub1 = ui$
+^INVAR ub2 = unsigned\(si\)$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/smv-word-level/verilog3.desc
+++ b/regression/ebmc/smv-word-level/verilog3.desc
@@ -3,8 +3,8 @@ verilog3.sv
 --smv-word-level
 ^MODULE main$
 ^VAR some_array : array 0\.\.31 of unsigned word\[8\];$
-^TRANS next\(main\.some_array\) = main\.some_array$
-^LTLSPEC G main\.some_array\[resize\(unsigned\(0sd32_0\), 5\)\] = 0ud8_123$
+^TRANS next\(some_array\) = some_array$
+^LTLSPEC G some_array\[resize\(unsigned\(0sd32_0\), 5\)\] = 0ud8_123$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/smv-word-level/verilog4.desc
+++ b/regression/ebmc/smv-word-level/verilog4.desc
@@ -1,7 +1,7 @@
 CORE
 verilog4.sv
 --smv-word-level
-^LTLSPEC X X extend\(main\.x\[31:1\], 1\) = unsigned\(0sd32_1\)$
+^LTLSPEC X X extend\(x\[31:1\], 1\) = unsigned\(0sd32_1\)$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/smv-word-level/verilog5.desc
+++ b/regression/ebmc/smv-word-level/verilog5.desc
@@ -1,9 +1,9 @@
 CORE
 verilog5.sv
 --smv-word-level
-^INIT ebmc::\$past1@1 = FALSE$
-^TRANS next\(ebmc::\$past1@1\) = main\.in$
-^LTLSPEC G main\.in = \(X ebmc::\$past1@1\)$
+^INIT ebmc__\$past1_1 = FALSE$
+^TRANS next\(ebmc__\$past1_1\) = in$
+^LTLSPEC G in = \(X ebmc__\$past1_1\)$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/ebmc/output_smv_word_level.cpp
+++ b/src/ebmc/output_smv_word_level.cpp
@@ -9,15 +9,44 @@ Author: Daniel Kroening, dkr@amazon.com
 #include "output_smv_word_level.h"
 
 #include <util/bitvector_types.h>
+#include <util/replace_symbol.h>
 
 #include <smvlang/expr2smv.h>
+#include <smvlang/smv_expr.h>
 #include <temporal-logic/sva_to_ltl.h>
+#include <trans-word-level/next_symbol.h>
 
 #include "ebmc_error.h"
 #include "ebmc_properties.h"
 #include "transition_system.h"
 
 #include <ostream>
+#include <unordered_set>
+
+std::string
+smv_expr_printer(const exprt &expr, const replace_symbolt &smv_identifier_map)
+{
+  exprt tmp = expr; // copy
+
+  // replace_symbolt does not do next_symbol; we hence replace next_symbol by
+  // smv_next_exprt{symbol_exprt{...}} first.
+  tmp.visit_pre(
+    [](exprt &node)
+    {
+      if(node.id() == ID_next_symbol)
+      {
+        auto identifier = to_next_symbol_expr(node).identifier();
+        node = smv_next_exprt{symbol_exprt{identifier, node.type()}};
+      }
+    });
+
+  // now apply replace_symbolt
+  smv_identifier_map(tmp);
+
+  symbol_tablet symbol_table;
+  namespacet ns{symbol_table};
+  return expr2smv(tmp, ns);
+}
 
 class smv_type_printert
 {
@@ -35,6 +64,13 @@ protected:
   const typet &_type;
 };
 
+static bool is_supported_type(const typet &type)
+{
+  return type.id() == ID_bool || type.id() == ID_signedbv ||
+         type.id() == ID_unsignedbv || type.id() == ID_range ||
+         type.id() == ID_array;
+}
+
 std::ostream &
 operator<<(std::ostream &out, const smv_type_printert &type_printer)
 {
@@ -43,21 +79,87 @@ operator<<(std::ostream &out, const smv_type_printert &type_printer)
   symbol_tablet symbol_table;
   namespacet ns(symbol_table);
 
-  if(
-    type.id() == ID_bool || type.id() == ID_signedbv ||
-    type.id() == ID_unsignedbv || type.id() == ID_range ||
-    type.id() == ID_array)
-  {
+  if(is_supported_type(type))
     return out << type2smv(type, ns);
-  }
   else
     throw ebmc_errort{} << "cannot convert type " << type.id() << " to SMV";
 
   return out;
 }
 
+/// Create an identifier that satisfies SMV's syntactic rules.
+irep_idt create_smv_identifier(const irep_idt &identifier)
+{
+  PRECONDITION(!identifier.empty());
+
+  std::string result;
+
+  // must start with letter or _
+  if(!isalpha(identifier[0]) && identifier[0] != '_')
+    result = '_';
+
+  // the rest must be alphanumeric, _ $ # -, or a complex identifier
+  for(auto ch : id2string(identifier))
+  {
+    if(isalnum(ch) || ch == '_' || ch == '$' || ch == '#' || ch == '-')
+      result += ch;
+    else
+      result += '_';
+  }
+
+  return result;
+}
+
+replace_symbolt smv_identifier_map(const transition_systemt &transition_system)
+{
+  const auto module = transition_system.main_symbol->name;
+  const auto &symbol_table = transition_system.symbol_table;
+  replace_symbolt result;
+  std::unordered_set<irep_idt, irep_id_hash> identifiers_used;
+
+  for(auto m_it = symbol_table.symbol_module_map.lower_bound(module);
+      m_it != symbol_table.symbol_module_map.upper_bound(module);
+      m_it++)
+  {
+    const irep_idt &identifier = m_it->second;
+
+    symbol_tablet::symbolst::const_iterator s_it =
+      symbol_table.symbols.find(identifier);
+
+    if(s_it == symbol_table.symbols.end())
+      throw ebmc_errort{} << "failed to find symbol " << identifier;
+
+    const symbolt &symbol = s_it->second;
+
+    if(is_supported_type(symbol.type))
+    {
+      // The SMV identifiers we generate might collide.
+      std::size_t collision_counter = 1;
+      irep_idt smv_identifier;
+
+      do
+      {
+        smv_identifier = create_smv_identifier(
+          !symbol.base_name.empty() ? symbol.base_name : symbol.name);
+
+        if(collision_counter != 1)
+          smv_identifier =
+            id2string(smv_identifier) + '#' + std::to_string(collision_counter);
+
+        collision_counter++;
+      } while(!identifiers_used.insert(smv_identifier).second);
+
+      smv_identifier_exprt replacement{smv_identifier, symbol.type};
+      result.insert(symbol.symbol_expr(), replacement);
+    }
+  }
+
+  return result;
+}
+
 static void smv_state_variables(
   const transition_systemt &transition_system,
+  const replace_symbolt &identifier_map,
   std::ostream &out)
 {
   bool found = false;
@@ -79,10 +181,10 @@ static void smv_state_variables(
 
     const symbolt &symbol = s_it->second;
 
-    if(symbol.is_state_var)
+    if(is_supported_type(symbol.type) && !symbol.is_type && !symbol.is_property)
     {
-      out << "VAR " << symbol.base_name << " : "
-          << smv_type_printert{symbol.type} << ";\n";
+      out << "VAR " << smv_expr_printer(symbol.symbol_expr(), identifier_map)
+          << " : " << smv_type_printert{symbol.type} << ";\n";
       found = true;
     }
   }
@@ -91,13 +193,15 @@ static void smv_state_variables(
     out << '\n';
 }
 
-static void
-smv_initial_states(const exprt &expr, const namespacet &ns, std::ostream &out)
+static void smv_initial_states(
+  const exprt &expr,
+  const replace_symbolt &identifier_map,
+  std::ostream &out)
 {
   if(expr.id() == ID_and)
   {
     for(auto &conjunct : expr.operands())
-      smv_initial_states(conjunct, ns, out);
+      smv_initial_states(conjunct, identifier_map, out);
   }
   else if(expr.is_true())
   {
@@ -105,52 +209,27 @@ smv_initial_states(const exprt &expr, const namespacet &ns, std::ostream &out)
   }
   else
   {
-    out << "INIT " << expr2smv(expr, ns) << '\n';
+    out << "INIT " << smv_expr_printer(expr, identifier_map) << '\n';
   }
 }
 
 static void smv_initial_states(
   const transition_systemt &transition_system,
+  const replace_symbolt &identifier_map,
   std::ostream &out)
 {
-  const namespacet ns(transition_system.symbol_table);
-  smv_initial_states(transition_system.trans_expr.init(), ns, out);
+  smv_initial_states(transition_system.trans_expr.init(), identifier_map, out);
 }
 
-static void
-smv_invar(const exprt &expr, const namespacet &ns, std::ostream &out)
-{
-  if(expr.id() == ID_and)
-  {
-    for(auto &conjunct : expr.operands())
-      smv_invar(conjunct, ns, out);
-  }
-  else if(expr.is_true())
-  {
-    // ignore
-  }
-  else
-  {
-    out << "INVAR " << expr2smv(expr, ns) << '\n';
-  }
-}
-
-static void
-smv_invar(const transition_systemt &transition_system, std::ostream &out)
-{
-  const namespacet ns(transition_system.symbol_table);
-  smv_invar(transition_system.trans_expr.invar(), ns, out);
-}
-
-static void smv_transition_relation(
+static void smv_invar_rec(
   const exprt &expr,
-  const namespacet &ns,
+  const replace_symbolt &identifier_map,
   std::ostream &out)
 {
   if(expr.id() == ID_and)
   {
     for(auto &conjunct : expr.operands())
-      smv_transition_relation(conjunct, ns, out);
+      smv_invar_rec(conjunct, identifier_map, out);
   }
   else if(expr.is_true())
   {
@@ -158,25 +237,53 @@ static void smv_transition_relation(
   }
   else
   {
-    out << "TRANS " << expr2smv(expr, ns) << '\n';
+    out << "INVAR " << smv_expr_printer(expr, identifier_map) << '\n';
+  }
+}
+
+static void smv_invar(
+  const transition_systemt &transition_system,
+  const replace_symbolt &identifier_map,
+  std::ostream &out)
+{
+  smv_invar_rec(transition_system.trans_expr.invar(), identifier_map, out);
+}
+
+static void smv_transition_relation_rec(
+  const exprt &expr,
+  const replace_symbolt &identifier_map,
+  std::ostream &out)
+{
+  if(expr.id() == ID_and)
+  {
+    for(auto &conjunct : expr.operands())
+      smv_transition_relation_rec(conjunct, identifier_map, out);
+  }
+  else if(expr.is_true())
+  {
+    // ignore
+  }
+  else
+  {
+    out << "TRANS " << smv_expr_printer(expr, identifier_map) << '\n';
   }
 }
 
 static void smv_transition_relation(
   const transition_systemt &transition_system,
+  const replace_symbolt &identifier_map,
   std::ostream &out)
 {
-  const namespacet ns(transition_system.symbol_table);
-  smv_transition_relation(transition_system.trans_expr.trans(), ns, out);
+  smv_transition_relation_rec(
+    transition_system.trans_expr.trans(), identifier_map, out);
 }
 
 static void smv_properties(
   const transition_systemt &transition_system,
   const ebmc_propertiest &properties,
+  const replace_symbolt &identifier_map,
   std::ostream &out)
 {
-  const namespacet ns(transition_system.symbol_table);
-
   for(auto &property : properties.properties)
   {
     if(property.is_disabled() || property.is_assumed())
@@ -184,11 +291,13 @@ static void smv_properties(
 
     if(is_CTL(property.normalized_expr))
     {
-      out << "CTLSPEC " << expr2smv(property.normalized_expr, ns);
+      out << "CTLSPEC "
+          << smv_expr_printer(property.normalized_expr, identifier_map);
     }
     else if(is_LTL(property.normalized_expr))
     {
-      out << "LTLSPEC " << expr2smv(property.normalized_expr, ns);
+      out << "LTLSPEC "
+          << smv_expr_printer(property.normalized_expr, identifier_map);
     }
     else if(is_SVA(property.normalized_expr))
     {
@@ -196,7 +305,7 @@ static void smv_properties(
       try
       {
         auto ltl = SVA_to_LTL(property.normalized_expr);
-        out << "LTLSPEC " << expr2smv(ltl, ns);
+        out << "LTLSPEC " << smv_expr_printer(ltl, identifier_map);
       }
       catch(sva_to_ltl_unsupportedt error)
       {
@@ -218,18 +327,20 @@ void output_smv_word_level(
 {
   out << "MODULE main\n\n";
 
+  auto identifier_map = smv_identifier_map(transition_system);
+
   // state-holding elements first
-  smv_state_variables(transition_system, out);
+  smv_state_variables(transition_system, identifier_map, out);
 
   // initial state constraints
-  smv_initial_states(transition_system, out);
+  smv_initial_states(transition_system, identifier_map, out);
 
   // in-state invariants
-  smv_invar(transition_system, out);
+  smv_invar(transition_system, identifier_map, out);
 
   // transition relation
-  smv_transition_relation(transition_system, out);
+  smv_transition_relation(transition_system, identifier_map, out);
 
   // properties
-  smv_properties(transition_system, properties, out);
+  smv_properties(transition_system, properties, identifier_map, out);
 }

--- a/src/smvlang/expr2smv.cpp
+++ b/src/smvlang/expr2smv.cpp
@@ -728,6 +728,24 @@ expr2smvt::resultt expr2smvt::convert_norep(const exprt &src)
 
 /*******************************************************************\
 
+Function: expr2smvt::convert_smv_identifier
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+expr2smvt::resultt
+expr2smvt::convert_smv_identifier(const smv_identifier_exprt &src)
+{
+  return {precedencet::MAX, id2string(src.identifier())};
+}
+
+/*******************************************************************\
+
 Function: expr2smvt::convert_symbol
 
   Inputs:
@@ -968,6 +986,9 @@ expr2smvt::resultt expr2smvt::convert_rec(const exprt &src)
   else if(src.id() == ID_mod)
     return convert_binary(to_mod_expr(src), src.id_string(), precedencet::MULT);
 
+  else if(src.id() == ID_smv_next)
+    return convert_function_application("next", to_smv_next_expr(src));
+
   else if(src.id() == ID_smv_range)
     return convert_binary(to_smv_range_expr(src), "..", precedencet::UNION);
   // precedence is unknown
@@ -1102,6 +1123,9 @@ expr2smvt::resultt expr2smvt::convert_rec(const exprt &src)
 
   else if(src.id() == ID_if)
     return convert_if(to_if_expr(src), precedencet::IF);
+
+  else if(src.id() == ID_smv_identifier)
+    return convert_smv_identifier(to_smv_identifier_expr(src));
 
   else if(src.id()==ID_symbol)
     return convert_symbol(to_symbol_expr(src));

--- a/src/smvlang/expr2smv_class.h
+++ b/src/smvlang/expr2smv_class.h
@@ -18,6 +18,8 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include "expr2smv.h"
 
+class smv_identifier_exprt;
+class smv_next_exprt;
 class smv_set_exprt;
 class smv_word1_exprt;
 
@@ -126,6 +128,10 @@ protected:
   resultt convert_index(const index_exprt &, precedencet);
 
   resultt convert_if(const if_exprt &, precedencet);
+
+  resultt convert_smv_identifier(const smv_identifier_exprt &);
+
+  resultt convert_smv_next(const smv_next_exprt &);
 
   resultt convert_symbol(const symbol_exprt &);
 

--- a/src/smvlang/smv_expr.h
+++ b/src/smvlang/smv_expr.h
@@ -332,7 +332,12 @@ class smv_identifier_exprt : public nullary_exprt
 {
 public:
   explicit smv_identifier_exprt(irep_idt _identifier)
-    : nullary_exprt{ID_smv_identifier, typet{}}
+    : smv_identifier_exprt{_identifier, typet{}}
+  {
+  }
+
+  smv_identifier_exprt(irep_idt _identifier, typet type)
+    : nullary_exprt{ID_smv_identifier, std::move(type)}
   {
     identifier(_identifier);
   }


### PR DESCRIPTION
This adds a map from symbol table identifiers to syntactically valid SMV identifiers to the SMV word-level output.