### PR TITLE
Verilog: create `$root` module instance

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # EBMC 6.0
 
+* Verilog: identifiers given on command-line must now include module identifier
 * BMC: strong sequences that exceed the bound are no longer reported as REFUTED
 * VCD traces now written into separate files per property
 * SMV: removed legacy keywords EXTERN and switch

--- a/regression/ebmc/CLI/reset1.desc
+++ b/regression/ebmc/CLI/reset1.desc
@@ -1,6 +1,6 @@
 CORE
 reset1.sv
---module top --bound 10 --reset reset_n
+--module top --bound 10 --reset top.reset_n
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/CLI/reset2.desc
+++ b/regression/ebmc/CLI/reset2.desc
@@ -1,6 +1,6 @@
 CORE
 reset2.sv
---module top --bound 10 --reset ~reset_n
+--module top --bound 10 --reset ~top.reset_n
 ^\[top\.p1\] always \(disable iff \(!top\.reset_n\) top\.data >= 0 && top\.data <= 10\): PROVED .*$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/ebmc/CLI/reset3.desc
+++ b/regression/ebmc/CLI/reset3.desc
@@ -1,6 +1,6 @@
 CORE
 reset3.sv
---reset rst --aig --simple-netlist --bound 5
+--reset main.rst --aig --simple-netlist --bound 5
 ^\[.*\] always \(disable iff \(main\.rst\) main\.data\): PROVED up to bound 5$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/ebmc/CLI/reset4.desc
+++ b/regression/ebmc/CLI/reset4.desc
@@ -1,7 +1,7 @@
 CORE
 reset4.sv
---reset some_unknown_identifier
-^line 1: unknown identifier some_unknown_identifier$
+--reset main.some_unknown_identifier
+^line 1: identifier `some_unknown_identifier' not found in module `main'$
 ^error: failed to parse reset constraint$
 ^EXIT=6$
 ^SIGNAL=0$

--- a/regression/ebmc/engine-heuristic/combinational2.desc
+++ b/regression/ebmc/engine-heuristic/combinational2.desc
@@ -1,6 +1,6 @@
 CORE
 combinational2.sv
---reset reset
+--reset main.reset
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/example4_reset/test.desc
+++ b/regression/ebmc/example4_reset/test.desc
@@ -1,6 +1,6 @@
 CORE
 example4.sv
---bound 10 --reset "reset==1"
+--bound 10 --reset "counter.reset==1"
 ^\[counter\.assert\.1\] .* PROVED up to bound 10$
 ^\[counter\.assert\.2\] .* PROVED up to bound 10$
 ^EXIT=0$

--- a/regression/ebmc/k-induction/disable_iff1.desc
+++ b/regression/ebmc/k-induction/disable_iff1.desc
@@ -1,6 +1,6 @@
 CORE
 disable_iff1.sv
---k-induction --reset reset
+--k-induction --reset main.reset
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[main\.p1\] always \(disable iff \(main\.reset\) main\.x <= 10\): PROVED$

--- a/regression/ebmc/netlist/netlist-output1.desc
+++ b/regression/ebmc/netlist/netlist-output1.desc
@@ -3,10 +3,10 @@ netlist-output1.v
 --show-netlist
 activate-multi-line-match
 ^Variable map:
-  Verilog::main\.clk=0->false \(input\)
-  Verilog::main\.data=1->false \(input\)
-  Verilog::main\.some_register=2->!3 \(latch\)
-  Verilog::main\.some_register_aux0=!3->false \(wire\)
+  Verilog::\$root.main\.clk=0->false \(input\)
+  Verilog::\$root.main\.data=1->false \(input\)
+  Verilog::\$root.main\.some_register=2->!3 \(latch\)
+  Verilog::\$root.main\.some_register_aux0=!3->false \(wire\)
 
 Total no. of variable bits: 3
 Total no. of latch bits: 1
@@ -15,10 +15,10 @@ Total no. of input bits: 2
 Total no. of output bits: 0
 
 Next state functions:
-  NEXT\(Verilog::main\.some_register\)=!\(!\(Verilog::main\.data\) & !\(Verilog::main\.some_register\)\)
+  NEXT\(Verilog::\$root.main\.some_register\)=!\(!\(Verilog::\$root.main\.data\) & !\(Verilog::\$root.main\.some_register\)\)
 
 Initial state: 
