### PR TITLE
Verilog: fix increment direction of sized unpacked arrays

### DIFF
--- a/regression/verilog/arrays/unpacked_array1.desc
+++ b/regression/verilog/arrays/unpacked_array1.desc
@@ -1,0 +1,7 @@
+CORE
+unpacked_array1.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+--

--- a/regression/verilog/arrays/unpacked_array1.sv
+++ b/regression/verilog/arrays/unpacked_array1.sv
@@ -1,0 +1,23 @@
+module main;
+
+  int my_array0[10];
+  int my_array1[9:0];
+  int my_array2[4:-5];
+  int my_array3[0:9];
+  int my_array4[-10:-1];
+
+  initial begin
+    p0a: assert($left(my_array0) == 0   && $right(my_array0) == 9);
+    p1a: assert($left(my_array1) == 9   && $right(my_array1) == 0);
+    p2a: assert($left(my_array2) == 4   && $right(my_array2) == -5);
+    p3a: assert($left(my_array3) == 0   && $right(my_array3) == 9);
+    p4a: assert($left(my_array4) == -10 && $right(my_array4) == -1);
+
+    p0b: assert($increment(my_array0) == -1);
+    p1b: assert($increment(my_array1) == 1);
+    p2b: assert($increment(my_array2) == 1);
+    p3b: assert($increment(my_array3) == -1);
+    p4b: assert($increment(my_array4) == -1);
+  end
+
+endmodule

--- a/regression/verilog/system-functions/array_functions1.desc
+++ b/regression/verilog/system-functions/array_functions1.desc
@@ -9,13 +9,13 @@ array_functions1.sv
 ^\[main\.pP5\] always \$increment\(main\.packed2\) == -1: PROVED .*$
 ^\[main\.pU0\] always \$left\(main\.unpacked1\) == 32 && \$right\(main\.unpacked1\) == 1: PROVED .*$
 ^\[main\.pU1\] always \$left\(main\.unpacked2\) == 0 && \$right\(main\.unpacked2\) == 31: PROVED .*$
-^\[main\.pU2\] always \$left\(main\.unpacked3\) == 31 && \$right\(main\.unpacked3\) == 0: PROVED .*$
+^\[main\.pU2\] always \$left\(main\.unpacked3\) == 0 && \$right\(main\.unpacked3\) == 31: PROVED .*$
 ^\[main\.pU3\] always \$low\(main\.unpacked1\) == 1 && \$high\(main\.unpacked1\) == 32: PROVED .*$
 ^\[main\.pU4\] always \$low\(main\.unpacked2\) == 0 && \$high\(main\.unpacked2\) == 31: PROVED .*$
 ^\[main\.pU5\] always \$low\(main\.unpacked3\) == 0 && \$high\(main\.unpacked3\) == 31: PROVED .*$
 ^\[main\.pU6\] always \$increment\(main\.unpacked1\) == 1: PROVED .*$
 ^\[main\.pU7\] always \$increment\(main\.unpacked2\) == -1: PROVED .*$
-^\[main\.pU8\] always \$increment\(main\.unpacked3\) == 1: PROVED .*$
+^\[main\.pU8\] always \$increment\(main\.unpacked3\) == -1: PROVED .*$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/system-functions/array_functions1.sv
+++ b/regression/verilog/system-functions/array_functions1.sv
@@ -16,12 +16,12 @@ module main;
 
   pU0: assert final ($left(unpacked1) == 32 && $right(unpacked1) == 1);
   pU1: assert final ($left(unpacked2) == 0 && $right(unpacked2) == 31);
-  pU2: assert final ($left(unpacked3) == 31 && $right(unpacked3) == 0);
+  pU2: assert final ($left(unpacked3) == 0 && $right(unpacked3) == 31);
   pU3: assert final ($low(unpacked1) == 1 && $high(unpacked1) == 32);
   pU4: assert final ($low(unpacked2) == 0 && $high(unpacked2) == 31);
   pU5: assert final ($low(unpacked3) == 0 && $high(unpacked3) == 31);
   pU6: assert final ($increment(unpacked1) == 1);
   pU7: assert final ($increment(unpacked2) == -1);
-  pU8: assert final ($increment(unpacked3) == 1);
+  pU8: assert final ($increment(unpacked3) == -1);
 
 endmodule

--- a/src/verilog/verilog_elaborate_type.cpp
+++ b/src/verilog/verilog_elaborate_type.cpp
@@ -51,7 +51,8 @@ array_typet verilog_typecheck_exprt::convert_unpacked_array_type(
   }
   else if(size_expr.is_not_nil())
   {
-    increasing = false;
+    // [size] is syntactic sugar for [0:size-1]
+    increasing = true;
     size = convert_integer_constant_expression(size_expr);
     offset = 0;
     if(size < 0)


### PR DESCRIPTION
A sized unpacked array

  `type id[size]`

is syntactic sugar for

  `type id[0:size-1]`

and hence, `$increment(id)` should return -1.