### PR TITLE
move logic for SVA `cover` into the property encoding

### DIFF
--- a/regression/verilog/SVA/cover1.k-induction.desc
+++ b/regression/verilog/SVA/cover1.k-induction.desc
@@ -1,9 +1,8 @@
 CORE
 cover1.sv
 --k-induction
-^\[main\.p0\] cover main\.counter == 1: PROVED$
-^\[main\.p1\] cover main\.counter == 100: INCONCLUSIVE$
-^EXIT=10$
+^error: there is no property suitable for k-induction$
+^EXIT=6$
 ^SIGNAL=0$
 --
 ^warning: ignoring

--- a/regression/verilog/SVA/cover3.desc
+++ b/regression/verilog/SVA/cover3.desc
@@ -2,8 +2,8 @@ KNOWNBUG
 cover3.sv
 
 ^\[main\.p0\] cover \(main\.counter == 1 and \(s_nexttime main\.counter == 2\)\): PROVED$
-^\[main\.p1\] cover \(main\.counter == 1 and \(s_nexttime main\.counter == 3\)\): REFUTED$
-^\[main\.p2\] cover \(disable iff \(main\.counter == 1\) s_nexttime main\.counter == 2\): REFUTED$
+^\[main\.p1\] cover \(main\.counter == 1 and \(s_nexttime main\.counter == 3\)\): REFUTED up to bound 5$
+^\[main\.p2\] cover \(disable iff \(main\.counter == 1\) s_nexttime main\.counter == 2\): REFUTED up to bound 5$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/cover4.k-induction.desc
+++ b/regression/verilog/SVA/cover4.k-induction.desc
@@ -1,11 +1,9 @@
-KNOWNBUG
+CORE
 cover4.sv
 --k-induction
-^\[main\.p0\] cover 1: PROVED$
-^\[main\.p1\] cover 0: REFUTED$
-^EXIT=10$
+^error: there is no property suitable for k-induction$
+^EXIT=6$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-This gives the wrong answer.

--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, daniel.kroening@inf.ethz.ch
 #include <util/string2int.h>
 
 #include <temporal-logic/temporal_logic.h>
+#include <temporal-logic/trivial_sva.h>
 #include <trans-word-level/instantiate_word_level.h>
 #include <trans-word-level/trans_trace_word_level.h>
 #include <trans-word-level/unwind.h>
@@ -69,9 +70,9 @@ protected:
   void induction_base();
   void induction_step();
 
-  static bool supported(const ebmc_propertiest::propertyt &p)
+  static bool supported(const ebmc_propertiest::propertyt &property)
   {
-    auto &expr = p.normalized_expr;
+    auto expr = rewrite_disable_iff(property.normalized_expr);
     if(expr.id() == ID_sva_always || expr.id() == ID_AG || expr.id() == ID_G)
     {
       // Must be AG p or equivalent.
@@ -80,6 +81,14 @@ protected:
     }
     else
       return false;
+  }
+
+  /// extract p from AGp/Gp/always p
+  static exprt extract_p(const ebmc_propertiest::propertyt &property)
+  {
+    PRECONDITION(supported(property));
+    auto expr = rewrite_disable_iff(property.normalized_expr);
+    return to_unary_expr(expr).op();
   }
 };
 
@@ -311,7 +320,7 @@ void k_inductiont::induction_step()
     for(auto &property : properties.properties)
       if(property.is_assumed())
       {
-        const exprt &p = to_unary_expr(property.normalized_expr).op();
+        const exprt p = extract_p(property);
         for(std::size_t c = 0; c < no_timeframes; c++)
         {
           exprt tmp = instantiate(p, c, no_timeframes);
@@ -319,8 +328,7 @@ void k_inductiont::induction_step()
         }
       }
 
-    const exprt property(p_it.normalized_expr);
-    const exprt &p = to_unary_expr(property).op();
+    const exprt p = extract_p(p_it);
 
     // assumption: time frames 0,...,k-1
     for(std::size_t c = 0; c < no_timeframes - 1; c++)

