### PR TITLE
Verilog: add net identifiers to the scope

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,10 @@
 # EBMC 6.0
+
 * VCD traces now written into separate files per property
-
 * SMV: removed legacy keywords EXTERN and switch
-
 * SMV: use NuSMV's operator precedence, as opposed to CMU SMV's
-
 * SystemVerilog: semantics fix for cover disable iff
+* SystemVerilog: nets from package scopes
 
 # EBMC 5.11
 

--- a/regression/verilog/packages/package_net1.desc
+++ b/regression/verilog/packages/package_net1.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE
 package_net1.sv
 
 ^EXIT=0$
 ^SIGNAL=0$
 --
 --
-The identifier my_net is not found.

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2172,11 +2172,15 @@ range:  part_select;
 
 net_decl_assignment:
           net_identifier unpacked_dimension_brace
-                { $$ = $1;
+                { // add to the scope
+                  PARSER.scopes.add_identifier(stack_expr($1).get(ID_base_name), verilog_scopet::NET);
+                  $$ = $1;
                   stack_expr($$).id(ID_declarator);
                   addswap($$, ID_type, $2); }
         | net_identifier unpacked_dimension_brace '=' expression
-                { $$ = $1;
+                { // add to the scope
+                  PARSER.scopes.add_identifier(stack_expr($1).get(ID_base_name), verilog_scopet::NET);
+                  $$ = $1;
                   stack_expr($$).id(ID_declarator);
                   addswap($$, ID_type, $2);
                   addswap($$, ID_value, $4); }

--- a/src/verilog/verilog_scope.cpp
+++ b/src/verilog/verilog_scope.cpp
@@ -93,6 +93,7 @@ unsigned verilog_scopet::identifier_token() const
   case verilog_scopet::PARAMETER:       return TOK_NON_TYPE_IDENTIFIER;
   case verilog_scopet::PROPERTY:        return TOK_NON_TYPE_IDENTIFIER;
   case verilog_scopet::SEQUENCE:        return TOK_NON_TYPE_IDENTIFIER;
+  case verilog_scopet::NET:             return TOK_NON_TYPE_IDENTIFIER;
   case verilog_scopet::VAR:             return TOK_NON_TYPE_IDENTIFIER;
   case verilog_scopet::OTHER:           return TOK_NON_TYPE_IDENTIFIER;
     // clang-format on

--- a/src/verilog/verilog_scope.h
+++ b/src/verilog/verilog_scope.h
@@ -32,6 +32,7 @@ struct verilog_scopet
     PARAMETER,
     PROPERTY,
     SEQUENCE,
+    NET,
     VAR,
     OTHER
   };


### PR DESCRIPTION
The parser now adds net identifiers to the current scope.