### PR TITLE
SystemVerilog: `break` and `continue`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 # EBMC 5.10
 
 * cast properties given with -p to Boolean if need be
-* SystemVerilog: return statements
+* SystemVerilog: break, continue and return statements
 * SystemVerilog: assignments to a part-select of a struct
 * SystemVerilog: timeunits and timeprecision
 * SystemVerilog: recursive module definitions

--- a/regression/verilog/for/break1.desc
+++ b/regression/verilog/for/break1.desc
@@ -1,8 +1,8 @@
 CORE
 break1.sv
 
-^file .* line 7: synthesis of break not supported$
-^EXIT=2$
+^\[main\.loop_exit\] main.i == 5: PROVED .*$
+^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring

--- a/regression/verilog/for/break1.sv
+++ b/regression/verilog/for/break1.sv
@@ -6,7 +6,7 @@ module main;
       if(i == 5)
         break;
     end
-    assert(i==5);
+    loop_exit: assert(i==5);
   end
 
 endmodule

--- a/regression/verilog/for/break2.desc
+++ b/regression/verilog/for/break2.desc
@@ -1,8 +1,7 @@
 CORE
 break2.sv
 
-^file .* line 10: synthesis of break not supported$
-^EXIT=2$
+^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring

--- a/regression/verilog/for/break2.sv
+++ b/regression/verilog/for/break2.sv
@@ -10,9 +10,9 @@ module main(input [31:0] bits);
         break;
 
      index = i;
