### PR TITLE
Verilog: conversion of packed arrays to vectors

### DIFF
--- a/regression/verilog/arrays/array_conversion3.desc
+++ b/regression/verilog/arrays/array_conversion3.desc
@@ -1,8 +1,17 @@
-KNOWNBUG
+CORE
 array_conversion3.sv
 
-^EXIT=0$
+^\[main\.p11\] main\.array1\[0\] == 1: PROVED .*$
+^\[main\.p12\] main\.array1\[1\] == 2: PROVED .*$
+^\[main\.p13\] main\.array1\[2\] == 3: PROVED .*$
+^\[main\.p14\] main\.array1\[3\] == 4: PROVED .*$
+^\[main\.p15\] main\.array1 == 32'h1020304: PROVED .*$
+^\[main\.p21\] main\.array2\[0\] == 4: REFUTED$
+^\[main\.p22\] main\.array2\[1\] == 3: REFUTED$
+^\[main\.p23\] main\.array2\[2\] == 2: REFUTED$
+^\[main\.p24\] main\.array2\[3\] == 1: REFUTED$
+^\[main\.p25\] main\.array2 == 32'h1020304: PROVED .*$
+^EXIT=10$
 ^SIGNAL=0$
 --
 --
-This yields a type checking error.

--- a/regression/verilog/arrays/array_conversion3.sv
+++ b/regression/verilog/arrays/array_conversion3.sv
@@ -1,23 +1,23 @@
 module main;
 
-  bit [1:4] [7:0] array1;
-  bit [4:1] [7:0] array2;
+  bit [0:3] [7:0] array1;
+  bit [3:0] [7:0] array2;
 
   initial begin
     array1 = '{ 1, 2, 3, 4 };
     array2 = '{ 1, 2, 3, 4 };
   
     // Expected to pass.
