### PR TITLE
BDD engine: extract CTL model checker into bdd_model_checker

### DIFF
--- a/src/ebmc/Makefile
+++ b/src/ebmc/Makefile
@@ -1,5 +1,6 @@
 SRC = \
       bdd_engine.cpp \
+      bdd_model_checker.cpp \
       bmc.cpp \
       build_transition_system.cpp \
       cegar/abstract.cpp \

--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -25,6 +25,7 @@ Author: Daniel Kroening, daniel.kroening@inf.ethz.ch
 #include <trans-netlist/trans_trace_netlist.h>
 #include <trans-netlist/unwind_netlist.h>
 
+#include "bdd_model_checker.h"
 #include "netlist.h"
 
 #include <algorithm>
@@ -136,35 +137,15 @@ protected:
     propertyt &,
     unsigned number_of_timeframes);
 
-  void check_AGp(propertyt &);
-  void check_CTL(propertyt &);
-  BDD CTL(const exprt &);
-  BDD EX(BDD);
-  BDD AX(BDD f)
-  {
-    return !EX(!f);
-  }
-  BDD EF(BDD);
-  BDD AF(BDD f)
-  {
-    return !EG(!f);
-  }
-  BDD EG(BDD);
-  BDD AG(BDD f)
-  {
-    return !EF(!f);
-  }
-  BDD EU(BDD, BDD);
-  BDD AU(BDD, BDD);
-  BDD ER(BDD f1, BDD f2)
-  {
-    return !AU(!f1, !f2);
-  }
-  BDD AR(BDD f1, BDD f2)
-  {
-    return !EU(!f1, !f2);
-  }
-  BDD fixedpoint(std::function<BDD(BDD)>, BDD);
+  /// Build a bdd_modelt from the constructed BDDs.
+  bdd_modelt make_bdd_model();
+
+  /// Build the atomic proposition BDD map for the model checker.
+  std::map<unsigned, mini_bddt> make_atomic_proposition_bdds() const;
+
+  /// Rewrite a property expression to use literal_exprt for
+  /// atomic propositions.
+  exprt property_to_literal_expr(const exprt &) const;
 };
 
 /*******************************************************************\
@@ -263,7 +244,12 @@ property_checker_resultt bdd_enginet::operator()()
         }
         else
         {
-          auto result = CTL(property.normalized_expr);
+          auto literal_property =
+            property_to_literal_expr(property.normalized_expr);
+          auto ap_bdds = make_atomic_proposition_bdds();
+          auto model = make_bdd_model();
+          auto result = bdd_ctl(
+            model, literal_property, ap_bdds, message.get_message_handler());
           std::cout << property.name << ":\n" << cubes(result) << '\n';
         }
       }
@@ -546,387 +532,42 @@ void bdd_enginet::check_property(propertyt &property)
     return;
 
   message.status() << "Checking " << property.name << messaget::eom;
-  property.status=propertyt::statust::UNKNOWN;
+  property.status = propertyt::statust::UNKNOWN;
+
+  auto literal_property = property_to_literal_expr(property.normalized_expr);
+  auto ap_bdds = make_atomic_proposition_bdds();
+  auto model = make_bdd_model();
+
+  bdd_check_resultt result;
 
   if(is_AGp(property.normalized_expr))
   {
-    check_AGp(property);
+    result = bdd_check_AGp(
+      model, literal_property, ap_bdds, message.get_message_handler());
   }
   else if(is_CTL(property.normalized_expr))
   {
-    check_CTL(property);
+    result = bdd_check_ctl(
+      model, literal_property, ap_bdds, message.get_message_handler());
   }
   else
     DATA_INVARIANT(false, "unexpected normalized property");
-}
 
-/*******************************************************************\
-
-Function: bdd_enginet::check_AGp
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-void bdd_enginet::check_AGp(propertyt &property)
-{
-  const exprt &sub_expr = to_unary_expr(property.normalized_expr).op();
-  BDD p = CTL(sub_expr);
-
-  // Start with !p, and go backwards until saturation or we hit an
-  // initial state.
-
-  BDD states = !p;
-  unsigned iteration = 0;
-
-  for(const auto &c : constraints_BDDs)
-    states = states & c;
-
-  std::size_t peak_bdd_nodes = 0;
-
-  while(true)
+  switch(result.status)
   {
-    iteration++;
-    message.statistics() << "Iteration " << iteration << messaget::eom;
-
-    // do we have an initial state?
-    BDD intersection = states;
-
-    for(const auto &i : initial_BDDs)
-      intersection = intersection & i;
-
-    peak_bdd_nodes = std::max(peak_bdd_nodes, mgr.number_of_nodes());
-
-    if(!intersection.is_false())
-    {
-      property.refuted();
-      message.status() << "Property refuted" << messaget::eom;
-      compute_counterexample(property, iteration);
-      break;
-    }
-
-    // make the states be expressed in terms of 'next' variables
-    BDD states_next = current_to_next(states);
-
-    // now conjoin with transition relation
-    BDD conjunction = states_next;
-
-    for(const auto &t : transition_BDDs)
-      conjunction = conjunction & t;
-
-    for(const auto &c : constraints_BDDs)
-      conjunction = conjunction & c;
-
-    // now project away 'next' variables
-    BDD pre_image = project_next(conjunction);
-
-    // compute union
-    BDD set_union = states | pre_image;
-
-    // have we saturated?
-    if((set_union == states).is_true())
-    {
-      property.proved("BDD");
-      message.status() << "Property proved" << messaget::eom;
-      break;
-    }
-
-    states = set_union;
-
-    peak_bdd_nodes = std::max(peak_bdd_nodes, mgr.number_of_nodes());
-  }
-}
-
-/*******************************************************************\
-
-Function: bdd_enginet::check_CTL
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-void bdd_enginet::check_CTL(propertyt &property)
-{
-  // For a CTL formula f, calculate the set of states that satisfy
-  // !f, and then check if that contains any initial state.
-  BDD not_f = !CTL(property.normalized_expr);
-
-  BDD intersection = not_f;
-
-  for(const auto &i : initial_BDDs)
-    intersection = intersection & i;
-
-  for(const auto &c : constraints_BDDs)
-    intersection = intersection & c;
-
-  if(intersection.is_false())
-  {
-    // intersection empty, proved
+  case bdd_check_resultt::statust::PROVED:
     property.proved("BDD");
     message.status() << "Property proved" << messaget::eom;
-  }
-  else
-  {
-    // refuted
+    break;
+  case bdd_check_resultt::statust::REFUTED:
     property.refuted();
     message.status() << "Property refuted" << messaget::eom;
+    if(is_AGp(property.normalized_expr))
+      compute_counterexample(property, result.number_of_timeframes);
+    break;
+  case bdd_check_resultt::statust::UNKNOWN:
+    break;
   }
-}
-
-/*******************************************************************\
-
-Function: bdd_enginet::CTL
-
-  Inputs: a CTL expression
-
- Outputs: a BDD for the set of states that satisfies the expression
-
- Purpose: compute states that satisfy a particular property
-
-\*******************************************************************/
-
-bdd_enginet::BDD bdd_enginet::CTL(const exprt &expr)
-{
-  if(expr.is_true())
-    return mgr.True();
-  else if(expr.is_false())
-    return mgr.False();
-  else if(expr.id()==ID_not)
-  {
-    return !CTL(to_not_expr(expr).op());
-  }
-  else if(expr.id() == ID_implies)
-  {
-    return (!CTL(to_binary_expr(expr).lhs())) | CTL(to_binary_expr(expr).rhs());
-  }
-  else if(expr.id()==ID_and)
-  {
-    BDD result=mgr.True();
-    for(const auto & op : expr.operands())
-      result = result & CTL(op);
-    return result;
-  }
-  else if(expr.id()==ID_or)
-  {
-    BDD result=mgr.False();
-    for(const auto & op : expr.operands())
-      result = result | CTL(op);
-    return result;
-  }
-  else if(
-    expr.id() == ID_equal && to_equal_expr(expr).lhs().type().id() == ID_bool)
-  {
-    return (
-      !(CTL(to_binary_expr(expr).lhs())) ^ CTL(to_binary_expr(expr).rhs()));
-  }
-  else if(expr.id() == ID_EX)
-  {
-    return EX(CTL(to_EX_expr(expr).op()));
-  }
-  else if(expr.id() == ID_EF)
-  {
-    return EF(CTL(to_EF_expr(expr).op()));
-  }
-  else if(expr.id() == ID_EG)
-  {
-    return EG(CTL(to_EG_expr(expr).op()));
-  }
-  else if(expr.id() == ID_AX)
-  {
-    return AX(CTL(to_AX_expr(expr).op()));
-  }
-  else if(expr.id() == ID_AF)
-  {
-    return AF(CTL(to_AF_expr(expr).op()));
-  }
-  else if(expr.id() == ID_AG)
-  {
-    return AG(CTL(to_AG_expr(expr).op()));
-  }
-  else if(expr.id() == ID_EU)
-  {
-    auto &EU_expr = to_EU_expr(expr);
-    return EU(CTL(EU_expr.lhs()), CTL(EU_expr.rhs()));
-  }
-  else if(expr.id() == ID_AU)
-  {
-    auto &AU_expr = to_AU_expr(expr);
-    return AU(CTL(AU_expr.lhs()), CTL(AU_expr.rhs()));
-  }
-  else if(expr.id() == ID_ER)
-  {
-    auto &ER_expr = to_ER_expr(expr);
-    return ER(CTL(ER_expr.lhs()), CTL(ER_expr.rhs()));
-  }
-  else if(expr.id() == ID_AR)
-  {
-    auto &AR_expr = to_AR_expr(expr);
-    return AR(CTL(AR_expr.lhs()), CTL(AR_expr.rhs()));
-  }
-  else
-  {
-    atomic_propositionst::const_iterator it=
-      atomic_propositions.find(expr);
-    
-    if(it!=atomic_propositions.end())
-      return it->second.bdd;
-  }
-
-  message.error() << "unsupported property -- `" << expr.id()
-                  << "' not implemented" << messaget::eom;
-  throw 0;
-}
-
-/*******************************************************************\
-
-Function: bdd_enginet::EX
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-bdd_enginet::BDD bdd_enginet::EX(BDD f)
-{
-  for(const auto &c : constraints_BDDs)
-    f = f & c;
-
-  // make 'f' be expressed in terms of 'next' variables
-  BDD p_next = current_to_next(f);
-
-  // now conjoin with transition relation
-  BDD conjunction = p_next;
-
-  for(const auto &t : transition_BDDs)
-    conjunction = conjunction & t;
-
-  for(const auto &c : constraints_BDDs)
-    conjunction = conjunction & c;
-
-  // now project away 'next' variables
-  BDD pre_image = project_next(conjunction);
-
-  return pre_image;
-}
-
-/*******************************************************************\
-
-Function: bdd_enginet::fixedpoint
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-bdd_enginet::BDD bdd_enginet::fixedpoint(std::function<BDD(BDD)> tau, BDD x)
-{
-  // Apply tau(x) until saturation.
-  while(true)
-  {
-    BDD image = tau(x);
-
-    // fixpoint?
-    if((image == x).is_true())
-      return x; // done
-
-    x = image;
-  }
-}
-
-/*******************************************************************\
-
-Function: bdd_enginet::EG
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-bdd_enginet::BDD bdd_enginet::EG(BDD f)
-{
-  // EG f = f ∧ EX EG f
-  // Iterate x ∧ EX x until saturation.
-  auto tau = [this](BDD x) { return x & EX(x); };
-
-  return fixedpoint(tau, f);
-}
-
-/*******************************************************************\
-
-Function: bdd_enginet::EF
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-bdd_enginet::BDD bdd_enginet::EF(BDD f)
-{
-  // EF f ↔ f ∨ EX EF f
-  // Iterate x ∨ EX x until saturation.
-  auto tau = [this](BDD x) { return x | EX(x); };
-
-  return fixedpoint(tau, f);
-}
-
-/*******************************************************************\
-
-Function: bdd_enginet::EU
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-bdd_enginet::BDD bdd_enginet::EU(BDD f1, BDD f2)
-{
-  // Iterate x ∨ f2 ∨ (f1 ∧ EX x) until saturation
-  auto tau = [this, f1, f2](BDD x) { return x | f2 | (f1 & EX(x)); };
-
-  return fixedpoint(tau, mgr.False());
-}
-
-/*******************************************************************\
-
-Function: bdd_enginet::AU
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-bdd_enginet::BDD bdd_enginet::AU(BDD f1, BDD f2)
-{
-  // Iterate x ∨ f2 ∨ (f1 ∧ AX x) until saturation
-  auto tau = [this, f1, f2](BDD x) { return x | f2 | (f1 & AX(x)); };
-
-  return fixedpoint(tau, mgr.False());
 }
 
 /*******************************************************************\
@@ -1071,6 +712,79 @@ void bdd_enginet::build_BDDs()
         constraints_BDDs.push_back(aig2bdd(l, BDDs));
       }
     }
+}
+
+/*******************************************************************\
+
+Function: bdd_enginet::make_bdd_model
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+bdd_modelt bdd_enginet::make_bdd_model()
+{
+  bdd_modelt model{mgr, {}, initial_BDDs, transition_BDDs, constraints_BDDs};
+
+  for(const auto &[_, var] : vars)
+    model.vars.push_back({var.is_input, var.current_bdd, var.next_bdd});
+
+  return model;
+}
+
+/*******************************************************************\
+
+Function: bdd_enginet::make_atomic_proposition_bdds
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+std::map<unsigned, mini_bddt> bdd_enginet::make_atomic_proposition_bdds() const
+{
+  std::map<unsigned, mini_bddt> result;
+  for(const auto &[expr, ap] : atomic_propositions)
+  {
+    auto var_no = ap.l.var_no();
+    if(ap.l.sign())
+      result[var_no] = !ap.bdd;
+    else
+      result[var_no] = ap.bdd;
+  }
+  return result;
+}
+
+/*******************************************************************\
+
+Function: bdd_enginet::property_to_literal_expr
+
+  Inputs:
+
+ Outputs:
+
+ Purpose: rewrite property to use literal_exprt for atomic propositions
+
+\*******************************************************************/
+
+exprt bdd_enginet::property_to_literal_expr(const exprt &expr) const
+{
+  auto it = atomic_propositions.find(expr);
+  if(it != atomic_propositions.end())
+    return literal_exprt(it->second.l);
+
+  exprt result = expr;
+  for(auto &op : result.operands())
+    if(op.type().id() == ID_bool)
+      op = property_to_literal_expr(op);
+  return result;
 }
 
 /*******************************************************************\

--- a/src/ebmc/bdd_model_checker.cpp
+++ b/src/ebmc/bdd_model_checker.cpp
@@ -1,0 +1,508 @@
+/*******************************************************************\
+
+Module: BDD-based CTL Model Checker
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#include "bdd_model_checker.h"
+
+#include <util/std_expr.h>
+
+#include <solvers/prop/literal_expr.h>
+#include <temporal-logic/ctl.h>
+
+#include <algorithm>
+
+using BDD = mini_bddt;
+
+// forward declarations of local helpers
+static BDD EX(const bdd_modelt &, BDD);
+static BDD fixedpoint(std::function<BDD(BDD)>, BDD);
+
+/*******************************************************************\
+
+Function: current_to_next
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static BDD current_to_next(const bdd_modelt &model, const BDD &bdd)
+{
+  BDD tmp = bdd;
+  for(const auto &v : model.vars)
+    tmp = substitute(tmp, v.current.var(), v.next);
+  return tmp;
+}
+
+/*******************************************************************\
+
+Function: project_next
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static BDD project_next(const bdd_modelt &model, const BDD &bdd)
+{
+  BDD tmp = bdd;
+  for(const auto &v : model.vars)
+    tmp = exists(tmp, v.next.var());
+  return tmp;
+}
+
+/*******************************************************************\
+
+Function: EX
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static BDD EX(const bdd_modelt &model, BDD f)
+{
+  for(const auto &c : model.constraints)
+    f = f & c;
+
+  BDD p_next = current_to_next(model, f);
+
+  BDD conjunction = p_next;
+  for(const auto &t : model.transition)
+    conjunction = conjunction & t;
+  for(const auto &c : model.constraints)
+    conjunction = conjunction & c;
+
+  return project_next(model, conjunction);
+}
+
+/*******************************************************************\
+
+Function: AX
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static BDD AX(const bdd_modelt &model, BDD f)
+{
+  return !EX(model, !f);
+}
+
+/*******************************************************************\
+
+Function: fixedpoint
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static BDD fixedpoint(std::function<BDD(BDD)> tau, BDD x)
+{
+  while(true)
+  {
+    BDD image = tau(x);
+    if((image == x).is_true())
+      return x;
+    x = image;
+  }
+}
+
+/*******************************************************************\
+
+Function: EG
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static BDD EG(const bdd_modelt &model, BDD f)
+{
+  return fixedpoint([&](BDD x) { return x & EX(model, x); }, f);
+}
+
+/*******************************************************************\
+
+Function: EF
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static BDD EF(const bdd_modelt &model, BDD f)
+{
+  return fixedpoint([&](BDD x) { return x | EX(model, x); }, f);
+}
+
+/*******************************************************************\
+
+Function: EU
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static BDD EU(const bdd_modelt &model, BDD f1, BDD f2)
+{
+  return fixedpoint(
+    [&](BDD x) { return x | f2 | (f1 & EX(model, x)); }, model.mgr.False());
+}
+
+/*******************************************************************\
+
+Function: AU
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static BDD AU(const bdd_modelt &model, BDD f1, BDD f2)
+{
+  return fixedpoint(
+    [&](BDD x) { return x | f2 | (f1 & AX(model, x)); }, model.mgr.False());
+}
+
+/*******************************************************************\
+
+Function: bdd_ctl
+
+  Inputs: a CTL expression with literal_exprt atomic propositions
+
+ Outputs: a BDD for the set of states satisfying the expression
+
+ Purpose: compute states that satisfy a CTL property
+
+\*******************************************************************/
+
+mini_bddt bdd_ctl(
+  const bdd_modelt &model,
+  const exprt &expr,
+  const std::map<unsigned, mini_bddt> &atomic_proposition_bdds,
+  message_handlert &message_handler)
+{
+  auto &mgr = model.mgr;
+
+  if(expr.is_true())
+    return mgr.True();
+  else if(expr.is_false())
+    return mgr.False();
+  else if(expr.id() == ID_not)
+  {
+    return !bdd_ctl(
+      model, to_not_expr(expr).op(), atomic_proposition_bdds, message_handler);
+  }
+  else if(expr.id() == ID_implies)
+  {
+    return (!bdd_ctl(
+             model,
+             to_binary_expr(expr).lhs(),
+             atomic_proposition_bdds,
+             message_handler)) |
+           bdd_ctl(
+             model,
+             to_binary_expr(expr).rhs(),
+             atomic_proposition_bdds,
+             message_handler);
+  }
+  else if(expr.id() == ID_and)
+  {
+    BDD result = mgr.True();
+    for(const auto &op : expr.operands())
+      result =
+        result & bdd_ctl(model, op, atomic_proposition_bdds, message_handler);
+    return result;
+  }
+  else if(expr.id() == ID_or)
+  {
+    BDD result = mgr.False();
+    for(const auto &op : expr.operands())
+      result =
+        result | bdd_ctl(model, op, atomic_proposition_bdds, message_handler);
+    return result;
+  }
+  else if(
+    expr.id() == ID_equal && to_equal_expr(expr).lhs().type().id() == ID_bool)
+  {
+    return !(
+      bdd_ctl(
+        model,
+        to_binary_expr(expr).lhs(),
+        atomic_proposition_bdds,
+        message_handler) ^
+      bdd_ctl(
+        model,
+        to_binary_expr(expr).rhs(),
+        atomic_proposition_bdds,
+        message_handler));
+  }
+  else if(expr.id() == ID_EX)
+  {
+    return EX(
+      model,
+      bdd_ctl(
+        model,
+        to_EX_expr(expr).op(),
+        atomic_proposition_bdds,
+        message_handler));
+  }
+  else if(expr.id() == ID_EF)
+  {
+    return EF(
+      model,
+      bdd_ctl(
+        model,
+        to_EF_expr(expr).op(),
+        atomic_proposition_bdds,
+        message_handler));
+  }
+  else if(expr.id() == ID_EG)
+  {
+    return EG(
+      model,
+      bdd_ctl(
+        model,
+        to_EG_expr(expr).op(),
+        atomic_proposition_bdds,
+        message_handler));
+  }
+  else if(expr.id() == ID_AX)
+  {
+    return AX(
+      model,
+      bdd_ctl(
+        model,
+        to_AX_expr(expr).op(),
+        atomic_proposition_bdds,
+        message_handler));
+  }
+  else if(expr.id() == ID_AF)
+  {
+    // AF f = !EG(!f)
+    return !EG(
+      model,
+      !bdd_ctl(
+        model,
+        to_AF_expr(expr).op(),
+        atomic_proposition_bdds,
+        message_handler));
+  }
+  else if(expr.id() == ID_AG)
+  {
+    // AG f = !EF(!f)
+    return !EF(
+      model,
+      !bdd_ctl(
+        model,
+        to_AG_expr(expr).op(),
+        atomic_proposition_bdds,
+        message_handler));
+  }
+  else if(expr.id() == ID_EU)
+  {
+    auto &EU_expr = to_EU_expr(expr);
+    return EU(
+      model,
+      bdd_ctl(model, EU_expr.lhs(), atomic_proposition_bdds, message_handler),
+      bdd_ctl(model, EU_expr.rhs(), atomic_proposition_bdds, message_handler));
+  }
+  else if(expr.id() == ID_AU)
+  {
+    auto &AU_expr = to_AU_expr(expr);
+    return AU(
+      model,
+      bdd_ctl(model, AU_expr.lhs(), atomic_proposition_bdds, message_handler),
+      bdd_ctl(model, AU_expr.rhs(), atomic_proposition_bdds, message_handler));
+  }
+  else if(expr.id() == ID_ER)
+  {
+    // ER(f1, f2) = !AU(!f1, !f2)
+    auto &ER_expr = to_ER_expr(expr);
+    return !AU(
+      model,
+      !bdd_ctl(model, ER_expr.lhs(), atomic_proposition_bdds, message_handler),
+      !bdd_ctl(model, ER_expr.rhs(), atomic_proposition_bdds, message_handler));
+  }
+  else if(expr.id() == ID_AR)
+  {
+    // AR(f1, f2) = !EU(!f1, !f2)
+    auto &AR_expr = to_AR_expr(expr);
+    return !EU(
+      model,
+      !bdd_ctl(model, AR_expr.lhs(), atomic_proposition_bdds, message_handler),
+      !bdd_ctl(model, AR_expr.rhs(), atomic_proposition_bdds, message_handler));
+  }
+  else if(expr.id() == ID_literal)
+  {
+    auto var_no = to_literal_expr(expr).get_literal().var_no();
+    auto it = atomic_proposition_bdds.find(var_no);
+    if(it != atomic_proposition_bdds.end())
+    {
+      if(to_literal_expr(expr).get_literal().sign())
+        return !it->second;
+      else
+        return it->second;
+    }
+  }
+
+  messaget message(message_handler);
+  message.error() << "unsupported property -- `" << expr.id()
+                  << "' not implemented" << messaget::eom;
+  throw 0;
+}
+
+/*******************************************************************\
+
+Function: initial_states
+
+  Inputs:
+
+ Outputs:
+
+ Purpose: conjunction of initial-state and constraint BDDs
+
+\*******************************************************************/
+
+static BDD initial_states(const bdd_modelt &model)
+{
+  BDD result = model.mgr.True();
+  for(const auto &i : model.initial)
+    result = result & i;
+  for(const auto &c : model.constraints)
+    result = result & c;
+  return result;
+}
+
+/*******************************************************************\
+
+Function: bdd_check_ctl
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+bdd_check_resultt bdd_check_ctl(
+  const bdd_modelt &model,
+  const exprt &property,
+  const std::map<unsigned, mini_bddt> &atomic_proposition_bdds,
+  message_handlert &message_handler)
+{
+  BDD not_f =
+    !bdd_ctl(model, property, atomic_proposition_bdds, message_handler);
+
+  BDD intersection = not_f & initial_states(model);
+
+  bdd_check_resultt result;
+  if(intersection.is_false())
+    result.status = bdd_check_resultt::statust::PROVED;
+  else
+    result.status = bdd_check_resultt::statust::REFUTED;
+  return result;
+}
+
+/*******************************************************************\
+
+Function: bdd_check_AGp
+
+  Inputs:
+
+ Outputs:
+
+ Purpose: backward reachability for AG p
+
+\*******************************************************************/
+
+bdd_check_resultt bdd_check_AGp(
+  const bdd_modelt &model,
+  const exprt &property,
+  const std::map<unsigned, mini_bddt> &atomic_proposition_bdds,
+  message_handlert &message_handler)
+{
+  messaget message(message_handler);
+
+  const exprt &sub_expr = to_unary_expr(property).op();
+  BDD p = bdd_ctl(model, sub_expr, atomic_proposition_bdds, message_handler);
+
+  BDD states = !p;
+  unsigned iteration = 0;
+
+  for(const auto &c : model.constraints)
+    states = states & c;
+
+  while(true)
+  {
+    iteration++;
+    message.statistics() << "Iteration " << iteration << messaget::eom;
+
+    BDD intersection = states & initial_states(model);
+
+    if(!intersection.is_false())
+    {
+      bdd_check_resultt result;
+      result.status = bdd_check_resultt::statust::REFUTED;
+      result.number_of_timeframes = iteration;
+      return result;
+    }
+
+    BDD states_next = current_to_next(model, states);
+
+    BDD conjunction = states_next;
+    for(const auto &t : model.transition)
+      conjunction = conjunction & t;
+    for(const auto &c : model.constraints)
+      conjunction = conjunction & c;
+
+    BDD pre_image = project_next(model, conjunction);
+    BDD set_union = states | pre_image;
+
+    if((set_union == states).is_true())
+    {
+      bdd_check_resultt result;
+      result.status = bdd_check_resultt::statust::PROVED;
+      result.number_of_timeframes = iteration;
+      return result;
+    }
+
+    states = set_union;
+  }
+}

