### PR TITLE
engine heuristic: copy result only

### DIFF
--- a/src/ebmc/ebmc_properties.cpp
+++ b/src/ebmc/ebmc_properties.cpp
@@ -16,6 +16,17 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include "ebmc_error.h"
 
+void ebmc_propertiest::propertyt::copy_results_from(
+  const ebmc_propertiest::propertyt &src)
+{
+  // copy the result fields of the property
+  status = src.status;
+  bound = src.bound;
+  witness_trace = src.witness_trace;
+  failure_reason = src.failure_reason;
+  proof_via = src.proof_via;
+}
+
 std::string ebmc_propertiest::propertyt::status_as_string() const
 {
   auto suffix = failure_reason.has_value() ? ": " + failure_reason.value() : "";

--- a/src/ebmc/ebmc_properties.h
+++ b/src/ebmc/ebmc_properties.h
@@ -35,6 +35,7 @@ public:
     exprt::operandst timeframe_handles; // word level
     std::string description;
 
+    // results
     enum class statust
     {
       UNKNOWN,            // no work done yet
@@ -54,6 +55,8 @@ public:
     std::optional<trans_tracet> witness_trace;
     std::optional<std::string> failure_reason;
     std::optional<std::string> proof_via;
+
+    void copy_results_from(const propertyt &);
 
     bool has_witness_trace() const
     {

--- a/src/ebmc/engine_heuristic.cpp
+++ b/src/ebmc/engine_heuristic.cpp
@@ -92,6 +92,21 @@ const enginet engines[] = {
   {bmc_bound_5_engine, "BMC with bound 5"},
 };
 
+void copy_results_to(
+  ebmc_propertiest::propertiest &src,
+  ebmc_propertiest::propertiest &dest)
+{
+  PRECONDITION(src.size() == dest.size());
+
+  // This could use std::views::zip with C++23
+  for(auto src_it = src.begin(), dest_it = dest.begin(); src_it != src.end();
+      src_it++, dest_it++)
+  {
+    // copy the result fields of the property
+    dest_it->copy_results_from(*src_it);
+  }
+}
+
 property_checker_resultt engine_heuristic(
   const cmdlinet &cmdline,
   transition_systemt &transition_system,
@@ -122,7 +137,7 @@ property_checker_resultt engine_heuristic(
     auto result = engine.f(
       cmdline, transition_system, properties, solver_factory, message_handler);
 
-    properties.properties = result.properties;
+    copy_results_to(result.properties, properties.properties);
 
     if(!properties.has_unfinished_property())
       return result; // done


### PR DESCRIPTION
Instead of copying the entire property data structure, the engine heuristic now only copies the fields that store the result.

This enables engines to make local changes to the other fields.