### PR TITLE
Move lowering of bit select expressions to `verilog_lowering`

### DIFF
--- a/regression/verilog/arrays/unpacked_direction1.desc
+++ b/regression/verilog/arrays/unpacked_direction1.desc
@@ -3,7 +3,7 @@ unpacked_direction1.sv
 --module main
 ^\[main\.p0\] main\.my_array0\[0\] == 1: PROVED .*$
 ^\[main\.p1\] main\.my_array1\[0\] == 1: PROVED .*$
-^\[main\.p2\] main\.my_array2\[3'b000 \+ 5 - 3'b001 - 0\] == 5: PROVED .*$
+^\[main\.p2\] main\.my_array2\[0\] == 5: PROVED .*$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/bit-extract5.desc
+++ b/regression/verilog/expressions/bit-extract5.desc
@@ -2,9 +2,9 @@ CORE
 bit-extract5.sv
 --module main
 ^\[main\.p0\] always main\.w1\[0\] && !main\.w1\[31\]: PROVED .*$
-^\[main\.p1\] always main\.w2\[0\] && !main\.w2\[31\]: PROVED .*$
-^\[main\.p2\] always main\.w3\[0\] && !main\.w3\[31\]: PROVED .*$
-^\[main\.p3\] always main\.w4\[0\] && !main\.w4\[31\]: PROVED .*$
+^\[main\.p1\] always main\.w2\[1\] && !main\.w2\[32\]: PROVED .*$
+^\[main\.p2\] always main\.w3\[31\] && !main\.w3\[0\]: PROVED .*$
+^\[main\.p3\] always main\.w4\[32\] && !main\.w4\[1\]: PROVED .*$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/expressions/bit-extract6.desc
+++ b/regression/verilog/expressions/bit-extract6.desc
@@ -1,8 +1,8 @@
 CORE
 bit-extract6.sv
 --module main
