### PR TITLE
Sequences: weak semantics for goto and non-consecutive repetition

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * SystemVerilog: assignment patterns for vectors
 * SystemVerilog: immediate cover statement
 * SystemVerilog: fix for SVA ##[a:b]
+* SystemVerilog: fix for weak [->n] and [=n]
 
 # EBMC 5.9
 

--- a/regression/verilog/SVA/goto_repetition1.desc
+++ b/regression/verilog/SVA/goto_repetition1.desc
@@ -1,0 +1,10 @@
+CORE
+goto_repetition1.sv
+--bound 10
+^\[goto\.assert_goto\] always \(goto\.req \|=> \(goto\.ack \[->1\]\)\): PROVED up to bound 10$
+^\[goto\.assert_equivalent\] always \(goto\.req \|=> \(\(!goto\.ack \[\*0:\$\]\) ##1 goto\.ack\)\): PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/goto_repetition1.sv
+++ b/regression/verilog/SVA/goto_repetition1.sv
@@ -1,0 +1,13 @@
+// https://github.com/diffblue/hw-cbmc/issues/1750
+
+module goto(input logic clk, req);
+
+    logic ack = 1'b0;
+
+    // This is refuted 
+    assert_goto: assert property (@(posedge clk) req |=> ack[->1]);
+
+    // This is equivalent, but proved up to bound
+    assert_equivalent: assert property ( @(posedge clk) req |=> (!ack)[*0:$] ##1 ack);
+
+endmodule

--- a/regression/verilog/SVA/sequence_repetition1.desc
+++ b/regression/verilog/SVA/sequence_repetition1.desc
@@ -5,8 +5,8 @@ sequence_repetition1.sv
 ^\[.*\] main\.half_x == 0 \[->2\]: PROVED up to bound 10$
 ^\[.*\] main\.half_x == 0 \[=2\]: PROVED up to bound 10$
 ^\[.*\] main\.x == 0 \[\*2\]: REFUTED$
-^\[.*\] main\.x == 0 \[->2\]: REFUTED$
-^\[.*\] main\.x == 0 \[=2\]: REFUTED$
+^\[.*\] main\.x == 0 \[->2\]: PROVED up to bound 10$
+^\[.*\] main\.x == 0 \[=2\]: PROVED up to bound 10$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/src/trans-word-level/sequence.cpp
+++ b/src/trans-word-level/sequence.cpp
@@ -376,9 +376,11 @@ sequence_matchest instantiate_sequence_rec(
     return instantiate_sequence_rec(
       repetition.lower(), semantics, t, no_timeframes);
   }
-  else if(expr.id() == ID_sva_sequence_goto_repetition) // [->...]
+  else if(
+    expr.id() == ID_sva_sequence_goto_repetition ||          // [->...]
+    expr.id() == ID_sva_sequence_non_consecutive_repetition) // [=...]
   {
-    auto &repetition = to_sva_sequence_goto_repetition_expr(expr);
+    auto &repetition = to_sva_sequence_repetition_expr(expr);
     auto &condition = repetition.op();
 
     sequence_matchest result;
@@ -400,35 +402,22 @@ sequence_matchest instantiate_sequence_rec(
 
       // We have a match for op[->n] if there is a match in timeframe
       // u and matches is n.
+      // We have a match for op[=n] if matches is n.
       result.emplace_back(u, sequence_count_condition(repetition, matches));
     }
 
-    return result;
-  }
-  else if(expr.id() == ID_sva_sequence_non_consecutive_repetition) // [=...]
-  {
-    auto &repetition = to_sva_sequence_non_consecutive_repetition_expr(expr);
-    auto &condition = repetition.op();
-
-    sequence_matchest result;
-
-    // We add up the number of matches of 'op' starting from
-    // timeframe u, until the end of our unwinding.
-    const auto type = sequence_count_type(repetition, no_timeframes);
-    const auto zero = from_integer(0, type);
-    const auto one = from_integer(1, type);
-    exprt matches = zero;
-
-    for(mp_integer u = t; u < no_timeframes; ++u)
+    // Weak semantics: the sequence could still complete beyond the
+    // bound. Add a pending match when the count hasn't yet reached
+    // the required minimum.
+    if(semantics == sva_sequence_semanticst::WEAK)
     {
-      // match of op in timeframe u?
-      auto rec_op = instantiate(condition, u, no_timeframes);
-
-      // add up
-      matches = plus_exprt{matches, if_exprt{rec_op, one, zero}};
-
-      // We have a match for op[=n] if matches is n.
-      result.emplace_back(u, sequence_count_condition(repetition, matches));
+      auto min = repetition.is_range()
+                   ? numeric_cast_v<mp_integer>(repetition.from())
+                   : numeric_cast_v<mp_integer>(repetition.repetitions());
+      result.emplace_back(
+        no_timeframes - 1,
+        binary_relation_exprt{
+          matches, ID_lt, from_integer(min, matches.type())});
     }
 
     return result;


### PR DESCRIPTION
The goto repetition (`[->n]`) and non-consecutive repetition (`[=n]`) handlers in `src/trans-word-level/sequence.cpp` ignored the weak/strong semantics parameter. Under weak semantics (the default for `assert property`), sequences that cannot complete within the bound should not be considered failures.

This caused `ack[->1]` to be incorrectly REFUTED while the semantically equivalent `(!ack)[*0:$] ##1 ack` was correctly PROVED up to bound.

The fix adds a pending match when the repetition count hasn't reached the required minimum at the end of the bound, analogous to how the cycle delay handler already treats timeframes beyond the bound.

Fixes #1750.