### PR TITLE
Verilog: extend sequence_repetition1.sv test with strong variants

### DIFF
--- a/regression/verilog/SVA/sequence_repetition1.desc
+++ b/regression/verilog/SVA/sequence_repetition1.desc
@@ -1,15 +1,16 @@
 CORE
 sequence_repetition1.sv
 --bound 10
-^\[.*\] main\.half_x == 0 \[\*2\]: PROVED up to bound 10$
-^\[.*\] main\.half_x == 0 \[->2\]: PROVED up to bound 10$
-^\[.*\] main\.half_x == 0 \[=2\]: PROVED up to bound 10$
-^\[.*\] main\.x == 0 \[\*2\]: REFUTED$
-^\[.*\] main\.x == 0 \[->2\]: PROVED up to bound 10$
-^\[.*\] main\.x == 0 \[=2\]: PROVED up to bound 10$
+^\[main\.p0\] main\.half_x == 0 \[\*2\]: PROVED up to bound 10$
+^\[main\.p1\] main\.half_x == 0 \[->2\]: PROVED up to bound 10$
+^\[main\.p2\] main\.half_x == 0 \[=2\]: PROVED up to bound 10$
+^\[main\.p3\] main\.x == 0 \[\*2\]: REFUTED$
+^\[main\.p4w\] main\.x == 0 \[->2\]: PROVED up to bound 10$
+^\[main\.p5w\] main\.x == 0 \[=2\]: PROVED up to bound 10$
+^\[main\.p4s\] strong\(main\.x == 0 \[->2\]\): REFUTED$
+^\[main\.p5s\] strong\(main\.x == 0 \[=2\]\): REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-currently not implemented

--- a/regression/verilog/SVA/sequence_repetition1.sv
+++ b/regression/verilog/SVA/sequence_repetition1.sv
@@ -14,9 +14,15 @@ module main(input clk);
   initial p1: assert property (half_x==0[->2]);
   initial p2: assert property (half_x==0[=2]);
 
-  // should fail
+  // should fail -- the repetition must be consecutive
   initial p3: assert property (x==0[*2]);
-  initial p4: assert property (x==0[->2]);
-  initial p5: assert property (x==0[=2]);
+
+  // these pass, since the weak variant allows postponing satisfaction
+  initial p4w: assert property (x==0[->2]);
+  initial p5w: assert property (x==0[=2]);
+
+  // these fail, since the strong variant requires the match
+  initial p4s: assert property (strong(x==0[->2]));
+  initial p5s: assert property (strong(x==0[=2]));
 
 endmodule


### PR DESCRIPTION
This extends the existing sequence_repetition1.sv test with strong variants of `[->...]` and `[=...]`.