--- a/src/ebmc/bdd_model_checker.h
+++ b/src/ebmc/bdd_model_checker.h
@@ -1,0 +1,74 @@
+/*******************************************************************\
+
+Module: BDD-based CTL Model Checker
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_EBMC_BDD_MODEL_CHECKER_H
+#define CPROVER_EBMC_BDD_MODEL_CHECKER_H
+
+#include <util/expr.h>
+#include <util/message.h>
+
+#include <solvers/bdd/miniBDD/miniBDD.h>
+
+#include <functional>
+#include <map>
+#include <vector>
+
+/// A BDD-based transition system model.
+/// Current and next-state variables are paired; inputs have no next-state.
+struct bdd_modelt
+{
+  struct vart
+  {
+    bool is_input;
+    mini_bddt current, next;
+  };
+
+  mini_bdd_mgrt &mgr;
+  std::vector<vart> vars;
+  std::vector<mini_bddt> initial, transition, constraints;
+};
+
+/// Result of BDD model checking a single property.
+struct bdd_check_resultt
+{
+  enum class statust
+  {
+    PROVED,
+    REFUTED,
+    UNKNOWN
+  };
+  statust status = statust::UNKNOWN;
+  /// Number of backward-reachability iterations (for AG p counterexamples).
+  unsigned number_of_timeframes = 0;
+};
+
+/// Evaluate a CTL property over a BDD model.
+/// Atomic propositions in the property expression must be literal_exprt,
+/// and their literal variable numbers index into \p atomic_proposition_bdds.
+/// \return the set of states (as a BDD) satisfying the property
+mini_bddt bdd_ctl(
+  const bdd_modelt &,
+  const exprt &property,
+  const std::map<unsigned, mini_bddt> &atomic_proposition_bdds,
+  message_handlert &);
+
+/// Check a CTL property: does every initial state satisfy it?
+bdd_check_resultt bdd_check_ctl(
+  const bdd_modelt &,
+  const exprt &property,
+  const std::map<unsigned, mini_bddt> &atomic_proposition_bdds,
+  message_handlert &);
+
+/// Optimized check for AG p properties using backward reachability.
+bdd_check_resultt bdd_check_AGp(
+  const bdd_modelt &,
+  const exprt &property,
+  const std::map<unsigned, mini_bddt> &atomic_proposition_bdds,
+  message_handlert &);
+
+#endif // CPROVER_EBMC_BDD_MODEL_CHECKER_H


### PR DESCRIPTION
Extract the BDD-based CTL model checking logic from `bdd_enginet` into a standalone module (`bdd_model_checker.h/cpp`).

## Changes

The new interface operates on a `bdd_modelt` struct and uses `literal_exprt` for atomic propositions in property expressions, decoupling the model checker from the netlist construction.

**New files:**
- `src/ebmc/bdd_model_checker.h` — `bdd_modelt` struct, `bdd_check_resultt`, and functions `bdd_ctl()`, `bdd_check_ctl()`, `bdd_check_AGp()`
- `src/ebmc/bdd_model_checker.cpp` — CTL evaluation (EX, AX, EG, EF, EU, AU, fixedpoint) and the two checking strategies

**Modified files:**
- `src/ebmc/bdd_engine.cpp` — `bdd_enginet` now builds a `bdd_modelt` and delegates to the new module via `make_bdd_model()`, `make_atomic_proposition_bdds()`, and `property_to_literal_expr()`
- `src/ebmc/Makefile` — added `bdd_model_checker.cpp`

All ebmc and verilog regression tests pass.