### PR TITLE
Verilog: KNOWNBUG test for union member part-select

### DIFF
--- a/regression/verilog/unions/unions5.desc
+++ b/regression/verilog/unions/unions5.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+unions5.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Part-select on a union member with a single wide field gives wrong bit mapping.

--- a/regression/verilog/unions/unions5.sv
+++ b/regression/verilog/unions/unions5.sv
@@ -1,0 +1,20 @@
+module minimal(input clk, input [15:0] in);
+
+  typedef struct packed { logic [15:0] data; } wrap_t;
+  typedef struct packed { logic [7:0] hi; logic [7:0] lo; } split_t;
+
+  typedef union packed {
+    split_t s;
+    wrap_t  w;
+  } u_t;
+
+  wire u_t x = in;
+
+  a0: assume property (@(posedge clk) in[3:0] == 4'h0);
+
+  // All three check the same bits: x[3:0] == 0
+  p0: assert property (@(posedge clk) x.w.data[3:0] == 4'h0);
+  p1: assert property (@(posedge clk) x.s.lo[3:0] == 4'h0);
+  p2: assert property (@(posedge clk) x[3:0] == 4'h0);
+
+endmodule

--- a/regression/verilog/unions/unions6.desc
+++ b/regression/verilog/unions/unions6.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+unions6.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Part-select on a union member with a single wide field gives wrong bit mapping.

--- a/regression/verilog/unions/unions6.sv
+++ b/regression/verilog/unions/unions6.sv
@@ -1,0 +1,15 @@
+module main(input clk);
+
+  typedef union packed {
+    logic [1:0] all;
+    struct packed { logic first, second; } s;
+  } u_t;
+
+  wire u_t x = 2;
+
+  p0: assert property (@(posedge clk) x.s.first == 1);
+  p1: assert property (@(posedge clk) x.s.second == 0);
+  p2: assert property (@(posedge clk) x.s == 2);
+  p3: assert property (@(posedge clk) x.all == 2);
+
+endmodule


### PR DESCRIPTION
Part-selecting through a union member that is a struct with a single wide field gives wrong bit mapping.

Given a `union packed` with two struct members:
- `split_t` with two 8-bit fields (`hi`, `lo`)
- `wrap_t` with one 16-bit field (`data`)

Accessing `x.w.data[3:0]` should give the same bits as `x[3:0]` and `x.s.lo[3:0]`, since all union members overlay the same bits. But ebmc falsely refutes the assertion on `x.w.data[3:0]` while correctly proving the other two.