### PR TITLE
`sequence_matcht::end_time()`

### DIFF
--- a/src/trans-word-level/property.cpp
+++ b/src/trans-word-level/property.cpp
@@ -660,7 +660,7 @@ static obligationst property_obligations_rec(
       {
         // The sequence must not match.
         if(!match.empty_match())
-          obligations.add(match.end_time, not_exprt{match.condition()});
+          obligations.add(match.end_time(), not_exprt{match.condition()});
       }
 
       return obligations;
@@ -725,8 +725,8 @@ static obligationst property_obligations_rec(
       // The RHS of the non-overlapped implication starts one timeframe later,
       // unless the LHS is an empty match.
       auto t_rhs = !overlapped && !lhs_match_point.empty_match()
-                     ? lhs_match_point.end_time + 1
-                     : lhs_match_point.end_time;
+                     ? lhs_match_point.end_time() + 1
+                     : lhs_match_point.end_time();
 
       // Do we exceed the bound? Make it 'true'
       if(t_rhs >= no_timeframes)
@@ -779,7 +779,7 @@ static obligationst property_obligations_rec(
         continue;
       }
 
-      mp_integer property_start = match.end_time;
+      mp_integer property_start = match.end_time();
 
       // #=# advances the clock by one from the sequence match point,
       // unless the LHS is an empty match.
@@ -830,7 +830,7 @@ static obligationst property_obligations_rec(
       if(!match.empty_match())
       {
         disjuncts.push_back(match.condition());
-        max = std::max(max, match.end_time);
+        max = std::max(max, match.end_time());
       }
     }
 

--- a/src/trans-word-level/sequence.cpp
+++ b/src/trans-word-level/sequence.cpp
@@ -123,7 +123,7 @@ sequence_matchest instantiate_sequence_rec(
       const auto from = numeric_cast_v<mp_integer>(sva_cycle_delay_expr.from());
       DATA_INVARIANT(from >= 0, "##n must not be negative");
 
-      auto t_rhs_from = lhs_match.end_time + from;
+      auto t_rhs_from = lhs_match.end_time() + from;
       mp_integer t_rhs_to;
 
       if(!sva_cycle_delay_expr.is_range()) // ##1 something
@@ -139,7 +139,7 @@ sequence_matchest instantiate_sequence_rec(
       {
         auto to = numeric_cast_v<mp_integer>(sva_cycle_delay_expr.to());
         DATA_INVARIANT(to >= from, "##[a:b] must have a<=b");
-        t_rhs_to = lhs_match.end_time + to;
+        t_rhs_to = lhs_match.end_time() + to;
       }
 
       // Add a potential match for each timeframe in the range
@@ -164,7 +164,7 @@ sequence_matchest instantiate_sequence_rec(
             {
               auto cond =
                 and_exprt{lhs_match.condition(), rhs_match.condition()};
-              result.emplace_back(rhs_match.end_time, cond);
+              result.emplace_back(rhs_match.end_time(), cond);
             }
           }
         }
@@ -206,10 +206,10 @@ sequence_matchest instantiate_sequence_rec(
       for(auto &rhs_match : rhs_matches)
       {
         // Same length?
-        if(lhs_match.end_time == rhs_match.end_time)
+        if(lhs_match.end_time() == rhs_match.end_time())
         {
           result.emplace_back(
-            lhs_match.end_time,
+            lhs_match.end_time(),
             and_exprt{lhs_match.condition(), rhs_match.condition()});
         }
       }
@@ -230,8 +230,8 @@ sequence_matchest instantiate_sequence_rec(
 
     for(auto &match : matches)
     {
-      if(!earliest.has_value() || earliest.value() > match.end_time)
-        earliest = match.end_time;
+      if(!earliest.has_value() || earliest.value() > match.end_time())
+        earliest = match.end_time();
     }
 
     if(!earliest.has_value())
@@ -242,7 +242,7 @@ sequence_matchest instantiate_sequence_rec(
     for(auto &match : matches)
     {
       // Earliest?
-      if(match.end_time == earliest.value())
+      if(match.end_time() == earliest.value())
       {
         result.push_back(match);
       }
@@ -267,14 +267,14 @@ sequence_matchest instantiate_sequence_rec(
     {
       exprt::operandst conjuncts = {match.condition()};
 
-      for(mp_integer new_t = t; new_t <= match.end_time; ++new_t)
+      for(mp_integer new_t = t; new_t <= match.end_time(); ++new_t)
       {
         auto lhs_inst =
           instantiate_state_predicate(throughout.lhs(), new_t, no_timeframes);
         conjuncts.push_back(lhs_inst);
       }
 
-      result.emplace_back(match.end_time, conjunction(conjuncts));
+      result.emplace_back(match.end_time(), conjunction(conjuncts));
     }
 
     return result;
@@ -292,7 +292,7 @@ sequence_matchest instantiate_sequence_rec(
 
     for(auto &match_rhs : matches_rhs)
     {
-      for(auto start_lhs = t; start_lhs <= match_rhs.end_time; ++start_lhs)
+      for(auto start_lhs = t; start_lhs <= match_rhs.end_time(); ++start_lhs)
       {
         auto matches_lhs = instantiate_sequence_rec(
           within_expr.lhs(), semantics, start_lhs, no_timeframes);
@@ -301,11 +301,11 @@ sequence_matchest instantiate_sequence_rec(
         {
           // The end_time of the lhs match must be no later than the
           // end_time of the rhs match.
-          if(match_lhs.end_time <= match_rhs.end_time)
+          if(match_lhs.end_time() <= match_rhs.end_time())
           {
             // return the rhs end_time
             auto cond = and_exprt{match_lhs.condition(), match_rhs.condition()};
-            result.emplace_back(match_rhs.end_time, std::move(cond));
+            result.emplace_back(match_rhs.end_time(), std::move(cond));
           }
         }
       }
@@ -331,7 +331,7 @@ sequence_matchest instantiate_sequence_rec(
     for(auto &match_lhs : matches_lhs)
       for(auto &match_rhs : matches_rhs)
       {
-        auto end_time = std::max(match_lhs.end_time, match_rhs.end_time);
+        auto end_time = std::max(match_lhs.end_time(), match_rhs.end_time());
         auto cond = and_exprt{match_lhs.condition(), match_rhs.condition()};
         result.emplace_back(std::move(end_time), std::move(cond));
       }

--- a/src/trans-word-level/sequence.h
+++ b/src/trans-word-level/sequence.h
@@ -14,7 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <verilog/sva_expr.h>
 
-/// A match for an SVA sequence.
+/// A potential match for an SVA sequence.
 class sequence_matcht
 {
 public:
@@ -22,13 +22,18 @@ public:
     : _is_empty_match(false),
       _is_pending(false),
       _condition(std::move(__condition)),
-      end_time(std::move(__end_time))
+      _end_time(std::move(__end_time))
   {
   }
 
-  exprt condition() const
+  const exprt &condition() const
   {
     return _condition;
+  }
+
+  const mp_integer &end_time() const
+  {
+    return _end_time;
   }
 
   bool empty_match() const
@@ -43,14 +48,6 @@ public:
   {
     return _is_pending;
   }
-
-protected:
-  bool _is_empty_match;
-  bool _is_pending;
-  exprt _condition;
-
-public:
-  mp_integer end_time;
 
   static sequence_matcht empty_match(mp_integer end_time)
   {
@@ -67,6 +64,12 @@ public:
     result._is_pending = true;
     return result;
   }
+
+protected:
+  bool _is_empty_match;
+  bool _is_pending;
+  exprt _condition;
+  mp_integer _end_time;
 };
 
 /// A set of matches of an SVA sequence.


### PR DESCRIPTION
This adds a getter method `sequence_matcht::end_time()`, for consistency with the other fields of the data structure.