### PR TITLE
SystemVerilog: pretty-printing for union constructors

### DIFF
--- a/regression/verilog/unions/trace1.desc
+++ b/regression/verilog/unions/trace1.desc
@@ -1,0 +1,10 @@
+CORE
+trace1.sv
+--trace
+^  main\.u = '\{ field1: 1 \}$
+^  main\.u = '\{ field1: 2 \}$
+^  main\.u = '\{ field1: 3 \}$
+^EXIT=10$
+^SIGNAL=0$
+--
+--

--- a/regression/verilog/unions/trace1.sv
+++ b/regression/verilog/unions/trace1.sv
@@ -1,0 +1,16 @@
+module main(input clk);
+
+  union packed {
+    bit [7:0] field1;
+    bit [7:0] field2;
+  } u;
+
+  // bit-vectors can be converted without cast to packed unions
+  initial u = 1;
+
+  always_ff @(posedge clk)
+    u.field2++;
+
+  assert property (@(posedge clk) u.field1 != 3);
+
+endmodule

--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -1579,6 +1579,26 @@ expr2verilogt::resultt expr2verilogt::convert_struct(const struct_exprt &src)
 
 /*******************************************************************\
 
+Function: expr2verilogt::convert_union
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+expr2verilogt::resultt expr2verilogt::convert_union(const union_exprt &src)
+{
+  std::string dest = "'{ " + id2string(src.get_component_name()) + ": " +
+                     convert_rec(src.op()).s + " }";
+
+  return {verilog_precedencet::MAX, dest};
+}
+
+/*******************************************************************\
+
 Function: expr2verilogt::convert_value_range
 
   Inputs:
@@ -2096,7 +2116,10 @@ expr2verilogt::resultt expr2verilogt::convert_rec(const exprt &src)
       to_sva_sequence_property_instance_expr(src)); } },
 
     { ID_struct, [](expr2verilogt &expr2verilog, const exprt &src) { 
-    return expr2verilog.convert_struct(to_struct_expr(src)); } }
+    return expr2verilog.convert_struct(to_struct_expr(src)); } },
+
+    { ID_union, [](expr2verilogt &expr2verilog, const exprt &src) {
+    return expr2verilog.convert_union(to_union_expr(src)); } }
   };
 
   auto action = action_table.find(src.id());

--- a/src/verilog/expr2verilog_class.h
+++ b/src/verilog/expr2verilog_class.h
@@ -189,6 +189,8 @@ protected:
 
   resultt convert_struct(const struct_exprt &);
 
+  resultt convert_union(const union_exprt &);
+
 protected:
   const namespacet &ns;
 };


### PR DESCRIPTION
This adds pretty-printing for union constructors, e.g., in traces.