### PR TITLE
Verilog: synthesize `$past` arguments

### DIFF
--- a/regression/verilog/system-functions/past4.desc
+++ b/regression/verilog/system-functions/past4.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 past4.sv
 
 ^EXIT=10$

--- a/regression/verilog/system-functions/past7.desc
+++ b/regression/verilog/system-functions/past7.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+past7.sv
+
+^\[main\.blk\.p1\] always main\.counter == 1 -> \$past\(main\.counter, 1\) == 0: PROVED \(1-induction\)$
+^\[main\.blk\.pn\] always main\.counter >= 2 -> \$past\(main\.counter, 1\) == main\.counter - 2: REFUTED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This gives the wrong answer.

--- a/regression/verilog/system-functions/past7.sv
+++ b/regression/verilog/system-functions/past7.sv
@@ -1,0 +1,11 @@
+module main(input clk);
+
+  reg [7:0] counter = 0;
+
+  always @(posedge clk) begin : blk
+    counter++;
+    p1: assert(counter == 1 -> $past(counter, 1) == 0);
+    pn: assert(counter >= 2 -> $past(counter, 1) == counter - 2);
+  end
+
+endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -367,7 +367,7 @@ exprt verilog_synthesist::expand_function_call(
     }
     else if(base_name == "$past")
     {
-      auto what = call.arguments()[0];
+      auto what = synth_expr_rec(call.arguments()[0], symbol_state);
       auto ticks = call.arguments().size() < 2
                      ? from_integer(1, integer_typet())
                      : call.arguments()[1];
@@ -378,7 +378,7 @@ exprt verilog_synthesist::expand_function_call(
       base_name == "$changed")
     {
       DATA_INVARIANT(call.arguments().size() >= 1, "must have argument");
-      auto what = call.arguments()[0];
+      auto what = synth_expr_rec(call.arguments()[0], symbol_state);
       auto past = verilog_past_exprt{what, from_integer(1, integer_typet())}
                     .with_source_location(call);
 


### PR DESCRIPTION
The arguments to `$past`, `$stable`, `$rose`, `$fell`, and `$changed` were not synthesized before being wrapped in `verilog_past_exprt`. This meant hierarchical identifiers like `m.x` were not expanded to symbol expressions, causing `warning: ignoring hierarchical_identifier` at the solver level.

Fixes the KNOWNBUG test `regression/verilog/system-functions/past4.desc`.