--- a/src/temporal-logic/ltl_sva_to_string.cpp
+++ b/src/temporal-logic/ltl_sva_to_string.cpp
@@ -593,6 +593,23 @@ ltl_sva_to_stringt::rec(const exprt &expr, modet mode)
     auto op_rec = rec(sequence, mode);
     return resultt{precedencet::ATOM, "first_match(" + op_rec.s + ')'};
   }
+  else if(expr.id() == ID_sva_cover)
+  {
+    auto &cover = to_sva_cover_expr(expr);
+    return rec(sva_always_exprt{not_exprt{cover.op()}}, mode);
+  }
+  else if(expr.id() == ID_sva_disable_iff)
+  {
+    PRECONDITION(mode == PROPERTY);
+    auto &disable_iff = to_sva_disable_iff_expr(expr);
+    return rec(disable_iff.lower(), mode);
+  }
+  else if(expr.id() == ID_sva_sequence_disable_iff)
+  {
+    PRECONDITION(mode == SEQUENCE);
+    auto &disable_iff = to_sva_sequence_disable_iff_expr(expr);
+    return rec(disable_iff.lower(), mode);
+  }
   else if(!is_temporal_operator(expr))
   {
     auto number = atoms.number(expr);

--- a/src/temporal-logic/nnf.cpp
+++ b/src/temporal-logic/nnf.cpp
@@ -167,6 +167,12 @@ std::optional<exprt> negate_property_node(const exprt &expr)
     return sva_followed_by_exprt{
       implication.antecedent(), ID_sva_nonoverlapped_followed_by, not_b};
   }
+  else if(expr.id() == ID_sva_disable_iff)
+  {
+    // not disable iff (a) b   --->  not (a ∨ b)   --->   ¬a ∧ ¬b
+    auto &disable_iff = to_sva_disable_iff_expr(expr);
+    return negate_property_node(disable_iff.lower());
+  }
   else
     return {};
 }

--- a/src/temporal-logic/normalize_property.cpp
+++ b/src/temporal-logic/normalize_property.cpp
@@ -109,55 +109,8 @@ exprt normalize_property_rec(exprt expr)
   return expr;
 }
 
-// Turn "disable iff" into an OR for assertions,
-// and into an AND for cover statements.
-void rewrite_disable_iff(exprt &expr, bool cover)
-{
-  expr.visit_post(
-    [cover](exprt &node)
-    {
-      if(node.id() == ID_sva_disable_iff)
-      {
-        auto &disable_iff = to_sva_disable_iff_expr(node);
-        if(cover)
-        {
-          // a sva_disable_iff b --> ¬a ∧ b
-          node = and_exprt{not_exprt{disable_iff.lhs()}, disable_iff.rhs()};
-        }
-        else // assertion
-        {
-          // a sva_disable_iff b --> a ∨ b
-          node = or_exprt{disable_iff.lhs(), disable_iff.rhs()};
-        }
-      }
-      else if(node.id() == ID_sva_sequence_disable_iff)
-      {
-        // only used in cover sequence (disable iff ...)
-        PRECONDITION(cover);
-        auto &disable_iff = to_sva_sequence_disable_iff_expr(node);
-        // a sva_disable_iff b --> ¬a and b
-        node = sva_and_exprt{
-          sva_boolean_exprt{
-            not_exprt{disable_iff.lhs()}, verilog_sva_sequence_typet{}},
-          disable_iff.rhs(),
-          verilog_sva_sequence_typet{}};
-      }
-    });
-}
-
 exprt normalize_property(exprt expr)
 {
-  // top-level only
-  if(expr.id() == ID_sva_cover)
-  {
-    rewrite_disable_iff(to_sva_cover_expr(expr).op(), true);
-    expr = sva_always_exprt{sva_not_exprt{to_sva_cover_expr(expr).op()}};
-  }
-  else
-  {
-    rewrite_disable_iff(expr, false);
-  }
-
   expr = trivial_sva(expr);
 
   // now do recursion

--- a/src/temporal-logic/normalize_property.h
+++ b/src/temporal-logic/normalize_property.h
@@ -29,11 +29,8 @@ Author: Daniel Kroening, dkr@amazon.com
 /// ##[i:$] φ --> s_nexttime[i] s_eventually φ
 /// ##[*] φ --> s_eventually φ
 /// ##[+] φ --> always[1:1] s_eventually φ
-/// strong(φ) --> φ
-/// weak(φ) --> φ
 /// ¬ sva_s_eventually φ --> sva_always ¬φ
 /// ¬ sva_always φ --> sva_s_eventually ¬φ
-/// cover φ --> sva_always_exprt ¬φ
 ///
 /// ----LTL-----
 /// ¬Xφ --> X¬φ

--- a/src/temporal-logic/rewrite_sva_sequence.cpp
+++ b/src/temporal-logic/rewrite_sva_sequence.cpp
@@ -225,6 +225,13 @@ exprt rewrite_sva_sequence(exprt expr)
     else // neither lhs nor rhs admit an empty match
       return cycle_delay_expr;
   }
