### PR TITLE
Verilog: implement `$size` system function

### DIFF
--- a/regression/verilog/system-functions/size1.desc
+++ b/regression/verilog/system-functions/size1.desc
@@ -1,0 +1,12 @@
+CORE
+size1.sv
+--module main
+^\[main\.p0\] always \$size\(main\.packed1\) == 32: PROVED .*$
+^\[main\.p1\] always \$size\(main\.packed2\) == 8: PROVED .*$
+^\[main\.p2\] always \$size\(main\.unpacked1\) == 4: PROVED .*$
+^\[main\.p3\] always \$size\(main\.unpacked2\) == 4: PROVED .*$
+^\[main\.p4\] always \$size\(main\.unpacked3\) == 8: PROVED .*$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/system-functions/size1.sv
+++ b/regression/verilog/system-functions/size1.sv
@@ -1,0 +1,16 @@
+module main;
+
+  wire [31:0] packed1;
+  wire [0:7] packed2;
+
+  wire unpacked1 [3:0];
+  wire unpacked2 [0:3];
+  wire unpacked3 [8];
+
+  p0: assert final ($size(packed1) == 32);
+  p1: assert final ($size(packed2) == 8);
+  p2: assert final ($size(unpacked1) == 4);
+  p3: assert final ($size(unpacked2) == 4);
+  p4: assert final ($size(unpacked3) == 8);
+
+endmodule

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -998,6 +998,26 @@ constant_exprt verilog_typecheck_exprt::high(const exprt &expr)
 
 /*******************************************************************\
 
+Function: verilog_typecheck_exprt::size
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+constant_exprt verilog_typecheck_exprt::size(const exprt &expr)
+{
+  // $size = $high - $low + 1
+  auto h = numeric_cast_v<mp_integer>(high(expr));
+  auto l = numeric_cast_v<mp_integer>(low(expr));
+  return from_integer(h - l + 1, integer_typet{});
+}
+
+/*******************************************************************\
+
 Function: verilog_typecheck_exprt::typename_string
 
   Inputs:
@@ -1117,7 +1137,8 @@ exprt verilog_typecheck_exprt::convert_system_function(function_call_exprt expr)
   }
   else if(
     base_name == "$bits" || base_name == "$left" || base_name == "$right" ||
-    base_name == "$increment" || base_name == "$low" || base_name == "$high")
+    base_name == "$increment" || base_name == "$low" || base_name == "$high" ||
+    base_name == "$size")
   {
     if(arguments.size() != 1)
     {
@@ -2002,6 +2023,11 @@ exprt verilog_typecheck_exprt::elaborate_constant_system_function_call(
   {
     DATA_INVARIANT(arguments.size() == 1, "$increment has one argument");
     return increment(arguments[0]);
+  }
+  else if(base_name == "$size")
+  {
+    DATA_INVARIANT(arguments.size() == 1, "$size has one argument");
+    return size(arguments[0]);
   }
   else if(base_name == "$countones")
   {

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -226,6 +226,7 @@ protected:
   constant_exprt low(const exprt &);
   constant_exprt high(const exprt &);
   constant_exprt increment(const exprt &);
+  constant_exprt size(const exprt &);
   exprt typename_string(const exprt &);
 };
 


### PR DESCRIPTION
Implement the `$size` array query function per IEEE 1800-2017 section 20.7.

`$size` returns `$high - $low + 1` for the given dimension. It works on both packed and unpacked array types and is evaluated at elaboration time.

Includes a regression test covering:
- Packed arrays with descending and ascending ranges
- Unpacked arrays with descending, ascending, and shorthand ranges