### PR TITLE
Verilog: signing cast lowering for four-valued types

### DIFF
--- a/regression/verilog/expressions/signing_cast2.desc
+++ b/regression/verilog/expressions/signing_cast2.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 signing_cast2.sv
 --module main
 ^EXIT=0$
@@ -6,4 +6,3 @@ signing_cast2.sv
 --
 ^warning: ignoring
 --
-This is not yet implemented.

--- a/src/verilog/verilog_lowering.cpp
+++ b/src/verilog/verilog_lowering.cpp
@@ -585,7 +585,18 @@ exprt verilog_lowering(exprt expr)
   }
   else if(expr.id() == ID_verilog_explicit_signing_cast)
   {
-    return to_verilog_explicit_signing_cast_expr(expr).lower();
+    auto &signing_cast = to_verilog_explicit_signing_cast_expr(expr);
+    if(is_aval_bval(signing_cast.op()))
+    {
+      // Change the signedness annotation in the aval/bval type.
+      auto result = signing_cast.op();
+      result.type().set(
+        ID_C_verilog_aval_bval,
+        signing_cast.is_signed() ? ID_verilog_signedbv : ID_verilog_unsignedbv);
+      return result;
+    }
+    else
+      return signing_cast.lower();
   }
   else if(expr.id() == ID_verilog_explicit_size_cast)
   {


### PR DESCRIPTION
`signed'()` and `unsigned'()` on four-valued operands (containing x/z) now correctly change the signedness annotation in the aval/bval encoding rather than producing a broken typecast.

When the operand has already been lowered to aval/bval encoding, the signing cast just flips the `ID_C_verilog_aval_bval` attribute — the bit pattern is identical for signed and unsigned at the same width. The actual sign/zero extension happens later when operands are widened for comparisons.

- Fixes lowering in `src/verilog/verilog_lowering.cpp`
- Promotes `regression/verilog/expressions/signing_cast2.desc` from KNOWNBUG to CORE