### PR TITLE
Fix ##0 concatenation after variable-length/goto sequences

### DIFF
--- a/regression/verilog/SVA/cycle_delay4.desc
+++ b/regression/verilog/SVA/cycle_delay4.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 cycle_delay4.sv
 --bound 10
 ^\[zero\.a1\] always \(zero\.req \|=> \(\(\!zero\.ack \[\*0:\$\]\) ##1 zero\.ack ##0 zero\.val == 1\)\): PROVED up to bound 10$

--- a/src/trans-word-level/sequence.cpp
+++ b/src/trans-word-level/sequence.cpp
@@ -110,6 +110,15 @@ sequence_matchest instantiate_sequence_rec(
       if(lhs_match.empty_match())
         continue; // handled by rewrite_sva_sequence
 
+      // A pending match represents a sequence that may complete beyond
+      // the bound. Propagate without evaluating the RHS.
+      if(lhs_match.is_pending())
+      {
+        if(semantics == sva_sequence_semanticst::WEAK)
+          result.push_back(lhs_match);
+        continue;
+      }
+
       // now delay
       const auto from = numeric_cast_v<mp_integer>(sva_cycle_delay_expr.from());
       DATA_INVARIANT(from >= 0, "##n must not be negative");
@@ -140,7 +149,8 @@ sequence_matchest instantiate_sequence_rec(
         if(t_rhs >= no_timeframes)
         {
           if(semantics == sva_sequence_semanticst::WEAK)
-            result.push_back(lhs_match);
+            result.push_back(
+              sequence_matcht::pending_match(lhs_match.condition()));
         }
         else // still inside bound
         {
@@ -418,10 +428,8 @@ sequence_matchest instantiate_sequence_rec(
       auto min = repetition.is_range()
                    ? numeric_cast_v<mp_integer>(repetition.from())
                    : numeric_cast_v<mp_integer>(repetition.repetitions());
-      result.emplace_back(
-        no_timeframes - 1,
-        binary_relation_exprt{
-          matches, ID_lt, from_integer(min, matches.type())});
+      result.push_back(sequence_matcht::pending_match(binary_relation_exprt{
+        matches, ID_lt, from_integer(min, matches.type())}));
     }
 
     return result;

--- a/src/trans-word-level/sequence.h
+++ b/src/trans-word-level/sequence.h
@@ -20,6 +20,7 @@ class sequence_matcht
 public:
   sequence_matcht(mp_integer __end_time, exprt __condition)
     : _is_empty_match(false),
+      _is_pending(false),
       _condition(std::move(__condition)),
       end_time(std::move(__end_time))
   {
@@ -35,8 +36,17 @@ public:
     return _is_empty_match;
   }
 
+  /// A pending match represents a sequence that may still complete beyond
+  /// the verification bound. Under weak semantics, such matches are
+  /// vacuously true; the sequence must not be evaluated further.
+  bool is_pending() const
+  {
+    return _is_pending;
+  }
+
 protected:
   bool _is_empty_match;
+  bool _is_pending;
   exprt _condition;
 
 public:
@@ -46,6 +56,15 @@ public:
   {
     auto result = sequence_matcht{end_time, true_exprt{}};
     result._is_empty_match = true;
+    return result;
+  }
+
+  /// A pending match carries no end time: it represents a sequence that
+  /// may complete beyond the verification bound.
+  static sequence_matcht pending_match(exprt condition)
+  {
+    auto result = sequence_matcht{0, std::move(condition)};
+    result._is_pending = true;
     return result;
   }
 };


### PR DESCRIPTION
## Summary

- `##0` after a variable-length (`[*0:$]`) or goto (`[->1]`) sequence incorrectly failed properties that should be proved (issue #1756).
- Root cause: a *pending match* (representing a sequence that may complete beyond the BMC bound) has `end_time = no_timeframes - 1`. For `##n` with n > 0, `t_rhs = end_time + n >= no_timeframes` hits the existing bound guard and propagates correctly. For `##0`, `t_rhs = end_time + 0` stays inside the bound, so the RHS was evaluated normally, yielding a contradictory condition (e.g. `!ack@0…@10 && ack@10 = false`) and losing the vacuous-truth property of weak semantics.
- Fix: introduce `sequence_matcht::pending_match(condition)` — a factory with **no end time** — and an `is_pending()` predicate. Pending matches are now created at their source (goto/non-consecutive repetition; `##n` when `t_rhs >= no_timeframes`) and propagated through `##0` without evaluating the RHS.

## Test plan

- [ ] `regression/verilog/SVA/cycle_delay4.desc` promoted from `KNOWNBUG` to `CORE`; all four assertions (`a1`, `a2`, `b1`, `b2`) prove with `--bound 10`
- [ ] All existing regression suites pass: `regression/verilog`, `regression/ebmc`, `regression/smv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)