### PR TITLE
Verilog: fix array_conversion1 test

### DIFF
--- a/regression/verilog/arrays/array_conversion1.desc
+++ b/regression/verilog/arrays/array_conversion1.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE
 array_conversion1.sv
 
 ^EXIT=0$
 ^SIGNAL=0$
 --
 --
-This yields a type checking error.

--- a/regression/verilog/arrays/array_conversion1.sv
+++ b/regression/verilog/arrays/array_conversion1.sv
@@ -6,6 +6,6 @@ module main;
   // can be converted implicitly
   wire [63:0] my_word = my_bytes;
 
-  assert final(my_word == 64'h04030201);
+  assert final(my_word == 64'h01020304);
 
 endmodule


### PR DESCRIPTION
This fixes the expected answer for the array_conversion1 test.