### PR TITLE
Verilog: `$root`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # EBMC 6.1
 
+* Verilog: $root.
 * Verilog: procedural assignments to hierarchical identifiers
 * SystemVerilog: ports for sequence and property declarations
 * Refreshed IC3 engine --new-ic3

--- a/regression/verilog/modules/root1.desc
+++ b/regression/verilog/modules/root1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 root1.sv
 --top the_top --bound 0
 ^EXIT=0$
@@ -6,4 +6,3 @@ root1.sv
 --
 ^warning: ignoring
 --
-This does not parse

--- a/regression/verilog/modules/root1.sv
+++ b/regression/verilog/modules/root1.sv
@@ -1,6 +1,7 @@
 // 1800-2017 23.3.1
 module somewhere;
   parameter P = 123;
+  somewhere_else B();
 endmodule
 
 module somewhere_else;
@@ -9,5 +10,4 @@ endmodule
 
 module the_top;
   somewhere A();
-  somewhere_else B();
 endmodule

--- a/src/verilog/scanner.l
+++ b/src/verilog/scanner.l
@@ -588,6 +588,11 @@ prove           { VL2SMV_VERILOG_KEYWORD(TOK_PROVE); }
 
                 /* Identifiers and numbers */
 
+\$root          { newstack(yyveriloglval);
+                  stack_expr(yyveriloglval).id(ID_verilog_identifier);
+                  stack_expr(yyveriloglval).set(ID_base_name, yytext);
+                  PARSER.set_source_location(stack_expr(yyveriloglval));
+                  return TOK_NON_TYPE_IDENTIFIER; }
 \$unit          { newstack(yyveriloglval);
                   stack_expr(yyveriloglval).id(ID_verilog_identifier);
                   stack_expr(yyveriloglval).set(ID_base_name, yytext);

--- a/src/verilog/verilog_ebmc_language.cpp
+++ b/src/verilog/verilog_ebmc_language.cpp
@@ -208,6 +208,30 @@ transition_systemt verilog_ebmc_languaget::typecheck(
   transition_systemt transition_system;
   transition_system.symbol_table = std::move(symbol_table);
 
+  // Create module instance symbols for the top-level modules under $root,
+  // so that $root.module hierarchical identifiers can be resolved
+  // while type checking.
+  auto root_identifier = verilog_module_symbol(verilog_root_module_name());
+
+  for(auto &top_level_module : top_level_modules)
+  {
+    auto module_identifier = verilog_module_symbol(top_level_module);
+
+    auto instance_identifier =
+      id2string(root_identifier) + "." + id2string(top_level_module);
+
+    symbolt instance_symbol{
+      instance_identifier, verilog_module_instance_typet{}, ID_Verilog};
+    instance_symbol.base_name = top_level_module;
+    instance_symbol.pretty_name = top_level_module;
+    instance_symbol.module = root_identifier;
+    instance_symbol.value = verilog_module_instancet{module_identifier};
+
+    auto add_result_instance =
+      transition_system.symbol_table.add(instance_symbol);
+    CHECK_RETURN(!add_result_instance);
+  }
+
   // now type check the top-level modules
   for(auto &top_level_module : top_level_modules)
   {
@@ -236,19 +260,10 @@ void verilog_ebmc_languaget::create_root_module(
   {
     auto module_identifier = verilog_module_symbol(top_level_module);
 
+    // The module instance symbol for the top-level module
+    // was already added before type checking.
     auto instance_identifier =
       id2string(root_identifier) + "." + id2string(top_level_module);
-
-    // Create a module instance symbol for the top-level module under $root
-    symbolt instance_symbol{
-      instance_identifier, verilog_module_instance_typet{}, ID_Verilog};
-    instance_symbol.base_name = top_level_module;
-    instance_symbol.pretty_name = top_level_module;
-    instance_symbol.module = root_identifier;
-    instance_symbol.value = verilog_module_instancet{module_identifier};
-
-    auto add_result_instance = symbol_table.add(instance_symbol);
-    CHECK_RETURN(!add_result_instance);
 
     // Build a verilog_instt module item for the instantiation
     verilog_instt inst;

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -80,9 +80,8 @@ exprt verilog_synthesist::synth_expr_rec(exprt expr, symbol_statet symbol_state)
   }
   else if(expr.id() == ID_hierarchical_identifier)
   {
-    expand_hierarchical_identifier(
-      to_hierarchical_identifier_expr(expr), symbol_state);
-    return expr;
+    return expand_hierarchical_identifier(
+      to_hierarchical_identifier_expr(std::move(expr)), symbol_state);
   }
 
   // Do the operands recursively
@@ -279,22 +278,17 @@ exprt verilog_synthesist::synth_lhs_expr(exprt expr)
   }
   else if(expr.id() == ID_hierarchical_identifier)
   {
-    expand_hierarchical_identifier(
-      to_hierarchical_identifier_expr(expr), symbol_statet::CURRENT);
-    local_symbols.insert(to_symbol_expr(expr).identifier());
-    return expr;
+    auto result = expand_hierarchical_identifier(
+      to_hierarchical_identifier_expr(std::move(expr)), symbol_statet::CURRENT);
+    if(result.id() == ID_symbol)
+      local_symbols.insert(to_symbol_expr(result).identifier());
+    return result;
   }
   else if(expr.id() == ID_typecast)
   {
     auto &typecast_expr = to_typecast_expr(expr);
     typecast_expr.op() = synth_lhs_expr(typecast_expr.op());
     return expr;
-  }
-  else if(expr.id() == ID_hierarchical_identifier)
-  {
-    expand_hierarchical_identifier(
-      to_hierarchical_identifier_expr(expr), symbol_statet::CURRENT);
-    return synth_lhs_expr(std::move(expr));
   }
   else
   {
@@ -561,8 +555,8 @@ Function: verilog_synthesist::expand_hierarchical_identifier
 
 \*******************************************************************/
 
-void verilog_synthesist::expand_hierarchical_identifier(
-  hierarchical_identifier_exprt &expr,
+exprt verilog_synthesist::expand_hierarchical_identifier(
+  hierarchical_identifier_exprt expr,
   symbol_statet symbol_state)
 {
   expr.lhs() = synth_expr(expr.lhs(), symbol_state);
@@ -590,13 +584,26 @@ void verilog_synthesist::expand_hierarchical_identifier(
   irep_idt full_identifier =
     id2string(lhs_identifier) + '.' + id2string(rhs_base_name);
 
+  // The identifier might be a macro, e.g., a parameter of the
+  // module instance. If so, substitute.
   // Note: the instance copy may not yet be in symbol table,
   // as the inst module item may be later.
   // The type checker already checked that it's fine.
+  const symbolt *symbol;
+  if(!ns.lookup(full_identifier, symbol) && symbol->is_macro)
+  {
+    DATA_INVARIANT(symbol->value.is_not_nil(), "macro must have value");
+
+    // These aren't lowered yet
+    auto lowered = verilog_lowering(symbol->value);
+
+    // recursive call
+    return synth_expr_rec(std::move(lowered), symbol_state);
+  }
 
   symbol_exprt new_symbol{full_identifier, expr.type()};
   new_symbol.add_source_location()=expr.source_location();
-  expr.swap(new_symbol);
+  return std::move(new_symbol);
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -342,8 +342,8 @@ protected:
     const verilog_instt::instancet &,
     transt &trans_dest);
 
-  void expand_hierarchical_identifier(
-    class hierarchical_identifier_exprt &expr,
+  exprt expand_hierarchical_identifier(
+    class hierarchical_identifier_exprt expr,
     symbol_statet symbol_state);
 
   exprt

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1841,6 +1841,28 @@ Function: verilog_typecheck_exprt::convert_hierarchical_identifier
 exprt verilog_typecheck_exprt::convert_hierarchical_identifier(
   hierarchical_identifier_exprt expr)
 {
+  if(
+    expr.lhs().id() == ID_verilog_identifier &&
+    to_verilog_identifier_expr(expr.lhs()).base_name() ==
+      verilog_root_module_name())
+  {
+    // $root.somewhere
+    auto module_base_name = to_verilog_identifier_expr(expr.rhs()).base_name();
+
+    const irep_idt full_instance_identifier =
+      id2string(verilog_root_module_identifier()) + '.' +
+      id2string(module_base_name);
+
+    const symbolt *symbol;
+    if(ns.lookup(full_instance_identifier, symbol))
+    {
+      throw errort().with_location(expr.source_location())
+        << "failed to find top module " << module_base_name;
+    }
+
+    return symbol->symbol_expr().with_source_location(expr);
+  }
+
   convert_expr(expr.lhs());
 
   DATA_INVARIANT(


### PR DESCRIPTION
This adds support for 1800 2017 23.6 `$root` names.