### PR TITLE
refactor completeness threshold computation

### DIFF
--- a/regression/ebmc/engine-heuristic/basic1.desc
+++ b/regression/ebmc/engine-heuristic/basic1.desc
@@ -2,7 +2,7 @@ CORE
 basic1.sv
 
 ^\[main\.a0\] always not s_eventually !main\.x: ASSUMED$
-^\[main\.p0\] always main\.x: PROVED \(structural CT=0\)$
+^\[main\.p0\] always main\.x: PROVED \(CT=0\)$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/engine-heuristic/basic2.desc
+++ b/regression/ebmc/engine-heuristic/basic2.desc
@@ -3,7 +3,7 @@ basic2.sv
 
 ^\[main\.a0\] always not s_eventually !main\.y: ASSUMED$
 ^\[main\.a1\] always !main\.x: ASSUMED$
-^\[main\.p0\] always !main\.z: PROVED \(structural CT=1\)$
+^\[main\.p0\] always !main\.z: PROVED \(CT=1\)$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/engine-heuristic/combinational1.desc
+++ b/regression/ebmc/engine-heuristic/combinational1.desc
@@ -1,7 +1,7 @@
 CORE
 combinational1.sv
 
-^\[main\.p0\] always main\.x == !main\.y: PROVED \(structural CT=0\)$
+^\[main\.p0\] always main\.x == !main\.y: PROVED \(CT=0\)$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/engine-heuristic/counter4.desc
+++ b/regression/ebmc/engine-heuristic/counter4.desc
@@ -2,7 +2,7 @@ CORE
 counter4.sv
 
 ^\[main\.p0\] always main\.cnt != 4'b1111: REFUTED$
-^\[main\.p1\] always main\.cnt == main\.shadow: PROVED \(structural CT=255\)$
+^\[main\.p1\] always main\.cnt == main\.shadow: PROVED \(CT=255\)$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/property_and1.desc
+++ b/regression/verilog/SVA/property_and1.desc
@@ -1,7 +1,7 @@
 CORE
 property_and1.sv
 
-^\[.*\] always \(main\.P1 and main\.P1\): PROVED \(structural CT=0\)$
+^\[.*\] always \(main\.P1 and main\.P1\): PROVED \(CT=0\)$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/ebmc/completeness_threshold.cpp
+++ b/src/ebmc/completeness_threshold.cpp
@@ -14,20 +14,12 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include <temporal-logic/ctl.h>
 #include <temporal-logic/ltl.h>
+#include <temporal-logic/nnf.h>
 #include <temporal-logic/temporal_logic.h>
 #include <verilog/sva_expr.h>
 
 #include "bmc.h"
 #include "transition_system.h"
-
-/// Returns true iff the property is either Gp or Fp,
-/// or an SVA or CTL equivalent, where p is a
-/// state predicate without temporal operators.
-static bool is_Gp_or_Fp(const exprt &expr)
-{
-  return is_SVA_always_p(expr) || is_Gp(expr) || is_AGp(expr) ||
-         is_SVA_s_eventually_p(expr) || is_Fp(expr) || is_AFp(expr);
-}
 
 /// An upper bound on the recurrence diameter of the state space.
 /// A purely combinational circuit (no state variables) has diameter 0.
@@ -53,8 +45,11 @@ recurrence_diameter(const transition_systemt &transition_system)
   return power(mp_integer{2}, total_bits) - 1;
 }
 