-     assert final(bits == 'b1 -> index == 0);
-     assert final(bits == 'b1000 -> index == 3);
-     assert final(bits == 0 -> index == 32);
+     p0: assert final(bits == 'b1 -> index == 0);
+     p3: assert final(bits == 'b1000 -> index == 3);
+     p32: assert final(bits == 0 -> index == 32);
   end
 
 endmodule

--- a/regression/verilog/for/break3.desc
+++ b/regression/verilog/for/break3.desc
@@ -1,8 +1,7 @@
 CORE
 break3.sv
 
-^file break3.sv line 9: synthesis of break not supported$
-^EXIT=2$
+^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring

--- a/regression/verilog/for/break3.sv
+++ b/regression/verilog/for/break3.sv
@@ -8,9 +8,9 @@ module main(input [31:0] bits);
       if(bits[index])
         break;
 
-     assert final(bits == 'b1 -> index == 0);
-     assert final(bits == 'b1000 -> index == 3);
-     assert final(bits == 0 -> index == 32);
+    p0: assert final(bits == 'b1 -> index == 0);
+    p3: assert final(bits == 'b1000 -> index == 3);
+    p32: assert final(bits == 0 -> index == 32);
   end
 
 endmodule

--- a/regression/verilog/for/continue1.desc
+++ b/regression/verilog/for/continue1.desc
@@ -1,8 +1,8 @@
 CORE
 continue1.sv
 
-^file .* line 8: synthesis of continue not supported$
-^EXIT=2$
+^\[main\.p0\] main\.j == 9: PROVED .*$
+^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring

--- a/regression/verilog/for/continue1.sv
+++ b/regression/verilog/for/continue1.sv
@@ -8,7 +8,7 @@ module main;
         continue;
       j++;
     end
-    assert(j==9);
+    p0: assert(j==9);
   end
 
 endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -2052,6 +2052,50 @@ void verilog_synthesist::synth_block(const verilog_blockt &statement)
 
 /*******************************************************************\
 
+Function: verilog_synthesist::synth_break
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void verilog_synthesist::synth_break(const verilog_breakt &statement)
+{
+  PRECONDITION(loop_frame.has_value());
+
+  loop_frame.value().break_statement_states.push_back(*value_map);
+
+  // set guard to false
+  value_map->guard.push_back(false_exprt{});
+}
+
+/*******************************************************************\
+
+Function: verilog_synthesist::synth_continue
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void verilog_synthesist::synth_continue(const verilog_continuet &statement)
+{
+  PRECONDITION(loop_frame.has_value());
+
+  loop_frame.value().continue_statement_states.push_back(*value_map);
+
+  // set guard to false
+  value_map->guard.push_back(false_exprt{});
+}
+
+/*******************************************************************\
+
 Function: verilog_synthesist::synth_continuous_assign
 
   Inputs:
@@ -2932,6 +2976,9 @@ void verilog_synthesist::synth_for(const verilog_fort &statement)
       << "for expected to have four operands";
   }
 
+  auto old_loop_frame = std::move(loop_frame);
+  loop_frame = loop_framet{};
+
   for(auto &init : statement.initialization())
   {
     // either an assignment or a declaration with assignment
@@ -2964,6 +3011,8 @@ void verilog_synthesist::synth_for(const verilog_fort &statement)
 
   while(true)
   {
+    loop_frame.value().continue_statement_states.clear();
+
     DATA_INVARIANT(
       statement.condition().type().id() == ID_bool,
       "for condition must be Boolean");
@@ -2983,9 +3032,33 @@ void verilog_synthesist::synth_for(const verilog_fort &statement)
     // execute the body
     synth_statement(statement.body());
 
+    // merge in edges from 'continue' statements, if any
+    for(auto &state : loop_frame.value().continue_statement_states)
+    {
+      auto guard_expr = conjunction(state.guard);
+      merge(
+        guard_expr,
+        state.current,
+        value_map->current,
+        false,
+        value_map->current);
+      merge(guard_expr, state.final, value_map->final, true, value_map->final);
+    }
+
     // execute the step statement
     synth_statement(statement.inc_statement());
   }
+
+  // merge in edges from 'break' statements, if any
+  for(auto &state : loop_frame.value().break_statement_states)
+  {
+    auto guard_expr = conjunction(state.guard);
+    merge(
+      guard_expr, state.current, value_map->current, false, value_map->current);
+    merge(guard_expr, state.final, value_map->final, true, value_map->final);
+  }
+
+  loop_frame = std::move(old_loop_frame);
 }
 
 /*******************************************************************\
@@ -3050,8 +3123,13 @@ void verilog_synthesist::synth_while(
       << "while expected to have two operands";
   }
 
+  auto old_loop_frame = std::move(loop_frame);
+  loop_frame = loop_framet{};
+
   while(true)
-  {  
+  {
+    loop_frame.value().continue_statement_states.clear();
+
     exprt tmp_guard=statement.condition();
     tmp_guard = typecast_exprt{tmp_guard, bool_typet{}};
     tmp_guard = synth_expr(tmp_guard, symbol_statet::CURRENT);
@@ -3068,7 +3146,31 @@ void verilog_synthesist::synth_while(
 
     // execute the body
     synth_statement(statement.body());
+
+    // merge in edges from 'continue' statements, if any
+    for(auto &state : loop_frame.value().continue_statement_states)
+    {
+      auto guard_expr = conjunction(state.guard);
+      merge(
+        guard_expr,
+        state.current,
+        value_map->current,
+        false,
+        value_map->current);
+      merge(guard_expr, state.final, value_map->final, true, value_map->final);
+    }
   }
+
+  // merge in edges from 'break' statements, if any
+  for(auto &state : loop_frame.value().break_statement_states)
+  {
+    auto guard_expr = conjunction(state.guard);
+    merge(
+      guard_expr, state.current, value_map->current, false, value_map->current);
+    merge(guard_expr, state.final, value_map->final, true, value_map->final);
+  }
+
+  loop_frame = std::move(old_loop_frame);
 }
 
 /*******************************************************************\
@@ -3279,10 +3381,7 @@ void verilog_synthesist::synth_statement(
   if(statement.id()==ID_block)
     synth_block(to_verilog_block(statement));
   else if(statement.id() == ID_break)
-  {
-    throw errort().with_location(statement.source_location())
-      << "synthesis of break not supported";
-  }
+    synth_break(to_verilog_break(statement));
   else if(statement.id()==ID_case ||
           statement.id()==ID_casex ||
           statement.id()==ID_casez)
@@ -3305,10 +3404,7 @@ void verilog_synthesist::synth_statement(
     synth_assign(to_verilog_assign(statement));
   }
   else if(statement.id() == ID_continue)
-  {
-    throw errort().with_location(statement.source_location())
-      << "synthesis of continue not supported";
-  }
+    synth_continue(to_verilog_continue(statement));
   else if(statement.id() == ID_procedural_continuous_assign)
   {
     throw errort().with_location(statement.source_location())

--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -219,6 +219,16 @@ protected:
   // the call frame is optional since we might not be in a task or function
   std::optional<tf_framet> tf_frame;
 
+  // states for break and continue
+  class loop_framet
+  {
+  public:
+    std::vector<value_mapt> break_statement_states;
+    std::vector<value_mapt> continue_statement_states;
+  };
+
+  std::optional<loop_framet> loop_frame;
+
   void merge(
     const exprt &guard,
     const value_mapt::mapt &true_map,
@@ -268,7 +278,9 @@ protected:
   void synth_decl(const verilog_declt &);
   void synth_function_or_task_decl(const verilog_function_or_task_declt &);
   void synth_block(const verilog_blockt &);
+  void synth_break(const verilog_breakt &);
   void synth_case(const verilog_statementt &);
+  void synth_continue(const verilog_continuet &);
   void synth_if(const verilog_ift &);
   void synth_event_guard(const verilog_event_guardt &);
   void synth_delay(const verilog_delayt &);


### PR DESCRIPTION
This adds support for `break` and `continue` inside `for` and `while` loops.