-  !\(Verilog::main\.some_register\)
+  !\(Verilog::\$root.main\.some_register\)
 
 State invariant constraints: 
 

--- a/regression/ebmc/neural-liveness/counter1.desc
+++ b/regression/ebmc/neural-liveness/counter1.desc
@@ -1,6 +1,6 @@
 CORE
 counter1.sv
---traces 2 --neural-liveness --neural-engine "echo Candidate: counter\\\\n"
+--traces 2 --neural-liveness --neural-engine "echo Candidate: main.counter\\\\n"
 ^\[main\.p0\] always s_eventually main.counter == 0: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/ebmc/p-command-line-option/p-command-line-option1.desc
+++ b/regression/ebmc/p-command-line-option/p-command-line-option1.desc
@@ -1,6 +1,6 @@
 CORE
 p-command-line-option1.v
---bound 1 -p "some_value >= 1"
+--bound 1 -p "main.some_value >= 1"
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[command-line assertion\] always main\.some_value >= 1: PROVED up to bound 1$

--- a/regression/ebmc/ranking-function/clock24h.day.desc
+++ b/regression/ebmc/ranking-function/clock24h.day.desc
@@ -1,6 +1,6 @@
 CORE
 clock24h.sv
---property main.p_day --ranking-function "{23-hours,59-minutes,59-seconds}"
+--property main.p_day --ranking-function "{23-main.hours,59-main.minutes,59-main.seconds}"
 ^\[main\.p_day\] .*: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/ebmc/ranking-function/clock24h.hour.desc
+++ b/regression/ebmc/ranking-function/clock24h.hour.desc
@@ -1,6 +1,6 @@
 CORE
 clock24h.sv
---property main.p_hour --ranking-function "{59-minutes,59-seconds}"
+--property main.p_hour --ranking-function "{59-main.minutes,59-main.seconds}"
 ^\[main\.p_hour\] .*: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/ebmc/ranking-function/clock24h.minute.desc
+++ b/regression/ebmc/ranking-function/clock24h.minute.desc
@@ -1,6 +1,6 @@
 CORE
 clock24h.sv
---property main.p_minute --ranking-function "59-seconds"
+--property main.p_minute --ranking-function "59-main.seconds"
 ^\[main\.p_minute\] .*: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/ebmc/ranking-function/counter1.fail.desc
+++ b/regression/ebmc/ranking-function/counter1.fail.desc
@@ -1,6 +1,6 @@
 CORE
 counter1.sv
---ranking-function "(-counter)"
+--ranking-function "(-main.counter)"
 ^\[main\.p0\] always s_eventually main.counter == 0: INCONCLUSIVE$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/ebmc/ranking-function/counter1.pass.desc
+++ b/regression/ebmc/ranking-function/counter1.pass.desc
@@ -1,6 +1,6 @@
 CORE
 counter1.sv
---ranking-function counter
+--ranking-function main.counter
 ^\[main\.p0\] always s_eventually main.counter == 0: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/ebmc/ranking-function/counter2.fail.desc
+++ b/regression/ebmc/ranking-function/counter2.fail.desc
@@ -1,6 +1,6 @@
 CORE
 counter2.sv
---ranking-function counter --numbered-trace
+--ranking-function main.counter --numbered-trace
 ^\[main\.p0\] always s_eventually main.counter == 10: INCONCLUSIVE$
 ^main\.counter@0 = .*$
 ^main\.counter@1 = .*$

--- a/regression/ebmc/ranking-function/counter2.pass.desc
+++ b/regression/ebmc/ranking-function/counter2.pass.desc
@@ -1,6 +1,6 @@
 CORE
 counter2.sv
---ranking-function 10-counter
+--ranking-function 10-main.counter
 ^\[main\.p0\] always s_eventually main.counter == 10: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/ebmc/ranking-function/counter_in_module1.desc
+++ b/regression/ebmc/ranking-function/counter_in_module1.desc
@@ -1,6 +1,6 @@
 CORE
 counter_in_module1.sv
---ranking-function my_instance.counter
+--ranking-function main.my_instance.counter
 ^\[main\.p0\] always s_eventually main\.my_instance\.counter == 0: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/ebmc/ranking-function/counter_with_reset1.fail.desc
