### PR TITLE
Verilog: skip include directives in inactive ifdef branches

### DIFF
--- a/regression/verilog/preprocessor/ifdef_include1.desc
+++ b/regression/verilog/preprocessor/ifdef_include1.desc
@@ -1,0 +1,6 @@
+CORE
+ifdef_include1.sv
+--preprocess
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/verilog/preprocessor/ifdef_include1.sv
+++ b/regression/verilog/preprocessor/ifdef_include1.sv
@@ -1,0 +1,6 @@
+`ifdef XXX
+  `include "nonexistent.svh"
+`endif
+
+module main;
+endmodule

--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -600,6 +600,13 @@ void verilog_preprocessort::directive()
   }
   else if(text=="include")
   {
+    if(!condition)
+    {
+      // ignore
+      tokenizer().skip_until_eol();
+      return;
+    }
+
     // skip whitespace
     tokenizer().skip_ws();
 


### PR DESCRIPTION
The preprocessor attempted to resolve include files even inside inactive ifdef/ifndef branches, causing spurious errors when the included file did not exist. This adds the same guard that define and undef already have.

Fixes #1803