### PR TITLE
refute cover properties using tautology check

### DIFF
--- a/regression/verilog/SVA/cover4.desc
+++ b/regression/verilog/SVA/cover4.desc
@@ -1,0 +1,10 @@
+CORE
+cover4.sv
+
+^\[main\.p0\] cover 1: PROVED$
+^\[main\.p1\] cover 0: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/src/ebmc/tautology_check.cpp
+++ b/src/ebmc/tautology_check.cpp
@@ -78,7 +78,10 @@ property_checker_resultt tautology_check(
       if(is_tautology(
            property.normalized_expr, solver_factory, message_handler))
       {
-        property.proved("tautology");
+        if(property.is_exists_path())
+          property.refuted("tautology");
+        else
+          property.proved("tautology");
       }
     }
   }

--- a/src/ebmc/transition_property.cpp
+++ b/src/ebmc/transition_property.cpp
@@ -151,7 +151,10 @@ property_checker_resultt transition_property(
     case decision_proceduret::resultt::D_UNSATISFIABLE:
       message.result() << "UNSAT: property holds for all transitions"
                        << messaget::eom;
-      property.proved("transition property");
+      if(property.is_exists_path())
+        property.refuted("transition property");
+      else
+        property.proved("transition property");
       break;
 
     case decision_proceduret::resultt::D_SATISFIABLE:


### PR DESCRIPTION
This adds support for refuting cover properties by means of the tautology check engine.