+++ b/regression/ebmc/ranking-function/counter_with_reset1.fail.desc
@@ -1,6 +1,6 @@
 CORE
 counter_with_reset1.sv
---property main.p0 --ranking-function 10-counter
+--property main.p0 --ranking-function 10-main.counter
 ^\[main\.p0\] always s_eventually main.counter == 10: INCONCLUSIVE$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/ebmc/ranking-function/counter_with_reset1.pass.desc
+++ b/regression/ebmc/ranking-function/counter_with_reset1.pass.desc
@@ -1,6 +1,6 @@
 CORE
 counter_with_reset1.sv
---property main.p1 --ranking-function 10-counter
+--property main.p1 --ranking-function 10-main.counter
 ^\[main\.p1\] always s_eventually main.reset \|\| main.counter == 10: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/ebmc/ranking-function/lexicographic_ranking_function1.desc
+++ b/regression/ebmc/ranking-function/lexicographic_ranking_function1.desc
@@ -1,6 +1,6 @@
 CORE
 lexicographic_ranking_function1.sv
---ranking-function "{digit1, digit2}"
+--ranking-function "{main.digit1, main.digit2}"
 ^\[main\.p0\] always s_eventually main\.digit1 == 0: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/ebmc/ranking-function/signed1.desc
+++ b/regression/ebmc/ranking-function/signed1.desc
@@ -1,6 +1,6 @@
 CORE
 signed1.sv
---ranking-function "(-$signed({1'b0,counter}))"
+--ranking-function "(-$signed({1'b0,main.counter}))"
 ^\[main\.p0\] always s_eventually main.counter == 0: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/ebmc/smv-netlist/array_assignment.desc
+++ b/regression/ebmc/smv-netlist/array_assignment.desc
@@ -1,6 +1,6 @@
 CORE
 array_assignment.sv
---reset rst --smv-netlist --simple-netlist
+--reset main.rst --smv-netlist --simple-netlist
 ^ASSIGN next\(main\.data\[0\]\):=nondet\[1\];$
 ^ASSIGN next\(main\.data\[1\]\):=nondet\[2\];$
 ^EXIT=0$

--- a/regression/ebmc/traces/json1.desc
+++ b/regression/ebmc/traces/json1.desc
@@ -1,7 +1,7 @@
 CORE
 json1.v
 --bound 10 --json-result -