-    p11: assert (array1[1] == 1);
-    p12: assert (array1[2] == 2);
-    p13: assert (array1[3] == 3);
-    p14: assert (array1[4] == 4);
+    p11: assert (array1[0] == 1);
+    p12: assert (array1[1] == 2);
+    p13: assert (array1[2] == 3);
+    p14: assert (array1[3] == 4);
     p15: assert (array1 == 32'h01020304);
 
-    p21: assert (array2[1] == 4);
-    p22: assert (array2[2] == 3);
-    p23: assert (array2[3] == 2);
-    p24: assert (array2[4] == 1);
+    p21: assert (array2[0] == 4);
+    p22: assert (array2[1] == 3);
+    p23: assert (array2[2] == 2);
+    p24: assert (array2[3] == 1);
     p25: assert (array2 == 32'h01020304);
 
   end

--- a/src/verilog/verilog_lowering.cpp
+++ b/src/verilog/verilog_lowering.cpp
@@ -60,6 +60,16 @@ exprt extract(
   const mp_integer &offset,
   const typet &dest_type)
 {
+  if(src.type().id() == ID_bool)
+  {
+    // turn into bitvector of size 1
+    return extract(typecast_exprt{src, unsignedbv_typet{1}}, offset, dest_type);
+  }
+
+  PRECONDITION(src.type().id() != ID_array);
+  PRECONDITION(src.type().id() != ID_struct);
+  PRECONDITION(src.type().id() != ID_union);
+
   auto src_width = to_bitvector_type(src.type()).get_width();
   auto dest_width = verilog_bits(dest_type);
 
@@ -131,6 +141,49 @@ exprt from_bitvector(
 
     return union_exprt{field.get_name(), std::move(field_value), union_type};
   }
+  else if(dest.id() == ID_array)
+  {
+    const auto &array_type = to_array_type(dest);
+    auto &element_type = array_type.element_type();
+    auto size_int =
+      numeric_cast_v<std::size_t>(to_constant_expr(array_type.size()));
+    exprt::operandst element_values;
+    element_values.reserve(size_int);
+
+    // For packed arrays, the first element is the most significant.
+    // For unpacked arrays, the first element is the least significant.
+    bool is_packed =
+      array_type.get(ID_C_verilog_type) == ID_verilog_packed_array;
+
+    mp_integer element_width = verilog_bits(element_type);
+
+    if(is_packed)
+    {
+      mp_integer element_offset = verilog_bits(dest);
+
+      for(std::size_t index = 0; index < size_int; index++)
+      {
+        element_offset -= element_width;
+        auto element_value =
+          from_bitvector(src, offset + element_offset, element_type);
+        element_values.push_back(std::move(element_value));
+      }
+    }
+    else
+    {
+      mp_integer element_offset = 0;
+
+      for(std::size_t index = 0; index < size_int; index++)
+      {
+        auto element_value =
+          from_bitvector(src, offset + element_offset, element_type);
+        element_values.push_back(std::move(element_value));
+        element_offset += element_width;
+      }
+    }
+
+    return array_exprt{std::move(element_values), array_type};
+  }
   else
   {
     return extract(src, offset, dest);
@@ -167,6 +220,44 @@ exprt to_bitvector(const exprt &src)
     auto &field = union_type.components().front();
     auto member = member_exprt{src, field};
     return to_bitvector(member); // rec. call
+  }
+  else if(src_type.id() == ID_array)
+  {
+    const auto &array_type = to_array_type(src_type);
+    auto size_int =
+      numeric_cast_v<std::size_t>(to_constant_expr(array_type.size()));
+    exprt::operandst element_values;
+    element_values.reserve(size_int);
+
+    // For packed arrays, the first element is the most significant.
+    // For unpacked arrays, the first element is the least significant.
+    // Concatenation puts the most significant first.
+    bool is_packed =
+      array_type.get(ID_C_verilog_type) == ID_verilog_packed_array;
+
+    if(is_packed)
+    {
+      for(std::size_t index = 0; index < size_int; index++)
+      {
+        auto element_expr =
+          index_exprt{src, from_integer(index, integer_typet{})};
+        auto element_value = to_bitvector(element_expr); // rec. call
+        element_values.push_back(std::move(element_value));
+      }
+    }
+    else
+    {
+      for(std::size_t index = size_int; index > 0; index--)
+      {
+        auto element_expr =
+          index_exprt{src, from_integer(index - 1, integer_typet{})};
+        auto element_value = to_bitvector(element_expr); // rec. call
+        element_values.push_back(std::move(element_value));
+      }
+    }
+
+    auto width_int = numeric_cast_v<std::size_t>(verilog_bits(src));
+    return concatenation_exprt{std::move(element_values), bv_typet{width_int}};
   }
   else
   {
@@ -318,13 +409,17 @@ exprt verilog_lowering_cast(typecast_exprt expr)
       auto aval_bval_type = lower_to_aval_bval(dest_type);
       return aval_bval_conversion(expr.op(), aval_bval_type);
     }
-    else if(dest_type.id() == ID_struct || dest_type.id() == ID_union)
+    else if(
+      dest_type.id() == ID_struct || dest_type.id() == ID_union ||
+      dest_type.id() == ID_array)
     {
       return from_bitvector(expr.op(), 0, dest_type);
     }
     else
     {
-      if(src_type.id() == ID_struct || src_type.id() == ID_union)
+      if(
+        src_type.id() == ID_struct || src_type.id() == ID_union ||
+        src_type.id() == ID_array)
       {
         return extract(to_bitvector(expr.op()), 0, dest_type);
       }

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -2398,6 +2398,7 @@ Function: verilog_typecheck_exprt::decay_to_vector
 
 void verilog_typecheck_exprt::decay_to_vector(exprt &expr) const
 {
+  array_decay(expr);
   enum_decay(expr);
   struct_decay(expr);
   union_decay(expr);
@@ -2428,6 +2429,33 @@ typet verilog_typecheck_exprt::enum_decay(const typet &type)
   }
   else
     return type;
+}
+
+/*******************************************************************\
+
+Function: verilog_typecheck_exprt::array_decay
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void verilog_typecheck_exprt::array_decay(exprt &expr) const
+{
+  // 1800-2017 7.4.3
+  // Packed arrays can be "treated as an integer in an expression"
+  auto &type = expr.type();
+  if(type.id() == ID_array)
+  {
+    auto new_type =
+      unsignedbv_typet{numeric_cast_v<std::size_t>(get_width(type))};
+    // The synthesis stage turns these typecasts into a concatenation
+    // of index expressions.
+    expr = typecast_exprt{expr, new_type};
+  }
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -148,6 +148,7 @@ protected:
 
   static typet enum_decay(const typet &);
   void decay_to_vector(exprt &) const;
+  void array_decay(exprt &) const;
   void enum_decay(exprt &) const;
   void union_decay(exprt &) const;
   void struct_decay(exprt &) const;


### PR DESCRIPTION
Verilog allows packed arrays to be "treated as an integer in an expression" (1800 2017 7.4.3).