### PR TITLE
Verilog: simple immediate cover statement

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * SystemVerilog: default direction for task/function ports
 * SystemVerilog: assignment patterns for unions
 * SystemVerilog: assignment patterns for vectors
+* SystemVerilog: immediate cover statement
 
 # EBMC 5.9
 

--- a/regression/verilog/SVA/immediate_cover1.desc
+++ b/regression/verilog/SVA/immediate_cover1.desc
@@ -1,0 +1,10 @@
+CORE
+immediate_cover1.sv
+--bound 10 --numbered-trace
+^\[main\.p0\] cover main\.counter == 5: PROVED$
+^\[main\.p1\] cover main\.counter == 200: REFUTED up to bound 10$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/immediate_cover1.sv
+++ b/regression/verilog/SVA/immediate_cover1.sv
@@ -1,0 +1,18 @@
+module main(input clk);
+
+  reg [7:0] counter;
+
+  initial counter = 0;
+
+  always @(posedge clk)
+    counter <= counter + 1;
+
+  // expected to pass: counter reaches 5
+  always @(posedge clk)
+    p0: cover(counter == 5);
+
+  // expected to fail: counter never reaches 200 within bound
+  always @(posedge clk)
+    p1: cover(counter == 200);
+
+endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -2403,6 +2403,7 @@ void verilog_synthesist::synth_assert_assume_cover(
       cond_for_comment = sva_assume_exprt(cond_for_comment);
     }
     else if(
+      statement.id() == ID_verilog_immediate_cover ||
       statement.id() == ID_verilog_cover_property ||
       statement.id() == ID_verilog_cover_sequence)
     {
@@ -2461,7 +2462,9 @@ void verilog_synthesist::synth_assert_assume_cover(
   {
     cond = sva_assume_exprt(cond);
   }
-  else if(statement.id() == ID_verilog_cover_property)
+  else if(
+    statement.id() == ID_verilog_immediate_cover ||
+    statement.id() == ID_verilog_cover_property)
   {
     // 'cover' properties are existential
     cond = sva_cover_exprt{cond};
@@ -3449,6 +3452,7 @@ void verilog_synthesist::synth_statement(
     statement.id() == ID_verilog_immediate_assert ||
     statement.id() == ID_verilog_assert_property ||
     statement.id() == ID_verilog_smv_assert ||
+    statement.id() == ID_verilog_immediate_cover ||
     statement.id() == ID_verilog_cover_property ||
     statement.id() == ID_verilog_cover_sequence)
   {

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -953,6 +953,7 @@ void verilog_typecheckt::convert_assert_assume_cover(
     std::string kind = statement.id() == ID_verilog_immediate_assert  ? "assert"
                        : statement.id() == ID_verilog_assert_property ? "assert"
                        : statement.id() == ID_verilog_smv_assert      ? "assert"
+                       : statement.id() == ID_verilog_immediate_cover ? "cover"
                        : statement.id() == ID_verilog_cover_property  ? "cover"
                        : statement.id() == ID_verilog_cover_sequence  ? "cover"
                        : statement.id() == ID_verilog_immediate_assume
@@ -1364,6 +1365,7 @@ void verilog_typecheckt::convert_statement(
     statement.id() == ID_verilog_immediate_assert ||
     statement.id() == ID_verilog_assert_property ||
     statement.id() == ID_verilog_smv_assert ||
+    statement.id() == ID_verilog_immediate_cover ||
     statement.id() == ID_verilog_cover_property ||
     statement.id() == ID_verilog_cover_sequence)
   {


### PR DESCRIPTION
The parser already created `ID_verilog_immediate_cover` nodes for `cover(expr)`, but the typecheck and synthesis stages did not handle this ID. This adds the missing dispatch and cover-property wrapping in both stages, plus a regression test.

### Changes
- **verilog_typecheck.cpp**: Add `ID_verilog_immediate_cover` to the `convert_statement` dispatch and the kind-string mapping (so unnamed properties get `cover.N` names).
- **verilog_synthesis.cpp**: Add `ID_verilog_immediate_cover` to the `synth_statement` dispatch and wrap the condition with `sva_cover_exprt` (existential/cover semantics) in both the comment and value paths.
- **regression/verilog/SVA/immediate_cover1**: Test with a passing and failing immediate cover property.