+  else if(expr.id() == ID_sva_sequence_disable_iff)
+  {
+    // leave as is
+    auto &disable_expr = to_sva_sequence_disable_iff_expr(expr);
+    disable_expr.sequence() = rewrite_sva_sequence(disable_expr.sequence());
+    return disable_expr;
+  }
   else if(expr.id() == ID_sva_sequence_repetition_star)
   {
     auto &repetition_expr = to_sva_sequence_repetition_star_expr(expr);

--- a/src/temporal-logic/sva_to_ltl.cpp
+++ b/src/temporal-logic/sva_to_ltl.cpp
@@ -270,6 +270,11 @@ exprt SVA_to_LTL(exprt expr)
     auto rec_rhs = SVA_to_LTL(sva_iff.rhs());
     return or_exprt{rec_rhs, rec_lhs};
   }
+  else if(expr.id() == ID_sva_disable_iff)
+  {
+    auto &disable_iff = to_sva_disable_iff_expr(expr);
+    return SVA_to_LTL(disable_iff.lower());
+  }
   else if(
     expr.id() == ID_and || expr.id() == ID_implies || expr.id() == ID_or ||
     expr.id() == ID_not ||

--- a/src/temporal-logic/trivial_sva.cpp
+++ b/src/temporal-logic/trivial_sva.cpp
@@ -134,3 +134,18 @@ exprt trivial_sva(exprt expr)
 
   return expr;
 }
+
+exprt rewrite_disable_iff(exprt expr)
+{
+  expr.visit_post(
+    [](exprt &node)
+    {
+      if(node.id() == ID_sva_disable_iff)
+      {
+        auto &disable_iff = to_sva_disable_iff_expr(node);
+        node = disable_iff.lower();
+      }
+    });
+
+  return expr;
+}

--- a/src/temporal-logic/trivial_sva.h
+++ b/src/temporal-logic/trivial_sva.h
@@ -28,4 +28,7 @@ Author: Daniel Kroening, dkr@amazon.com
 /// a sva_sync_reject_on b --> ¬a ∧ b
 exprt trivial_sva(exprt);
 
+/// disable_iff (c) φ --> c ∨ φ
+exprt rewrite_disable_iff(exprt);
+
 #endif

--- a/src/trans-netlist/unwind_netlist.cpp
+++ b/src/trans-netlist/unwind_netlist.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <temporal-logic/ctl.h>
 #include <temporal-logic/ltl.h>
 #include <temporal-logic/temporal_logic.h>
+#include <temporal-logic/trivial_sva.h>
 #include <verilog/sva_expr.h>
 
 #include "instantiate_netlist.h"
@@ -143,12 +144,13 @@ bvt unwind_property(const exprt &property_expr, const bmc_mapt &bmc_map)
 {
   bvt prop_bv{bmc_map.timeframe_map.size()};
 
+  auto rewritten = rewrite_disable_iff(property_expr);
+
   // We only do Gp/AGp
   PRECONDITION(
-    is_Gp(property_expr) || is_AGp(property_expr) ||
-    is_SVA_always_p(property_expr));
+    is_Gp(rewritten) || is_AGp(rewritten) || is_SVA_always_p(rewritten));
 
-  auto &p = to_unary_expr(property_expr).op();
+  auto &p = to_unary_expr(rewritten).op();
   PRECONDITION(p.id() == ID_literal);
 
   auto p_node = to_literal_expr(p).get_literal();
@@ -180,13 +182,15 @@ bool netlist_bmc_supports_property(const exprt &expr)
   if(has_subexpr(expr, ID_verilog_past))
     return false;
 
