### PR TITLE
Restore the SVA Buechi tests

### DIFF
--- a/regression/verilog/SVA/case1.buechi.desc
+++ b/regression/verilog/SVA/case1.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+case1.sv
+--buechi --bound 20 --numbered-trace
+^\[main\.p0\] always \(case\(main\.x\) 10: 0; endcase\): REFUTED$
+^Counterexample with 11 states:$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/cover1.buechi.desc
+++ b/regression/verilog/SVA/cover1.buechi.desc
@@ -1,0 +1,13 @@
+CORE buechi
+cover1.sv
+--buechi --bound 10 --numbered-trace
+^\[main\.p0\] cover main\.counter == 1: PROVED$
+^Trace with 2 states:$
+^main\.counter@0 = 0$
+^main\.counter@1 = 1$
+^\[main\.p1\] cover main\.counter == 100: REFUTED up to bound 10$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/cover2.buechi.desc
+++ b/regression/verilog/SVA/cover2.buechi.desc
@@ -1,0 +1,13 @@
+CORE buechi
+cover2.sv
+--buechi --bound 10 --numbered-trace
+^\[main\.p0\] cover main\.counter == 1: PROVED$
+^Trace with 2 states:$
+^main\.counter@0 = 0$
+^main\.counter@1 = 1$
+^\[main\.p1\] cover main\.counter == 100: REFUTED up to bound 10$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/cover_sequence1.bmc.buechi.desc
+++ b/regression/verilog/SVA/cover_sequence1.bmc.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+cover_sequence1.sv
+--buechi --bound 10 --numbered-trace
+^\[main\.p0\] cover \(main\.x == 2 ##1 main\.x == 3 ##1 main\.x == 4\): PROVED$
+^\[main\.p1\] cover \(main\.x == 2 ##1 main\.x == 3 ##1 main\.x == 5\): REFUTED up to bound 10$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/cover_sequence2.bmc.buechi.desc
+++ b/regression/verilog/SVA/cover_sequence2.bmc.buechi.desc
@@ -1,0 +1,12 @@
+CORE buechi
+cover_sequence2.sv
+--buechi --bound 5
+^\[main\.p0\] cover \(main\.x == 2 ##1 main\.x == 3 ##1 main\.x == 100\): REFUTED up to bound 5$
+^\[main\.p1\] cover \(main\.x == 98 ##1 main\.x == 99 ##1 main\.x == 100\): REFUTED up to bound 5$
+^\[main\.p2\] cover \(main\.x == 3 ##1 main\.x == 4 ##1 main\.x == 5\): PROVED$
+^\[main\.p3\] cover \(main\.x == 4 ##1 main\.x == 5 ##1 main\.x == 6\): REFUTED up to bound 5$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/cover_sequence3.bmc.buechi.desc
+++ b/regression/verilog/SVA/cover_sequence3.bmc.buechi.desc
@@ -1,0 +1,12 @@
+KNOWNBUG buechi
+cover_sequence3.sv
+--buechi --bound 3
+^\[main\.p0\] cover \(1 \[\*10\]\): REFUTED up to bound 3$
+^\[main\.p1\] cover \(1 \[\*4:10\]\): PROVED$
+^\[main\.p2\] cover \(1 \[\*5:10\]\): REFUTED up to bound 3$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Trace one too short.

--- a/regression/verilog/SVA/cover_sequence4.bmc.buechi.desc
+++ b/regression/verilog/SVA/cover_sequence4.bmc.buechi.desc
@@ -1,0 +1,12 @@
+KNOWNBUG buechi
+cover_sequence4.sv
+--buechi --bound 3
+^\[main\.p0\] cover \(1 \[=10\]\): REFUTED up to bound 3$
+^\[main\.p1\] cover \(1 \[=4:10\]\): PROVED$
+^\[main\.p2\] cover \(1 \[=5:10\]\): REFUTED up to bound 3$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Trace one too short.

--- a/regression/verilog/SVA/cycle_delay2.bmc.buechi.desc
+++ b/regression/verilog/SVA/cycle_delay2.bmc.buechi.desc
@@ -1,0 +1,7 @@
+CORE buechi
+cycle_delay2.sv
+--buechi --bound 10
+^\[.*\] ##\[1:2\] main\.x == 2: PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/verilog/SVA/cycle_delay2.k.buechi.desc
+++ b/regression/verilog/SVA/cycle_delay2.k.buechi.desc
@@ -1,0 +1,7 @@
+CORE buechi
+cycle_delay2.sv
+--buechi --k-induction --bound 3
+^\[.*\] ##\[1:2\] main\.x == 2: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/verilog/SVA/cycle_delay_plus4.buechi.desc
+++ b/regression/verilog/SVA/cycle_delay_plus4.buechi.desc
@@ -1,0 +1,12 @@
+CORE buechi
+cycle_delay_plus4.sv
+--buechi
+^\[main\.p0\] main\.x == 0 ##\[\+\] main\.x == 1: PROVED \(1-induction\)$
+^\[main\.p1\] main\.x == 0 ##\[\+\] main\.x == 2: PROVED \(1-induction\)$
+^\[main\.p2\] main\.x == 1 ##\[\+\] main\.x == 1: REFUTED$
+^\[main\.p3\] main\.x == 0 ##\[\+\] main\.x == 6: PROVED \(1-induction\)$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/cycle_delay_star1.bdd.buechi.desc
+++ b/regression/verilog/SVA/cycle_delay_star1.bdd.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+cycle_delay_star1.sv
+--buechi --bdd
+^\[main.p0\] ##\[\*\] main\.x == 2 ##1 main\.x == 3: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/cycle_delay_star1.bmc.buechi.desc
+++ b/regression/verilog/SVA/cycle_delay_star1.bmc.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+cycle_delay_star1.sv
+--buechi --bound 10
+^\[main.p0\] ##\[\*\] main\.x == 2 ##1 main\.x == 3: PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/cycle_delay_star2.bdd.buechi.desc
+++ b/regression/verilog/SVA/cycle_delay_star2.bdd.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+cycle_delay_star2.sv
+--buechi --bdd
+^\[main.p0\] ##\[\*\] main\.x == 4: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/cycle_delay_star2.bmc.buechi.desc
+++ b/regression/verilog/SVA/cycle_delay_star2.bmc.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+cycle_delay_star2.sv
+--buechi --bound 10
+^\[main.p0\] ##\[\*\] main\.x == 4: PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/cycle_delay_star3.bdd.buechi.desc
+++ b/regression/verilog/SVA/cycle_delay_star3.bdd.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+cycle_delay_star3.sv
+--buechi --bdd
+^\[main.p0\] ##\[\*\] main\.x == 4: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/cycle_delay_star3.bmc.buechi.desc
+++ b/regression/verilog/SVA/cycle_delay_star3.bmc.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+cycle_delay_star3.sv
+--buechi --bound 10
+^\[main.p0\] ##\[\*\] main\.x == 4: PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/cycle_delay_star4.buechi.desc
+++ b/regression/verilog/SVA/cycle_delay_star4.buechi.desc
@@ -1,0 +1,13 @@
+CORE buechi
+cycle_delay_star4.sv
+--buechi
+^\[main\.p0\] main\.x == 0 ##\[\*\] main\.x == 0: PROVED \(1-induction\)$
+^\[main\.p1\] main\.x == 0 ##\[\*\] main\.x == 1: PROVED \(1-induction\)$
+^\[main\.p2\] main\.x == 0 ##\[\*\] main\.x == 2: PROVED \(1-induction\)$
+^\[main\.p3\] main\.x == 1 ##\[\*\] main\.x == 1: REFUTED$
+^\[main\.p4\] main\.x == 0 ##\[\*\] main\.x == 6: PROVED \(1-induction\)$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/default_disable1.buechi.desc
+++ b/regression/verilog/SVA/default_disable1.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+default_disable1.sv
+--buechi
+^file .* line 5: default disable iff is unsupported$
+^EXIT=2$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/disable_iff1.bdd.buechi.desc
+++ b/regression/verilog/SVA/disable_iff1.bdd.buechi.desc
@@ -1,0 +1,13 @@
+CORE buechi
+disable_iff1.sv
+--buechi --module main --bdd --numbered-trace
+^\[main\.p0\] always \(disable iff \(main.counter == 0\) main\.counter != 0\): PROVED$
+^\[main\.p1\] always \(disable iff \(1\) 0\): PROVED$
+^\[main\.p2\] always \(disable iff \(main\.counter == 1\) main\.counter == 0\): REFUTED$
+^Counterexample with 3 states:$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The trace is missing.

--- a/regression/verilog/SVA/disable_iff1.bmc.buechi.desc
+++ b/regression/verilog/SVA/disable_iff1.bmc.buechi.desc
@@ -1,0 +1,12 @@
+CORE buechi
+disable_iff1.sv
+--buechi --module main --bound 10 --numbered-trace
+^\[main\.p0\] always \(disable iff \(main.counter == 0\) main\.counter != 0\): PROVED up to bound 10$
+^\[main\.p1\] always \(disable iff \(1\) 0\): PROVED up to bound 10$
+^\[main\.p2\] always \(disable iff \(main\.counter == 1\) main\.counter == 0\): REFUTED$
+^Counterexample with 3 states:$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/empty_sequence1.bdd.buechi.desc
+++ b/regression/verilog/SVA/empty_sequence1.bdd.buechi.desc
@@ -1,0 +1,13 @@
+CORE buechi
+empty_sequence1.sv
+--buechi --bdd
+^\[main\.p0\] 1 \[\*0\]: REFUTED$
+^\[main\.p1\] \(1 \[\*0\]\) ##1 main\.x == 0: PROVED$
+^\[main\.p2\] main\.x == 0 ##1 \(1 \[\*0\]\): PROVED$
+^\[main\.p3\] \(1 \[\*0\]\) ##0 1: REFUTED$
+^\[main\.p4\] 1 ##0 \(1 \[\*0\]\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/empty_sequence1.bmc.buechi.desc
+++ b/regression/verilog/SVA/empty_sequence1.bmc.buechi.desc
@@ -1,0 +1,13 @@
+CORE buechi
+empty_sequence1.sv
+--buechi --bound 5
+^\[main\.p0\] 1 \[\*0\]: REFUTED$
+^\[main\.p1\] \(1 \[\*0\]\) ##1 main\.x == 0: PROVED up to bound 5$
+^\[main\.p2\] main\.x == 0 ##1 \(1 \[\*0\]\): PROVED up to bound 5$
+^\[main\.p3\] \(1 \[\*0\]\) ##0 1: REFUTED$
+^\[main\.p4\] 1 ##0 \(1 \[\*0\]\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/empty_sequence1.k.buechi.desc
+++ b/regression/verilog/SVA/empty_sequence1.k.buechi.desc
@@ -1,0 +1,13 @@
+CORE buechi
+empty_sequence1.sv
+--buechi --k-induction --bound 1
+^\[main\.p0\] 1 \[\*0\]: REFUTED$
+^\[main\.p1\] \(1 \[\*0\]\) ##1 main\.x == 0: PROVED$
+^\[main\.p2\] main\.x == 0 ##1 \(1 \[\*0\]\): PROVED$
+^\[main\.p3\] \(1 \[\*0\]\) ##0 1: REFUTED$
+^\[main\.p4\] 1 ##0 \(1 \[\*0\]\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/eventually1.bmc.buechi.desc
+++ b/regression/verilog/SVA/eventually1.bmc.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+eventually1.sv
+--buechi --bound 20
+^\[main\.p0\] always \(main\.counter == 1 implies \(eventually \[1:2\] main\.counter == 3\)\): PROVED up to bound 20$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/SVA/eventually1.k.buechi.desc
+++ b/regression/verilog/SVA/eventually1.k.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+eventually1.sv
+--buechi --k-induction --bound 2
+^\[main\.p0\] always \(main\.counter == 1 implies \(eventually \[1:2\] main\.counter == 3\)\): PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/SVA/eventually2.buechi.desc
+++ b/regression/verilog/SVA/eventually2.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+eventually2.sv
+--buechi --bound 20
+^\[main\.p0\] always \(eventually \[0:2\] main\.counter == 3\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/SVA/eventually4.bmc.buechi.desc
+++ b/regression/verilog/SVA/eventually4.bmc.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+eventually4.sv
+--buechi --bound 2
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/eventually4.k.buechi.desc
+++ b/regression/verilog/SVA/eventually4.k.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+eventually4.sv
+--buechi --k-induction --bound 1
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/followed-by1.bdd.buechi.desc
+++ b/regression/verilog/SVA/followed-by1.bdd.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+followed-by1.sv
+--buechi --bdd
+^\[main\.p0\] main\.x == 0 #=# \(main\.x == 1 #=# main\.x == 2\): PROVED$
+^\[main\.p1\] main\.x == 0 #-# \(\(##1 main\.x == 1\) #-# \(##1 main\.x == 2\)\): PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/followed-by1.bmc.buechi.desc
+++ b/regression/verilog/SVA/followed-by1.bmc.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+followed-by1.sv
+--buechi --bound 20 --numbered-trace
+^\[main\.p0\] main\.x == 0 #=# \(main\.x == 1 #=# main\.x == 2\): PROVED up to bound 20$
+^\[main\.p1\] main\.x == 0 #-# \(\(##1 main\.x == 1\) #-# \(##1 main\.x == 2\)\): PROVED up to bound 20$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/followed-by1.k.buechi.desc
+++ b/regression/verilog/SVA/followed-by1.k.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+followed-by1.sv
+--buechi --k-induction --bound 1
+^\[main\.p0\] main\.x == 0 #=# \(main\.x == 1 #=# main\.x == 2\): PROVED$
+^\[main\.p1\] main\.x == 0 #-# \(\(##1 main\.x == 1\) #-# \(##1 main\.x == 2\)\): PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/followed-by2.bdd.buechi.desc
+++ b/regression/verilog/SVA/followed-by2.bdd.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+followed-by2.sv
+--buechi --bdd
+^\[main\.p0\] always \(\(main\.a #-# main\.b\) iff \(not \(main\.a |-> \(not main\.b\)\)\)\): PROVED$
+^\[main\.p1\] always \(\(main\.a #=# main\.b\) iff \(not \(main\.a |=> \(not main\.b\)\)\)\): PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/followed-by2.bmc.buechi.desc
+++ b/regression/verilog/SVA/followed-by2.bmc.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+followed-by2.sv
+--buechi --bound 20
+^\[main\.p0\] always \(\(main\.a #-# main\.b\) iff \(not \(main\.a |-> \(not main\.b\)\)\)\): PROVED up to bound 20$
+^\[main\.p1\] always \(\(main\.a #=# main\.b\) iff \(not \(main\.a |=> \(not main\.b\)\)\)\): PROVED up to bound 20$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/followed-by2.k.buechi.desc
+++ b/regression/verilog/SVA/followed-by2.k.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+followed-by2.sv
+--buechi --k-induction --bound 1
+^\[main\.p0\] always \(\(main\.a #-# main\.b\) iff \(not \(main\.a |-> \(not main\.b\)\)\)\): PROVED$
+^\[main\.p1\] always \(\(main\.a #=# main\.b\) iff \(not \(main\.a |=> \(not main\.b\)\)\)\): PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/followed-by3.buechi.desc
+++ b/regression/verilog/SVA/followed-by3.buechi.desc
@@ -1,0 +1,14 @@
+CORE buechi
+followed-by3.sv
+--buechi --bound 20
+^\[.*\] \(main\.x == 0 ##1 main\.x == 1\) #-# \(s_eventually main\.x == 10\): PROVED up to bound 20$
+^\[.*\] \(main\.x == 0 ##1 main\.x == 1\) #=# \(s_eventually main\.x == 10\): PROVED up to bound 20$
+^\[.*\] \(main\.x == 0 ##1 main\.x == 1\) #-# \(s_eventually main\.x == 2\): PROVED up to bound 20$
+^\[.*\] \(main\.x == 0 ##1 main\.x == 1\) #-# \(s_eventually main\.x == 11\): REFUTED$
+^\[.*\] \(main\.x == 0 ##1 main\.x == 1\) #=# \(s_eventually main\.x == 1\): REFUTED$
+^\[.*\] \(main\.x == 0 ##1 main\.x == 2\) #-# 1: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/followed-by4.bdd.buechi.desc
+++ b/regression/verilog/SVA/followed-by4.bdd.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+followed-by4.sv
+--buechi --bdd
+^\[main\.p1\] always \(main\.x == 0 #-# 1\): REFUTED$
+^\[main\.p2\] \(1 or \(##2 1\)\) #-# main\.x == 2: PROVED$
+^\[main\.p3\] \(1 or \(##2 1\)\) #-# main\.x == 0: PROVED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/followed-by4.bmc.buechi.desc
+++ b/regression/verilog/SVA/followed-by4.bmc.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+followed-by4.sv
+--buechi --bound 3
+^\[main\.p1\] always \(main\.x == 0 #-# 1\): REFUTED$
+^\[main\.p2\] \(1 or \(##2 1\)\) #-# main\.x == 2: PROVED up to bound 3$
+^\[main\.p3\] \(1 or \(##2 1\)\) #-# main\.x == 0: PROVED up to bound 3$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/followed-by4.k.buechi.desc
+++ b/regression/verilog/SVA/followed-by4.k.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+followed-by4.sv
+--buechi --k-induction --bound 3
+^\[main\.p1\] always \(main\.x == 0 #-# 1\): REFUTED$
+^\[main\.p2\] \(1 or \(##2 1\)\) #-# main\.x == 2: PROVED$
+^\[main\.p3\] \(1 or \(##2 1\)\) #-# main\.x == 0: PROVED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/followed-by5.bdd.buechi.desc
+++ b/regression/verilog/SVA/followed-by5.bdd.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+followed-by5.sv
+--buechi --bdd
+^\[main\.p0\] \(1 \[\*0\]\) #=# main\.x == 0: PROVED$
+^\[main\.p1\] \(1 \[\*0\]\) #-# 1: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/followed-by5.bmc.buechi.desc
+++ b/regression/verilog/SVA/followed-by5.bmc.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+followed-by5.sv
+--buechi --bound 2
+^\[main\.p0\] \(1 \[\*0\]\) #=# main\.x == 0: PROVED up to bound 2$
+^\[main\.p1\] \(1 \[\*0\]\) #-# 1: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/if1.bdd.buechi.desc
+++ b/regression/verilog/SVA/if1.bdd.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+if1.sv
+--buechi --bdd
+^\[main\.p0\] always \(if\(main\.counter == 0\) nexttime main\.counter == 1\): PROVED$
+^\[main\.p1\] always \(if\(main\.counter == 0\) nexttime main\.counter == 1 else nexttime main\.counter == 3\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/if1.bmc.buechi.desc
+++ b/regression/verilog/SVA/if1.bmc.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+if1.sv
+--buechi --bound 2
+^\[main\.p0\] always \(if\(main\.counter == 0\) nexttime main\.counter == 1\): PROVED up to bound 2$
+^\[main\.p1\] always \(if\(main\.counter == 0\) nexttime main\.counter == 1 else nexttime main\.counter == 3\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/if1.k.buechi.desc
+++ b/regression/verilog/SVA/if1.k.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+if1.sv
+--buechi --k-induction --bound 2
+^\[main\.p0\] always \(if\(main\.counter == 0\) nexttime main\.counter == 1\): PROVED$
+^\[main\.p1\] always \(if\(main\.counter == 0\) nexttime main\.counter == 1 else nexttime main\.counter == 3\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/immediate1.bmc.buechi.desc
+++ b/regression/verilog/SVA/immediate1.bmc.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+immediate1.sv
+--buechi --bound 20
+^\[main\.assert\.1\] always main\.x & 1: PROVED up to bound 20$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/immediate1.k.buechi.desc
+++ b/regression/verilog/SVA/immediate1.k.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+immediate1.sv
+--buechi --k-induction --bound 1
+^\[main\.assert\.1\] always main\.x & 1: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/immediate2.buechi.desc
+++ b/regression/verilog/SVA/immediate2.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+immediate2.sv
+--buechi
+^\[main\.assume\.1\] assume always 0: ASSUMED$
+^\[main\.assert\.2\] always main\.index < 10: PROVED \(.*\)$
+^\[main\.assert\.3\] always 0: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/immediate3.buechi.desc
+++ b/regression/verilog/SVA/immediate3.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+immediate3.sv
+--buechi
+^\[full_adder\.assert\.1\] always \{ full_adder\.carry, full_adder\.sum \} == \{ 1'b0, full_adder\.a \} \+ full_adder\.b \+ full_adder\.c: PROVED \(.*\)$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/initial1.bmc.buechi.desc
+++ b/regression/verilog/SVA/initial1.bmc.buechi.desc
@@ -1,0 +1,14 @@
+CORE buechi
+initial1.sv
+--buechi --bound 5
+^\[main\.p0\] main\.counter == 0: PROVED up to bound 5$
+^\[main\.p1\] main\.counter == 100: REFUTED$
+^\[main\.p2\] ##1 main\.counter == 1: PROVED up to bound 5$
+^\[main\.p3\] ##1 main\.counter == 100: REFUTED$
+^\[main\.p4\] s_nexttime main\.counter == 1: PROVED up to bound 5$
+^\[main\.p5\] always \[1:1\] main\.counter == 1: PROVED up to bound 5$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/initial1.k.buechi.desc
+++ b/regression/verilog/SVA/initial1.k.buechi.desc
@@ -1,0 +1,14 @@
+CORE buechi
+initial1.sv
+--buechi --k-induction --bound 2
+^\[main\.p0\] main\.counter == 0: PROVED$
+^\[main\.p1\] main\.counter == 100: REFUTED$
+^\[main\.p2\] ##1 main\.counter == 1: PROVED$
+^\[main\.p3\] ##1 main\.counter == 100: REFUTED$
+^\[main\.p4\] s_nexttime main\.counter == 1: PROVED$
+^\[main\.p5\] always \[1:1\] main\.counter == 1: PROVED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/initial2.bmc.buechi.desc
+++ b/regression/verilog/SVA/initial2.bmc.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+initial2.sv
+--buechi --module main
+^\[main\.p0\] main\.counter == 1: PROVED \(1-induction\)$
+^\[main\.p1\] main\.counter == 2: PROVED \(1-induction\)$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/initial2.k.buechi.desc
+++ b/regression/verilog/SVA/initial2.k.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+initial2.sv
+--buechi --k-induction --bound 1 --module main
+^\[main\.p0\] main\.counter == 1: PROVED$
+^\[main\.p1\] main\.counter == 2: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/issue669.bmc.buechi.desc
+++ b/regression/verilog/SVA/issue669.bmc.buechi.desc
@@ -1,0 +1,17 @@
+CORE buechi
+issue669.sv
+--buechi --bound 5 --top top
+\[top\.assert\.1\] always not s_eventually 0: PROVED up to bound 5$
+\[top\.assert\.2\] always \(\(top\.a until_with top\.b\) implies \(not \(\(not top\.b\) s_until \(not top\.a\)\)\)\): PROVED up to bound 5$
+\[top\.assert\.3\] always \(\(not \(\(not top\.b\) s_until \(not top\.a\)\)\) implies \(top\.a until_with top\.b\)\): PROVED up to bound 5$
+\[top\.assert\.4\] always \(\(top\.a until_with top\.b\) implies \(top\.a until \(top\.a and top\.b\)\)\): PROVED up to bound 5$
+\[top\.assert\.5\] always \(\(top\.a until \(top\.a and top\.b\)\) implies \(top\.a until_with top\.b\)\): PROVED up to bound 5$
+\[top\.assert\.6\] always \(\(s_eventually top\.a\) implies \(1 s_until top\.a\)\): PROVED up to bound 5$
+\[top\.assert\.7\] always \(\(1 s_until top\.a\) implies \(s_eventually top\.a\)\): PROVED up to bound 5$
+\[top\.assert\.8\] always \(\(top\.a s_until top\.b\) implies \(\(s_eventually top\.b\) and \(top\.a until top\.b\)\)\): PROVED up to bound 5$
+\[top\.assert\.9\] always \(\(\(s_eventually top\.b\) and \(top\.a until top\.b\)\) implies \(top\.a s_until top\.b\)\): PROVED up to bound 5$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+https://github.com/diffblue/hw-cbmc/issues/669

--- a/regression/verilog/SVA/issue669.k.buechi.desc
+++ b/regression/verilog/SVA/issue669.k.buechi.desc
@@ -1,0 +1,17 @@
+CORE buechi
+issue669.sv
+--buechi --k-induction --bound 1 --top top
+\[top\.assert\.1\] always not s_eventually 0: PROVED$
+\[top\.assert\.2\] always \(\(top\.a until_with top\.b\) implies \(not \(\(not top\.b\) s_until \(not top\.a\)\)\)\): PROVED$
+\[top\.assert\.3\] always \(\(not \(\(not top\.b\) s_until \(not top\.a\)\)\) implies \(top\.a until_with top\.b\)\): PROVED$
+\[top\.assert\.4\] always \(\(top\.a until_with top\.b\) implies \(top\.a until \(top\.a and top\.b\)\)\): PROVED$
+\[top\.assert\.5\] always \(\(top\.a until \(top\.a and top\.b\)\) implies \(top\.a until_with top\.b\)\): PROVED$
+\[top\.assert\.6\] always \(\(s_eventually top\.a\) implies \(1 s_until top\.a\)\): PROVED$
+\[top\.assert\.7\] always \(\(1 s_until top\.a\) implies \(s_eventually top\.a\)\): PROVED$
+\[top\.assert\.8\] always \(\(top\.a s_until top\.b\) implies \(\(s_eventually top\.b\) and \(top\.a until top\.b\)\)\): PROVED$
+\[top\.assert\.9\] always \(\(\(s_eventually top\.b\) and \(top\.a until top\.b\)\) implies \(top\.a s_until top\.b\)\): PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+https://github.com/diffblue/hw-cbmc/issues/669

--- a/regression/verilog/SVA/nexttime1.bdd.buechi.desc
+++ b/regression/verilog/SVA/nexttime1.bdd.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+nexttime1.sv
+--buechi --bdd
+^\[main\.p1\] s_nexttime\[0\] main\.counter == 0: PROVED$
+^\[main\.p2\] s_nexttime\[1\] main\.counter == 1: PROVED$
+^\[main\.p3\] nexttime\[8\] main\.counter == 8: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/nexttime1.bmc.buechi.desc
+++ b/regression/verilog/SVA/nexttime1.bmc.buechi.desc
@@ -1,0 +1,12 @@
+CORE buechi
+nexttime1.sv
+--buechi --module main --bound 10
+^\[main\.p1\] s_nexttime\[0\] main\.counter == 0: PROVED up to bound 10$
+^\[main\.p2\] s_nexttime\[1\] main\.counter == 1: PROVED up to bound 10$
+^\[main\.p3\] nexttime\[8\] main\.counter == 8: PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Backend support missing.

--- a/regression/verilog/SVA/nexttime1.k.buechi.desc
+++ b/regression/verilog/SVA/nexttime1.k.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+nexttime1.sv
+--buechi --k-induction --bound 9
+^\[main\.p1\] s_nexttime\[0\] main\.counter == 0: PROVED$
+^\[main\.p2\] s_nexttime\[1\] main\.counter == 1: PROVED$
+^\[main\.p3\] nexttime\[8\] main\.counter == 8: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/restrict1.bdd.buechi.desc
+++ b/regression/verilog/SVA/restrict1.bdd.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+restrict1.sv
+--buechi --bdd
+^\[main\.p0\] always main\.x != 5: ASSUMED$
+^\[main\.p1\] always main\.x != 6: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/restrict1.bmc.buechi.desc
+++ b/regression/verilog/SVA/restrict1.bmc.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+restrict1.sv
+--buechi --module main --bound 10
+^\[main\.p0\] always main\.x != 5: ASSUMED$
+^\[main\.p1\] always main\.x != 6: PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/restrict1.k.buechi.desc
+++ b/regression/verilog/SVA/restrict1.k.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+restrict1.sv
+--buechi --k-induction --bound 1
+^\[main\.p0\] always main\.x != 5: ASSUMED$
+^\[main\.p1\] always main\.x != 6: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/s_always1.bmc.buechi.desc
+++ b/regression/verilog/SVA/s_always1.bmc.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+s_always1.sv
+--buechi --bound 20
+^\[main\.p0\] s_always \[0:9\] main\.x < 10: PROVED up to bound 20$
+^\[main\.p1\] not \(s_always \[0:9\] main\.x < 10\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/s_always1.k.buechi.desc
+++ b/regression/verilog/SVA/s_always1.k.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+s_always1.sv
+--buechi --k-induction --bound 10
+^\[main\.p0\] s_always \[0:9\] main\.x < 10: PROVED$
+^\[main\.p1\] not \(s_always \[0:9\] main\.x < 10\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/s_eventually1.bdd.buechi.desc
+++ b/regression/verilog/SVA/s_eventually1.bdd.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+s_eventually1.sv
+--buechi --bdd
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/s_eventually2.bdd.buechi.desc
+++ b/regression/verilog/SVA/s_eventually2.bdd.buechi.desc
@@ -1,0 +1,11 @@
+KNOWNBUG buechi
+s_eventually2.sv
+--buechi --module main --bdd
+^\[main\.p0\] always s_eventually main.reset \|\| main\.counter == 10: PROVED up to bound 20$
+^\[main\.p1\] always \(s_eventually \[0:2\] main.reset \|\| main\.counter == 10\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This gives the wrong answer for main.p0.

--- a/regression/verilog/SVA/s_eventually2.bmc.buechi.desc
+++ b/regression/verilog/SVA/s_eventually2.bmc.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+s_eventually2.sv
+--buechi --module main --bound 20
+^\[main\.p0\] always s_eventually main.reset \|\| main\.counter == 10: PROVED up to bound 20$
+^\[main\.p1\] always \(s_eventually \[0:2\] main.reset \|\| main\.counter == 10\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/s_eventually2.k.buechi.desc
+++ b/regression/verilog/SVA/s_eventually2.k.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+s_eventually2.sv
+--buechi --k-induction --bound 2
+^\[main\.p0\] always s_eventually main.reset \|\| main\.counter == 10: UNSUPPORTED: unsupported by k-induction$
+^\[main\.p1\] always \(s_eventually \[0:2\] main.reset \|\| main\.counter == 10\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/s_eventually3.buechi.desc
+++ b/regression/verilog/SVA/s_eventually3.buechi.desc
@@ -1,0 +1,8 @@
+KNOWNBUG buechi
+s_eventually3.sv
+--buechi --module main --bound 11
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.p0\] always s_eventually main\.counter <= 5: REFUTED$
+--
+^warning: ignoring

--- a/regression/verilog/SVA/s_eventually4.buechi.desc
+++ b/regression/verilog/SVA/s_eventually4.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+s_eventually4.sv
+--buechi --module main --bound 11
+^\[main\.p0\] always \(\(s_eventually main\.counter == 1\) or \(s_eventually main.counter == 10\)\): PROVED up to bound 11$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/SVA/s_until1.bdd.buechi.desc
+++ b/regression/verilog/SVA/s_until1.bdd.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+s_until1.sv
+--buechi --bdd
+^\[.*\] \$past\(main\.counter\) <= main\.counter s_until main\.counter == 10: PROVED$
+^\[.*\] 1 s_until main\.counter == 11: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/verilog/SVA/sequence1.buechi.desc
+++ b/regression/verilog/SVA/sequence1.buechi.desc
@@ -1,0 +1,12 @@
+CORE buechi
+sequence1.sv
+--buechi --bound 20 --numbered-trace
+^\[main\.p0\] ##\[0:9\] main\.x == 100: REFUTED$
+^Counterexample with 10 states:$
+^main\.x@0 = 0$
+^main\.x@9 = 9$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence2.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence2.bmc.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sequence2.sv
+--buechi --bound 10
+^\[main\.p0] weak\(##\[0:\$\] main\.x == 10\): PROVED up to bound 10$
+^\[main\.p1] strong\(##\[0:\$\] main\.x == 10\): UNSUPPORTED: sva_cycle_delay not convertible to Buechi$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence2.k.buechi.desc
+++ b/regression/verilog/SVA/sequence2.k.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sequence2.sv
+--buechi --k-induction --bound 1
+^\[main\.p0] weak\(##\[0:\$\] main\.x == 10\): PROVED$
+^\[main\.p1] strong\(##\[0:\$\] main\.x == 10\): UNSUPPORTED: unsupported by k-induction$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence3.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence3.bmc.buechi.desc
@@ -1,0 +1,12 @@
+CORE buechi
+sequence3.sv
+--buechi --bound 20 --numbered-trace
+^\[main\.p0\] strong\(##\[\*\] main\.x == 6\): UNSUPPORTED: sva_cycle_delay_star not convertible to Buechi$
+^\[main\.p1\] strong\(##\[\*\] main\.x == 5\): UNSUPPORTED: sva_cycle_delay_star not convertible to Buechi$
+^\[main\.p2\] strong\(##\[\+\] main\.x == 0\): UNSUPPORTED: sva_cycle_delay_plus not convertible to Buechi$
+^\[main\.p3\] strong\(##\[\+\] main\.x == 5\): UNSUPPORTED: sva_cycle_delay_plus not convertible to Buechi$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence4.bdd.buechi.desc
+++ b/regression/verilog/SVA/sequence4.bdd.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+sequence4.sv
+--buechi --bdd
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence4.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence4.bmc.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+sequence4.sv
+--buechi --bound 10
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence4.k.buechi.desc
+++ b/regression/verilog/SVA/sequence4.k.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+sequence4.sv
+--buechi --k-induction --bound 1
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence5.buechi.desc
+++ b/regression/verilog/SVA/sequence5.buechi.desc
@@ -1,0 +1,12 @@
+CORE buechi
+sequence5.sv
+--buechi
+^\[main\.p0\] 1: PROVED \(tautology\)$
+^\[main\.p1\] 0: REFUTED$
+^\[main\.p2\] 1'bx: REFUTED$
+^\[main\.p3\] 1'bz: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence6.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence6.bmc.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sequence6.sv
+--buechi
+^\[main\.p0\] \(1 ##1 1\) \|-> main\.x == 1: PROVED up to bound 5$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+

--- a/regression/verilog/SVA/sequence6.k.buechi.desc
+++ b/regression/verilog/SVA/sequence6.k.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sequence6.sv
+--buechi --k-induction --bound 2
+^\[main\.p0\] \(1 ##1 1\) \|-> main\.x == 1: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+

--- a/regression/verilog/SVA/sequence_and1.bdd.buechi.desc
+++ b/regression/verilog/SVA/sequence_and1.bdd.buechi.desc
@@ -1,0 +1,13 @@
+CORE buechi
+sequence_and1.sv
+--buechi --bdd
+^\[main\.p0\] main\.x == 0 and main\.x == 1: REFUTED$
+^\[main\.p1\] strong\(main\.x == 0 and main\.x == 1\): REFUTED$
+^\[main\.p2\] main\.x == 0 and \(nexttime main\.x == 1\): PROVED$
+^\[main\.p3\] \(nexttime main\.x == 1\) and main\.x == 0: PROVED$
+^\[main\.p4\] \(main\.x == 0 and main\.x != 10\) |=> main\.x == 1: PROVED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_and1.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence_and1.bmc.buechi.desc
@@ -1,0 +1,13 @@
+CORE buechi
+sequence_and1.sv
+--buechi --bound 5
+^\[main\.p0\] main\.x == 0 and main\.x == 1: REFUTED$
+^\[main\.p1\] strong\(main\.x == 0 and main\.x == 1\): REFUTED$
+^\[main\.p2\] main\.x == 0 and \(nexttime main\.x == 1\): PROVED up to bound \d+$
+^\[main\.p3\] \(nexttime main\.x == 1\) and main\.x == 0: PROVED up to bound \d+$
+^\[main\.p4\] \(main\.x == 0 and main\.x != 10\) |=> main\.x == 1: PROVED up to bound \d+$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_and2.bdd.buechi.desc
+++ b/regression/verilog/SVA/sequence_and2.bdd.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+sequence_and2.sv
+--buechi --bdd
+\[.*\] \(1 and \(##2 1\)\) \|-> main\.x == 2: PROVED$
+\[.*\] \(\(##2 1\) and 1\) \|-> main\.x == 2: PROVED$
+\[.*\] \(\(##2 1\) and 1\) #-# main\.x == 2: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_and2.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence_and2.bmc.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+sequence_and2.sv
+--buechi
+\[.*\] \(1 and \(##2 1\)\) \|-> main\.x == 2: PROVED up to bound 5$
+\[.*\] \(\(##2 1\) and 1\) \|-> main\.x == 2: PROVED up to bound 5$
+\[.*\] \(\(##2 1\) and 1\) #-# main\.x == 2: PROVED up to bound 5$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_and2.k.buechi.desc
+++ b/regression/verilog/SVA/sequence_and2.k.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+sequence_and2.sv
+--buechi --k-induction --bound 3
+\[.*\] \(1 and \(##2 1\)\) \|-> main\.x == 2: PROVED$
+\[.*\] \(\(##2 1\) and 1\) \|-> main\.x == 2: PROVED$
+\[.*\] \(\(##2 1\) and 1\) #-# main\.x == 2: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_and3.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence_and3.bmc.buechi.desc
@@ -1,0 +1,12 @@
+CORE buechi
+sequence_and3.sv
+--buechi --bound 5
+^\[.*\] \(\(1 or \(##2 1\)\) and 1\) \|-> main\.x == 2: REFUTED$
+^\[.*\] \(1 and \(1 or \(##2 1\)\)\) \|-> main\.x == 2: REFUTED$
+^\[.*\] \(\(1 or \(##2 1\)\) and 1\) \|-> main\.x == 0 \|\| main\.x == 2: PROVED up to bound 5$
+^\[.*\] \(1 and \(1 or \(##2 1\)\)\) \|-> main\.x == 0 \|\| main\.x == 2: PROVED up to bound 5$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_and3.k.buechi.desc
+++ b/regression/verilog/SVA/sequence_and3.k.buechi.desc
@@ -1,0 +1,12 @@
+CORE buechi
+sequence_and3.sv
+--buechi --k-induction --bound 3
+^\[.*\] \(\(1 or \(##2 1\)\) and 1\) \|-> main\.x == 2: REFUTED$
+^\[.*\] \(1 and \(1 or \(##2 1\)\)\) \|-> main\.x == 2: REFUTED$
+^\[.*\] \(\(1 or \(##2 1\)\) and 1\) \|-> main\.x == 0 \|\| main\.x == 2: PROVED$
+^\[.*\] \(1 and \(1 or \(##2 1\)\)\) \|-> main\.x == 0 \|\| main\.x == 2: PROVED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_first_match1.k.buechi.desc
+++ b/regression/verilog/SVA/sequence_first_match1.k.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sequence_first_match1.sv
+--buechi --k-induction --bound 1
+^\[.*\] first_match\(main\.x == 0\): PROVED$
+^\[.*\] first_match\(main\.x == 0, main\.x\+\+\): PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_first_match2.k.buechi.desc
+++ b/regression/verilog/SVA/sequence_first_match2.k.buechi.desc
@@ -1,0 +1,12 @@
+CORE buechi
+sequence_first_match2.sv
+--buechi --k-induction --bound 2
+^\[.*\] \(\(##1 1\) or \(##2 1\)\) \|-> main.x == 1: REFUTED$
+^\[.*\] first_match\(\(##1 1\) or \(##2 1\)\) \|-> main\.x == 1: PROVED$
+^\[.*\] \(1 or \(##1 1\)\) \|-> main\.x == 0: REFUTED$
+^\[.*\] first_match\(1 or \(##1 1\)\) \|-> main\.x == 0: PROVED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_implication1.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence_implication1.bmc.buechi.desc
@@ -1,0 +1,12 @@
+CORE buechi
+sequence_implication1.sv
+--buechi --bound 20
+^\[.*\] always \(\(main\.counter == 1 ##1 main\.counter == 2\) \|-> \(##1 main.counter == 0\)\): PROVED up to bound 20$
+^\[.*\] always \(\(main\.counter == 1 ##1 main\.counter == 2\) \|=> main\.counter == 0\): PROVED up to bound 20$
+^\[.*\] always \(0 \|-> 0\): PROVED up to bound 20$
+^\[.*\] \(1 or \(##1 1\)\) \|-> main\.counter == 0: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_implication1.k.buechi.desc
+++ b/regression/verilog/SVA/sequence_implication1.k.buechi.desc
@@ -1,0 +1,12 @@
+CORE buechi
+sequence_implication1.sv
+--buechi --k-induction --bound 2
+^\[.*\] always \(\(main\.counter == 1 ##1 main\.counter == 2\) \|-> \(##1 main.counter == 0\)\): PROVED$
+^\[.*\] always \(\(main\.counter == 1 ##1 main\.counter == 2\) \|=> main\.counter == 0\): PROVED$
+^\[.*\] always \(0 \|-> 0\): PROVED$
+^\[.*\] \(1 or \(##1 1\)\) \|-> main\.counter == 0: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_implication2.buechi.desc
+++ b/regression/verilog/SVA/sequence_implication2.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+sequence_implication2.sv
+--buechi --module main
+^file .* line 4: sequence required, but got property$
+^EXIT=2$
+^SIGNAL=0$
+--
+--

--- a/regression/verilog/SVA/sequence_intersect1.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence_intersect1.bmc.buechi.desc
@@ -1,0 +1,14 @@
+CORE buechi
+sequence_intersect1.sv
+--buechi --bound 10
+^\[main\.p0\] main\.x == 0 intersect main\.x == 1: REFUTED$
+^\[main\.p1\] always main\.x >= 0: PROVED up to bound 10$
+^\[main\.p2\] always main\.x <= 5: PROVED up to bound 10$
+^\[main\.p3\] always main\.x <= 3: REFUTED$
+^\[main\.p4\] always \(main\.x >= 0 intersect main\.x <= 5\): PROVED up to bound 10$
+^\[main\.p5\] always \(main\.x >= 0 intersect main\.x <= 3\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_intersect1.k.buechi.desc
+++ b/regression/verilog/SVA/sequence_intersect1.k.buechi.desc
@@ -1,0 +1,14 @@
+CORE buechi
+sequence_intersect1.sv
+--buechi --k-induction --bound 4
+^\[main\.p0\] main\.x == 0 intersect main\.x == 1: REFUTED$
+^\[main\.p1\] always main\.x >= 0: PROVED$
+^\[main\.p2\] always main\.x <= 5: PROVED$
+^\[main\.p3\] always main\.x <= 3: REFUTED$
+^\[main\.p4\] always \(main\.x >= 0 intersect main\.x <= 5\): PROVED$
+^\[main\.p5\] always \(main\.x >= 0 intersect main\.x <= 3\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_or1.bdd.buechi.desc
+++ b/regression/verilog/SVA/sequence_or1.bdd.buechi.desc
@@ -1,0 +1,12 @@
+CORE buechi
+sequence_or1.sv
+--buechi --bdd
+^\[main\.p0\] main\.x == 0 or main\.x == 1: PROVED$
+^\[main\.p1\] strong\(main\.x == 0 or main\.x == 1\): PROVED$
+^\[main\.p2\] main\.x == 0 or \(nexttime main\.x == 1\): PROVED$
+^\[main\.p3\] \(nexttime main\.x == 1\) or main\.x == 1: PROVED$
+^\[main\.p4\] \(main\.x == 0 or main\.x != 10\) |=> main\.x == 1: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+--

--- a/regression/verilog/SVA/sequence_or1.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence_or1.bmc.buechi.desc
@@ -1,0 +1,13 @@
+CORE buechi
+sequence_or1.sv
+--buechi --bound 5
+^\[main\.p0\] main\.x == 0 or main\.x == 1: PROVED up to bound \d+$
+^\[main\.p1\] strong\(main\.x == 0 or main\.x == 1\): PROVED up to bound \d+$
+^\[main\.p2\] main\.x == 0 or \(nexttime main\.x == 1\): PROVED up to bound \d+$
+^\[main\.p3\] \(nexttime main\.x == 1\) or main\.x == 1: PROVED up to bound \d+$
+^\[main\.p4\] \(main\.x == 0 or main\.x != 10\) |=> main\.x == 1: PROVED up to bound \d+$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_or1.k.buechi.desc
+++ b/regression/verilog/SVA/sequence_or1.k.buechi.desc
@@ -1,0 +1,13 @@
+CORE buechi
+sequence_or1.sv
+--buechi --k-induction --bound 2
+^\[main\.p0\] main\.x == 0 or main\.x == 1: PROVED$
+^\[main\.p1\] strong\(main\.x == 0 or main\.x == 1\): PROVED$
+^\[main\.p2\] main\.x == 0 or \(nexttime main\.x == 1\): PROVED$
+^\[main\.p3\] \(nexttime main\.x == 1\) or main\.x == 1: PROVED$
+^\[main\.p4\] \(main\.x == 0 or main\.x != 10\) |=> main\.x == 1: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_repetition1.bdd.buechi.desc
+++ b/regression/verilog/SVA/sequence_repetition1.bdd.buechi.desc
@@ -1,0 +1,13 @@
+CORE buechi
+sequence_repetition1.sv
+--buechi --bdd
+^\[.*\] main\.half_x == 0 \[\*2\]: PROVED$
+^\[.*\] main\.half_x == 0 \[->2\]: FAILURE: property not supported by BDD engine$
+^\[.*\] main\.half_x == 0 \[=2\]: FAILURE: property not supported by BDD engine$
+^\[.*\] main\.x == 0 \[\*2\]: REFUTED$
+^\[.*\] main\.x == 0 \[->2\]: FAILURE: property not supported by BDD engine$
+^\[.*\] main\.x == 0 \[=2\]: FAILURE: property not supported by BDD engine$
+^EXIT=10$
+^SIGNAL=0$
+--
+--

--- a/regression/verilog/SVA/sequence_repetition1.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence_repetition1.bmc.buechi.desc
@@ -1,0 +1,14 @@
+CORE buechi
+sequence_repetition1.sv
+--buechi --bound 10
+^\[.*\] main\.half_x == 0 \[\*2\]: PROVED up to bound 10$
+^\[.*\] main\.half_x == 0 \[->2\]: UNSUPPORTED: sva_sequence_goto_repetition not convertible to Buechi$
+^\[.*\] main\.half_x == 0 \[=2\]: UNSUPPORTED: sva_sequence_non_consecutive_repetition not convertible to Buechi$
+^\[.*\] main\.x == 0 \[\*2\]: REFUTED$
+^\[.*\] main\.x == 0 \[->2\]: UNSUPPORTED: sva_sequence_goto_repetition not convertible to Buechi$
+^\[.*\] main\.x == 0 \[=2\]: UNSUPPORTED: sva_sequence_non_consecutive_repetition not convertible to Buechi$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_repetition1.k.buechi.desc
+++ b/regression/verilog/SVA/sequence_repetition1.k.buechi.desc
@@ -1,0 +1,14 @@
+CORE buechi
+sequence_repetition1.sv
+--buechi --k-induction --bound 2
+^\[.*\] main\.half_x == 0 \[\*2\]: PROVED$
+^\[.*\] main\.half_x == 0 \[->2\]: UNSUPPORTED: unsupported by k-induction$
+^\[.*\] main\.half_x == 0 \[=2\]: UNSUPPORTED: unsupported by k-induction$
+^\[.*\] main\.x == 0 \[\*2\]: REFUTED$
+^\[.*\] main\.x == 0 \[->2\]: UNSUPPORTED: unsupported by k-induction$
+^\[.*\] main\.x == 0 \[=2\]: UNSUPPORTED: unsupported by k-induction$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_repetition2.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence_repetition2.bmc.buechi.desc
@@ -1,0 +1,17 @@
+CORE buechi
+sequence_repetition2.sv
+--buechi --bound 10
+^\[main\.p0\] main\.x == 0 \[\*\]: PROVED up to bound 10$
+^\[main\.p1\] \(main\.x == 0 \[\+\]\) #=# main\.x == 1: PROVED up to bound 10$
+^\[main\.p2\] main\.x == 0 \[\+\]: PROVED up to bound 10$
+^\[main\.p3\] main\.half_x == 0 \[\*\]: PROVED up to bound 10$
+^\[main\.p4\] main\.x == 1 \[\*\]: REFUTED$
+^\[main\.p5\] 0 \[\*\]: REFUTED$
+^\[main\.p6\] main\.x == 1 \[\+\]: REFUTED$
+^\[main\.p7\] \(main\.x == 0 \[\+\]\) #-# main\.x == 1: REFUTED$
+^\[main\.p8\] 0 \[\+\]: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_repetition3.bdd.buechi.desc
+++ b/regression/verilog/SVA/sequence_repetition3.bdd.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+sequence_repetition3.sv
+--buechi --bdd
+^\[main\.p0\] \(main\.x == 0 \[\*1\]\) #=# \(main\.x == 1 \[\*1\]\): PROVED$
+^\[main\.p1\] \(main\.half_x == 0 \[\*2\]\) #=# \(main\.half_x == 1 \[\*2\]\): PROVED$
+^\[main\.p2\] main\.half_x == 0 \[\*3\]: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_repetition3.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence_repetition3.bmc.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+sequence_repetition3.sv
+--buechi --bound 10
+^\[main\.p0\] \(main\.x == 0 \[\*1\]\) #=# \(main\.x == 1 \[\*1\]\): PROVED up to bound 10$
+^\[main\.p1\] \(main\.half_x == 0 \[\*2\]\) #=# \(main\.half_x == 1 \[\*2\]\): PROVED up to bound 10$
+^\[main\.p2\] main\.half_x == 0 \[\*3\]: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_repetition3.k.buechi.desc
+++ b/regression/verilog/SVA/sequence_repetition3.k.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+sequence_repetition3.sv
+--buechi --k-induction --bound 2
+^\[main\.p0\] \(main\.x == 0 \[\*1\]\) #=# \(main\.x == 1 \[\*1\]\): PROVED$
+^\[main\.p1\] \(main\.half_x == 0 \[\*2\]\) #=# \(main\.half_x == 1 \[\*2\]\): PROVED$
+^\[main\.p2\] main\.half_x == 0 \[\*3\]: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_repetition4.bdd.buechi.desc
+++ b/regression/verilog/SVA/sequence_repetition4.bdd.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sequence_repetition4.sv
+--buechi --bdd
+^\[main\.p0\] \(main\.x == 0 ##1 main\.x == 1\) \[\*2\]: PROVED$
+^\[main\.p1\] \(main\.x == 0 ##1 main\.x == 1 ##1 main\.x == 0\) \[\*2\]: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_repetition4.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence_repetition4.bmc.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sequence_repetition4.sv
+--buechi --bound 10
+^\[main\.p0\] \(main\.x == 0 ##1 main\.x == 1\) \[\*2\]: PROVED up to bound \d+$
+^\[main\.p1\] \(main\.x == 0 ##1 main\.x == 1 ##1 main\.x == 0\) \[\*2\]: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_repetition4.k.buechi.desc
+++ b/regression/verilog/SVA/sequence_repetition4.k.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sequence_repetition4.sv
+--buechi --k-induction --bound 4
+^\[main\.p0\] \(main\.x == 0 ##1 main\.x == 1\) \[\*2\]: PROVED$
+^\[main\.p1\] \(main\.x == 0 ##1 main\.x == 1 ##1 main\.x == 0\) \[\*2\]: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_repetition5.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence_repetition5.bmc.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sequence_repetition5.sv
+--buechi --bound 20
+^\[.*\] main\.pulse ##1 \(\!main\.pulse \[\*1:9\]\) ##1 main.pulse: PROVED up to bound 20$
+^\[.*\] main\.pulse ##1 \(\!main\.pulse \[\*1:8\]\) ##1 main.pulse: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_repetition5.k.buechi.desc
+++ b/regression/verilog/SVA/sequence_repetition5.k.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sequence_repetition5.sv
+--buechi --k-induction --bound 10
+^\[.*\] main\.pulse ##1 \(\!main\.pulse \[\*1:9\]\) ##1 main.pulse: PROVED$
+^\[.*\] main\.pulse ##1 \(\!main\.pulse \[\*1:8\]\) ##1 main.pulse: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_repetition7.bdd.buechi.desc
+++ b/regression/verilog/SVA/sequence_repetition7.bdd.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+sequence_repetition7.sv
+--buechi --bdd
+^\[.*\] \(main\.a ##1 main\.b\) \[\*5\]: PROVED$
+^\[.*\] \(\!main\.b ##1 \!main\.a\) \[\*5\]: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+--

--- a/regression/verilog/SVA/sequence_repetition7.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence_repetition7.bmc.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sequence_repetition7.sv
+--buechi --bound 20
+^\[.*\] \(main\.a ##1 main\.b\) \[\*5\]: PROVED up to bound 20$
+^\[.*\] \(\!main\.b ##1 \!main\.a\) \[\*5\]: PROVED up to bound 20$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_repetition7.k.buechi.desc
+++ b/regression/verilog/SVA/sequence_repetition7.k.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sequence_repetition7.sv
+--buechi --k-induction --bound 2
+^\[.*\] \(main\.a ##1 main\.b\) \[\*5\]: PROVED$
+^\[.*\] \(\!main\.b ##1 \!main\.a\) \[\*5\]: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_throughout1.buechi.desc
+++ b/regression/verilog/SVA/sequence_throughout1.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+sequence_throughout1.sv
+--buechi --bound 10
+^\[main\.p0\] main\.x >= 0 throughout \(main\.x == 0 ##1 main\.x == 1 ##1 main\.x == 2\): UNSUPPORTED: sva_sequence_throughout not convertible to Buechi$
+^\[main\.p1\] main\.x <= 1 throughout \(main\.x == 0 ##1 main\.x == 1 ##1 main\.x == 2\): UNSUPPORTED: sva_sequence_throughout not convertible to Buechi$
+^\[main\.p2\] 1 throughout \(main\.x == 0 ##1 main\.x == 1 ##1 main\.x == 3\): UNSUPPORTED: sva_sequence_throughout not convertible to Buechi$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sequence_within1.buechi.desc
+++ b/regression/verilog/SVA/sequence_within1.buechi.desc
@@ -1,0 +1,13 @@
+CORE buechi
+sequence_within1.sv
+--buechi --bound 20
+^\[main\.p0\] main\.x == 0 within main\.x == 1: UNSUPPORTED: sva_sequence_within not convertible to Buechi$
+^\[main\.p1\] main\.x == 0 within \(##10 1\): UNSUPPORTED: sva_sequence_within not convertible to Buechi$
+^\[main\.p2\] main\.x == 5 within \(##10 1\): UNSUPPORTED: sva_sequence_within not convertible to Buechi$
+^\[main\.p3\] main\.x == 10 within \(##10 1\): UNSUPPORTED: sva_sequence_within not convertible to Buechi$
+^\[main\.p4\] main\.x == 11 within \(##10 1\): UNSUPPORTED: sva_sequence_within not convertible to Buechi$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/stable1.k.buechi.desc
+++ b/regression/verilog/SVA/stable1.k.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+stable1.sv
+--buechi --k-induction --bound 2
+^\[main\.p0\] always \(\$stable\(main\.data\) \|=> main\.counter >= 1\): PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/static_final1.bmc.buechi.desc
+++ b/regression/verilog/SVA/static_final1.bmc.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+static_final1.sv
+--buechi
+^\[full_adder\.p0\] always \{ full_adder\.carry, full_adder\.sum \} == \{ 1'b0, full_adder\.a \} \+ full_adder\.b \+ full_adder\.c: PROVED \(1-induction\)$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/static_final1.k.buechi.desc
+++ b/regression/verilog/SVA/static_final1.k.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+static_final1.sv
+--buechi --k-induction --bound 1
+^\[full_adder\.p0\] always \{ full_adder\.carry, full_adder\.sum \} == \{ 1'b0, full_adder\.a \} \+ full_adder\.b \+ full_adder\.c: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/strong1.buechi.desc
+++ b/regression/verilog/SVA/strong1.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+strong1.sv
+--buechi --bound 4
+^\[main\.p0\] strong\(##\[0:9\] main\.x == 5\): UNSUPPORTED: sva_cycle_delay not convertible to Buechi$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sva_abort1.bdd.buechi.desc
+++ b/regression/verilog/SVA/sva_abort1.bdd.buechi.desc
@@ -1,0 +1,13 @@
+CORE buechi
+sva_abort1.sv
+--buechi --module main --bdd
+^\[main\.p0\] always \(accept_on \(main\.counter == 0\) main\.counter != 0\): PROVED$
+^\[main\.p1\] always \(accept_on \(1\) 0\): PROVED$
+^\[main\.p2\] always \(accept_on \(main\.counter == 1\) main\.counter == 0\): REFUTED$
+^\[main\.p3\] always \(reject_on \(main\.counter != 0\) 1\): REFUTED$
+^\[main\.p4\] always \(reject_on \(1\) 1\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sva_abort1.bmc.buechi.desc
+++ b/regression/verilog/SVA/sva_abort1.bmc.buechi.desc
@@ -1,0 +1,13 @@
+CORE buechi
+sva_abort1.sv
+--buechi --module main --bound 10
+^\[main\.p0\] always \(accept_on \(main\.counter == 0\) main\.counter != 0\): PROVED up to bound 10$
+^\[main\.p1\] always \(accept_on \(1\) 0\): PROVED up to bound 10$
+^\[main\.p2\] always \(accept_on \(main\.counter == 1\) main\.counter == 0\): REFUTED$
+^\[main\.p3\] always \(reject_on \(main\.counter != 0\) 1\): REFUTED$
+^\[main\.p4\] always \(reject_on \(1\) 1\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sva_abort1.k.buechi.desc
+++ b/regression/verilog/SVA/sva_abort1.k.buechi.desc
@@ -1,0 +1,13 @@
+CORE buechi
+sva_abort1.sv
+--buechi --k-induction --bound 2
+^\[main\.p0\] always \(accept_on \(main\.counter == 0\) main\.counter != 0\): PROVED$
+^\[main\.p1\] always \(accept_on \(1\) 0\): PROVED$
+^\[main\.p2\] always \(accept_on \(main\.counter == 1\) main\.counter == 0\): REFUTED$
+^\[main\.p3\] always \(reject_on \(main\.counter != 0\) 1\): REFUTED$
+^\[main\.p4\] always \(reject_on \(1\) 1\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sva_and1.buechi.desc
+++ b/regression/verilog/SVA/sva_and1.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+sva_and1.sv
+--buechi
+^\[main\.p0\] always \(1 and 1\): PROVED \(tautology\)$
+^\[main\.p1\] always \(1 and 0\): REFUTED$
+^\[main\.p2\] always \(1 and 32'b0000000000000000000000000000000x\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sva_assume1.bdd.buechi.desc
+++ b/regression/verilog/SVA/sva_assume1.bdd.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sva_assume1.sv
+--buechi --bdd
+^\[main\.assume\.1\] always main\.a: ASSUMED$
+^\[main\.assert\.2\] s_eventually main\.a: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sva_assume1.bmc.buechi.desc
+++ b/regression/verilog/SVA/sva_assume1.bmc.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sva_assume1.sv
+--buechi --bound 10
+^\[main\.assume\.1\] always main\.a: ASSUMED$
+^\[main\.assert\.2\] s_eventually main\.a: PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sva_assume2.bdd.buechi.desc
+++ b/regression/verilog/SVA/sva_assume2.bdd.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sva_assume2.sv
+--buechi --bdd
+^\[main\.assume\.1\] always \(main\.a implies \(nexttime main\.a\)\): ASSUMED$
+^\[main\.assert\.2\] always \(main\.a \|=> \$stable\(main\.a\)\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sva_assume2.bmc.buechi.desc
+++ b/regression/verilog/SVA/sva_assume2.bmc.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sva_assume2.sv
+--buechi --bound 10
+^\[main\.assume\.1\] always \(main\.a implies \(nexttime main\.a\)\): ASSUMED$
+^\[main\.assert\.2\] always \(main\.a \|=> \$stable\(main\.a\)\): PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sva_assume2.k.buechi.desc
+++ b/regression/verilog/SVA/sva_assume2.k.buechi.desc
@@ -1,0 +1,10 @@
+CORE buechi
+sva_assume2.sv
+--buechi --k-induction --bound 1
+^\[main\.assume\.1\] always \(main\.a implies \(nexttime main\.a\)\): UNSUPPORTED: unsupported by k-induction$
+^\[main\.assert\.2\] always \(main\.a \|=> \$stable\(main\.a\)\): INCONCLUSIVE$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sva_iff1.buechi.desc
+++ b/regression/verilog/SVA/sva_iff1.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+sva_iff1.sv
+--buechi
+^\[main\.p0\] always \(1 iff 1\): PROVED \(tautology\)$
+^\[main\.p1\] always \(1 iff 0\): REFUTED$
+^\[main\.p2\] always \(1 iff 32'b0000000000000000000000000000000x\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sva_iff2.bmc.buechi.desc
+++ b/regression/verilog/SVA/sva_iff2.bmc.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+sva_iff2.sv
+--buechi --bound 10
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sva_iff2.k.buechi.desc
+++ b/regression/verilog/SVA/sva_iff2.k.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+sva_iff2.sv
+--buechi --k-induction --bound 1
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sva_implies1.buechi.desc
+++ b/regression/verilog/SVA/sva_implies1.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+sva_implies1.sv
+--buechi
+^\[main\.p0\] always \(1 implies 1\): PROVED \(tautology\)$
+^\[main\.p1\] always \(1 implies 0\): REFUTED$
+^\[main\.p2\] always \(1 implies 32'b0000000000000000000000000000000x\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sva_implies2.bmc.buechi.desc
+++ b/regression/verilog/SVA/sva_implies2.bmc.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+sva_implies2.sv
+--buechi --bound 2
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sva_implies2.k.buechi.desc
+++ b/regression/verilog/SVA/sva_implies2.k.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+sva_implies2.sv
+--buechi --k-induction --bound 2
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/sva_not1.buechi.desc
+++ b/regression/verilog/SVA/sva_not1.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+sva_not1.sv
+--buechi
+^\[main\.p0] always not 0: PROVED \(tautology\)$
+^\[main\.p1] always not 1: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/SVA/sva_until1.buechi.desc
+++ b/regression/verilog/SVA/sva_until1.buechi.desc
@@ -1,0 +1,11 @@
+CORE buechi
+sva_until1.sv
+--buechi
+^\[main\.p0\] always \(main.a until_with main.b\): REFUTED$
+^\[main\.p1\] always \(main.a until main.b\): REFUTED$
+^\[main\.p2\] always \(main.a s_until main.b\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/system_verilog_assertion1.buechi.desc
+++ b/regression/verilog/SVA/system_verilog_assertion1.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+system_verilog_assertion1.sv
+--buechi --module main --bound 20 --trace
+^EXIT=10$
+^SIGNAL=0$
+^Counterexample:$
+--
+^warning: ignoring

--- a/regression/verilog/SVA/system_verilog_assertion2.buechi.desc
+++ b/regression/verilog/SVA/system_verilog_assertion2.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+system_verilog_assertion2.sv
+--buechi --module main --bound 20 --trace
+^EXIT=10$
+^SIGNAL=0$
+^Counterexample:$
+^\[main\.my_label\] .* REFUTED$
+--
+^warning: ignoring

--- a/regression/verilog/SVA/system_verilog_assertion3.buechi.desc
+++ b/regression/verilog/SVA/system_verilog_assertion3.buechi.desc
@@ -1,0 +1,7 @@
+CORE buechi
+system_verilog_assertion3.sv
+--buechi --module main
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/SVA/system_verilog_assertion4.buechi.desc
+++ b/regression/verilog/SVA/system_verilog_assertion4.buechi.desc
@@ -1,0 +1,8 @@
+CORE buechi
+system_verilog_assertion4.sv
+--buechi --module main --bound 10
+^\[main\.p11\] always \(main\.x == 0 \|-> \(\(##1 main\.x == 1\) and \(not \(##2 main\.x == 3\)\)\)\): PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/SVA/unbounded1.buechi.desc
+++ b/regression/verilog/SVA/unbounded1.buechi.desc
@@ -1,0 +1,7 @@
+CORE buechi
+unbounded1.sv
+--buechi --module main --bound 1
+^\[.*\] always \(main\.a ##\[0:main\.upper\] main\.b\): UNSUPPORTED: sva_cycle_delay not convertible to Buechi$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/verilog/SVA/weak1.buechi.desc
+++ b/regression/verilog/SVA/weak1.buechi.desc
@@ -1,0 +1,9 @@
+CORE buechi
+weak1.sv
+--buechi --bound 20
+^\[main\.p0\] weak\(##\[0:9\] main\.x == 100\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--


### PR DESCRIPTION
PR #1598 claimed to move the SVA Buechi tests to regression/verilog/SVA, but the `git add` was forgotten.