### PR TITLE
fix for SVA ranged sequence delay

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * SystemVerilog: assignment patterns for unions
 * SystemVerilog: assignment patterns for vectors
 * SystemVerilog: immediate cover statement
+* SystemVerilog: fix for SVA ##[a:b]
 
 # EBMC 5.9
 

--- a/regression/verilog/SVA/cycle_delay3.desc
+++ b/regression/verilog/SVA/cycle_delay3.desc
@@ -1,0 +1,8 @@
+CORE
+cycle_delay3.sv
+--bound 10
+^\[top\.pause_window\] always \(top.pause \|-> \(##\[1:3\] !top\.pause\)\): ASSUMED$
+^\[top\.never_4pauses\] always \(\(top\.pause \[\*4\]\) \|-> 0\): PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/verilog/SVA/cycle_delay3.sv
+++ b/regression/verilog/SVA/cycle_delay3.sv
@@ -1,0 +1,12 @@
+// https://github.com/diffblue/hw-cbmc/issues/1747
+
+module top (input logic clk, pause);
+
+    // Assumption: If pause is high, it MUST go low within the next 3 cycles.
+    // This makes 4 consecutive high cycles impossible.
+    pause_window: assume property (@(posedge clk) pause |-> ##[1:3] !pause );
+
+    // Assertion: Checks for the impossible condition (4 consecutive high cycles).
+    never_4pauses: assert property (@(posedge clk) pause [*4] |-> 1'b0 );
+
+endmodule

--- a/src/trans-word-level/sequence.cpp
+++ b/src/trans-word-level/sequence.cpp
@@ -129,7 +129,8 @@ sequence_matchest instantiate_sequence_rec(
       else // ##[from:to] something
       {
         auto to = numeric_cast_v<mp_integer>(sva_cycle_delay_expr.to());
-        t_rhs_to = t_rhs_from + to;
+        DATA_INVARIANT(to >= from, "##[a:b] must have a<=b");
+        t_rhs_to = lhs_match.end_time + to;
       }
 
       // Add a potential match for each timeframe in the range


### PR DESCRIPTION
This fixes the BMC encoding for SVA's ranged sequence delay `##[a:b]`, where the upper time frame was incorrectly calculated.

Fixes #1747