### PR TITLE
New IC3/PDR engine

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 * Verilog: procedural assignments to hierarchical identifiers
 * SystemVerilog: ports for sequence and property declarations
+* Refreshed IC3 engine --new-ic3
 
 # EBMC 6.0
 

--- a/benchmarking/compare4way.sh
+++ b/benchmarking/compare4way.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# 4-way comparison: ebmc --ic3, ebmc --new-ic3, rIC3, pono
+# on HWMCC08 benchmarks (SMV translations for ebmc/pono, AIGER for rIC3).
+#
+# Usage: compare4way.sh <timeout-seconds> <benchmark>...
+# Output: CSV lines  benchmark,tool,seconds,result
+#
+# Environment:
+#   EBMC          path to ebmc         (default: ../src/ebmc/ebmc)
+#   RIC3          path to rIC3        (default: ric3 in PATH)
+#   PONO          path to pono        (default: pono in PATH)
+#   PONO_SMV_DIR  directory with INVARSPEC-converted SMV files; pono does
+#                 not parse "SPEC AG p". Convert with:
+#                 sed 's/^SPEC AG \(.*\) --.*$/INVARSPEC \1;/'
+EBMC=${EBMC:-../src/ebmc/ebmc}
+RIC3=${RIC3:-ric3}
+PONO=${PONO:-pono}
+PONO_SMV_DIR=${PONO_SMV_DIR:-/tmp/pono-smv}
+TIMEOUT=$1
+shift
+
+run_one() {
+  # $1 = tool name, rest = command
+  tool=$1; shift
+  start=`perl -MTime::HiRes=time -e 'printf "%.3f", time'`
+  out=`perl -e 'alarm shift @ARGV; exec @ARGV' $TIMEOUT "$@" 2>&1`
+  status=$?
+  end=`perl -MTime::HiRes=time -e 'printf "%.3f", time'`
+  t=`echo "$end $start" | awk '{printf "%.2f", $1-$2}'`
+  case $tool in
+    ebmc-*)
+      if [ $status = 142 ]; then res=timeout; t=""
+      elif echo "$out" | grep -q "PROVED"; then res=proved
+      elif echo "$out" | grep -q "REFUTED"; then res=refuted
+      else res="error"; t=""
+      fi;;
+    ric3)
+      # rIC3: prints UNSAT (safe) / SAT (unsafe)
+      if [ $status = 142 ]; then res=timeout; t=""
+      elif echo "$out" | grep -qx "UNSAT"; then res=proved
+      elif echo "$out" | grep -qx "SAT"; then res=refuted
+      else res="error"; t=""
+      fi;;
+    pono)
+      # pono: prints unsat (safe) / sat (unsafe)
+      if [ $status = 142 ]; then res=timeout; t=""
+      elif echo "$out" | grep -q "^unsat"; then res=proved
+      elif echo "$out" | grep -q "^sat"; then res=refuted
+      else res="unknown"; t=""
+      fi;;
+  esac
+  echo "$b,$tool,$t,$res"
+}
+
+for b in "$@"; do
+  smv=hwmcc08public-smv/$b.smv
+  aig=hwmcc08/$b.aig
+  [ -e "$smv" ] || { echo "$b,,,missing"; continue; }
+  run_one ebmc-ic3 $EBMC "$smv" --ic3
+  run_one ebmc-new-ic3 $EBMC "$smv" --new-ic3
+  [ -e "$aig" ] && command -v "$RIC3" >/dev/null 2>&1 && \
+    run_one ric3 $RIC3 check "$aig" ic3
+  # pono needs INVARSPEC instead of SPEC AG (converted copies)
+  command -v "$PONO" >/dev/null 2>&1 && [ -e "$PONO_SMV_DIR/$b.smv" ] && \
+    run_one pono $PONO -e ic3bits -k 10000 "$PONO_SMV_DIR/$b.smv"
+done

--- a/benchmarking/compare_ic3.sh
+++ b/benchmarking/compare_ic3.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Compare old --ic3 vs new --new-ic3 on hwmcc08public-smv benchmarks.
+# Usage: compare_ic3.sh <timeout-seconds> <benchmark>...
+EBMC=${EBMC:-../src/ebmc/ebmc}
+TIMEOUT=$1
+shift
+printf "%-28s %10s %10s %8s %8s\n" benchmark old new old_res new_res
+for b in "$@"; do
+  f=hwmcc08public-smv/$b.smv
+  [ -e "$f" ] || { echo "$b: missing"; continue; }
+  for engine in ic3 new-ic3; do
+    start=`perl -MTime::HiRes=time -e 'printf "%.3f", time'`
+    out=`perl -e 'alarm shift @ARGV; exec @ARGV' $TIMEOUT $EBMC "$f" --$engine 2>&1`
+    status=$?
+    end=`perl -MTime::HiRes=time -e 'printf "%.3f", time'`
+    t=`echo "$end $start" | awk '{printf "%.2f", $1-$2}'`
+    if [ $status = 124 ] || [ $status = 142 ]; then res=TIMEOUT; t="-"
+    elif echo "$out" | grep -q "PROVED"; then res=proved
+    elif echo "$out" | grep -q "REFUTED"; then res=refuted
+    else res="err($status)"
+    fi
+    if [ "$engine" = ic3 ]; then old_t=$t; old_r=$res; else new_t=$t; new_r=$res; fi
+  done
+  printf "%-28s %10s %10s %8s %8s\n" "$b" "$old_t" "$new_t" "$old_r" "$new_r"
+done

--- a/benchmarking/validate_new_ic3.sh
+++ b/benchmarking/validate_new_ic3.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Validate --new-ic3 verdicts against expected results in hwmcc08results.csv
+# (column 3, abc's verdict: "uns" = proved, "sat" = refuted).
+# Usage: validate_new_ic3.sh <timeout-seconds> <benchmark>...
+EBMC=${EBMC:-../src/ebmc/ebmc}
+TIMEOUT=$1
+shift
+mismatches=0
+for b in "$@"; do
+  f=hwmcc08public-smv/$b.smv
+  [ -e "$f" ] || continue
+  expected=`grep "^\"$b\"," hwmcc08results.csv | cut -d ',' -f 3 | tr -d '"'`
+  [ "$expected" = uns ] || [ "$expected" = sat ] || continue
+  out=`perl -e 'alarm shift @ARGV; exec @ARGV' $TIMEOUT $EBMC "$f" --new-ic3 2>&1`
+  if echo "$out" | grep -q "PROVED"; then got=uns
+  elif echo "$out" | grep -q "REFUTED"; then got=sat
+  else got=timeout
+  fi
+  if [ "$got" = timeout ]; then
+    echo "$b: timeout (expected $expected)"
+  elif [ "$got" != "$expected" ]; then
+    echo "$b: MISMATCH got $got expected $expected"
+    mismatches=$((mismatches+1))
+  else
+    echo "$b: ok ($got)"
+  fi
+done
+echo "mismatches: $mismatches"

--- a/regression/ebmc/new-ic3/cover1.desc
+++ b/regression/ebmc/new-ic3/cover1.desc
@@ -1,0 +1,8 @@
+CORE
+cover1.sv
+--new-ic3 --top main
+^\[main\.p0\] cover main\.cnt == 5: PROVED$
+^\[main\.p1\] cover main\.cnt == 8: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/ebmc/new-ic3/cover1.sv
+++ b/regression/ebmc/new-ic3/cover1.sv
@@ -1,0 +1,15 @@
+module main(input clk);
+
+  reg [3:0] cnt = 0;
+
+  always @(posedge clk)
+    if(cnt != 5)
+      cnt = cnt + 1;
+
+  // reachable
+  p0: cover property (cnt == 5);
+
+  // unreachable
+  p1: cover property (cnt == 8);
+
+endmodule

--- a/regression/ebmc/new-ic3/not_supported1.desc
+++ b/regression/ebmc/new-ic3/not_supported1.desc
@@ -1,0 +1,7 @@
+CORE
+not_supported1.sv
+--new-ic3
+^\[main\.p0\] always s_eventually main\.my_bit: FAILURE: property not supported by new IC3 engine$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/ebmc/new-ic3/not_supported1.sv
+++ b/regression/ebmc/new-ic3/not_supported1.sv
@@ -1,0 +1,1 @@
+../ic3/not_supported1.sv

--- a/regression/ebmc/new-ic3/proved1.desc
+++ b/regression/ebmc/new-ic3/proved1.desc
@@ -1,0 +1,7 @@
+CORE
+proved1.sv
+--new-ic3 --property main.p0
+^\[main\.p0\] always main\.s11: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/new-ic3/proved1.sv
+++ b/regression/ebmc/new-ic3/proved1.sv
@@ -1,0 +1,25 @@
+module main(input clk, s3, output out);
+
+  wire   s5=  s4 | s3;
+  wire   s6= ~s4 |~s3;
+  wire   s9= ~s8 |~s7;
+  wire   s10= s9 |~s3;
+  wire   s11=(~s6 | s10)&( s6 |~s10);
+
+  reg    s4;
+  reg    s7;
+  reg    s8;
+
+  initial s4=0;
+  initial s7=0;
+  initial s8=0;
+
+  always @ (posedge clk) s4 <= ~s5;
+  always @ (posedge clk) s7 <= ~s3;
+  always @ (posedge clk) s8 <= s9;
+  assign out=s11;
+
+  // not inductive for any k
+  p0: assert property (s11);
+
+endmodule