+  auto rewritten = rewrite_disable_iff(expr);
+
   // We do AG p only.
-  if(expr.id() == ID_AG)
-    return !has_temporal_operator(to_AG_expr(expr).op());
-  else if(expr.id() == ID_G)
-    return !has_temporal_operator(to_G_expr(expr).op());
-  else if(expr.id() == ID_sva_always)
-    return !has_temporal_operator(to_sva_always_expr(expr).op());
+  if(rewritten.id() == ID_AG)
+    return !has_temporal_operator(to_AG_expr(rewritten).op());
+  else if(rewritten.id() == ID_G)
+    return !has_temporal_operator(to_G_expr(rewritten).op());
+  else if(rewritten.id() == ID_sva_always)
+    return !has_temporal_operator(to_sva_always_expr(rewritten).op());
   else
     return false;
 }

--- a/src/trans-word-level/property.cpp
+++ b/src/trans-word-level/property.cpp
@@ -850,6 +850,25 @@ static obligationst property_obligations_rec(
     // Should have been turned into sva_implict_weak or sva_implict_strong in the type checker.
     PRECONDITION(false);
   }
+  else if(property_expr.id() == ID_sva_cover)
+  {
+    // These are existential properties, i.e., cover φ means
+    // "does there exist a path that satisfies φ".
+    // We go via the negation to turn our universal encoding
+    // into an existential one.
+    return property_obligations_rec(
+      sva_always_exprt{not_exprt{to_sva_cover_expr(property_expr).op()}},
+      current,
+      no_timeframes,
+      lasso);
+  }
+  else if(property_expr.id() == ID_sva_disable_iff)
+  {
+    // assertions pass vacuously when disabled
+    auto &disable_iff = to_sva_disable_iff_expr(property_expr);
+    auto or_expr = disable_iff.lower();
+    return property_obligations_rec(or_expr, current, no_timeframes, lasso);
+  }
   else
   {
     return obligationst{

--- a/src/trans-word-level/sequence.cpp
+++ b/src/trans-word-level/sequence.cpp
@@ -522,6 +522,20 @@ sequence_matchest instantiate_sequence_rec(
       instantiate_state_predicate(predicate, t, no_timeframes);
     return {{t, instantiated}};
   }
+  else if(expr.id() == ID_sva_sequence_disable_iff)
+  {
+    // sequences don't match when disabled
+    auto &disable_iff = to_sva_sequence_disable_iff_expr(expr);
+
+    // a sva_disable_iff b --> ¬a and b
+    auto and_expr = sva_and_exprt{
+      sva_boolean_exprt{
+        not_exprt{disable_iff.lhs()}, verilog_sva_sequence_typet{}},
+      disable_iff.rhs(),
+      verilog_sva_sequence_typet{}};
+
+    return instantiate_sequence_rec(and_expr, t, no_timeframes);
+  }
   else
   {
     DATA_INVARIANT_WITH_DIAGNOSTICS(

--- a/src/verilog/sva_expr.cpp
+++ b/src/verilog/sva_expr.cpp
@@ -11,6 +11,13 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/arith_tools.h>
 #include <util/mathematical_types.h>
 
+exprt sva_sequence_disable_iff_exprt::lower() const
+{
+  // sequences don't match when disabled
+  auto type = verilog_sva_sequence_typet{};
+  return sva_and_exprt{sva_boolean_exprt{condition(), type}, sequence(), type};
+}
+
 exprt sva_iff_exprt::implications() const
 {
   return sva_and_exprt{

--- a/src/verilog/sva_expr.h
+++ b/src/verilog/sva_expr.h
@@ -70,6 +70,8 @@ public:
     return op1();
   }
 
+  exprt lower() const;
+
 protected:
   using binary_exprt::op0;
   using binary_exprt::op1;
@@ -148,6 +150,12 @@ public:
         std::move(condition),
         std::move(property))
   {
+  }
+
+  // lhs ∨ rhs
+  exprt lower() const
+  {
+    return or_exprt{lhs(), rhs()};
   }
 };
 


### PR DESCRIPTION
This moves the logic for SVA `cover` from the property normalization into the property encoding in order to treat SVA `cover` differently from SVA sequences with strong semantics.