### PR TITLE
Add KNOWNBUG tests for pending match propagation in sequence operators

### DIFF
--- a/regression/verilog/SVA/pending_and1.desc
+++ b/regression/verilog/SVA/pending_and1.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+pending_and1.sv
+--bound 10
+^\[m\.a1\] always \(m\.req \|=> \(\(\(m\.ack \[->2\]\) and \(m\.ack \[->3\]\)\) ##0 m\.val == 1\)\): PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Pending matches from ack[->2] and ack[->3] are combined by the 'and'
+operator (using max end_time) without propagating the pending status,
+so ##0 spuriously evaluates val at the bound.

--- a/regression/verilog/SVA/pending_and1.sv
+++ b/regression/verilog/SVA/pending_and1.sv
@@ -1,0 +1,16 @@
+// Pending match propagation through the SVA 'and' sequence operator.
+// https://github.com/diffblue/hw-cbmc/issues/1763
+
+module m(input logic clk, req, ack);
+  logic val;
+  assign val = ack;
+
+  // ack[->2] and ack[->3] have no concrete matches (different end times).
+  // Both produce pending matches; the 'and' operator must propagate pending.
+  // BUG: pending flag is lost in sva_and -- the cross product uses max(end_time),
+  //      producing a non-pending match that ##0 then spuriously evaluates.
+  a1: assert property (
+      @(posedge clk) req |=> (ack[->2] and ack[->3]) ##0 (val == 1)
+  );
+
+endmodule

--- a/regression/verilog/SVA/pending_cycle_delay_rhs1.desc
+++ b/regression/verilog/SVA/pending_cycle_delay_rhs1.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+pending_cycle_delay_rhs1.sv
+--bound 10
+^\[m\.a1\] always \(m\.req \|=> \(1 ##1 \(m\.ack \[->1\]\) ##0 m\.val == 1\)\): PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Pending match from ack[->1] (RHS of ##1) loses its pending flag when
+propagated through the outer ##1 result, so ##0 spuriously evaluates
+val at the bound rather than treating the match as vacuous.

--- a/regression/verilog/SVA/pending_cycle_delay_rhs1.sv
+++ b/regression/verilog/SVA/pending_cycle_delay_rhs1.sv
@@ -1,0 +1,16 @@
+// Pending match propagation through ##n when RHS of the delay generates a pending match.
+// https://github.com/diffblue/hw-cbmc/issues/1763
+
+module m(input logic clk, req, ack);
+  logic val;
+  assign val = ack;
+
+  // (1'b1 ##1 ack[->1]) can produce a pending match (ack never fires).
+  // ##0 must propagate the pending as vacuous, not evaluate val at time 0.
+  // BUG: the pending flag is lost through the inner ##1 RHS,
+  //      so ##0 then evaluates val at an earlier timeframe -- spurious failure.
+  a1: assert property (
+      @(posedge clk) req |=> 1'b1 ##1 ack[->1] ##0 (val == 1)
+  );
+
+endmodule

--- a/regression/verilog/SVA/pending_first_match1.desc
+++ b/regression/verilog/SVA/pending_first_match1.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+pending_first_match1.sv
+--bound 10
+^\[m\.a1\] always \(m\.req \|=> \(first_match\(m\.ack \[->1\]\) ##0 m\.val == 1\)\): PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+The pending match from ack[->1] (at the bound) wins the 'earliest
+end_time' search in first_match; it is returned as a concrete match
+and ##0 then spuriously evaluates val at the bound.

--- a/regression/verilog/SVA/pending_first_match1.sv
+++ b/regression/verilog/SVA/pending_first_match1.sv
@@ -1,0 +1,18 @@
+// Pending match propagation through first_match().
+// https://github.com/diffblue/hw-cbmc/issues/1763
+
+module m(input logic clk, req, ack);
+  logic val;
+  assign val = ack;
+
+  // first_match(ack[->1]): when ack never fires, ack[->1] has only a pending
+  // match at the bound.  first_match should propagate it as pending.
+  // BUG: the pending match at the bound wins the 'earliest end_time' search
+  //      because its stored end_time (no_timeframes-1) is used directly;
+  //      first_match returns it as a concrete match and ##0 spuriously
+  //      evaluates val.
+  a1: assert property (
+      @(posedge clk) req |=> first_match(ack[->1]) ##0 (val == 1)
+  );
+
+endmodule

--- a/regression/verilog/SVA/pending_intersect1.desc
+++ b/regression/verilog/SVA/pending_intersect1.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+pending_intersect1.sv
+--bound 10
+^\[m\.a1\] always \(m\.req \|=> \(\(\(m\.ack \[->2\]\) intersect \(m\.ack \[->3\]\)\) ##0 m\.val == 1\)\): PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+The two pending matches at the bound (from ack[->2] and ack[->3])
+have equal end_time, so 'intersect' combines them without propagating
+the pending status; ##0 then spuriously evaluates val at the bound.

--- a/regression/verilog/SVA/pending_intersect1.sv
+++ b/regression/verilog/SVA/pending_intersect1.sv
@@ -1,0 +1,17 @@
+// Pending match propagation through the SVA 'intersect' sequence operator.
+// https://github.com/diffblue/hw-cbmc/issues/1763
+
+module m(input logic clk, req, ack);
+  logic val;
+  assign val = ack;
+
+  // ack[->2] intersect ack[->3]: pending matches of both sides have the same
+  // end_time (they are both at the bound), so 'intersect' does combine them.
+  // The result must be a pending match, not a concrete match at the bound.
+  // BUG: pending flag lost in sva_sequence_intersect -- produces a non-pending
+  //      match that ##0 then spuriously evaluates.
+  a1: assert property (
+      @(posedge clk) req |=> (ack[->2] intersect ack[->3]) ##0 (val == 1)
+  );
+
+endmodule

--- a/regression/verilog/SVA/pending_throughout1.desc
+++ b/regression/verilog/SVA/pending_throughout1.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+pending_throughout1.sv
+--bound 10
+^\[m\.a1\] always \(m\.req \|=> \(\(1 throughout \(m\.ack \[->2\]\)\) ##0 m\.val == 1\)\): PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+The pending match from ack[->2] passes through 'throughout' without
+retaining its pending status; ##0 then spuriously evaluates val at
+the bound instead of treating the match as vacuous.

--- a/regression/verilog/SVA/pending_throughout1.sv
+++ b/regression/verilog/SVA/pending_throughout1.sv
@@ -1,0 +1,17 @@
+// Pending match propagation through the SVA 'throughout' sequence operator.
+// https://github.com/diffblue/hw-cbmc/issues/1763
+
+module m(input logic clk, req, ack);
+  logic val;
+  assign val = ack;
+
+  // ack[->2] can produce a pending match (ack fires fewer than 2 times).
+  // '1 throughout ack[->2]' adds a trivially-true LHS condition and passes
+  // through the match, but must propagate the pending status.
+  // BUG: sva_sequence_throughout creates a concrete result from a pending
+  //      sequence match, so ##0 then spuriously evaluates val.
+  a1: assert property (
+      @(posedge clk) req |=> (1 throughout ack[->2]) ##0 (val == 1)
+  );
+
+endmodule

--- a/regression/verilog/SVA/pending_within1.desc
+++ b/regression/verilog/SVA/pending_within1.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+pending_within1.sv
+--bound 10
+^\[m\.a1\] always \(m\.req \|=> \(\(\(m\.ack \[->1\]\) within \(m\.ack \[->2\]\)\) ##0 m\.val == 1\)\): PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+The pending match from ack[->2] (RHS of 'within') is used as a concrete
+bound at the boundary timeframe; 'within' creates a non-pending result
+and ##0 then spuriously evaluates val at the bound.

--- a/regression/verilog/SVA/pending_within1.sv
+++ b/regression/verilog/SVA/pending_within1.sv
@@ -1,0 +1,18 @@
+// Pending match propagation through the SVA 'within' sequence operator.
+// https://github.com/diffblue/hw-cbmc/issues/1763
+
+module m(input logic clk, req, ack);
+  logic val;
+  assign val = ack;
+
+  // ack[->2] (RHS of 'within') can produce a pending match.
+  // A pending RHS means the containing interval extends beyond the bound;
+  // the result of 'within' must also be pending.
+  // BUG: sva_sequence_within treats the pending RHS as a concrete match at
+  //      the bound, so 'within' creates a non-pending result and ##0 then
+  //      spuriously evaluates val.
+  a1: assert property (
+      @(posedge clk) req |=> ((ack[->1]) within (ack[->2])) ##0 (val == 1)
+  );
+
+endmodule


### PR DESCRIPTION
## Summary

- Adds six KNOWNBUG regression tests, one per sequence operator that fails to propagate pending matches through to downstream `##0` operators:
  - `pending_cycle_delay_rhs1`: `##n` RHS produces a pending match whose flag is lost, so `##0` evaluates the consequent at the wrong timeframe
  - `pending_and1`: `and` cross-product uses `max(end_time)` without retaining the pending flag
  - `pending_intersect1`: `intersect` combines two pending matches (both at the bound) without retaining the pending flag
  - `pending_throughout1`: `throughout` wraps a pending sequence match in a concrete result
  - `pending_within1`: `within` treats a pending RHS as a concrete interval endpoint
  - `pending_first_match1`: `first_match` picks the pending match as the earliest (end_time = bound) and returns it as concrete

Each property should PROVE under correct weak semantics (pending matches are vacuous beyond the bound) but is currently REFUTED because the pending status is silently dropped.

Note: `pending_and1` and `pending_throughout1` currently also trigger a crash in `admits_empty()` due to missing cases for `sva_and` and `sva_sequence_throughout` — that fix is a prerequisite for those two tests and will come in a follow-up commit.

## Test plan

- [ ] All new `.desc` files are marked `KNOWNBUG` and the existing test suite still passes (`All tests were successful, 62 tests skipped`)
- [ ] Each `.sv` file currently produces `REFUTED` with `--bound 10`
- [ ] After the pending-propagation fixes are applied, each property should produce `PROVED up to bound 10` and the desc files can be changed to `CORE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)