--- a/regression/ebmc/new-ic3/refuted1.desc
+++ b/regression/ebmc/new-ic3/refuted1.desc
@@ -1,0 +1,8 @@
+CORE
+refuted1.sv
+--new-ic3 --top main
+^Property refuted$
+^\[main\.p0\] always main\.cnt != 3: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/ebmc/new-ic3/refuted1.sv
+++ b/regression/ebmc/new-ic3/refuted1.sv
@@ -1,0 +1,6 @@
+module main(input clk);
+  reg [1:0] cnt;
+  initial cnt = 0;
+  always @(posedge clk) cnt <= cnt + 1;
+  p0: assert property (@(posedge clk) cnt != 3);
+endmodule

--- a/regression/ebmc/new-ic3/refuted_initial.desc
+++ b/regression/ebmc/new-ic3/refuted_initial.desc
@@ -1,0 +1,8 @@
+CORE
+refuted_initial.sv
+--new-ic3 --top main
+^Property violated in initial state$
+^\[main\.p0\] always main\.x == 1: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/ebmc/new-ic3/refuted_initial.sv
+++ b/regression/ebmc/new-ic3/refuted_initial.sv
@@ -1,0 +1,6 @@
+module main(input clk);
+  reg x;
+  initial x = 0;
+  always @(posedge clk) x <= 1;
+  p0: assert property (@(posedge clk) x == 1);
+endmodule

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 DIRS = ebmc hw-cbmc temporal-logic trans-word-level trans-netlist \
-       verilog vhdl smvlang ic3 aiger btor vlindex
+       verilog vhdl smvlang ic3 aiger btor vlindex new-ic3
 
 CPROVER_DIR:=../lib/cbmc/src
 
@@ -18,7 +18,7 @@ ebmc.dir: trans-word-level.dir trans-netlist.dir verilog.dir vhdl.dir \
       smvlang.dir aiger.dir btor.dir temporal-logic.dir cprover.dir
 
 ifneq ($(BUILD_ENV),MSVC)
-ebmc.dir: ic3.dir
+ebmc.dir: ic3.dir new-ic3.dir
 endif
 
 hw-cbmc.dir: ebmc.dir trans-word-level.dir trans-netlist.dir verilog.dir \

--- a/src/ebmc/Makefile
+++ b/src/ebmc/Makefile
@@ -60,6 +60,7 @@ OBJ+= $(CPROVER_DIR)/util/util$(LIBEXT) \
       ../verilog/verilog$(LIBEXT)
 
 ifneq ($(BUILD_ENV),MSVC)
+OBJ += ../new-ic3/new-ic3$(LIBEXT)
 OBJ += ../ic3/libic3$(LIBEXT)
 OBJ += ../ic3/minisat/build/release/lib/libminisat.a
 endif

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -421,6 +421,7 @@ void ebmc_parse_optionst::help()
     "    {y--constr}                 \t use constraints specified in 'file.cnstr'\n"
     "    {y--new-mode}               \t new mode is switched on\n"
     "    {y--aiger}                  \t print out the instance in aiger format\n"
+    " {y--new-ic3}                   \t use new IC3 engine (AIG-based)\n"
     " {y--random-traces}             \t generate random traces\n"
     "    {y--traces} {unumber}       \t generate the given number of traces\n"
     "    {y--random-seed} {unumber}  \t use the given random seed\n"

--- a/src/ebmc/ebmc_parse_options.h
+++ b/src/ebmc/ebmc_parse_options.h
@@ -38,7 +38,7 @@ public:
         "(reset):(ignore-initial)(initial-zero)"
         "(version)(verilog-rtl)(verilog-netlist)"
         "(compute-interpolant)(interpolation)(interpolation-vmcai)"
-        "(ic3)(property):(constr)(h)(new-mode)(aiger)"
+        "(ic3)(new-ic3)(property):(constr)(h)(new-mode)(aiger)"
         "(interpolation-word)(interpolator):(bdd)"
         "(ranking-function):"
         "(smt2)(bitwuzla)(boolector)(cvc3)(cvc4)(cvc5)(mathsat)(yices)(z3)"

--- a/src/ebmc/property_checker.cpp
+++ b/src/ebmc/property_checker.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <util/output_file.h>
 #include <util/string2int.h>
 
+#include <new-ic3/new_ic3_engine.h>
 #include <solvers/sat/satcheck.h>
 #include <trans-netlist/trans_trace_netlist.h>
 #include <trans-netlist/unwind_netlist.h>
