### PR TITLE
Refactor engine heuristic to use loop

### DIFF
--- a/src/ebmc/engine_heuristic.cpp
+++ b/src/ebmc/engine_heuristic.cpp
@@ -14,6 +14,68 @@ Author: Daniel Kroening, dkr@amazon.com
 #include "k_induction.h"
 #include "tautology_check.h"
 
+[[nodiscard]] property_checker_resultt tautology_check_engine(
+  const cmdlinet &,           // unused
+  const transition_systemt &, // unused
+  const ebmc_propertiest &properties,
+  const ebmc_solver_factoryt &solver,
+  message_handlert &message_handler)
+{
+  return tautology_check(properties, solver, message_handler);
+}
+
+// Basic 1-induction for given solver
+[[nodiscard]] property_checker_resultt one_induction_engine(
+  const cmdlinet &, // unused
+  const transition_systemt &transition_system,
+  const ebmc_propertiest &properties,
+  const ebmc_solver_factoryt &solver,
+  message_handlert &message_handler)
+{
+  return k_induction(1, transition_system, properties, solver, message_handler);
+}
+
+// BMC with bound 5
+[[nodiscard]] property_checker_resultt bmc_bound_5_engine(
+  const cmdlinet &cmdline,
+  const transition_systemt &transition_system,
+  const ebmc_propertiest &properties,
+  const ebmc_solver_factoryt &solver,
+  message_handlert &message_handler)
+{
+  return bmc(
+    5,     // bound
+    false, // convert_only
+    cmdline.isset("bmc-with-assumptions"),
+    transition_system,
+    properties,
+    solver,
+    message_handler);
+}
+
+struct enginet
+{
+  // the function to call
+  std::function<property_checker_resultt(
+    const cmdlinet &,
+    transition_systemt &,
+    ebmc_propertiest &,
+    ebmc_solver_factoryt &,
+    message_handlert &)>
+    f;
+
+  // a descriptive name
+  const std::string name;
+};
+
+// engines to try, in given order
+const enginet engines[] = {
+  {tautology_check_engine, "tautology check"},
+  {completeness_threshold, "completeness threshold"},
+  {one_induction_engine, "one induction"},
+  {bmc_bound_5_engine, "BMC with bound 5"},
+};
+
 property_checker_resultt engine_heuristic(
   const cmdlinet &cmdline,
   transition_systemt &transition_system,
@@ -28,77 +90,31 @@ property_checker_resultt engine_heuristic(
     return property_checker_resultt::error();
   }
 
-  auto solver_factory = ebmc_solver_factory(cmdline);
-
   if(!properties.has_unfinished_property())
     return property_checker_resultt{properties}; // done
 
   message.status() << "No engine given, attempting heuristic engine selection"
                    << messaget::eom;
 
-  // First check if we can tell that the property is a tautology
-  message.status() << "Tautology check" << messaget::eom;
+  auto solver_factory = ebmc_solver_factory(cmdline);
 
-  auto tautology_check_result =
-    tautology_check(cmdline, properties, solver_factory, message_handler);
+  // try engines in given order
+  for(auto &engine : engines)
+  {
+    message.status() << "Attempting " << engine.name << messaget::eom;
 
-  properties.properties = tautology_check_result.properties;
+    auto result = engine.f(
+      cmdline, transition_system, properties, solver_factory, message_handler);
 
-  if(!properties.has_unfinished_property())
-    return tautology_check_result; // done
+    properties.properties = result.properties;
 
-  properties.reset_failure();
-  properties.reset_inconclusive();
-  properties.reset_unsupported();
+    if(!properties.has_unfinished_property())
+      return result; // done
 
-  // Check whether we have a low completenes threshold
-  message.status() << "Attempting completeness threshold" << messaget::eom;
-
-  auto completeness_threshold_result = completeness_threshold(
-    cmdline, transition_system, properties, solver_factory, message_handler);
-
-  properties.properties = completeness_threshold_result.properties;
-
-  if(!properties.has_unfinished_property())
-    return completeness_threshold_result; // done
-
-  properties.reset_failure();
-  properties.reset_inconclusive();
-  properties.reset_unsupported();
-
-  // Now try 1-induction, word-level
-  message.status() << "Attempting 1-induction" << messaget::eom;
-
-  auto k_induction_result = k_induction(
-    1, transition_system, properties, solver_factory, message_handler);
-
-  properties.properties = k_induction_result.properties;
-
-  if(!properties.has_unfinished_property())
-    return k_induction_result; // done
-
-  properties.reset_failure();
-  properties.reset_inconclusive();
-  properties.reset_unsupported();
-
-  // Now try BMC with bound 5, word-level
-  message.status() << "Attempting BMC with bound 5" << messaget::eom;
-
-  auto bmc_result = bmc(
-    5,     // bound
-    false, // convert_only
-    cmdline.isset("bmc-with-assumptions"),
-    transition_system,
-    properties,
-    solver_factory,
-    message_handler);
-
-  properties.properties = std::move(bmc_result.properties);
-
-  if(!properties.has_unfinished_property())
-    return property_checker_resultt{properties}; // done
-
-  properties.reset_failure();
+    properties.reset_failure();
+    properties.reset_inconclusive();
+    properties.reset_unsupported();
+  }
 
   // Give up
   return property_checker_resultt{properties}; // done

--- a/src/ebmc/tautology_check.cpp
+++ b/src/ebmc/tautology_check.cpp
@@ -65,7 +65,6 @@ static bool is_tautology(
 }
 
 property_checker_resultt tautology_check(
-  const cmdlinet &,
   const ebmc_propertiest &properties,
   const ebmc_solver_factoryt &solver_factory,
   message_handlert &message_handler)

--- a/src/ebmc/tautology_check.h
+++ b/src/ebmc/tautology_check.h
@@ -12,12 +12,10 @@ Author: Daniel Kroening, dkr@amazon.com
 #include "ebmc_solver_factory.h"
 #include "property_checker.h"
 
-class cmdlinet;
 class ebmc_propertiest;
 class message_handlert;
 
 [[nodiscard]] property_checker_resultt tautology_check(
-  const cmdlinet &,
   const ebmc_propertiest &,
   const ebmc_solver_factoryt &,
   message_handlert &);


### PR DESCRIPTION
This replaces the linear sequence of engine invocations in `engine_heuristic(...)` by a loop, removing duplication.