### PR TITLE
Cleanup: remove redundant `ID_sva_s_nexttime` case

### DIFF
--- a/src/ebmc/completeness_threshold.cpp
+++ b/src/ebmc/completeness_threshold.cpp
@@ -33,9 +33,7 @@ std::optional<mp_integer> completeness_threshold(const exprt &expr)
     else
       return {};
   }
-  else if(
-    expr.id() == ID_sva_nexttime || expr.id() == ID_sva_s_nexttime ||
-    expr.id() == ID_sva_s_nexttime)
+  else if(expr.id() == ID_sva_nexttime || expr.id() == ID_sva_s_nexttime)
   {
     // these are rewritten to always/s_always by normalize_property
     PRECONDITION(false);


### PR DESCRIPTION
This removes a redundant check for the `ID_sva_s_nexttime` case in the completeness threshold logic.