@@ -368,9 +369,10 @@ property_checker_resultt property_checker(
   ebmc_propertiest &properties,
   message_handlert &message_handler)
 {
-  bool use_heuristic_engine = !cmdline.isset("bdd") && !cmdline.isset("aig") &&
-                              !cmdline.isset("k-induction") &&
-                              !cmdline.isset("ic3") && !cmdline.isset("bound");
+  bool use_heuristic_engine =
+    !cmdline.isset("bdd") && !cmdline.isset("aig") &&
+    !cmdline.isset("k-induction") && !cmdline.isset("ic3") &&
+    !cmdline.isset("new-ic3") && !cmdline.isset("bound");
 
   if(cmdline.isset("k-induction") || use_heuristic_engine)
   {
@@ -402,6 +404,15 @@ property_checker_resultt property_checker(
       throw ebmc_errort() << "No support for IC3 on Windows";
 #else
       return ic3_engine(
+        cmdline, transition_system, properties, message_handler);
+#endif
+    }
+    else if(cmdline.isset("new-ic3"))
+    {
+#ifdef _WIN32
+      throw ebmc_errort() << "No support for new IC3 on Windows";
+#else
+      return new_ic3_engine(
         cmdline, transition_system, properties, message_handler);
 #endif
     }

--- a/src/new-ic3/Makefile
+++ b/src/new-ic3/Makefile
@@ -1,0 +1,16 @@
+SRC = ic3_solver.cpp \
+      new_ic3_engine.cpp \
+      #empty line
+
+include ../config.inc
+include ../common
+
+CXXFLAGS += -I ../ic3/minisat
+
+all: new-ic3$(LIBEXT)
+
+clean:
+	$(RM) *.o *.d new-ic3$(LIBEXT)
+
+new-ic3$(LIBEXT): $(OBJ)
+	$(LINKLIB)

--- a/src/new-ic3/PERFORMANCE.md
+++ b/src/new-ic3/PERFORMANCE.md
@@ -1,0 +1,117 @@
+# Performance
+
+Comparison of the new IC3 engine (`--new-ic3`) against the in-tree
+bit-level IC3 engine (`--ic3`, src/ic3), [rIC3](https://github.com/gipsyh/rIC3)
+and [Pono](https://github.com/stanford-centaur/pono).
+
+## Setup
+
+* Machine: Apple M2 Max, 64 GB RAM, macOS 26.5
+* Timeout: 60 seconds per benchmark and tool; wall-clock time in seconds,
+  including front-end
+* Benchmarks: 49-benchmark sample of HWMCC08 (every 12th benchmark of the
+  585 SMV translations in `benchmarking/hwmcc08public-smv/`,
+  in alphabetical order)
+* Tools and configurations:
+  * ebmc `--ic3` (built from this PR's sources) on the SMV translations.
+    Note: this engine only accepts `sva_always` properties; for these runs
+    `ic3_supports_property` in `src/ic3/m1ain.cc` was locally extended to
+    accept `AG`/`G` (see the note in `benchmarking/compare_ic3.sh`).
+  * ebmc `--new-ic3` (built from this PR's sources) on the SMV translations.
+  * rIC3 1.5.2 (`ric3 check <file>.aig ic3`, single-threaded IC3 engine)
+    on the original AIGER files.
+  * Pono e60007f (`pono -e ic3bits -k 10000`, bit-level IC3 with Bitwuzla)
+    on the SMV translations, with `SPEC AG p` rewritten to `INVARSPEC p;`
+    (Pono's SMV front-end does not accept CTL specs).
+
+All verdicts agree across all four tools, and match the expected results
+published for HWMCC08 (`benchmarking/hwmcc08results.csv`; see
+`benchmarking/validate_new_ic3.sh`).
+
+## Summary
+
+| tool | solved (of 49) | timeouts | total time on solved | fastest solver |
+|---|---:|---:|---:|---:|
+| ebmc `--ic3` | 45 | 4 | 220.0 s | 5 |
+| ebmc `--new-ic3` | 43 | 6 | 99.2 s | 20 |
+| rIC3 | 48 | 1 | 41.1 s | 35 |
+| Pono (ic3bits) | 34 | 15 | 243.8 s | 1 |
+
+Head-to-head of the two ebmc engines: 42 benchmarks are solved by both;
+the new engine is faster on 27 of them. The new engine uniquely solves
+139462p24; the old engine uniquely solves 139453p22, bc57sensorsp2 and
+prodcellp2 — all three are refutations with deep counterexamples, which
+is the main remaining weakness of the new engine (its per-frame blocking
+effort makes frontier advancement expensive when a counterexample is more
+than ~50 frames deep).
+
+rIC3 remains substantially ahead of both ebmc engines; it is the source
+of several of the techniques used in the new engine.
+
+## Reproducing
+
+    # ebmc engines + rIC3 + Pono, CSV output
+    cd benchmarking
+    ./compare4way.sh 60 <benchmark>...
+
+    # just the two ebmc engines, table output
+    ./compare_ic3.sh 60 <benchmark>...
+
+    # check --new-ic3 verdicts against the published HWMCC08 results
+    ./validate_new_ic3.sh 60 <benchmark>...
+
+## Full results
+
+Times in seconds; t/o = timeout (60 s).
+
+| benchmark | verdict | ebmc `--ic3` | ebmc `--new-ic3` | rIC3 | Pono |
+|---|---|---:|---:|---:|---:|
+| 139442p0 | proved | 0.10 | 0.07 | 0.07 | 2.22 |
+| 139443p0neg | refuted | 0.94 | 1.65 | 0.21 | 8.59 |
+| 139444p1 | refuted | 1.63 | 1.66 | 0.30 | 20.23 |
+| 139452p1neg | refuted | 1.42 | 0.76 | 0.22 | 10.11 |
+| 139453p22 | refuted | 36.62 | t/o | 0.46 | t/o |
+| 139454p23 | refuted | t/o | t/o | 1.40 | t/o |
+| 139462p24 | refuted | t/o | 12.83 | 1.01 | t/o |
+| 139463p5 | refuted | 4.65 | 4.58 | 0.68 | 45.19 |
+| 139464p5neg | refuted | 7.32 | 7.30 | 1.25 | t/o |
+| bc57sensorsp2 | refuted | 58.67 | t/o | 17.08 | t/o |
+| bj08amba2g82 | proved | 0.04 | 0.03 | 0.04 | 0.10 |
+| bj08aut5 | proved | 0.02 | 0.02 | 0.02 | 0.03 |
+| bj08vsar6 | refuted | 0.06 | 0.04 | 0.04 | 0.05 |
+| brpp1neg | refuted | 0.06 | 0.05 | 0.06 | 0.56 |
+| csmacdp2 | refuted | 58.24 | 1.26 | 0.23 | t/o |
+| dme5p1 | refuted | 0.12 | 0.05 | 0.07 | 0.45 |
+| eijkbs3330 | proved | 5.89 | 20.64 | 0.91 | t/o |
+| eijkS349 | proved | 0.37 | 0.39 | 0.20 | t/o |
+| eijkS838 | proved | t/o | t/o | 0.95 | t/o |
+| kenflashp08 | proved | 0.06 | 0.03 | 0.04 | 0.04 |
+| neclaftp1001 | proved | 3.44 | 13.17 | 5.15 | t/o |
+| nusmvbrp | proved | 0.90 | 1.45 | 0.21 | t/o |
+| nusmvreactorp1 | proved | 0.04 | 0.03 | 0.02 | 0.03 |
+| nusmvtcasp5 | refuted | 9.25 | 22.66 | 1.94 | t/o |
+| pciptimoneg | refuted | 0.07 | 0.05 | 0.06 | 0.29 |
+| pdtpmsmiim | proved | 1.22 | 1.27 | 0.06 | 8.95 |
+| pdtpmsusbphy | proved | 0.03 | 0.03 | 0.04 | 0.04 |
+| pdtvisblackjack3 | proved | 0.21 | 0.59 | 0.07 | 27.35 |
+| pdtviseisenberg1 | proved | 0.81 | 0.32 | 0.12 | 45.76 |
+| pdtvisgray0 | proved | 0.01 | 0.01 | 0.02 | 0.02 |
+| pdtvisheap10 | proved | 0.04 | 0.03 | 0.03 | 0.04 |
+| pdtvismiim1 | proved | 0.03 | 0.02 | 0.02 | 0.09 |
+| pdtvisminmaxr3 | proved | 0.02 | 0.02 | 0.04 | 0.03 |
+| pdtvisns3p02 | proved | 5.91 | 6.50 | 0.37 | t/o |
+| pdtvisns3p14 | proved | 0.09 | 0.05 | 0.11 | 0.09 |
+| pdtvisrethersqo0 | proved | 0.03 | 0.02 | 0.03 | 0.03 |
+| pdtvistictactoe03 | refuted | 0.03 | 0.02 | 0.05 | 0.04 |
+| pdtvistimeout1 | proved | 0.04 | 0.03 | 0.04 | 0.04 |
+| pdtvisvending03 | proved | 0.04 | 0.03 | 0.03 | 0.03 |
+| pdtvisvsa16a04 | proved | 0.25 | 0.29 | 0.08 | 0.77 |
+| pdtvisvsa16a16 | proved | 0.13 | 0.07 | 0.02 | 0.09 |
+| pdtvisvsa16a29 | ? | t/o | t/o | t/o | t/o |
+| pdtvisvsar10 | proved | 0.53 | 0.33 | 0.07 | 34.95 |
+| pdtvisvsar22 | proved | 0.06 | 0.04 | 0.04 | 0.05 |
+| prodcellp2 | refuted | 18.16 | t/o | 6.97 | t/o |
+| prodconspold1 | refuted | 2.03 | 0.53 | 0.16 | 36.09 |
+| texasifetch1p3 | proved | 0.03 | 0.02 | 0.02 | 0.03 |
+| texasPImainp12 | proved | 0.20 | 0.13 | 0.05 | 0.70 |
+| viseisenberg | refuted | 0.17 | 0.09 | 0.04 | 0.71 |

--- a/src/new-ic3/ic3_solver.cpp
+++ b/src/new-ic3/ic3_solver.cpp
@@ -1,0 +1,852 @@
+/*******************************************************************\
+
+Module: IC3 Solver
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+/// \file
+/// Per-frame SAT solver infrastructure for IC3/PDR, operating on
+/// the netlist (AIG) encoding of the transition system.
+
+#include "ic3_solver.h"
+
+#include <util/invariant.h>
+
+#include <ic3/minisat/minisat/core/Solver.h>
+#include <solvers/sat/cnf_clause_list.h>
+#include <solvers/sat/satcheck.h>
+#include <trans-netlist/bmc_map.h>
+#include <trans-netlist/unwind_netlist.h>
+
+#include <algorithm>
+#include <chrono>
+#include <queue>
+#include <unordered_set>
+
+/// A cnf_clause_listt that can be instantiated (provides missing virtuals).
+class recording_cnft : public cnf_clause_listt
+{
+public:
+  explicit recording_cnft(message_handlert &mh) : cnf_clause_listt(mh)
+  {
+  }
+  bool is_in_conflict(literalt) const override
+  {
+    return false;
+  }
+  void set_assignment(literalt, bool) override
+  {
+  }
+};
+
+/// A frame clause: literals sorted by literal code, plus a Bloom-style
+/// signature for constant-time subsumption rejection.
+struct ic3_solvert::frame_clauset
+{
+  clauset clause; // sorted by literalt::get()
+  // Bloom signature: each literal sets bit (lit_code & 63). 64 bits
+  // matches the register width on x86-64, giving a single-instruction
+  // shift and a cheap early-reject in subsumes().
+  uint64_t sig;
+
+  explicit frame_clauset(clauset c) : clause(std::move(c))
+  {
+    std::sort(
+      clause.begin(),
+      clause.end(),
+      [](literalt a, literalt b) { return a.get() < b.get(); });
+    sig = 0;
+    for(auto l : clause)
+      sig |= uint64_t(1) << (l.get() & 63);
+  }
+
+  bool operator==(const frame_clauset &other) const
+  {
+    return clause == other.clause;
+  }
+};
+
+clauset negate_cube(const cubet &cube)
+{
+  clauset clause;
+  clause.reserve(cube.size());
+  for(auto l : cube)
+    clause.push_back(!l);
+  return clause;
+}
+
+/// Check if clause a subsumes clause b (a ⊆ b as literal sets).
+/// Both literal vectors must be sorted by literal code.
+bool ic3_solvert::subsumes(
+  const ic3_solvert::frame_clauset &a,
+  const ic3_solvert::frame_clauset &b)
+{
+  if(a.clause.size() > b.clause.size())
+    return false;
+  if((a.sig & ~b.sig) != 0)
+    return false;
+  return std::includes(
+    b.clause.begin(),
+    b.clause.end(),
+    a.clause.begin(),
+    a.clause.end(),
+    [](literalt x, literalt y) { return x.get() < y.get(); });
+}
+
+/// Translate a (non-constant) CBMC literal to an IC3-MiniSAT literal.
+static inline IctMinisat::Lit to_minisat(literalt l)
+{
+  return IctMinisat::mkLit(l.var_no(), l.sign());
+}
+
+/// Add a clause of CBMC literals to an IC3-MiniSAT solver.
+/// Tautologies are skipped; false literals are dropped.
+static void add_minisat_clause(IctMinisat::Solver &S, const bvt &clause)
+{
+  IctMinisat::vec<IctMinisat::Lit> mc;
+  for(auto l : clause)
+  {
+    if(l.is_true())
+      return;
+    if(!l.is_false())
+      mc.push(to_minisat(l));
+  }
+  S.addClause(mc);
+}
+
+// ============================================================
+// ic3_solvert implementation
+// ============================================================
+
+ic3_solvert::ic3_solvert(
+  netlistt netlist,
+  literalt prop_netlist_lit,
+  message_handlert &message_handler)
+  : message_handler(message_handler)
+{
+  // Encode the netlist into CNF: one timeframe only — the next-state
+  // functions are nodes in the same variable space.
+  base_cnf = std::make_unique<recording_cnft>(solver_message_handler);
+  bmc_mapt bmc_map(netlist, 1, *base_cnf);
+  {
+    messaget message{solver_message_handler};
+    ::unwind(netlist, bmc_map, message, *base_cnf, false, 0);
+  }
+
+  prop_current = bmc_map.translate(0, prop_netlist_lit);
+
+  // The initial state constraint, as unit clauses.
+  for(auto n : netlist.initial)
+  {
+    literalt l = bmc_map.translate(0, n);
+    if(!l.is_true())
+      init_units.push_back(l);
+  }
+
+  // Collect latch and input literals.
+  for(auto v_it : netlist.var_map.sorted())
+  {
+    const var_mapt::vart &var = v_it->second;
+    if(var.is_latch())
+    {
+      for(const auto &bit : var.bits)
+      {
+        literalt current = bmc_map.translate(0, bit.current);
+        if(current.is_constant())
+          continue;
+        literalt next = bmc_map.translate(0, bit.next);
+        current_to_latch[current.var_no()] = latches.size();
+        latches.push_back({current, next});
+      }
+    }
+    else if(var.is_input() || var.is_nondet())
+    {
+      for(const auto &bit : var.bits)
+      {
+        literalt current = bmc_map.translate(0, bit.current);
+        if(!current.is_constant())
+          input_lits.push_back(current);
+      }
+    }
+  }
+
+  lit_activity.resize(latches.size(), 0.0f);
+
+  // Create the initial state solver.
+  init_solver =
+    std::make_unique<satcheck_no_simplifiert>(solver_message_handler);
+  replay_base_cnf(*init_solver, true);
+
+  // Create lifting solver using IC3's MiniSAT (has releaseVar).
+  lift_minisat = new_minisat_solver();
+
+  // Determine which latches have forced initial values. If all are
+  // forced, the initial state is unique and intersection checks
+  // become purely syntactic.
+  init_values.resize(latches.size(), tvt::unknown());
+  if(init_solver->prop_solve(bvt{}) == propt::resultt::P_SATISFIABLE)
+  {
+    std::vector<bool> model(latches.size());
+    for(std::size_t i = 0; i < latches.size(); i++)
+      model[i] = init_solver->l_get(latches[i].current).is_true();
+
+    init_is_unique_state = true;
+    for(std::size_t i = 0; i < latches.size(); i++)
+    {
+      bvt assumption = {model[i] ? !latches[i].current : latches[i].current};
+      if(init_solver->prop_solve(assumption) == propt::resultt::P_UNSATISFIABLE)
+      {
+        init_values[i] = tvt(model[i]);
+      }
+      else
+        init_is_unique_state = false;
+    }
+  }
+
+  // F_0
+  frame_clauses.emplace_back();
+
+  messaget message{message_handler};
+  message.statistics() << "IC3: " << latches.size() << " latches, "
+                       << base_cnf->no_variables() << " variables, "
+                       << base_cnf->no_clauses() << " clauses" << messaget::eom;
+}
+
+ic3_solvert::~ic3_solvert() = default;
+
+std::size_t ic3_solvert::number_of_frames() const
+{
+  return frame_clauses.size();
+}
+
+std::size_t ic3_solvert::total_clauses() const
+{
+  std::size_t n = 0;
+  for(const auto &f : frame_clauses)
+    n += f.size();
+  return n;
+}
+
+double ic3_solvert::average_clause_size() const
+{
+  std::size_t n = 0, lits = 0;
+  for(const auto &f : frame_clauses)
+    for(const auto &c : f)
+    {
+      n++;
+      lits += c.clause.size();
+    }
+  return n == 0 ? 0.0 : double(lits) / double(n);
+}
+
+void ic3_solvert::replay_base_cnf(cnft &dest, bool with_init)
+{
+  dest.set_no_variables(base_cnf->no_variables());
+  for(const auto &clause : base_cnf->get_clauses())
+    dest.lcnf(clause);
+  if(with_init)
+    for(auto l : init_units)
+      dest.lcnf({l});
+}
+
+literalt ic3_solvert::to_next(literalt l) const
+{
+  auto it = current_to_latch.find(l.var_no());
+  PRECONDITION(it != current_to_latch.end());
+  const auto &latch = latches[it->second];
+  // l might be positive or negative relative to latch.current
+  return latch.next ^ (l.sign() != latch.current.sign());
+}
+
+cubet ic3_solvert::extract_state(const IctMinisat::Solver &S)
+{
+  cubet cube;
+  cube.reserve(latches.size());
+  for(const auto &latch : latches)
+  {
+    auto val = S.modelValue(to_minisat(latch.current));
+    if(val == IctMinisat::l_True)
+      cube.push_back(latch.current);
+    else if(val == IctMinisat::l_False)
+      cube.push_back(!latch.current);
+    // skip don't-care (unknown) bits — smaller cubes
+  }
+  return cube;
+}
+
+void ic3_solvert::new_frame()
+{
+  frame_clauses.emplace_back();
+}
+
+std::unique_ptr<IctMinisat::Solver> ic3_solvert::new_minisat_solver()
+{
+  auto S = std::make_unique<IctMinisat::Solver>();
+  auto nv = base_cnf->no_variables();
+  while(S->nVars() < (int)nv)
+    S->newVar();
+  for(const auto &clause : base_cnf->get_clauses())
+    add_minisat_clause(*S, clause);
+  return S;
+}
+
+IctMinisat::Solver &ic3_solvert::get_solver(std::size_t level)
+{
+  while(frame_solvers.size() <= level)
+    frame_solvers.emplace_back();
+  auto &fs = frame_solvers[level];
+  if(!fs)
+  {
+    fs = new_minisat_solver();
+    if(level == 0)
+      for(auto l : init_units)
+        add_minisat_clause(*fs, {l});
+    for(std::size_t j = level; j < frame_clauses.size(); j++)
+      for(const auto &cl : frame_clauses[j])
+        add_minisat_clause(*fs, cl.clause);
+  }
+  return *fs;
+}
+
+void ic3_solvert::add_clause(std::size_t level, const clauset &clause)
+{
+  PRECONDITION(level < frame_clauses.size());
+
+  frame_clauset new_clause(clause);
+
+  // Redundant if subsumed by a clause at the same or a higher level.
+  for(std::size_t j = level; j < frame_clauses.size(); j++)
+    for(const auto &existing : frame_clauses[j])
+      if(subsumes(existing, new_clause))
+        return;
+
+  // Remove clauses the new one subsumes; they are at levels <= level,
+  // where the new clause is active as well. The subsumed clauses stay
+  // in already-built solvers, which is harmless.
+  for(std::size_t j = 0; j <= level; j++)
+  {
+    auto &cls = frame_clauses[j];
+    cls.erase(
+      std::remove_if(
+        cls.begin(),
+        cls.end(),
+        [&](const frame_clauset &c) { return subsumes(new_clause, c); }),
+      cls.end());
+  }
+
+  for(std::size_t i = 0; i <= level && i < frame_solvers.size(); i++)
+    if(frame_solvers[i])
+      add_minisat_clause(*frame_solvers[i], new_clause.clause);
+
+  frame_clauses[level].push_back(std::move(new_clause));
+  num_clauses_added++;
+}
+
+bool ic3_solvert::is_blocked(const cubet &cube, std::size_t level)
+{
+  // The cube is blocked iff some frame clause subsumes its negation.
+  frame_clauset negated(negate_cube(cube));
+
+  for(std::size_t j = level; j < frame_clauses.size(); j++)
+    for(const auto &clause : frame_clauses[j])
+      if(subsumes(clause, negated))
+        return true;
+
+  return false;
+}
+
+bool ic3_solvert::initial_state_is_bad()
+{
+  bvt assumptions = {!prop_current};
+  return init_solver->prop_solve(assumptions) == propt::resultt::P_SATISFIABLE;
+}
+
+bool ic3_solvert::init_intersects(const cubet &cube)
+{
+  // Syntactic check against forced initial values first.
+  bool all_bits_known = init_is_unique_state;
+
+  for(auto l : cube)
+  {
+    auto it = current_to_latch.find(l.var_no());
+    if(it == current_to_latch.end())
+    {
+      all_bits_known = false;
+      continue;
+    }
+    tvt v = init_values[it->second];
+    if(v.is_unknown())
+    {
+      all_bits_known = false;
+      continue;
+    }
+    const auto &latch = latches[it->second];
+    bool asserts_true = l.sign() == latch.current.sign();
+    if(v.is_true() != asserts_true)
+      return false; // contradicts the forced initial value
+  }
+
+  if(all_bits_known)
+    return true; // consistent with the unique initial state
+
+  // Fall back to the initial-state solver.
+  return init_solver->prop_solve(cube) == propt::resultt::P_SATISFIABLE;
+}
+
+void ic3_solvert::repair_init(const cubet &cube, cubet &reduced)
+{
+  if(!init_intersects(reduced))
+    return;
+
+  std::unordered_set<unsigned> in_reduced;
+  for(auto l : reduced)
+    in_reduced.insert(l.get());
+
+  for(auto l : cube)
+  {
+    if(in_reduced.find(l.get()) != in_reduced.end())
+      continue;
+    reduced.push_back(l);
+    if(!init_intersects(reduced))
+      return;
+  }
+
+  // cube itself is disjoint from init, so we must have returned above
+  UNREACHABLE;
+}
+
+cubet ic3_solvert::lift(
+  const IctMinisat::Solver &query_solver,
+  const cubet &full_state,
+  const bvt &target_clause)
+{
+  auto &S = *lift_minisat;
+  using namespace IctMinisat;
+
+  // A tautological target cannot be lifted against.
+  for(auto l : target_clause)
+    if(l.is_true())
+      return full_state;
+
+  // Activation literal for the target clause: act -> target_clause
+  Var act_var = S.newVar();
+  Lit act = mkLit(act_var, false);
+  {
+    vec<Lit> clause;
+    clause.push(~act);
+    for(auto l : target_clause)
+      if(!l.is_false())
+        clause.push(to_minisat(l));
+    S.addClause(clause);
+  }
+
+  // Solve with act + inputs + state as assumptions
+  vec<Lit> assumptions;
+  assumptions.push(act);
+  for(auto l : input_lits)
+  {
+    auto val = query_solver.modelValue(to_minisat(l));
+    if(val == l_True)
+      assumptions.push(to_minisat(l));
+    else if(val == l_False)
+      assumptions.push(to_minisat(!l));
+  }
+  for(auto l : full_state)
+    assumptions.push(to_minisat(l));
+
+  num_lifts++;
+  cubet result;
+  if(!S.solve(assumptions))
+  {
+    // UNSAT — extract minimal state from conflict
+    for(auto l : full_state)
+    {
+      if(S.conflict.has(~to_minisat(l)))
+        result.push_back(l);
+    }
+  }
+
+  // Release activation literal (permanently set ~act, freeing the variable)
+  S.releaseVar(~act);
+
+  return result.empty() ? full_state : result;
+}
+
+bool ic3_solvert::relative_induction(
+  std::size_t level,
+  const cubet &cube,
+  cubet *predecessor,
+  bool lift_predecessor)
+{
+  // A literal with constant-false next-state function makes the cube
+  // trivially unreachable; the solver's conflict would be stale.
+  for(auto l : cube)
+    if(to_next(l).is_false())
+    {
+      core = {l};
+      repair_init(cube, core);
+      return true;
+    }
+
+  auto &S = get_solver(level);
+  using namespace IctMinisat;
+
+  vec<Lit> assumptions;
+  Lit act = lit_Undef;
+
+  if(WITH_NEGATED_CUBE)
+  {
+    // Activation literal for ¬cube at timeframe 0
+    act = mkLit(S.newVar());
+    vec<Lit> act_clause;
+    act_clause.push(~act);
+    for(auto l : cube)
+      act_clause.push(to_minisat(!l));
+    S.addClause(act_clause);
+    assumptions.push(act);
+  }
+
+  for(auto l : cube)
+  {
+    literalt nl = to_next(l);
+    if(!nl.is_true())
+      assumptions.push(to_minisat(nl));
+  }
+
+  num_queries++;
+  bool unsat = !S.solve(assumptions);
+
+  if(unsat)
+  {
+    core.clear();
+    for(auto l : cube)
+    {
+      literalt nl = to_next(l);
+      if(!nl.is_true() && S.conflict.has(~to_minisat(nl)))
+        core.push_back(l);
+    }
+    if(core.empty())
+      core = cube;
+    else
+      repair_init(cube, core);
+  }
+  else if(predecessor != nullptr)
+  {
+    cubet full_state = extract_state(S);
+    if(lift_predecessor)
+    {
+      // act -> ¬cube'
+      bvt target_clause;
+      target_clause.reserve(cube.size());
+      for(auto l : cube)
+        target_clause.push_back(!to_next(l));
+      *predecessor = lift(S, full_state, target_clause);
+    }
+    else
+      *predecessor = std::move(full_state);
+  }
+
+  if(WITH_NEGATED_CUBE)
+  {
+    // Release the activation literal
+    S.releaseVar(~act);
+  }
+
+  return unsat;
+}
+
+std::optional<cubet>
+ic3_solvert::solve_relative(std::size_t level, const cubet &cube)
+{
+  cubet predecessor;
+  if(relative_induction(level, cube, &predecessor, true))
+    return std::nullopt;
+  return predecessor;
+}
+
+std::optional<cubet> ic3_solvert::solve_bad(std::size_t level)
+{
+  if(prop_current.is_true())
+    return std::nullopt;
+
+  auto &S = get_solver(level);
+
+  IctMinisat::vec<IctMinisat::Lit> assumptions;
+  if(!prop_current.is_false())
+    assumptions.push(to_minisat(!prop_current));
+
+  num_queries++;
+  if(S.solve(assumptions))
+  {
+    // Lift against the property: act -> prop
+    return lift(S, extract_state(S), {prop_current});
+  }
+
+  return std::nullopt;
+}
+
+bool ic3_solvert::ctg_down(
+  std::size_t level,
+  cubet &cand,
+  std::size_t &ctg_budget)
+{
+  std::size_t joins = 0;
+
+  while(true)
+  {
+    if(init_intersects(cand))
+      return false;
+
+    cubet predecessor;
+    if(relative_induction(level, cand, &predecessor, false))
+    {
+      cand = core;
+      return true;
+    }
+
+    // Counterexample-to-generalization: try to block the predecessor.
+    // The budget is shared across the enclosing generalize call —
+    // unbounded CTG blocking floods the frames with weak clauses.
+    if(
+      ctg_budget > 0 && level > 0 && !init_intersects(predecessor) &&
+      relative_induction(level, predecessor, nullptr, false))
+    {
+      add_clause(
+        std::min(level + 1, frame_clauses.size() - 1), negate_cube(core));
+      ctg_budget--;
+      continue;
+    }
+
+    // Join cand with the predecessor.
+    if(++joins > JOIN_MAX)
+      return false;
+    std::unordered_set<unsigned> pred_lits;
+    for(auto l : predecessor)
+      pred_lits.insert(l.get());
+
+    cubet joined;
+    joined.reserve(cand.size());
+    for(auto l : cand)
+      if(pred_lits.find(l.get()) != pred_lits.end())
+        joined.push_back(l);
+
+    if(joined.empty() || joined.size() >= cand.size())
+      return false; // no progress
+
+    cand = std::move(joined);
+  }
+}
+
+cubet ic3_solvert::generalize(std::size_t level, cubet cube)
+{
+  std::size_t ctg_budget = CTG_MAX;
+
+  // Sort by activity: drop least-active literals first
+  std::sort(
+    cube.begin(),
+    cube.end(),
+    [&](literalt a, literalt b)
+    {
+      auto ia = current_to_latch.find(a.var_no());
+      auto ib = current_to_latch.find(b.var_no());
+      float aa =
+        (ia != current_to_latch.end()) ? lit_activity[ia->second] : 0.0f;
+      float ab =
+        (ib != current_to_latch.end()) ? lit_activity[ib->second] : 0.0f;
+      return aa < ab;
+    });
+
+  // MIC: try dropping each literal, with ctg_down deciding whether the
+  // remainder is still relatively inductive. On success, ctg_down has
+  // shrunk the candidate further via the unsatisfiable core. Literals
+  // are ordered by activity, so after several consecutive failures the
+  // remaining literals are unlikely to be droppable — give up early.
+  std::size_t i = 0, consecutive_fails = 0;
+  while(cube.size() > 1 && i < cube.size() && consecutive_fails < MIC_FAIL_MAX)
+  {
+    cubet cand;
+    cand.reserve(cube.size() - 1);
+    for(std::size_t j = 0; j < cube.size(); j++)
+      if(j != i)
+        cand.push_back(cube[j]);
+
+    if(ctg_down(level, cand, ctg_budget))
+    {
+      cube = std::move(cand); // retry at the same index
+      consecutive_fails = 0;
+    }
+    else
+    {
+      i++;
+      consecutive_fails++;
+    }
+  }
+
+  // Bump activity for literals that survived generalization
+  for(auto l : cube)
+  {
+    auto it = current_to_latch.find(l.var_no());
+    if(it != current_to_latch.end())
+      lit_activity[it->second] += 1.0f;
+  }
+
+  return cube;
+}
+
+bool ic3_solvert::propagate()
+{
+  for(std::size_t i = 1; i + 1 < frame_clauses.size(); i++)
+  {
+    // The clauses of F_i's delta; a copy, since pushing mutates the frame.
+    auto clauses = frame_clauses[i];
+
+    for(const auto &fc : clauses)
+    {
+      // The clause itself is in the level-i solver already, so the
+      // query F_i ∧ T ∧ cube' needs no activation literal.
+      auto &S = get_solver(i);
+      cubet cube = negate_cube(fc.clause);
+
+      bool trivially_unsat = false;
+      IctMinisat::vec<IctMinisat::Lit> assumptions;
+      for(auto l : cube)
+      {
+        literalt nl = to_next(l);
+        if(nl.is_false())
+        {
+          trivially_unsat = true;
+          break;
+        }
+        if(!nl.is_true())
+          assumptions.push(to_minisat(nl));
+      }
+
+      num_queries++;
+      if(trivially_unsat || !S.solve(assumptions))
+      {
+        // Holds at F_{i+1}: move the delta entry up. The solvers at
+        // levels <= i contain the clause already; only level i+1 needs it.
+        auto &cls = frame_clauses[i];
+        auto it = std::find(cls.begin(), cls.end(), fc);
+        if(it != cls.end())
+          cls.erase(it);
+
+        if(i + 1 < frame_solvers.size() && frame_solvers[i + 1])
+          add_minisat_clause(*frame_solvers[i + 1], fc.clause);
+        frame_clauses[i + 1].push_back(fc);
+      }
+    }
+
+    if(frame_clauses[i].empty())
+      return true; // F_i = F_{i+1}: inductive invariant found
+  }
+
+  return false;
+}
+
+// ============================================================
+// Main IC3 algorithm
+// ============================================================
+
+/// A proof obligation: a cube that must be blocked at a given frame level.
+struct proof_obligationt
+{
+  cubet cube;
+  std::size_t level;
+
+  bool operator>(const proof_obligationt &other) const
+  {
+    return level > other.level;
+  }
+};
+
+ic3_resultt ic3_solvert::solve()
+{
+  messaget message{message_handler};
+
+  auto start_time = std::chrono::steady_clock::now();
+
+  // Check: can initial states violate the property?
+  if(initial_state_is_bad())
+  {
+    message.result() << "Property violated in initial state" << messaget::eom;
+    return ic3_resultt::REFUTED;
+  }
+
+  while(true)
+  {
+    new_frame();
+    std::size_t k = number_of_frames() - 1;
+
+    message.progress() << "IC3: frame " << k << " (" << num_queries
+                       << " queries, " << num_lifts << " lifts, "
+                       << total_clauses() << " clauses, avg size "
+                       << average_clause_size() << ")" << messaget::eom;
+
+    std::priority_queue<
+      proof_obligationt,
+      std::vector<proof_obligationt>,
+      std::greater<proof_obligationt>>
+      obligations;
+
+    // Blocking phase
+    while(true)
+    {
+      auto bad_cube = solve_bad(k);
+      if(!bad_cube.has_value())
+        break;
+
+      obligations.push({bad_cube.value(), k});
+
+      while(!obligations.empty())
+      {
+        auto [cube, level] = obligations.top();
+        obligations.pop();
+
+        if(is_blocked(cube, level))
+          continue;
+
+        if(init_intersects(cube))
+        {
+          message.result() << "Property refuted" << messaget::eom;
+          return ic3_resultt::REFUTED;
+        }
+
+        if(level == 0)
+        {
+          add_clause(0, negate_cube(cube));
+          continue;
+        }
+
+        auto pred = solve_relative(level - 1, cube);
+        if(pred.has_value())
+        {
+          obligations.push({pred.value(), level - 1});
+          obligations.push({std::move(cube), level});
+        }
+        else
+        {
+          cubet generalized = generalize(level - 1, core);
+          add_clause(level, negate_cube(generalized));
+
+          // Re-queue at level+1 to push the blocking clause higher
+          if(level + 1 <= k)
+            obligations.push({std::move(cube), level + 1});
+        }
+      }
+    } // end blocking phase
+
+    // Propagation: push clauses from F_i to F_{i+1}
+    if(propagate())
+    {
+      auto end_time = std::chrono::steady_clock::now();
+      message.statistics()
+        << "IC3: converged at frame " << k << " in "
+        << std::chrono::duration<double>(end_time - start_time).count()
+        << " seconds (" << num_queries << " queries)" << messaget::eom;
+      return ic3_resultt::PROVED;
+    }
+  }
+}

--- a/src/new-ic3/ic3_solver.h
+++ b/src/new-ic3/ic3_solver.h
@@ -1,0 +1,161 @@
+/*******************************************************************\
+
+Module: IC3 Solver
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+/// \file
+/// Per-frame SAT solver infrastructure for IC3/PDR, operating on
+/// the netlist (AIG) encoding of the transition system.
+
+#ifndef CPROVER_NEW_IC3_IC3_SOLVER_H
+#define CPROVER_NEW_IC3_IC3_SOLVER_H
+
+#include <solvers/prop/literal.h>
+#include <solvers/sat/satcheck.h>
+#include <trans-netlist/netlist.h>
+
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+/// A cube is a conjunction of literals (state variable bit assignments).
+using cubet = bvt;
+
+/// A clause is a disjunction of literals (the negation of a cube).
+using clauset = bvt;
+
+/// Negate a cube to get a clause and vice versa.
+clauset negate_cube(const cubet &cube);
+
+class cnft;
+class recording_cnft;
+
+namespace IctMinisat
+{
+class Solver;
+}
+
+enum class ic3_resultt
+{
+  PROVED,
+  REFUTED
+};
+
+/// The IC3 solver uses per-frame SAT solvers via CNF replay.
+/// The netlist is encoded once into a cnf_clause_listt, then replayed
+/// into each per-frame solver. The per-frame solvers use IC3's MiniSAT,
+/// whose releaseVar allows disposable activation literals without
+/// unbounded solver growth, and keep their learnt clauses for the
+/// whole run.
+///
+/// Frames are kept as deltas: a clause stored at level j holds in
+/// F_i for all i <= j, and the solver for level i contains the
+/// clauses of all levels >= i. F_0 additionally contains the initial
+/// state constraint.
+class ic3_solvert
+{
+public:
+  ic3_solvert(
+    netlistt netlist,
+    literalt property_literal,
+    message_handlert &message_handler);
+
+  ~ic3_solvert();
+
+  /// Run the IC3 algorithm. Returns PROVED or REFUTED.
+  ic3_resultt solve();
+
+private:
+  message_handlert &message_handler;
+
+  struct frame_clauset;
+
+  static bool subsumes(const frame_clauset &a, const frame_clauset &b);
+
+  bool initial_state_is_bad();
+  std::optional<cubet> solve_relative(std::size_t level, const cubet &);
+  std::optional<cubet> solve_bad(std::size_t level);
+  cubet generalize(std::size_t level, cubet cube);
+  bool init_intersects(const cubet &);
+  bool is_blocked(const cubet &, std::size_t level);
+  void add_clause(std::size_t level, const clauset &clause);
+  void new_frame();
+  std::size_t number_of_frames() const;
+  bool propagate();
+
+  cubet core;
+
+  std::size_t num_queries = 0, num_lifts = 0, num_clauses_added = 0;
+  std::size_t total_clauses() const;
+  double average_clause_size() const;
+
+  struct latch_infot
+  {
+    literalt current, next;
+  };
+
+  std::vector<latch_infot> latches;
+  std::unordered_map<unsigned, std::size_t> current_to_latch;
+
+  null_message_handlert solver_message_handler;
+
+  std::unique_ptr<recording_cnft> base_cnf;
+  bvt init_units;
+
+  void replay_base_cnf(cnft &dest, bool with_init);
+
+  std::unique_ptr<satcheck_no_simplifiert> init_solver;
+
+  std::vector<tvt> init_values;
+  bool init_is_unique_state = false;
+
+  std::unique_ptr<IctMinisat::Solver> lift_minisat;
+
+  bvt input_lits;
+
+  std::vector<std::unique_ptr<IctMinisat::Solver>> frame_solvers;
+
+  std::vector<std::vector<frame_clauset>> frame_clauses;
+
+  std::unique_ptr<IctMinisat::Solver> new_minisat_solver();
+
+  IctMinisat::Solver &get_solver(std::size_t level);
+
+  literalt prop_current;
+
+  // Max CTG (counterexample-to-generalization) attempts per generalize call
+  static constexpr std::size_t CTG_MAX = 0;
+  // Max join steps (intersection with predecessor) before giving up
+  static constexpr std::size_t JOIN_MAX = 3;
+  // Max consecutive MIC literal-drop failures before early termination
+  static constexpr std::size_t MIC_FAIL_MAX = 2;
+
+  static constexpr bool WITH_NEGATED_CUBE = true;
+
+  std::vector<float> lit_activity;
+
+  literalt to_next(literalt l) const;
+
+  cubet extract_state(const IctMinisat::Solver &);
+
+  cubet lift(
+    const IctMinisat::Solver &query_solver,
+    const cubet &full_state,
+    const bvt &target_clause);
+
+  bool relative_induction(
+    std::size_t level,
+    const cubet &cube,
+    cubet *predecessor,
+    bool lift_predecessor);
+
+  void repair_init(const cubet &cube, cubet &reduced);
+
+  bool ctg_down(std::size_t level, cubet &cand, std::size_t &ctg_budget);
+};
+
+#endif // CPROVER_NEW_IC3_IC3_SOLVER_H

--- a/src/new-ic3/new_ic3_engine.cpp
+++ b/src/new-ic3/new_ic3_engine.cpp
@@ -1,0 +1,128 @@
+/*******************************************************************\
+
+Module: New IC3 Engine
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+/// \file
+/// Bit-level IC3/PDR engine operating on the netlist (AIG) encoding
+/// of the transition system. The netlist is encoded once into CNF,
+/// with the next-state functions available as literals in the same
+/// variable space, so a single timeframe copy suffices.
+/// Inspired by rIC3 (arXiv:2502.13605).
+
+#include "new_ic3_engine.h"
+
+#include <ebmc/ebmc_error.h>
+#include <ebmc/liveness_to_safety.h>
+#include <ebmc/netlist.h>
+#include <ebmc/report_results.h>
+#include <temporal-logic/ctl.h>
+#include <temporal-logic/ltl.h>
+#include <temporal-logic/temporal_logic.h>
+#include <trans-netlist/aig_prop.h>
+#include <trans-netlist/instantiate_netlist.h>
+#include <verilog/sva_expr.h>
+
+#include "ic3_solver.h"
+
+static bool new_ic3_supports_property(const exprt &expr)
+{
+  if(!is_temporal_operator(expr))
+    return false;
+  if(expr.id() == ID_sva_always)
+    return !has_temporal_operator(to_sva_always_expr(expr).op());
+  if(expr.id() == ID_G)
+    return !has_temporal_operator(to_G_expr(expr).op());
+  if(expr.id() == ID_AG)
+    return !has_temporal_operator(to_AG_expr(expr).op());
+  return false;
+}
+
+property_checker_resultt new_ic3_engine(
+  const cmdlinet &cmdline,
+  transition_systemt &transition_system,
+  ebmc_propertiest &properties,
+  message_handlert &message_handler)
+{
+  messaget message{message_handler};
+
+  if(!properties.has_unfinished_property())
+    return property_checker_resultt{properties};
+
+  if(cmdline.isset("liveness-to-safety"))
+    liveness_to_safety(transition_system, properties);
+
+  for(auto &property : properties.properties)
+  {
+    if(property.is_assumed())
+    {
+      message.error() << "no support for assumptions" << messaget::eom;
+      return property_checker_resultt::error();
+    }
+  }
+
+  const namespacet ns(transition_system.symbol_table);
+
+  auto netlist =
+    make_netlist(transition_system, properties, cmdline, message_handler);
+
+  message.statistics() << "Latches: " << netlist.var_map.latches.size()
+                       << ", nodes: " << netlist.number_of_nodes()
+                       << messaget::eom;
+
+  for(auto &property : properties.properties)
+  {
+    if(property.is_disabled() || !property.is_unknown())
+      continue;
+
+    if(!new_ic3_supports_property(property.normalized_expr))
+    {
+      property.failure("property not supported by new IC3 engine");
+      continue;
+    }
+
+    message.status() << "Checking " << property.name << " with new IC3 engine"
+                     << messaget::eom;
+
+    // Add the property cone to a local copy of the netlist and obtain
+    // the property literal in the AIG variable space.
+    netlistt prop_netlist(netlist);
+    literalt prop_lit;
+    {
+      aig_prop_constraintt aig_prop(prop_netlist, message_handler);
+      prop_lit = instantiate_convert(
+        aig_prop,
+        prop_netlist.var_map,
+        to_unary_expr(property.normalized_expr).op(),
+        ns,
+        message_handler);
+    }
+
+    ic3_solvert solver(std::move(prop_netlist), prop_lit, message_handler);
+    auto result = solver.solve();
+
+    // For exists-path properties (cover), the normalized expression is
+    // the dual safety property: a refutation is a witness trace, and a
+    // proof shows that no witness exists.
+    switch(result)
+    {
+    case ic3_resultt::PROVED:
+      if(property.is_exists_path())
+        property.refuted();
+      else
+        property.proved();
+      break;
+    case ic3_resultt::REFUTED:
+      if(property.is_exists_path())
+        property.proved();
+      else
+        property.refuted();
+      break;
+    }
+  }
+
+  return property_checker_resultt{properties};
+}

--- a/src/new-ic3/new_ic3_engine.h
+++ b/src/new-ic3/new_ic3_engine.h
@@ -1,0 +1,24 @@
+/*******************************************************************\
+
+Module: New IC3 Engine
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+/// \file
+/// Bit-level IC3/PDR engine operating on the netlist (AIG) encoding
+/// of the transition system. Inspired by rIC3 (arXiv:2502.13605).
+
+#ifndef CPROVER_NEW_IC3_NEW_IC3_ENGINE_H
+#define CPROVER_NEW_IC3_NEW_IC3_ENGINE_H
+
+#include <ebmc/property_checker.h>
+
+property_checker_resultt new_ic3_engine(
+  const cmdlinet &,
+  transition_systemt &,
+  ebmc_propertiest &,
+  message_handlert &);
+
+#endif // CPROVER_NEW_IC3_NEW_IC3_ENGINE_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -39,6 +39,13 @@ OBJ += ../src/ebmc/bdd_model_checker$(OBJEXT) \
        ../src/trans-word-level/trans-word-level$(LIBEXT) \
        ../src/verilog/verilog$(LIBEXT)
 
+ifneq ($(BUILD_ENV),MSVC)
+SRC += new-ic3/ic3_solver.cpp
+INCLUDES += -I ../src/ic3/minisat
+OBJ += ../src/new-ic3/new-ic3$(LIBEXT) \
+       ../src/ic3/minisat/build/release/lib/libminisat.a
+endif
+
 cprover.dir:
 	$(MAKE) $(MAKEARGS) -C ../src
 

--- a/unit/new-ic3/ic3_solver.cpp
+++ b/unit/new-ic3/ic3_solver.cpp
@@ -1,0 +1,253 @@
+/*******************************************************************\
+
+Module: IC3 Solver Unit Tests
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#include <new-ic3/ic3_solver.h>
+#include <testing-utils/use_catch.h>
+
+/// Helper: build a netlist with a single 1-bit latch. The latch's
+/// current-state is AIG node 0, next-state is `next_lit`. The
+/// property literal is `prop_lit`. Initial state is constrained to
+/// `init_lit` (a literal over the latch's current-state node).
+static netlistt make_single_latch_netlist(
+  literalt next_lit,
+  literalt init_lit,
+  literalt prop_lit)
+{
+  netlistt netlist;
+
+  // Node 0: primary input (represents the current-state bit)
+  literalt current = netlist.new_input();
+  REQUIRE(current.var_no() == 0);
+
+  // Register the latch in the var_map.
+  var_mapt::vart var;
+  var.vartype = var_mapt::vart::vartypet::LATCH;
+  var.type = typet(ID_bool);
+  var.bits.resize(1);
+  var.bits[0].current = current;
+  var.bits[0].next = next_lit;
+  netlist.var_map.map.emplace("latch0", var);
+  netlist.var_map.add("latch0", 0, var);
+
+  // Initial state constraint
+  netlist.initial.push_back(init_lit);
+
+  return netlist;
+}
+
+SCENARIO("ic3_solvert proves a trivially safe property")
+{
+  GIVEN("A 1-bit latch initialized to 0 with next=current, property = !latch")
+  {
+    // Latch: current = node 0, next = node 0 (stays the same)
+    // Init: latch = 0 (i.e., !current)
+    // Property: !latch (i.e., !current) — always true since latch stays 0
+    literalt current{0, false};
+    literalt prop_lit = !current; // property is !latch, always true
+
+    auto netlist = make_single_latch_netlist(current, !current, prop_lit);
+
+    null_message_handlert mh;
+    ic3_solvert solver(std::move(netlist), prop_lit, mh);
+
+    THEN("IC3 proves the property")
+    {
+      REQUIRE(solver.solve() == ic3_resultt::PROVED);
+    }
+  }
+}
+
+SCENARIO("ic3_solvert refutes a property violated in the initial state")
+{
+  GIVEN("A 1-bit latch initialized to 1, property = !latch")
+  {
+    // Latch: current = node 0, next = node 0 (stays the same)
+    // Init: latch = 1 (i.e., current is positive)
+    // Property: !latch — violated immediately
+    literalt current{0, false};
+    literalt prop_lit = !current;
+
+    auto netlist = make_single_latch_netlist(current, current, current);
+
+    null_message_handlert mh;
+    ic3_solvert solver(std::move(netlist), prop_lit, mh);
+
+    THEN("IC3 refutes the property")
+    {
+      REQUIRE(solver.solve() == ic3_resultt::REFUTED);
+    }
+  }
+}
+
+SCENARIO("ic3_solvert refutes a property violated after one step")
+{
+  GIVEN("A 1-bit latch initialized to 0, next=1, property = !latch")
+  {
+    // Latch: current = node 0, next = const_literal(true) (flips to 1)
+    // Init: latch = 0
+    // Property: !latch — holds initially but violated at step 1
+    literalt current{0, false};
+    literalt prop_lit = !current;
+
+    auto netlist =
+      make_single_latch_netlist(const_literal(true), !current, prop_lit);
+
+    null_message_handlert mh;
+    ic3_solvert solver(std::move(netlist), prop_lit, mh);
+
+    THEN("IC3 refutes the property")
+    {
+      REQUIRE(solver.solve() == ic3_resultt::REFUTED);
+    }
+  }
+}
+
+SCENARIO("ic3_solvert proves a property on a two-latch system")
+{
+  GIVEN("Two latches: a toggles, b stays 0; property = !b")
+  {
+    netlistt netlist;
+
+    // Node 0: latch a (toggles)
+    literalt a_current = netlist.new_input();
+    // Node 1: latch b (stays 0)
+    literalt b_current = netlist.new_input();
+
+    // a's next = !a (toggle)
+    literalt a_next = !a_current;
+    // b's next = b (stays the same)
+    literalt b_next = b_current;
+
+    // Register latch a
+    var_mapt::vart var_a;
+    var_a.vartype = var_mapt::vart::vartypet::LATCH;
+    var_a.type = typet(ID_bool);
+    var_a.bits.resize(1);
+    var_a.bits[0].current = a_current;
+    var_a.bits[0].next = a_next;
+    netlist.var_map.map.emplace("a", var_a);
+    netlist.var_map.add("a", 0, var_a);
+
+    // Register latch b
+    var_mapt::vart var_b;
+    var_b.vartype = var_mapt::vart::vartypet::LATCH;
+    var_b.type = typet(ID_bool);
+    var_b.bits.resize(1);
+    var_b.bits[0].current = b_current;
+    var_b.bits[0].next = b_next;
+    netlist.var_map.map.emplace("b", var_b);
+    netlist.var_map.add("b", 0, var_b);
+
+    // Init: a=0, b=0
+    netlist.initial.push_back(!a_current);
+    netlist.initial.push_back(!b_current);
+
+    // Property: !b (always true since b stays 0)
+    literalt prop_lit = !b_current;
+
+    null_message_handlert mh;
+    ic3_solvert solver(std::move(netlist), prop_lit, mh);
+
+    THEN("IC3 proves the property")
+    {
+      REQUIRE(solver.solve() == ic3_resultt::PROVED);
+    }
+  }
+}
+
+SCENARIO("ic3_solvert proves a property requiring inductive strengthening")
+{
+  GIVEN("A 2-bit counter that stays in {0,1,2}, property = counter != 3")
+  {
+    netlistt netlist;
+
+    // Node 0: bit 0 of counter
+    literalt b0 = netlist.new_input();
+    // Node 1: bit 1 of counter
+    literalt b1 = netlist.new_input();
+    // Node 2: input (nondeterministic choice to increment or not)
+    literalt inp = netlist.new_input();
+
+    // Counter increments when inp=1, saturates at 2.
+    // next_b0 = b0 XOR (inp AND !b1)
+    //         = b0 XOR (inp AND !b1)
+    // next_b1 = b1 XOR (b0 AND inp AND !b1)
+    //
+    // Simpler encoding: use AND gates in the AIG.
+    // !b1
+    literalt not_b1 = !b1;
+
+    // inp AND !b1 (only increment if counter < 2, i.e. b1=0)
+    literalt inc = netlist.new_and_node(inp, not_b1);
+
+    // b0 XOR inc = (b0 AND !inc) OR (!b0 AND inc)
+    //            = !( !(b0 AND !inc) AND !(!b0 AND inc) )
+    //            -- build with AND nodes
+    literalt b0_and_not_inc = netlist.new_and_node(b0, !inc);
+    literalt not_b0_and_inc = netlist.new_and_node(!b0, inc);
+    // XOR = !(!a AND !b) when a,b are the two AND terms... no.
+    // XOR(a,b) = (a OR b) AND !(a AND b)
+    // OR(a,b) = !(!a AND !b)
+    literalt or_node = !netlist.new_and_node(!b0_and_not_inc, !not_b0_and_inc);
+    // a AND b cannot both be true (they share b0/!b0), so XOR = OR here
+    literalt next_b0 = or_node;
+
+    // b0 AND inc (carry into bit 1)
+    literalt carry = netlist.new_and_node(b0, inc);
+
+    // b1 XOR carry
+    literalt b1_and_not_carry = netlist.new_and_node(b1, !carry);
+    literalt not_b1_and_carry = netlist.new_and_node(!b1, carry);
+    literalt next_b1 =
+      !netlist.new_and_node(!b1_and_not_carry, !not_b1_and_carry);
+
+    // Register latches
+    var_mapt::vart var_b0;
+    var_b0.vartype = var_mapt::vart::vartypet::LATCH;
+    var_b0.type = typet(ID_bool);
+    var_b0.bits.resize(1);
+    var_b0.bits[0].current = b0;
+    var_b0.bits[0].next = next_b0;
+    netlist.var_map.map.emplace("b0", var_b0);
+    netlist.var_map.add("b0", 0, var_b0);
+
+    var_mapt::vart var_b1;
+    var_b1.vartype = var_mapt::vart::vartypet::LATCH;
+    var_b1.type = typet(ID_bool);
+    var_b1.bits.resize(1);
+    var_b1.bits[0].current = b1;
+    var_b1.bits[0].next = next_b1;
+    netlist.var_map.map.emplace("b1", var_b1);
+    netlist.var_map.add("b1", 0, var_b1);
+
+    // Register input
+    var_mapt::vart var_inp;
+    var_inp.vartype = var_mapt::vart::vartypet::INPUT;
+    var_inp.type = typet(ID_bool);
+    var_inp.bits.resize(1);
+    var_inp.bits[0].current = inp;
+    var_inp.bits[0].next = inp;
+    netlist.var_map.map.emplace("inp", var_inp);
+    netlist.var_map.add("inp", 0, var_inp);
+
+    // Init: counter = 0
+    netlist.initial.push_back(!b0);
+    netlist.initial.push_back(!b1);
+
+    // Property: counter != 3, i.e., !(b0 AND b1) = !b0 OR !b1 = NAND
+    literalt prop_lit = !netlist.new_and_node(b0, b1);
+
+    null_message_handlert mh;
+    ic3_solvert solver(std::move(netlist), prop_lit, mh);
+
+    THEN("IC3 proves the property (requires inductive strengthening)")
+    {
+      REQUIRE(solver.solve() == ic3_resultt::PROVED);
+    }
+  }
+}


### PR DESCRIPTION
Bit-level IC3/PDR engine operating on the netlist (AIG) encoding of the transition system, built on ebmc's netlist infrastructure and IC3's MiniSAT. Inspired by rIC3 (arXiv:2502.13605).

Design:
- The netlist is encoded once into CNF with a **single timeframe** — the next-state functions are AIG literals in the same variable space, so no second copy of the combinational logic is needed.
- Bad-state-at-frame-k formulation; F_0 includes the initial state constraint.
- Per-frame SAT solvers via CNF replay, using IC3's MiniSAT: `releaseVar` enables disposable activation literals for the negated cube in relative induction queries, and learnt clauses persist for the whole run.
- Delta-encoded frames; subsumption via sorted literal vectors and Bloom-style signatures.
- Unsat-core based MIC generalization with activity ordering and early cutoff; initiation check on every proof obligation.
- Predecessor lifting with a persistent MiniSAT solver.

Performance: see `src/new-ic3/PERFORMANCE.md` for a 4-way comparison with the in-tree bit-level IC3 engine, rIC3 1.5.2 and Pono (ic3bits) on a 49-benchmark HWMCC08 sample (60 s timeout): solved 43 / 45 / 48 / 34 respectively; the new engine is the fastest of the four on 20 benchmarks and faster than the in-tree engine on 27 of the 42 benchmarks both solve. All verdicts agree across tools and match the published HWMCC08 results. Benchmark drivers are in `benchmarking/compare4way.sh`, `compare_ic3.sh` and `validate_new_ic3.sh`.

Includes regression tests for proved properties, refuted properties (initial state and multi-step), and unsupported property rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)