### PR TITLE
cleanup SVA sequence encoding

### DIFF
--- a/src/trans-word-level/property.cpp
+++ b/src/trans-word-level/property.cpp
@@ -652,12 +652,16 @@ static obligationst property_obligations_rec(
       auto semantics = sva_sequence_semantics(op.id());
 
       const auto matches =
-        instantiate_sequence(sequence, semantics, current, no_timeframes);
+        instantiate_sequence(sequence, current, no_timeframes);
 
       obligationst obligations;
 
       for(auto &match : matches)
       {
+        // drop pending matches when using strong semantics
+        if(semantics == sva_sequence_semanticst::STRONG && match.is_pending())
+          continue;
+
         // The sequence must not match.
         if(!match.empty_match())
           obligations.add(match.end_time(), not_exprt{match.condition()});
@@ -704,11 +708,8 @@ static obligationst property_obligations_rec(
     // The LHS is a sequence, the RHS is a property.
     // The implication must hold for _all_ (strong) matches on the LHS,
     // i.e., each pair of LHS match and RHS obligation yields an obligation.
-    const auto lhs_match_points = instantiate_sequence(
-      implication.lhs(),
-      sva_sequence_semanticst::STRONG,
-      current,
-      no_timeframes);
+    const auto lhs_match_points =
+      instantiate_sequence(implication.lhs(), current, no_timeframes);
 
     const bool overlapped = property_expr.id() == ID_sva_overlapped_implication;
 
@@ -716,6 +717,10 @@ static obligationst property_obligations_rec(
 
     for(auto &lhs_match_point : lhs_match_points)
     {
+      // drop pending matches
+      if(lhs_match_point.is_pending())
+        continue;
+
       if(lhs_match_point.empty_match() && overlapped)
       {
         // does not yield an obligation
@@ -759,17 +764,18 @@ static obligationst property_obligations_rec(
     auto &followed_by = to_sva_followed_by_expr(property_expr);
 
     // get match points for LHS sequence
-    auto matches = instantiate_sequence(
-      followed_by.antecedent(),
-      sva_sequence_semanticst::STRONG,
-      current,
-      no_timeframes);
+    auto matches =
+      instantiate_sequence(followed_by.antecedent(), current, no_timeframes);
 
     exprt::operandst disjuncts;
     mp_integer t = current;
 
     for(auto &match : matches)
     {
+      // drop pending matches
+      if(match.is_pending())
+        continue;
+
       bool overlapped = property_expr.id() == ID_sva_overlapped_followed_by;
 
       // empty match?
@@ -818,14 +824,17 @@ static obligationst property_obligations_rec(
       to_sva_sequence_property_expr_base(property_expr).sequence();
     auto semantics = sva_sequence_semantics(property_expr.id());
 
-    const auto matches =
-      instantiate_sequence(sequence, semantics, current, no_timeframes);
+    const auto matches = instantiate_sequence(sequence, current, no_timeframes);
     exprt::operandst disjuncts;
     disjuncts.reserve(matches.size());
     mp_integer max = current;
 
     for(auto &match : matches)
     {
+      // drop pending matches when using strong semantics
+      if(semantics == sva_sequence_semanticst::STRONG && match.is_pending())
+        continue;
+
       // empty matches are not considered
       if(!match.empty_match())
       {

--- a/src/trans-word-level/sequence.cpp
+++ b/src/trans-word-level/sequence.cpp
@@ -87,7 +87,6 @@ typet sequence_count_type(
 
 sequence_matchest instantiate_sequence_rec(
   exprt expr,
-  sva_sequence_semanticst semantics,
   const mp_integer &t,
   const mp_integer &no_timeframes)
 {
@@ -108,8 +107,8 @@ sequence_matchest instantiate_sequence_rec(
     }
     else
     {
-      lhs_matches = instantiate_sequence_rec(
-        sva_cycle_delay_expr.lhs(), semantics, t, no_timeframes);
+      lhs_matches =
+        instantiate_sequence_rec(sva_cycle_delay_expr.lhs(), t, no_timeframes);
     }
 
     sequence_matchest result;
@@ -123,8 +122,7 @@ sequence_matchest instantiate_sequence_rec(
       // the bound. Propagate without evaluating the RHS.
       if(lhs_match.is_pending())
       {
-        if(semantics == sva_sequence_semanticst::WEAK)
-          result.push_back(lhs_match);
+        result.push_back(lhs_match);
         continue;
       }
 
@@ -157,14 +155,13 @@ sequence_matchest instantiate_sequence_rec(
         // Do we exceed the bound?
         if(t_rhs >= no_timeframes)
         {
-          if(semantics == sva_sequence_semanticst::WEAK)
-            result.push_back(
-              sequence_matcht::pending_match(lhs_match.condition()));
+          result.push_back(
+            sequence_matcht::pending_match(lhs_match.condition()));
         }
         else // still inside bound
         {
           const auto rhs_matches = instantiate_sequence_rec(
-            sva_cycle_delay_expr.rhs(), semantics, t_rhs, no_timeframes);
+            sva_cycle_delay_expr.rhs(), t_rhs, no_timeframes);
 
           for(auto &rhs_match : rhs_matches)
           {
@@ -175,9 +172,8 @@ sequence_matchest instantiate_sequence_rec(
                 and_exprt{lhs_match.condition(), rhs_match.condition()};
               if(rhs_match.is_pending())
               {
-                if(semantics == sva_sequence_semanticst::WEAK)
-                  result.push_back(
-                    sequence_matcht::pending_match(std::move(cond)));
+                result.push_back(
+                  sequence_matcht::pending_match(std::move(cond)));
               }
               else
                 result.emplace_back(rhs_match.end_time(), std::move(cond));
@@ -192,14 +188,12 @@ sequence_matchest instantiate_sequence_rec(
   else if(expr.id() == ID_sva_cycle_delay_star) // ##[*] something
   {
     auto &cycle_delay_star = to_sva_cycle_delay_star_expr(expr);
-    return instantiate_sequence_rec(
-      cycle_delay_star.lower(), semantics, t, no_timeframes);
+    return instantiate_sequence_rec(cycle_delay_star.lower(), t, no_timeframes);
   }
   else if(expr.id() == ID_sva_cycle_delay_plus) // ##[+] something
   {
     auto &cycle_delay_plus = to_sva_cycle_delay_plus_expr(expr);
-    return instantiate_sequence_rec(
-      cycle_delay_plus.lower(), semantics, t, no_timeframes);
+    return instantiate_sequence_rec(cycle_delay_plus.lower(), t, no_timeframes);
   }
   else if(expr.id() == ID_sva_sequence_intersect)
   {
@@ -211,9 +205,9 @@ sequence_matchest instantiate_sequence_rec(
     auto &intersect = to_sva_sequence_intersect_expr(expr);
 
     const auto lhs_matches =
-      instantiate_sequence_rec(intersect.lhs(), semantics, t, no_timeframes);
+      instantiate_sequence_rec(intersect.lhs(), t, no_timeframes);
     const auto rhs_matches =
-      instantiate_sequence_rec(intersect.rhs(), semantics, t, no_timeframes);
+      instantiate_sequence_rec(intersect.rhs(), t, no_timeframes);
 
     sequence_matchest result;
 
@@ -239,16 +233,12 @@ sequence_matchest instantiate_sequence_rec(
     // If either operand has a pending match, the intersect might
     // still match beyond the bound. The pending condition is:
     // no concrete match has fired.
-    if(semantics == sva_sequence_semanticst::WEAK)
+    if(has_pending(lhs_matches) || has_pending(rhs_matches))
     {
-      if(has_pending(lhs_matches) || has_pending(rhs_matches))
-      {
-        auto no_concrete =
-          concrete_match_conditions.empty()
-            ? static_cast<exprt>(true_exprt{})
-            : not_exprt{disjunction(concrete_match_conditions)};
-        result.push_back(sequence_matcht::pending_match(no_concrete));
-      }
+      auto no_concrete = concrete_match_conditions.empty()
+                           ? static_cast<exprt>(true_exprt{})
+                           : not_exprt{disjunction(concrete_match_conditions)};
+      result.push_back(sequence_matcht::pending_match(no_concrete));
     }
 
     return result;
@@ -257,8 +247,8 @@ sequence_matchest instantiate_sequence_rec(
   {
     auto &first_match = to_sva_sequence_first_match_expr(expr);
 
-    const auto matches = instantiate_sequence_rec(
-      first_match.sequence(), semantics, t, no_timeframes);
+    const auto matches =
+      instantiate_sequence_rec(first_match.sequence(), t, no_timeframes);
 
     // first_match(seq): the match of seq with the earliest ending
     // clock tick. In the symbolic setting, we must encode that a
@@ -307,8 +297,8 @@ sequence_matchest instantiate_sequence_rec(
     // - exp evaluates to true at each clock tick of the interval.
     auto &throughout = to_sva_sequence_throughout_expr(expr);
 
-    const auto matches = instantiate_sequence_rec(
-      throughout.sequence(), semantics, t, no_timeframes);
+    const auto matches =
+      instantiate_sequence_rec(throughout.sequence(), t, no_timeframes);
 
     sequence_matchest result;
 
@@ -317,8 +307,7 @@ sequence_matchest instantiate_sequence_rec(
       if(match.is_pending())
       {
         // Propagate pending status.
-        if(semantics == sva_sequence_semanticst::WEAK)
-          result.push_back(match);
+        result.push_back(match);
         continue;
       }
 
@@ -343,7 +332,7 @@ sequence_matchest instantiate_sequence_rec(
 
     auto &within_expr = to_sva_sequence_within_expr(expr);
     const auto matches_rhs =
-      instantiate_sequence_rec(within_expr.rhs(), semantics, t, no_timeframes);
+      instantiate_sequence_rec(within_expr.rhs(), t, no_timeframes);
 
     sequence_matchest result;
     bool has_pending = false;
@@ -359,8 +348,8 @@ sequence_matchest instantiate_sequence_rec(
 
       for(auto start_lhs = t; start_lhs <= match_rhs.end_time(); ++start_lhs)
       {
-        auto matches_lhs = instantiate_sequence_rec(
-          within_expr.lhs(), semantics, start_lhs, no_timeframes);
+        auto matches_lhs =
+          instantiate_sequence_rec(within_expr.lhs(), start_lhs, no_timeframes);
 
         for(auto &match_lhs : matches_lhs)
         {
@@ -385,16 +374,12 @@ sequence_matchest instantiate_sequence_rec(
 
     // If either operand has a pending match, 'within' might
     // still match beyond the bound.
-    if(semantics == sva_sequence_semanticst::WEAK)
+    if(has_pending)
     {
-      if(has_pending)
-      {
-        auto no_concrete =
-          concrete_match_conditions.empty()
-            ? static_cast<exprt>(true_exprt{})
-            : not_exprt{disjunction(concrete_match_conditions)};
-        result.push_back(sequence_matcht::pending_match(no_concrete));
-      }
+      auto no_concrete = concrete_match_conditions.empty()
+                           ? static_cast<exprt>(true_exprt{})
+                           : not_exprt{disjunction(concrete_match_conditions)};
+      result.push_back(sequence_matcht::pending_match(no_concrete));
     }
 
     return result;
@@ -408,9 +393,9 @@ sequence_matchest instantiate_sequence_rec(
     //    the end time of the operand sequence that completes last.
     auto &and_expr = to_sva_and_expr(expr);
     auto matches_lhs =
-      instantiate_sequence_rec(and_expr.lhs(), semantics, t, no_timeframes);
+      instantiate_sequence_rec(and_expr.lhs(), t, no_timeframes);
     auto matches_rhs =
-      instantiate_sequence_rec(and_expr.rhs(), semantics, t, no_timeframes);
+      instantiate_sequence_rec(and_expr.rhs(), t, no_timeframes);
 
     sequence_matchest result;
     exprt::operandst concrete_match_conditions;
@@ -430,16 +415,12 @@ sequence_matchest instantiate_sequence_rec(
     // If either operand has a pending match, the 'and' might
     // still match beyond the bound. The pending condition is:
     // no concrete match has fired.
-    if(semantics == sva_sequence_semanticst::WEAK)
+    if(has_pending(matches_lhs) || has_pending(matches_rhs))
     {
-      if(has_pending(matches_lhs) || has_pending(matches_rhs))
-      {
-        auto no_concrete =
-          concrete_match_conditions.empty()
-            ? static_cast<exprt>(true_exprt{})
-            : not_exprt{disjunction(concrete_match_conditions)};
-        result.push_back(sequence_matcht::pending_match(no_concrete));
-      }
+      auto no_concrete = concrete_match_conditions.empty()
+                           ? static_cast<exprt>(true_exprt{})
+                           : not_exprt{disjunction(concrete_match_conditions)};
+      result.push_back(sequence_matcht::pending_match(no_concrete));
     }
 
     return result;
@@ -452,8 +433,7 @@ sequence_matchest instantiate_sequence_rec(
     sequence_matchest result;
 
     for(auto &op : expr.operands())
-      for(auto &match :
-          instantiate_sequence_rec(op, semantics, t, no_timeframes))
+      for(auto &match : instantiate_sequence_rec(op, t, no_timeframes))
       {
         result.push_back(match);
       }
@@ -476,21 +456,18 @@ sequence_matchest instantiate_sequence_rec(
       auto new_repetition = sva_sequence_repetition_star_exprt{
         repetition.op(), repetition.from(), to};
 
-      return instantiate_sequence_rec(
-        new_repetition.lower(), semantics, t, no_timeframes);
+      return instantiate_sequence_rec(new_repetition.lower(), t, no_timeframes);
     }
     else
     {
       // [*], [*n], [*x:y]
-      return instantiate_sequence_rec(
-        repetition.lower(), semantics, t, no_timeframes);
+      return instantiate_sequence_rec(repetition.lower(), t, no_timeframes);
     }
   }
   else if(expr.id() == ID_sva_sequence_repetition_plus) // [+]
   {
     auto &repetition = to_sva_sequence_repetition_plus_expr(expr);
-    return instantiate_sequence_rec(
-      repetition.lower(), semantics, t, no_timeframes);
+    return instantiate_sequence_rec(repetition.lower(), t, no_timeframes);
   }
   else if(
     expr.id() == ID_sva_sequence_goto_repetition ||          // [->...]
@@ -529,14 +506,11 @@ sequence_matchest instantiate_sequence_rec(
     // Weak semantics: the sequence could still complete beyond the
     // bound. Add a pending match when the count hasn't yet reached
     // the required minimum.
-    if(semantics == sva_sequence_semanticst::WEAK)
-    {
-      auto min = repetition.is_range()
-                   ? numeric_cast_v<mp_integer>(repetition.from())
-                   : numeric_cast_v<mp_integer>(repetition.repetitions());
-      result.push_back(sequence_matcht::pending_match(binary_relation_exprt{
-        matches, ID_lt, from_integer(min, matches.type())}));
-    }
+    auto min = repetition.is_range()
+                 ? numeric_cast_v<mp_integer>(repetition.from())
+                 : numeric_cast_v<mp_integer>(repetition.repetitions());
+    result.push_back(sequence_matcht::pending_match(binary_relation_exprt{
+      matches, ID_lt, from_integer(min, matches.type())}));
 
     return result;
   }
@@ -557,10 +531,9 @@ sequence_matchest instantiate_sequence_rec(
 
 sequence_matchest instantiate_sequence(
   exprt expr,
-  sva_sequence_semanticst semantics,
   const mp_integer &t,
   const mp_integer &no_timeframes)
 {
   auto rewritten = rewrite_sva_sequence(expr);
-  return instantiate_sequence_rec(rewritten, semantics, t, no_timeframes);
+  return instantiate_sequence_rec(rewritten, t, no_timeframes);
 }

--- a/src/trans-word-level/sequence.h
+++ b/src/trans-word-level/sequence.h
@@ -79,7 +79,6 @@ using sequence_matchest = std::vector<sequence_matcht>;
 /// for the given sequence expression starting at time t
 [[nodiscard]] sequence_matchest instantiate_sequence(
   exprt expr,
-  sva_sequence_semanticst,
   const mp_integer &t,
   const mp_integer &no_timeframes);
 


### PR DESCRIPTION
When calculating the set of potential matches of an SVA sequence, there is no need to know the semantics that is used when interpreting these potential matches.  This removes the semantics parameter from the function that encodes a given SVA sequence.