### PR TITLE
`smv_next_exprt`

### DIFF
--- a/src/smvlang/parser.y
+++ b/src/smvlang/parser.y
@@ -654,7 +654,7 @@ assignment : init_Token '(' complex_identifier ')' BECOMES_Token simple_expr ';'
            | next_Token '(' complex_identifier ')' BECOMES_Token next_expr ';'
            {
              PARSER.module->add_assign_next(
-               unary_exprt{ID_smv_next, std::move(stack_expr($3))},
+               smv_next_exprt{std::move(stack_expr($3))},
                std::move(stack_expr($6)));
            }
            | complex_identifier BECOMES_Token formula ';'

--- a/src/smvlang/smv_expr.h
+++ b/src/smvlang/smv_expr.h
@@ -560,4 +560,26 @@ inline smv_cases_exprt &to_smv_cases_expr(exprt &expr)
   return static_cast<smv_cases_exprt &>(expr);
 }
 
+class smv_next_exprt : public unary_exprt
+{
+public:
+  explicit smv_next_exprt(exprt _op) : unary_exprt{ID_smv_next, _op, _op.type()}
+  {
+  }
+};
+
+inline const smv_next_exprt &to_smv_next_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_smv_next);
+  smv_next_exprt::check(expr);
+  return static_cast<const smv_next_exprt &>(expr);
+}
+
+inline smv_next_exprt &to_smv_next_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_smv_next);
+  smv_next_exprt::check(expr);
+  return static_cast<smv_next_exprt &>(expr);
+}
+
 #endif // CPROVER_SMV_EXPR_H

--- a/src/smvlang/smv_typecheck.cpp
+++ b/src/smvlang/smv_typecheck.cpp
@@ -818,7 +818,7 @@ void smv_typecheckt::process_smv_next_rec(exprt &expr, bool next)
         << "next(next(...)) encountered";
     }
 
-    expr = to_unary_expr(expr).op();
+    expr = to_smv_next_expr(expr).op();
 
     process_smv_next_rec(expr, true);
     return;
@@ -911,7 +911,7 @@ void smv_typecheckt::typecheck_expr_node(exprt &expr, modet mode)
   else if(expr.id() == ID_smv_next)
   {
     // handled by process_smv_next
-    expr.type() = to_unary_expr(expr).op().type();
+    expr.type() = to_smv_next_expr(expr).op().type();
   }
   else if(expr.id() == ID_next_symbol)
   {


### PR DESCRIPTION
This introduces `smv_next_exprt`, documenting the unary expression generated by the SMV front-end.