-^\[main\.p0\] always main\.index == 8 -> main\.vector\[7 - main\.index - 1\] == 1: PROVED .*$
-^\[main\.p1\] always main\.index >= 1 \&\& main\.index <= 7 -> main\.vector\[7 - main\.index - 1\] == 0: PROVED .*$
+^\[main\.p0\] always main\.index == 8 -> main\.vector\[main\.index\] == 1: PROVED .*$
+^\[main\.p1\] always main\.index >= 1 \&\& main\.index <= 7 -> main\.vector\[main\.index\] == 0: PROVED .*$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -1023,6 +1023,38 @@ expr2verilogt::resultt expr2verilogt::convert_indexed_part_select(
 
 /*******************************************************************\
 
+Function: expr2verilogt::convert_bit_select
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+expr2verilogt::resultt expr2verilogt::convert_bit_select(
+  const verilog_bit_select_exprt &src,
+  verilog_precedencet precedence)
+{
+  auto op = convert_rec(src.src());
+
+  std::string dest;
+  if(precedence > op.p)
+    dest += '(';
+  dest += op.s;
+  if(precedence > op.p)
+    dest += ')';
+
+  dest += '[';
+  dest += convert_rec(src.index()).s;
+  dest += ']';
+
+  return {precedence, dest};
+}
+
+/*******************************************************************\
+
 Function: expr2verilogt::convert_extractbit
 
   Inputs:
@@ -1702,6 +1734,10 @@ expr2verilogt::resultt expr2verilogt::convert_rec(const exprt &src)
     { ID_extractbit, [](expr2verilogt &expr2verilog, const exprt &src) { 
     return expr2verilog.convert_extractbit(
       to_extractbit_expr(src), verilog_precedencet::MEMBER); } },
+
+    { ID_verilog_bit_select, [](expr2verilogt &expr2verilog, const exprt &src) { 
+    return expr2verilog.convert_bit_select(
+      to_verilog_bit_select_expr(src), verilog_precedencet::MEMBER); } },
 
     { ID_extractbits, [](expr2verilogt &expr2verilog, const exprt &src) { 
     return expr2verilog.convert_extractbits(

--- a/src/verilog/expr2verilog_class.h
+++ b/src/verilog/expr2verilog_class.h
@@ -91,6 +91,10 @@ protected:
 
   resultt convert_index(const index_exprt &, verilog_precedencet);
 
+  resultt convert_bit_select(
+    const class verilog_bit_select_exprt &,
+    verilog_precedencet);
+
   resultt convert_extractbit(const extractbit_exprt &, verilog_precedencet);
 
   resultt convert_member(const member_exprt &, verilog_precedencet);

--- a/src/verilog/verilog_lowering.cpp
+++ b/src/verilog/verilog_lowering.cpp
@@ -794,6 +794,68 @@ exprt verilog_lowering(exprt expr)
     else
       return expr;
   }
+  else if(expr.id() == ID_verilog_bit_select)
+  {
+    // This may be an array index or a bit extraction, depending
+    // on the type of the first operand.
+    auto &bit_select = to_verilog_bit_select_expr(expr);
+    auto &src = bit_select.src();
+
+    if(src.type().id() == ID_array)
+    {
+      // Lower to array index expression
+      auto &array_type = to_verilog_array_type(src.type());
+      auto index_type = array_type.index_type();
+      exprt index = typecast_exprt{bit_select.index(), index_type};
+
+      if(array_type.is_unpacked())
+      {
+        // For unpacked arrays, the internal representation stores
+        // elements starting from the left index of the range.
+        // We need to adjust the Verilog index to the internal index.
+        auto array_size = array_type.size_int();
+        auto offset = array_type.offset();
+
+        if(array_type.increasing())
+        {
+          // ascending range [l:r] with l<r, e.g., [0:4]
+          // internal index = verilog_index - offset
+          if(offset != 0)
+            index = minus_exprt{index, from_integer(offset, index_type)};
+        }
+        else
+        {
+          // descending range [l:r] with l>=r, e.g., [4:0]
+          // internal index = (offset + size - 1) - verilog_index
+          index = minus_exprt{
+            minus_exprt{
+              plus_exprt{
+                from_integer(offset, index_type),
+                from_integer(array_size, index_type)},
+              from_integer(1, index_type)},
+            index};
+        }
+      }
+
+      return index_exprt{src, index, array_type.element_type()};
+    }
+    else
+    {
+      // Lower to extractbit
+      auto width = verilog_bits(src.type());
+      auto offset = src.type().get_int(ID_C_offset);
+
+      auto index = bit_select.index();
+
+      if(offset != 0)
+        index = minus_exprt{index, from_integer(offset, index.type())};
+
+      if(src.type().get_bool(ID_C_increasing))
+        index = minus_exprt{from_integer(width - 1, index.type()), index};
+
+      return extractbit_exprt{src, index};
+    }
+  }
   else if(expr.id() == ID_member)
   {
     auto &member_expr = to_member_expr(expr);

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -264,6 +264,11 @@ exprt verilog_synthesist::synth_lhs_expr(exprt expr)
       synth_expr(extractbit_expr.index(), symbol_statet::CURRENT);
     return expr;
   }
+  else if(expr.id() == ID_verilog_bit_select)
+  {
+    // Lower to extractbit or index, then process the result.
+    return synth_lhs_expr(verilog_lowering(std::move(expr)));
+  }
   else if(expr.id() == ID_member)
   {
     auto &member_expr = to_member_expr(expr);
@@ -1213,6 +1218,10 @@ const symbolt &verilog_synthesist::assignment_symbol(const exprt &lhs)
       }
 
       e = &to_extractbit_expr(*e).src();
+    }
+    else if(e->id() == ID_verilog_bit_select)
+    {
+      e = &to_verilog_bit_select_expr(*e).src();
     }
     else if(e->id() == ID_verilog_non_indexed_part_select)
     {

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -551,6 +551,10 @@ void verilog_typecheckt::check_lhs(
 
     check_lhs(to_extractbit_expr(lhs).src(), vassign);
   }
+  else if(lhs.id() == ID_verilog_bit_select)
+  {
+    check_lhs(to_verilog_bit_select_expr(lhs).src(), vassign);
+  }
   else if(lhs.id() == ID_verilog_non_indexed_part_select)
   {
     auto &part_select = to_verilog_non_indexed_part_select_expr(lhs);

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -3008,44 +3008,8 @@ exprt verilog_typecheck_exprt::convert_bit_select_expr(
 
   if(src.type().id() == ID_array)
   {
-    // This is really an array index
-    auto &array_type = to_verilog_array_type(src.type());
-    typet index_type = array_type.index_type();
-    index = typecast_exprt{index, index_type};
-
-    // For unpacked arrays, the internal representation stores
-    // elements starting from the left index of the range.
-    // We need to adjust the Verilog index to the internal index.
-    if(array_type.is_unpacked())
-    {
-      auto offset_expr = from_integer(array_type.offset(), index_type);
-
-      if(array_type.get_bool(ID_C_increasing))
-      {
-        // ascending range [l:r] with l<r, e.g., [0:4]
-        // internal index = verilog_index - offset
-        if(!offset_expr.is_zero())
-        {
-          expr.index() =
-            minus_exprt{expr.index(), typecast_exprt{offset_expr, index_type}};
-        }
-      }
-      else
-      {
-        // descending range [l:r] with l>=r, e.g., [4:0]
-        // internal index = (offset + size - 1) - verilog_index
-        expr.index() = minus_exprt{
-          minus_exprt{
-            plus_exprt{
-              typecast_exprt{offset_expr, index_type},
-              typecast_exprt{array_type.size(), index_type}},
-            from_integer(1, index_type)},
-          expr.index()};
-      }
-    }
-
+    auto &array_type = to_array_type(src.type());
     expr.type() = array_type.element_type();
-    expr.id(ID_index);
   }
   else
   {
@@ -3065,31 +3029,9 @@ exprt verilog_typecheck_exprt::convert_bit_select_expr(
 
       if(index_int < offset || index_int >= width + offset)
         return false_exprt().with_source_location(expr);
-
-      index_int -= offset;
-
-      if(src.type().get_bool(ID_C_increasing))
-        index_int = width - index_int - 1;
-
-      expr.index() = from_integer(index_int, natural_typet());
-    }
-    else // non-constant index
-    {
-      if(offset != 0)
-      {
-        expr.index() =
-          minus_exprt{expr.index(), from_integer(offset, expr.index().type())};
-      }
-
-      if(src.type().get_bool(ID_C_increasing))
-      {
-        expr.index() = minus_exprt{
-          from_integer(width - 1, expr.index().type()), expr.index()};
-      }
     }
 
-    expr.type()=bool_typet();
-    expr.id(ID_extractbit);
+    expr.type() = bool_typet{};
   }
 
   return std::move(expr);


### PR DESCRIPTION
This moves the lowering of Verilog's bit select expressions `a[b]` from the expression type checker to the lowering function.