### PR TITLE
Verilog: test for signed division overflow

### DIFF
--- a/regression/verilog/expressions/signed-division-overflow1.desc
+++ b/regression/verilog/expressions/signed-division-overflow1.desc
@@ -1,0 +1,7 @@
+CORE
+signed-division-overflow1.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/expressions/signed-division-overflow1.sv
+++ b/regression/verilog/expressions/signed-division-overflow1.sv
@@ -1,0 +1,9 @@
+module main(input signed [7:0] a, b);
+
+  // -128 / -1 overflows: +128 is not representable in 8 signed bits.
+  // Per 1800-2017 6.9.1, arithmetic is modulo 2^n, yielding -128.
+  initial assert (8'sh80 / 8'shff == 8'sh80);
+
+  initial assert (a == 8'sh80 && b == 8'shff -> a / b == a);
+
+endmodule


### PR DESCRIPTION
Test that `8'sh80 / 8'shff` yields `8'sh80`, exercising the case where the minimum representable 8-bit signed value (-128) is divided by -1. Per IEEE 1800-2017 section 6.9.1, arithmetic is modulo 2^n, so the result wraps back to -128.