### PR TITLE
EBMC: extract `engine_heuristic` into separate file

### DIFF
--- a/src/ebmc/Makefile
+++ b/src/ebmc/Makefile
@@ -12,6 +12,7 @@ SRC = \
       diameter.cpp \
       diatest.cpp \
       dimacs_writer.cpp \
+      engine_heuristic.cpp \
       ebmc_language.cpp \
       ebmc_languages.cpp \
       ebmc_parse_options.cpp \

--- a/src/ebmc/engine_heuristic.cpp
+++ b/src/ebmc/engine_heuristic.cpp
@@ -1,0 +1,105 @@
+/*******************************************************************\
+
+Module: EBMC Heuristic Engine Selection
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#include "engine_heuristic.h"
+
+#include "bmc.h"
+#include "completeness_threshold.h"
+#include "ebmc_solver_factory.h"
+#include "k_induction.h"
+#include "tautology_check.h"
+
+property_checker_resultt engine_heuristic(
+  const cmdlinet &cmdline,
+  transition_systemt &transition_system,
+  ebmc_propertiest &properties,
+  message_handlert &message_handler)
+{
+  messaget message(message_handler);
+
+  if(properties.properties.empty())
+  {
+    message.error() << "no properties" << messaget::eom;
+    return property_checker_resultt::error();
+  }
+
+  auto solver_factory = ebmc_solver_factory(cmdline);
+
+  if(!properties.has_unfinished_property())
+    return property_checker_resultt{properties}; // done
+
+  message.status() << "No engine given, attempting heuristic engine selection"
+                   << messaget::eom;
+
+  // First check if we can tell that the property is a tautology
+  message.status() << "Tautology check" << messaget::eom;
+
+  auto tautology_check_result =
+    tautology_check(cmdline, properties, solver_factory, message_handler);
+
+  properties.properties = tautology_check_result.properties;
+
+  if(!properties.has_unfinished_property())
+    return tautology_check_result; // done
+
+  properties.reset_failure();
+  properties.reset_inconclusive();
+  properties.reset_unsupported();
+
+  // Check whether we have a low completenes threshold
+  message.status() << "Attempting completeness threshold" << messaget::eom;
+
+  auto completeness_threshold_result = completeness_threshold(
+    cmdline, transition_system, properties, solver_factory, message_handler);
+
+  properties.properties = completeness_threshold_result.properties;
+
+  if(!properties.has_unfinished_property())
+    return completeness_threshold_result; // done
+
+  properties.reset_failure();
+  properties.reset_inconclusive();
+  properties.reset_unsupported();
+
+  // Now try 1-induction, word-level
+  message.status() << "Attempting 1-induction" << messaget::eom;
+
+  auto k_induction_result = k_induction(
+    1, transition_system, properties, solver_factory, message_handler);
+
+  properties.properties = k_induction_result.properties;
+
+  if(!properties.has_unfinished_property())
+    return k_induction_result; // done
+
+  properties.reset_failure();
+  properties.reset_inconclusive();
+  properties.reset_unsupported();
+
+  // Now try BMC with bound 5, word-level
+  message.status() << "Attempting BMC with bound 5" << messaget::eom;
+
+  auto bmc_result = bmc(
+    5,     // bound
+    false, // convert_only
+    cmdline.isset("bmc-with-assumptions"),
+    transition_system,
+    properties,
+    solver_factory,
+    message_handler);
+
+  properties.properties = std::move(bmc_result.properties);
+
+  if(!properties.has_unfinished_property())
+    return property_checker_resultt{properties}; // done
+
+  properties.reset_failure();
+
+  // Give up
+  return property_checker_resultt{properties}; // done
+}

--- a/src/ebmc/engine_heuristic.h
+++ b/src/ebmc/engine_heuristic.h
@@ -1,0 +1,20 @@
+/*******************************************************************\
+
+Module: EBMC Heuristic Engine Selection
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_EBMC_ENGINE_HEURISTIC_H
+#define CPROVER_EBMC_ENGINE_HEURISTIC_H
+
+#include "property_checker.h"
+
+property_checker_resultt engine_heuristic(
+  const cmdlinet &,
+  transition_systemt &,
+  ebmc_propertiest &,
+  message_handlert &);
+
+#endif // CPROVER_EBMC_ENGINE_HEURISTIC_H

--- a/src/ebmc/property_checker.cpp
+++ b/src/ebmc/property_checker.cpp
@@ -16,17 +16,16 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include "bdd_engine.h"
 #include "bmc.h"
-#include "completeness_threshold.h"
 #include "dimacs_writer.h"
 #include "ebmc_error.h"
 #include "ebmc_solver_factory.h"
+#include "engine_heuristic.h"
 #include "ic3_engine.h"
 #include "instrument_past.h"
 #include "k_induction.h"
 #include "netlist.h"
 #include "output_file.h"
 #include "report_results.h"
-#include "tautology_check.h"
 
 #include <chrono>
 #include <iostream>
@@ -361,96 +360,6 @@ property_checker_resultt bit_level_bmc(
     return bit_level_bmc(
       satcheck, false, cmdline, transition_system, properties, message_handler);
   }
-}
-
-property_checker_resultt engine_heuristic(
-  const cmdlinet &cmdline,
-  transition_systemt &transition_system,
-  ebmc_propertiest &properties,
-  message_handlert &message_handler)
-{
-  messaget message(message_handler);
-
-  if(properties.properties.empty())
-  {
-    message.error() << "no properties" << messaget::eom;
-    return property_checker_resultt::error();
-  }
-
-  auto solver_factory = ebmc_solver_factory(cmdline);
-
-  if(!properties.has_unfinished_property())
-    return property_checker_resultt{properties}; // done
-
-  message.status() << "No engine given, attempting heuristic engine selection"
-                   << messaget::eom;
-
-  // First check if we can tell that the property is a tautology
-  message.status() << "Tautology check" << messaget::eom;
-
-  auto tautology_check_result =
-    tautology_check(cmdline, properties, solver_factory, message_handler);
-
-  properties.properties = tautology_check_result.properties;
-
-  if(!properties.has_unfinished_property())
-    return tautology_check_result; // done
-
-  properties.reset_failure();
-  properties.reset_inconclusive();
-  properties.reset_unsupported();
-
-  // Check whether we have a low completenes threshold
-  message.status() << "Attempting completeness threshold" << messaget::eom;
-
-  auto completeness_threshold_result = completeness_threshold(
-    cmdline, transition_system, properties, solver_factory, message_handler);
-
-  properties.properties = completeness_threshold_result.properties;
-
-  if(!properties.has_unfinished_property())
-    return completeness_threshold_result; // done
-
-  properties.reset_failure();
-  properties.reset_inconclusive();
-  properties.reset_unsupported();
-
-  // Now try 1-induction, word-level
-  message.status() << "Attempting 1-induction" << messaget::eom;
-
-  auto k_induction_result = k_induction(
-    1, transition_system, properties, solver_factory, message_handler);
-
-  properties.properties = k_induction_result.properties;
-
-  if(!properties.has_unfinished_property())
-    return k_induction_result; // done
-
-  properties.reset_failure();
-  properties.reset_inconclusive();
-  properties.reset_unsupported();
-
-  // Now try BMC with bound 5, word-level
-  message.status() << "Attempting BMC with bound 5" << messaget::eom;
-
-  auto bmc_result = bmc(
-    5,     // bound
-    false, // convert_only
-    cmdline.isset("bmc-with-assumptions"),
-    transition_system,
-    properties,
-    solver_factory,
-    message_handler);
-
-  properties.properties = std::move(bmc_result.properties);
-
-  if(!properties.has_unfinished_property())
-    return property_checker_resultt{properties}; // done
-
-  properties.reset_failure();
-
-  // Give up
-  return property_checker_resultt{properties}; // done
 }
 
 property_checker_resultt property_checker(


### PR DESCRIPTION
Move the `engine_heuristic` function from `property_checker.cpp` into its own `engine_heuristic.cpp` and `engine_heuristic.h` files, reducing the size of `property_checker.cpp`.