### PR TITLE
Verilog: division and modulo by zero return all-x

### DIFF
--- a/regression/verilog/expressions/div1.desc
+++ b/regression/verilog/expressions/div1.desc
@@ -1,9 +1,7 @@
-KNOWNBUG
+CORE
 div1.sv
 
 ^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring
---
-The result is wrong.

--- a/regression/verilog/expressions/mod1.desc
+++ b/regression/verilog/expressions/mod1.desc
@@ -1,9 +1,7 @@
-KNOWNBUG
+CORE
 mod1.sv
 
 ^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring
---
-The result is wrong.

--- a/src/verilog/aval_bval_encoding.cpp
+++ b/src/verilog/aval_bval_encoding.cpp
@@ -751,3 +751,35 @@ exprt default_aval_bval_lowering(const exprt &expr)
     make_x(type),
     aval_bval_conversion(two_valued_expr, lower_to_aval_bval(type))};
 }
+
+exprt aval_bval_div_mod(const binary_exprt &expr)
+{
+  auto &type = expr.type();
+
+  PRECONDITION(is_four_valued(type));
+  PRECONDITION(expr.id() == ID_div || expr.id() == ID_mod);
+
+  auto rhs_aval = aval_underlying(expr.rhs());
+  auto zero = from_integer(0, rhs_aval.type());
+
+  // The result is 'x' when any operand has x/z or the divisor is zero.
+  auto is_x = disjunction(
+    {has_xz(expr.lhs()), has_xz(expr.rhs()), equal_exprt{rhs_aval, zero}});
+
+  binary_exprt two_valued_expr = expr; // copy
+
+  two_valued_expr.lhs() = aval_underlying(two_valued_expr.lhs());
+  two_valued_expr.rhs() = aval_underlying(two_valued_expr.rhs());
+
+  if(type.id() == ID_verilog_unsignedbv)
+    two_valued_expr.type() = unsignedbv_typet{to_bitvector_type(type).width()};
+  else if(type.id() == ID_verilog_signedbv)
+    two_valued_expr.type() = signedbv_typet{to_bitvector_type(type).width()};
+  else
+    PRECONDITION(false);
+
+  return if_exprt{
+    is_x,
+    make_x(type),
+    aval_bval_conversion(two_valued_expr, lower_to_aval_bval(type))};
+}

--- a/src/verilog/aval_bval_encoding.h
+++ b/src/verilog/aval_bval_encoding.h
@@ -83,4 +83,8 @@ exprt aval_bval(const zero_extend_exprt &);
 /// of the operands.
 exprt default_aval_bval_lowering(const exprt &);
 
+/// lowering for / and %
+/// If any operand has x/z, or the divisor is zero, the result is 'x'.
+exprt aval_bval_div_mod(const binary_exprt &);
+
 #endif

--- a/src/verilog/verilog_lowering.cpp
+++ b/src/verilog/verilog_lowering.cpp
@@ -771,12 +771,17 @@ exprt verilog_lowering(exprt expr)
     else
       return expr;
   }
-  else if(
-    expr.id() == ID_plus || expr.id() == ID_minus || expr.id() == ID_mult ||
-    expr.id() == ID_div || expr.id() == ID_mod)
+  else if(expr.id() == ID_plus || expr.id() == ID_minus || expr.id() == ID_mult)
   {
     if(is_four_valued(expr))
       return default_aval_bval_lowering(expr);
+    else
+      return expr;
+  }
+  else if(expr.id() == ID_div || expr.id() == ID_mod)
+  {
+    if(is_four_valued(expr))
+      return aval_bval_div_mod(to_binary_expr(expr));
     else
       return expr;
   }


### PR DESCRIPTION
Per IEEE 1800-2017, the result of division or modulo by zero is `x`.

The lowering of these operators now checks for a zero divisor in addition to x/z in the operands, by adding a specialized `aval_bval_div_mod()` function.

The `div1` and `mod1` regression tests are promoted from KNOWNBUG to CORE.