### PR TITLE
CI: add CVC5

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -20,12 +20,14 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get remove --purge man-db
-          packages_to_install="ccache z3"
+          packages_to_install="ccache cvc5 z3"
           if ! sudo apt-get install --no-install-recommends -yq $packages_to_install ; then
             # retry after updating package indices
             sudo apt-get update
             sudo apt-get install --no-install-recommends -yq $packages_to_install
           fi
+      - name: Confirm cvc5 solver is available and log the version installed
+        run: cvc5 --version
       - name: Confirm z3 solver is available and log the version installed
         run: z3 --version
       - name: Log the version of gcc
@@ -58,14 +60,20 @@ jobs:
           key: ${{ runner.os }}-24.04-make-gcc-${{ github.ref }}-${{ github.sha }}-PR
       - name: Run the ebmc tests with SAT
         run: make -C regression/ebmc test
+      - name: Run the ebmc tests with CVC5
+        run: make -C regression/ebmc test-cvc5
       - name: Run the ebmc tests with Z3
         run: make -C regression/ebmc test-z3
       - name: Run the verilog tests
         run: make -C regression/verilog test
       - name: Run the verilog tests with Z3
         run: make -C regression/verilog test-z3
+      - name: Run the verilog tests with CVC5
+        run: make -C regression/verilog test-cvc5
       - name: Run the smv tests
         run: make -C regression/smv test
+      - name: Run the smv tests with CVC5
+        run: make -C regression/smv test-cvc5
       - name: Run the smv tests with Z3
         run: make -C regression/smv test-z3
       - name: Run the vlindex tests

--- a/regression/ebmc/Makefile
+++ b/regression/ebmc/Makefile
@@ -5,5 +5,8 @@ TEST_PL = ../../lib/cbmc/regression/test.pl
 test:
 	@$(TEST_PL) -e -p -c ../../../src/ebmc/ebmc
 
+test-cvc5:
+	@$(TEST_PL) -e -p -c "../../../src/ebmc/ebmc --cvc5" -X broken-smt-backend
+
 test-z3:
 	@$(TEST_PL) -e -p -c "../../../src/ebmc/ebmc --z3" -X broken-smt-backend

--- a/regression/smv/Makefile
+++ b/regression/smv/Makefile
@@ -8,6 +8,9 @@ test:
 test-buechi:
 	@$(TEST_PL) -e -p -c ../../../src/ebmc/ebmc -I buechi
 
+test-cvc5:
+	@$(TEST_PL) -e -p -c "../../../src/ebmc/ebmc --cvc5" -X broken-smt-backend -X buechi
+
 test-z3:
 	@$(TEST_PL) -e -p -c "../../../src/ebmc/ebmc --z3" -X broken-smt-backend -X buechi
 

--- a/regression/smv/expressions/smv_set2.desc
+++ b/regression/smv/expressions/smv_set2.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 smv_set2.smv
 
 ^\[spec1\] x in \{ 1, 2 \}: REFUTED$

--- a/regression/verilog/Makefile
+++ b/regression/verilog/Makefile
@@ -8,6 +8,9 @@ test:
 test-buechi:
 	@$(TEST_PL) -e -p -c ../../../src/ebmc/ebmc -I buechi
 
+test-cvc5:
+	@$(TEST_PL) -e -p -c "../../../src/ebmc/ebmc --cvc5" -X broken-smt-backend -X buechi
+
 test-z3:
 	@$(TEST_PL) -e -p -c "../../../src/ebmc/ebmc --z3" -X broken-smt-backend -X buechi
 

--- a/regression/verilog/unions/array_in_union1.desc
+++ b/regression/verilog/unions/array_in_union1.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 array_in_union1.sv
 
 ^EXIT=0$


### PR DESCRIPTION
This adds test runs with CVC5 to CI.

This is in addition to the existing runs with Z3.