### PR TITLE
refute cover properties using k-induction

### DIFF
--- a/regression/verilog/SVA/cover4.k-induction.desc
+++ b/regression/verilog/SVA/cover4.k-induction.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 cover4.sv
 --k-induction
 ^\[main\.p0\] cover 1: PROVED$
@@ -8,4 +8,3 @@ cover4.sv
 --
 ^warning: ignoring
 --
-This gives the wrong answer.

--- a/src/ebmc/ebmc_properties.h
+++ b/src/ebmc/ebmc_properties.h
@@ -159,6 +159,13 @@ public:
       proof_via = {};
     }
 
+    void refuted(std::string _proof_via)
+    {
+      status = statust::REFUTED;
+      failure_reason = {};
+      proof_via = std::move(_proof_via);
+    }
+
     void refuted_with_bound(std::size_t _bound)
     {
       status = statust::REFUTED_WITH_BOUND;

--- a/src/ebmc/k_induction.cpp
+++ b/src/ebmc/k_induction.cpp
@@ -349,7 +349,14 @@ void k_inductiont::induction_step()
     case decision_proceduret::resultt::D_UNSATISFIABLE:
       message.result() << "UNSAT: inductive proof successful, property holds"
                        << messaget::eom;
-      p_it.proved(std::to_string(no_timeframes - 1) + "-induction");
+      {
+        auto engine = std::to_string(no_timeframes - 1) + "-induction";
+
+        if(p_it.is_exists_path())
+          p_it.refuted(engine);
+        else
+          p_it.proved(engine);
+      }
       break;
 
     case decision_proceduret::resultt::D_ERROR:


### PR DESCRIPTION
This adds support for refuting cover properties by means of a k-inductive proof that the cover criterion can never be satisfied.