-// counting number of transitions
-std::optional<mp_integer> completeness_threshold(const exprt &expr)
+/// Completeness threshold for given property.
+/// Counting number of transitions.
+/// May use recurrence diameter if available.
+std::optional<mp_integer>
+completeness_threshold(const exprt &expr, const std::optional<mp_integer> &rd)
 {
   if(!has_temporal_operator(expr))
   {
@@ -64,7 +59,7 @@ std::optional<mp_integer> completeness_threshold(const exprt &expr)
   {
     // X p
     // Increases the CT by one.
-    auto ct_p = completeness_threshold(to_X_expr(expr).op());
+    auto ct_p = completeness_threshold(to_X_expr(expr).op(), rd);
     if(ct_p.has_value())
       return *ct_p + 1;
     else
@@ -87,7 +82,7 @@ std::optional<mp_integer> completeness_threshold(const exprt &expr)
         numeric_cast_v<mp_integer>(to_constant_expr(always_expr.to()));
 
       // increases the CT by to_int
-      auto ct_op = completeness_threshold(always_expr.op());
+      auto ct_op = completeness_threshold(always_expr.op(), rd);
       if(ct_op.has_value())
         return *ct_op + to_int;
       else
@@ -106,7 +101,7 @@ std::optional<mp_integer> completeness_threshold(const exprt &expr)
       return {};
 
     // increases the CT by to_int
-    auto ct_op = completeness_threshold(s_always_expr.op());
+    auto ct_op = completeness_threshold(s_always_expr.op(), rd);
     if(ct_op.has_value())
       return *ct_op + to_int;
     else
@@ -117,7 +112,7 @@ std::optional<mp_integer> completeness_threshold(const exprt &expr)
     expr.id() == ID_sva_implicit_strong || expr.id() == ID_sva_implicit_weak)
   {
     auto &sequence = to_sva_sequence_property_expr_base(expr).sequence();
-    return completeness_threshold(sequence);
+    return completeness_threshold(sequence, rd);
   }
   else if(expr.id() == ID_sva_boolean)
   {
@@ -130,7 +125,7 @@ std::optional<mp_integer> completeness_threshold(const exprt &expr)
 
     if(cycle_delay.lhs().is_not_nil())
     {
-      auto ct_lhs_opt = completeness_threshold(cycle_delay.lhs());
+      auto ct_lhs_opt = completeness_threshold(cycle_delay.lhs(), rd);
       if(ct_lhs_opt.has_value())
         ct_lhs = ct_lhs_opt.value();
       else
@@ -141,7 +136,7 @@ std::optional<mp_integer> completeness_threshold(const exprt &expr)
       return {};
     else // singleton
     {
-      auto ct_rhs = completeness_threshold(cycle_delay.rhs());
+      auto ct_rhs = completeness_threshold(cycle_delay.rhs(), rd);
       if(ct_rhs.has_value())
         return ct_lhs + numeric_cast_v<mp_integer>(cycle_delay.from()) +
                *ct_rhs;
@@ -153,24 +148,33 @@ std::optional<mp_integer> completeness_threshold(const exprt &expr)
   {
     PRECONDITION(false); // should have been turned into implicit weak/strong
   }
+  else if(
+    is_Gp(expr) || is_Fp(expr) || is_SVA_always_p(expr) ||
+    is_SVA_s_eventually_p(expr))
+  {
+    // the recurrence diameter is a CT
+    return rd;
+  }
   else
     return {};
 }
 
-std::optional<mp_integer>
-completeness_threshold(const ebmc_propertiest::propertyt &property)
+std::optional<mp_integer> completeness_threshold(
+  const ebmc_propertiest::propertyt &property,
+  const std::optional<mp_integer> &rd)
 {
-  return completeness_threshold(property.normalized_expr);
+  return completeness_threshold(property.normalized_expr, rd);
 }
 
-std::optional<mp_integer>
-completeness_threshold(const ebmc_propertiest &properties)
+std::optional<mp_integer> max_completeness_threshold(
+  const ebmc_propertiest &properties,
+  const std::optional<mp_integer> &rd)
 {
   std::optional<mp_integer> max_ct;
 
   for(auto &property : properties.properties)
   {
-    auto ct_opt = completeness_threshold(property);
+    auto ct_opt = completeness_threshold(property, rd);
     if(ct_opt.has_value())
       max_ct = std::max(max_ct.value_or(0), *ct_opt);
   }
@@ -185,26 +189,18 @@ property_checker_resultt completeness_threshold(
   const ebmc_solver_factoryt &solver_factory,
   message_handlert &message_handler)
 {
-  auto structural_ct = recurrence_diameter(transition_system);
-  auto property_ct = completeness_threshold(properties);
+  auto rd_opt = recurrence_diameter(transition_system);
+  auto max_ct_opt = max_completeness_threshold(properties, rd_opt);
 
-  if(!structural_ct.has_value() && !property_ct.has_value())
+  if(!max_ct_opt.has_value())
     return property_checker_resultt{properties}; // give up
 
-  // Take the minimum of structural and property CT.
-  mp_integer min_ct;
+  // Do BMC, using the max CT as the bound
+  auto &bound = max_ct_opt.value();
 
-  if(structural_ct.has_value() && property_ct.has_value())
-    min_ct = std::min(*structural_ct, *property_ct);
-  else if(structural_ct.has_value())
-    min_ct = structural_ct.value();
-  else
-    min_ct = property_ct.value();
-
-  // Do BMC, using the CT as the bound
   auto result = bmc(
-    numeric_cast_v<std::size_t>(min_ct), // bound
-    false,                               // convert_only
+    numeric_cast_v<std::size_t>(bound), // bound
+    false,                              // convert_only
     cmdline.isset("bmc-with-assumptions"),
     transition_system,
     properties,
@@ -216,19 +212,10 @@ property_checker_resultt completeness_threshold(
     if(property.is_proved_with_bound())
     {
       // Turn "PROVED up to bound k" into "PROVED" if k>=CT
-      auto property_ct_opt = completeness_threshold(property);
+      auto property_ct_opt = completeness_threshold(property, rd_opt);
 
-      if(property_ct_opt.has_value() && property_ct_opt.value() >= min_ct)
+      if(property_ct_opt.has_value() && property_ct_opt.value() >= bound)
         property.proved("CT=" + integer2string(*property_ct_opt));
-      else if(
-        structural_ct.has_value() && is_Gp_or_Fp(property.normalized_expr) &&
-        structural_ct.value() >= min_ct)
-      {
-        // The structural CT is the reachability diameter, which is
-        // only a completeness threshold for reachability properties,
-        // not for liveness properties.
-        property.proved("structural CT=" + integer2string(*structural_ct));
-      }
       else
         property.unknown();
     }


### PR DESCRIPTION
This refactors the computation of the completness threshold to include `Gp`/`Fp`, as opposed to special-casing these properties.