### PR TITLE
SystemVerilog: assignment patterns for unions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * SystemVerilog: typdefs in compilation-unit scope
 * SystemVerilog: functions in package and compilation-unit scopes
 * SystemVerilog: default direction for task/function ports
+* SystemVerilog: assignment patterns for unions
 
 # EBMC 5.9
 

--- a/regression/verilog/unions/assignment_pattern1.desc
+++ b/regression/verilog/unions/assignment_pattern1.desc
@@ -1,0 +1,6 @@
+CORE
+assignment_pattern1.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/verilog/unions/assignment_pattern1.sv
+++ b/regression/verilog/unions/assignment_pattern1.sv
@@ -1,0 +1,14 @@
+module main;
+
+  typedef union packed {
+    logic [6:0] field1;
+    logic [6:0] field2;
+  } u_t;
+
+  // an assignment pattern
+  wire u_t u = '{ field2: 3 };
+
+  // Expected to pass.
+  p0: assert property (u.field1 == 3);
+
+endmodule

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -186,6 +186,32 @@ void verilog_typecheck_exprt::assignment_conversion(
 
       return;
     }
+    else if(lhs_type.id() == ID_union)
+    {
+      if(
+        rhs.operands().size() == 1 &&
+        rhs.operands().front().id() == ID_member_initializer)
+      {
+        // find the named component
+        auto &union_type = to_struct_union_type(lhs_type);
+        auto &initializer = rhs.operands().front();
+        auto member_name = initializer.get(ID_member_name);
+        auto &component = union_type.get_component(member_name);
+        if(component.is_nil())
+        {
+          throw errort().with_location(initializer.source_location())
+            << "union does not have a member `" << member_name << "'";
+        }
+
+        auto value = to_unary_expr(initializer).op();
+
+        // rec. call
+        assignment_conversion(value, component.type());
+        rhs = union_exprt{member_name, std::move(value), union_type}
+                .with_source_location(rhs.source_location());
+        return;
+      }
+    }
     else if(lhs_type.id() == ID_array)
     {
       auto &array_type = to_array_type(lhs_type);


### PR DESCRIPTION
This allows the use of assignment patters to assign values to unions.