### PR TITLE
Implication: fix early return discarding obligations at bound

### DIFF
--- a/regression/verilog/SVA/sequence_implication4.desc
+++ b/regression/verilog/SVA/sequence_implication4.desc
@@ -1,0 +1,11 @@
+CORE
+sequence_implication4.sv
+--bound 5
+^\[main\.p0\] \(1 \[\*1:\$\]\) \|=> main\.c: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The sequence 1[*1:$] matches at every cycle; the consequent c
+becomes false at cycle 3, so the property should fail.

--- a/regression/verilog/SVA/sequence_implication4.sv
+++ b/regression/verilog/SVA/sequence_implication4.sv
@@ -1,0 +1,26 @@
+module main(input clk);
+
+  // Test that a sequence match at the bound does not cause the
+  // entire non-overlapped implication to become vacuously true.
+  //
+  // x:    0 1 2 3 4 5
+  // c:    1 1 1 0 0 0   (true at cycles 0-2, false from cycle 3)
+  //
+  // 1[*1:$] matches at every cycle from 0 onwards. With |=>,
+  // the consequent c is checked one cycle later. At match cycle 2,
+  // c at cycle 3 is false, so the property should fail.
+  //
+  // The match at the last bound cycle has its consequent beyond
+  // the bound; this must not discard earlier obligations.
+
+  reg [7:0] x = 0;
+
+  always_ff @(posedge clk)
+    x <= x + 8'd1;
+
+  wire c = (x <= 8'd2);
+
+  // should fail
+  initial p0: assert property (1[*1:$] |=> c);
+
+endmodule

--- a/src/trans-word-level/property.cpp
+++ b/src/trans-word-level/property.cpp
@@ -731,8 +731,9 @@ static obligationst property_obligations_rec(
       // Do we exceed the bound? Make it 'true'
       if(t_rhs >= no_timeframes)
       {
-        DATA_INVARIANT(no_timeframes != 0, "must have timeframe");
-        return obligationst{no_timeframes - 1, true_exprt()};
+        // The consequent can't be checked beyond the bound.
+        // The implication is vacuously true for this match point.
+        continue;
       }
 
       // Get obligations for RHS


### PR DESCRIPTION
When processing a non-overlapped implication (`|=>`), if any LHS match point's consequent start time exceeded the bound, the code returned `true` for the entire property, discarding all previously computed obligations from earlier match points. This caused properties to be incorrectly proved.

Replace the early `return` with `continue`, skipping just that match point since the implication is vacuously true when the consequent cannot be checked.

Includes a regression test (`sequence_implication4`) that uses `1[*1:$] |=> c` to exercise this bug independently.