### PR TITLE
KNOWNBUG test for generate case

### DIFF
--- a/regression/verilog/generate/generate-case1.desc
+++ b/regression/verilog/generate/generate-case1.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+generate-case1.sv
+--module main --bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Generate case is not yet elaborated.

--- a/regression/verilog/generate/generate-case1.sv
+++ b/regression/verilog/generate/generate-case1.sv
@@ -1,0 +1,17 @@
+module main;
+
+  parameter P = 1;
+
+  reg [7:0] out;
+
+  generate
+    case (P)
+      0: assign out = 8'h00;
+      1: assign out = 8'hff;
+      default: assign out = 8'h42;
+    endcase
+  endgenerate
+
+  always assert p1: out == 8'hff;
+
+endmodule


### PR DESCRIPTION
Adds a regression test for the `generate case` construct (IEEE 1800-2017 section 27.5). The test is marked KNOWNBUG since `elaborate_generate_case` is not yet implemented.