### PR TITLE
Verilog: compilation-unit scoped parameters

### DIFF
--- a/regression/verilog/parameters/compilation_unit_parameter1.desc
+++ b/regression/verilog/parameters/compilation_unit_parameter1.desc
@@ -1,9 +1,8 @@
-KNOWNBUG
+CORE
 compilation_unit_parameter1.sv
 
-^EXIT=10$
+^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-The parameters are not added to the symbol table.

--- a/regression/verilog/parameters/compilation_unit_parameter1.sv
+++ b/regression/verilog/parameters/compilation_unit_parameter1.sv
@@ -2,7 +2,9 @@ parameter some_parameter = 1;
 parameter [3:0] other_parameter = 2;
 parameter int third_parameter = 3;
 parameter dependent_parameter = third_parameter;
+localparam local_parameter = 4;
 
 module main;
   parameter X = dependent_parameter;
+  initial assert(local_parameter == 4);
 endmodule

--- a/src/verilog/verilog_elaborate_compilation_unit.cpp
+++ b/src/verilog/verilog_elaborate_compilation_unit.cpp
@@ -78,5 +78,30 @@ void verilog_elaborate_compilation_unit(
           throw ebmc_errort{};
       }
     }
+    else if(
+      item.id() == ID_parameter_decl || item.id() == ID_local_parameter_decl)
+    {
+      // compilation-unit scoped parameters
+      try
+      {
+        verilog_typecheckt verilog_typecheck(
+          parse_tree.standard,
+          warn_implicit_nets,
+          symbol_table,
+          message_handler);
+        verilog_typecheck.typecheck_parameter_decl(
+          static_cast<const verilog_module_itemt &>(item));
+      }
+      catch(const typecheckt::errort &error)
+      {
+        if(!error.what().empty())
+        {
+          throw ebmc_errort{}.with_location(error.source_location())
+            << error.what();
+        }
+        else
+          throw ebmc_errort{};
+      }
+    }
   }
 }

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1839,6 +1839,31 @@ void verilog_typecheckt::typecheck_decl(const verilog_declt &decl)
 
 /*******************************************************************\
 
+Function: verilog_typecheckt::typecheck_parameter_decl
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void verilog_typecheckt::typecheck_parameter_decl(
+  const verilog_module_itemt &parameter_decl)
+{
+  PRECONDITION(
+    parameter_decl.id() == ID_parameter_decl ||
+    parameter_decl.id() == ID_local_parameter_decl);
+
+  collect_symbols(parameter_decl);
+
+  for(auto identifier : symbols_added)
+    elaborate_symbol_rec(identifier);
+}
+
+/*******************************************************************\
+
 Function: copy_module_source
 
   Inputs:

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -73,6 +73,7 @@ public:
   // type checking for compilation-unit scoped nets, variables,
   // typedefs, functions, tasks, parameters
   void typecheck_decl(const verilog_declt &);
+  void typecheck_parameter_decl(const verilog_module_itemt &);
 
 protected:
   const namespacet ns;


### PR DESCRIPTION
Parameters and localparams declared at compilation-unit scope (outside any module) were not being added to the symbol table. This adds handling for `ID_parameter_decl` and `ID_local_parameter_decl` in the compilation unit elaboration, creating symbols in the `$unit` scope.

The existing `$unit` lookup mechanism in the expression typechecker already supported this — only the symbol creation was missing.