### PR TITLE
test to determine binding of `else` vs. `if` action blocks

### DIFF
--- a/regression/verilog/SVA/immediate4.sv
+++ b/regression/verilog/SVA/immediate4.sv
@@ -6,13 +6,11 @@ module main(input clk);
 
   always @(posedge clk) begin : blk
 
-    // It is unclear whether this should parse
-    // as an if-then-else or as an if followed
-    // by an assertion with an action block.
+    // This is an assertion in an action block of
+    // an assertion.
     if(x != 11)
       P: assert(x & 1); // fails
-    else
-      Q: assert(x & 1); // holds
+         else Q: assert(x & 1); // holds
 
     x<=x+1;
   end

--- a/regression/verilog/SVA/immediate5.desc
+++ b/regression/verilog/SVA/immediate5.desc
@@ -1,0 +1,10 @@
+CORE
+immediate5.sv
+
+^\[main\.blk1\.P\] main\.blk1\.x == 1: REFUTED$
+^\[main\.blk2\.P\] main\.blk2\.x == 0: PROVED .*$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/immediate5.sv
+++ b/regression/verilog/SVA/immediate5.sv
@@ -1,0 +1,29 @@
+module main;
+
+  initial begin : blk1
+    int x;
+    x = 0;
+    if(1)
+      assert(1);
+    else
+      x = 1;
+
+    // This passes if the 'else' binds to the if.
+    // This passes for Riviera Pro 2025.04, and fails
+    // for the others.
+    P: assert(x == 1);
+  end
+
+  initial begin : blk2
+    int x;
+    x = 0;
+    if(1)
+      assert(1) ; else x = 1;
+
+    // This passes if the 'else' binds to the assert.
+    // This is the case for Icarus Verilog 12.0,
+    // Xcelium 25.03, Questa 2025.2, VCS 2025.06.
+    P: assert(x == 0);
+  end
+
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3780,6 +3780,12 @@ subroutine_call_statement:
 // System Verilog standard 1800-2017
 // A.6.3 Parallel and sequential blocks
 
+// When assert is used in an conditional_statement,
+// it is unclear whether the TOK_ELSE is reduced as action_block
+// or as part of the conditional_statement.
+// We follow the "match to most recent" principle, and
+// reduce as part of action_block, i.e., the "else" binds
+// to the assertion.
 action_block:
           statement_or_null %prec LT_TOK_ELSE
                 { init($$, ID_verilog_action_then); mto($$, $1); }


### PR DESCRIPTION
This test determines whether an `else` binds to the most recent assertion as part of an `action_block`, or to the most recent `if`, as part of an `conditional_statement`.