-^      "identifier": "Verilog::main\.property\.p1",$
+^      "identifier": "Verilog::\$root\.main\.property\.p1",$
 ^      "status": "REFUTED",$
 ^      "trace": \{$
 ^        "states": \[ \[$

--- a/regression/verilog/modules/show-module-hierarchy1.desc
+++ b/regression/verilog/modules/show-module-hierarchy1.desc
@@ -1,13 +1,14 @@
 CORE
 show-module-hierarchy1.v
 --show-module-hierarchy
-^main:$
-^  inner main\.inner_instance1$
-^    leaf1 main\.inner_instance1\.leaf1_instance$
-^    leaf2 main\.inner_instance1\.leaf2_instance$
-^  inner main\.inner_instance2$
-^    leaf1 main\.inner_instance2\.leaf1_instance$
-^    leaf2 main\.inner_instance2\.leaf2_instance$
+^\$root:$
+^  main main$
+^    inner main\.inner_instance1$
+^      leaf1 main\.inner_instance1\.leaf1_instance$
+^      leaf2 main\.inner_instance1\.leaf2_instance$
+^    inner main\.inner_instance2$
+^      leaf1 main\.inner_instance2\.leaf1_instance$
+^      leaf2 main\.inner_instance2\.leaf2_instance$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/trans-netlist/trans_trace.cpp
+++ b/src/trans-netlist/trans_trace.cpp
@@ -817,14 +817,17 @@ void show_trans_trace_vcd(
 
   auto &module_symbol = ns.lookup(symbol1.module);
 
-  // print those in the top module
-
-  out << "$scope module " << module_symbol.display_name() << " $end\n";
-
-  // split up into hierarchy
-  vcd_hierarchy_rec(ns, ids, id2string(module_symbol.name) + ".", out, 1);
-
-  out << "$upscope $end\n";  
+  // print those in the top module -- skip $root scope in VCD output
+  if(module_symbol.base_name == "$root")
+  {
+    vcd_hierarchy_rec(ns, ids, id2string(module_symbol.name) + ".", out, 0);
+  }
+  else
+  {
+    out << "$scope module " << module_symbol.display_name() << " $end\n";
+    vcd_hierarchy_rec(ns, ids, id2string(module_symbol.name) + ".", out, 1);
+    out << "$upscope $end\n";
+  }
 
   out << "$enddefinitions $end\n";
 

--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -15,11 +15,13 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/lispexpr.h>
 #include <util/lispirep.h>
 #include <util/namespace.h>
+#include <util/prefix.h>
 #include <util/std_expr.h>
 #include <util/symbol.h>
 
 #include "sva_expr.h"
 #include "verilog_expr.h"
+#include "verilog_typecheck_base.h"
 #include "verilog_types.h"
 
 #include <algorithm>
@@ -1205,6 +1207,15 @@ expr2verilogt::resultt expr2verilogt::convert_symbol(const exprt &src)
  
   if(std::string(dest, 0, 9)=="Verilog::")
     dest.erase(0, 9);
+
+  // We special-case the pretty name for identifiers under $root:
+  // it is customary to use the name of the module only as root
+  // of the hierarchical identifier.
+  const static std::string root_module_prefix =
+    id2string(verilog_root_module_name()) + '.';
+
+  if(has_prefix(dest, root_module_prefix))
+    dest.erase(0, root_module_prefix.size());
 
   return {verilog_precedencet::MAX, dest};
 }

--- a/src/verilog/verilog_ebmc_language.cpp
+++ b/src/verilog/verilog_ebmc_language.cpp
@@ -28,6 +28,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #include "verilog_preprocessor.h"
 #include "verilog_synthesis.h"
 #include "verilog_typecheck.h"
+#include "verilog_types.h"
 
 #include <fstream>
 #include <functional>
@@ -326,14 +327,87 @@ verilog_ebmc_languaget::top_level_module(const parse_treest &parse_trees) const
   return *top_level_modules.begin();
 }
 
-static bool get_main(
+/// Create a $root module instance containing the given top-level module,
+/// and synthesize it so that the top-level module is expanded into $root.
+static void create_root_module(
   irep_idt top_level_module,
+  verilog_standardt standard,
+  bool ignore_initial,
+  bool initial_zero,
+  symbol_tablet &symbol_table,
+  message_handlert &message_handler)
+{
+  auto module_identifier = verilog_module_symbol(top_level_module);
+  auto root_identifier = verilog_module_symbol(verilog_root_module_name());
+  auto instance_identifier =
+    id2string(root_identifier) + "." + id2string(top_level_module);
+
+  // Create a module instance symbol for the top-level module under $root
+  symbolt instance_symbol{
+    instance_identifier, typet{ID_module_instance}, ID_Verilog};
+  instance_symbol.base_name = top_level_module;
+  instance_symbol.pretty_name = top_level_module;
+  instance_symbol.module = root_identifier;
+  instance_symbol.value.set(ID_module, module_identifier);
+
+  auto add_result_instance = symbol_table.add(instance_symbol);
+  CHECK_RETURN(!add_result_instance);
+
+  // Build a verilog_instt module item for the instantiation
+  verilog_instt inst;
+  inst.set_module(module_identifier);
+  verilog_inst_baset::instancet instance_expr;
+  instance_expr.set(ID_base_name, top_level_module);
+  instance_expr.identifier(instance_identifier);
+  inst.instances().push_back(std::move(instance_expr));
+
+  // Create the $root module symbol with the inst as its only module item.
+  // Copy the type from the top-level module, updating port identifiers.
+  auto &top_symbol = symbol_table.lookup_ref(module_identifier);
+
+  symbolt root_symbol{root_identifier, top_symbol.type, ID_Verilog};
+  root_symbol.base_name = verilog_root_module_name();
+  root_symbol.pretty_name = verilog_root_module_name();
+  root_symbol.module = root_identifier;
+  root_symbol.value = verilog_module_exprt({std::move(inst)});
+
+  const std::string &module_identifier_string = id2string(module_identifier);
+
+  // Update port identifiers to reflect the $root hierarchy
+  for(auto &port : to_module_type(root_symbol.type).ports())
+  {
+    auto old_id = id2string(port.identifier());
+    // Replace Verilog::MODULE with Verilog::$root.MODULE
+    if(
+      old_id.compare(0, module_identifier.size(), module_identifier_string) ==
+      0)
+    {
+      port.identifier(
+        id2string(instance_identifier) +
+        old_id.substr(module_identifier.size()));
+    }
+  }
+
+  auto add_result_root = symbol_table.add(root_symbol);
+  CHECK_RETURN(!add_result_root);
+
+  // Synthesize $root, which expands the top-level module instance
+  verilog_synthesis(
+    symbol_table,
+    root_identifier,
+    standard,
+    ignore_initial,
+    initial_zero,
+    message_handler);
+}
+
+static bool get_main(
   message_handlert &message_handler,
   transition_systemt &transition_system)
 {
   try
   {
-    auto identifier = verilog_module_symbol(top_level_module);
+    auto identifier = verilog_module_symbol(verilog_root_module_name());
     auto symbol_it = transition_system.symbol_table.symbols.find(identifier);
     CHECK_RETURN(symbol_it != transition_system.symbol_table.symbols.end());
     transition_system.main_symbol = &symbol_it->second;
@@ -461,13 +535,24 @@ std::optional<transition_systemt> verilog_ebmc_languaget::transition_system()
   auto transition_system =
     typecheck(parse_trees, top_level_module, std::move(symbol_table));
 
+  // Create the $root module instance and synthesize it
+  const bool ignore_initial = cmdline.isset("ignore-initial");
+  const bool initial_zero = cmdline.isset("initial-zero");
+  create_root_module(
+    top_level_module,
+    parse_trees.front().standard,
+    ignore_initial,
+    initial_zero,
+    transition_system.symbol_table,
+    message_handler);
+
   if(cmdline.isset("show-symbol-table"))
   {
     std::cout << transition_system.symbol_table;
     return {};
   }
 
-  if(get_main(top_level_module, message_handler, transition_system))
+  if(get_main(message_handler, transition_system))
     throw ebmc_errort{}.with_exit_code(1);
 
   if(cmdline.isset("show-module-hierarchy"))

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -1729,7 +1729,13 @@ void verilog_synthesist::expand_module_instance(
       std::string full_identifier =
         id2string(instance.identifier()) + identifier_without_module;
 
-      new_symbol.pretty_name=strip_verilog_prefix(full_identifier);
+      // We special-case the pretty name for identifiers under $root:
+      // it is customary to use the name of the module only as root
+      // of the hierarchical identifier.
+      new_symbol.pretty_name =
+        module == verilog_module_symbol(verilog_root_module_name())
+          ? symbol.pretty_name
+          : strip_verilog_prefix(full_identifier);
       new_symbol.name=full_identifier;
 
       if(symbol_table.add(new_symbol))

--- a/src/verilog/verilog_typecheck_base.cpp
+++ b/src/verilog/verilog_typecheck_base.cpp
@@ -17,6 +17,12 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "verilog_bits.h"
 #include "verilog_types.h"
 
+irep_idt verilog_root_module_name()
+{
+  const static irep_idt name = "$root";
+  return name;
+}
+
 /*******************************************************************\
 
 Function: verilog_module_symbol

--- a/src/verilog/verilog_typecheck_base.h
+++ b/src/verilog/verilog_typecheck_base.h
@@ -16,6 +16,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "verilog_standard.h"
 
+irep_idt verilog_root_module_name(); // $root
+
 irep_idt verilog_module_symbol(const irep_idt &base_name);
 irep_idt verilog_package_identifier(const irep_idt &base_name);
 irep_idt verilog_package_identifier(


### PR DESCRIPTION
Create a $root module instance that contains an instance of the top-level module, per IEEE 1800-2017.

## Changes

- **$root module creation**: After typechecking the top-level module, a synthetic $root module is created with a `verilog_instt` that instantiates the top-level module. `verilog_synthesis` expands this, copying all symbols into $root's namespace.

- **main_symbol points to $root**: The transition system's `main_symbol` now points to `Verilog::$root`. The $root module's type is copied from the top-level module (including ports).

- **Display**: Pretty names and the expression printer strip the $root prefix since it is implicit in SystemVerilog. Internal identifiers retain $root for correct lookups.

- **Regression tests**: Updated test descriptors to reflect $root in hierarchy display, identifiers, and variable map output.