### PR TITLE
BMC: semantics of pending matches

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # EBMC 6.0
 
+* BMC: strong sequences that exceed the bound are no longer reported as REFUTED
 * VCD traces now written into separate files per property
 * SMV: removed legacy keywords EXTERN and switch
 * SMV: use NuSMV's operator precedence, as opposed to CMU SMV's

--- a/regression/verilog/SVA/cover3.desc
+++ b/regression/verilog/SVA/cover3.desc
@@ -1,12 +1,11 @@
-KNOWNBUG
+CORE
 cover3.sv
 
 ^\[main\.p0\] cover \(main\.counter == 1 and \(s_nexttime main\.counter == 2\)\): PROVED$
-^\[main\.p1\] cover \(main\.counter == 1 and \(s_nexttime main\.counter == 3\)\): REFUTED$
-^\[main\.p2\] cover \(disable iff \(main\.counter == 1\) s_nexttime main\.counter == 2\): REFUTED$
+^\[main\.p1\] cover \(main\.counter == 1 and \(s_nexttime main\.counter == 3\)\): REFUTED up to bound 5$
+^\[main\.p2\] cover \(disable iff \(main\.counter == 1\) s_nexttime main\.counter == 2\): REFUTED up to bound 5$
 ^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-This gives the wrong answer.

--- a/regression/verilog/SVA/cover4.buechi.desc
+++ b/regression/verilog/SVA/cover4.buechi.desc
@@ -1,4 +1,4 @@
-KNOWNBUG buechi
+CORE buechi
 cover4.sv
 --buechi
 ^\[main\.p0\] cover 1: PROVED$
@@ -8,4 +8,3 @@ cover4.sv
 --
 ^warning: ignoring
 --
-This gives the wrong answer.

--- a/regression/verilog/SVA/sequence2.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence2.bmc.buechi.desc
@@ -1,8 +1,9 @@
 CORE buechi
 sequence2.sv
 --buechi --bound 10
-^\[main\.p0] weak\(##\[0:\$\] main\.x == 10\): PROVED up to bound 10$
-^\[main\.p1] strong\(##\[0:\$\] main\.x == 10\): REFUTED$
+^\[main\.p0\] weak\(##\[0:\$\] main\.x == 10\): PROVED up to bound 10$
+^\[main\.p1\] strong\(##\[0:\$\] main\.x == 10\): REFUTED$
+^\[main\.c0\] cover strong\(##\[0:\$\] main\.x == 10\): REFUTED up to bound 10$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/sequence2.bmc.desc
+++ b/regression/verilog/SVA/sequence2.bmc.desc
@@ -2,7 +2,8 @@ CORE
 sequence2.sv
 --bound 10
 ^\[main\.p0] weak\(##\[0:\$\] main\.x == 10\): PROVED up to bound 10$
-^\[main\.p1] strong\(##\[0:\$\] main\.x == 10\): REFUTED$
+^\[main\.p1] strong\(##\[0:\$\] main\.x == 10\): PROVED up to bound 10$
+^\[main\.c0] cover strong\(##\[0:\$\] main\.x == 10\): REFUTED up to bound 10$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/sequence2.sv
+++ b/regression/verilog/SVA/sequence2.sv
@@ -12,7 +12,10 @@ module main;
   // does not match -- passes
   initial p0: assert property (weak(##[0:$] x==10));
 
-  // does not match -- fails
+  // does not match -- proved up to bound (pending match)
   initial p1: assert property (strong(##[0:$] x==10));
+
+  // cover: no witness found
+  initial c0: cover property (strong(##[0:$] x==10));
 
 endmodule

--- a/regression/verilog/SVA/sequence3.bmc.buechi.desc
+++ b/regression/verilog/SVA/sequence3.bmc.buechi.desc
@@ -9,6 +9,8 @@ sequence3.sv
 ^\[main\.pw1\] weak\(##\[\*\] main\.x == 5\): PROVED up to bound 20$
 ^\[main\.pw2\] weak\(##\[\+\] main\.x == 0\): PROVED up to bound 20$
 ^\[main\.pw3\] weak\(##\[\+\] main\.x == 5\): PROVED up to bound 20$
+^\[main\.cs0\] cover strong\(##\[\*\] main\.x == 6\): REFUTED up to bound 20$
+^\[main\.cs2\] cover strong\(##\[\+\] main\.x == 0\): REFUTED up to bound 20$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/sequence3.bmc.desc
+++ b/regression/verilog/SVA/sequence3.bmc.desc
@@ -1,14 +1,16 @@
 CORE
 sequence3.sv
 --bound 20 --numbered-trace
-^\[main\.ps0\] strong\(##\[\*\] main\.x == 6\): REFUTED$
+^\[main\.ps0\] strong\(##\[\*\] main\.x == 6\): PROVED up to bound 20$
 ^\[main\.ps1\] strong\(##\[\*\] main\.x == 5\): PROVED up to bound 20$
-^\[main\.ps2\] strong\(##\[\+\] main\.x == 0\): REFUTED$
+^\[main\.ps2\] strong\(##\[\+\] main\.x == 0\): PROVED up to bound 20$
 ^\[main\.ps3\] strong\(##\[\+\] main\.x == 5\): PROVED up to bound 20$
 ^\[main\.pw0\] weak\(##\[\*\] main\.x == 6\): PROVED up to bound 20$
 ^\[main\.pw1\] weak\(##\[\*\] main\.x == 5\): PROVED up to bound 20$
 ^\[main\.pw2\] weak\(##\[\+\] main\.x == 0\): PROVED up to bound 20$
 ^\[main\.pw3\] weak\(##\[\+\] main\.x == 5\): PROVED up to bound 20$
+^\[main\.cs0\] cover strong\(##\[\*\] main\.x == 6\): REFUTED up to bound 20$
+^\[main\.cs2\] cover strong\(##\[\+\] main\.x == 0\): REFUTED up to bound 20$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/sequence3.sv
+++ b/regression/verilog/SVA/sequence3.sv
@@ -25,4 +25,8 @@ module main;
   initial pw2: assert property (weak(##[+] x==0)); // no match
   initial pw3: assert property (weak(##[+] x==5)); // match
 
+  // cover: no witness found (pending matches dropped for cover)
+  initial cs0: cover property (strong(##[*] x==6));
+  initial cs2: cover property (strong(##[+] x==0));
+
 endmodule

--- a/regression/verilog/SVA/sequence_repetition1.desc
+++ b/regression/verilog/SVA/sequence_repetition1.desc
@@ -7,8 +7,10 @@ sequence_repetition1.sv
 ^\[main\.p3\] main\.x == 0 \[\*2\]: REFUTED$
 ^\[main\.p4w\] main\.x == 0 \[->2\]: PROVED up to bound 10$
 ^\[main\.p5w\] main\.x == 0 \[=2\]: PROVED up to bound 10$
-^\[main\.p4s\] strong\(main\.x == 0 \[->2\]\): REFUTED$
-^\[main\.p5s\] strong\(main\.x == 0 \[=2\]\): REFUTED$
+^\[main\.p4s\] strong\(main\.x == 0 \[->2\]\): PROVED up to bound 10$
+^\[main\.p5s\] strong\(main\.x == 0 \[=2\]\): PROVED up to bound 10$
+^\[main\.c4s\] cover strong\(main\.x == 0 \[->2\]\): REFUTED up to bound 10$
+^\[main\.c5s\] cover strong\(main\.x == 0 \[=2\]\): REFUTED up to bound 10$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/sequence_repetition1.sv
+++ b/regression/verilog/SVA/sequence_repetition1.sv
@@ -21,8 +21,12 @@ module main(input clk);
   initial p4w: assert property (x==0[->2]);
   initial p5w: assert property (x==0[=2]);
 
-  // these fail, since the strong variant requires the match
+  // these are proved up to bound (pending matches suffice for assert)
   initial p4s: assert property (strong(x==0[->2]));
   initial p5s: assert property (strong(x==0[=2]));
+
+  // cover: no witness found (pending matches dropped for cover)
+  initial c4s: cover property (strong(x==0[->2]));
+  initial c5s: cover property (strong(x==0[=2]));
 
 endmodule

--- a/regression/verilog/SVA/strong1.buechi.desc
+++ b/regression/verilog/SVA/strong1.buechi.desc
@@ -1,10 +1,10 @@
-KNOWNBUG buechi
+CORE buechi
 strong1.sv
 --buechi --bound 4
-^\[main\.p0\] strong\(##\[0:9\] main\.x == 5\): REFUTED$
+^\[main\.p0\] strong\(##\[0:9\] main\.x == 5\): PROVED up to bound 4$
+^\[main\.c0\] cover strong\(##\[0:9\] main\.x == 5\): REFUTED up to bound 4$
 ^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-This should be refuted.

--- a/regression/verilog/SVA/strong1.desc
+++ b/regression/verilog/SVA/strong1.desc
@@ -1,7 +1,8 @@
 CORE
 strong1.sv
 --bound 4
-^\[main\.p0\] strong\(##\[0:9\] main\.x == 5\): REFUTED$
+^\[main\.p0\] strong\(##\[0:9\] main\.x == 5\): PROVED up to bound 4$
+^\[main\.c0\] cover strong\(##\[0:9\] main\.x == 5\): REFUTED up to bound 4$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/strong1.sv
+++ b/regression/verilog/SVA/strong1.sv
@@ -8,7 +8,10 @@ module main;
   always @(posedge clk)
     x<=x+1;
 
-  // fails if bound is too low
+  // proved up to bound if bound is too low
   initial p0: assert property (strong(##[0:9] x==5));
+
+  // cover: no witness found within bound
+  initial c0: cover property (strong(##[0:9] x==5));
 
 endmodule

--- a/src/ebmc/bmc.cpp
+++ b/src/ebmc/bmc.cpp
@@ -277,8 +277,11 @@ property_checker_resultt bmc(
       continue;
     }
 
-    auto obligations =
-      ::property(property.normalized_expr, message_handler, no_timeframes);
+    auto obligations = ::property(
+      property.normalized_expr,
+      !property.is_exists_path(),
+      message_handler,
+      no_timeframes);
 
     if(uses_lasso_symbol(obligations))
       requires_lasso_constraints = true;

--- a/src/ebmc/transition_property.cpp
+++ b/src/ebmc/transition_property.cpp
@@ -73,6 +73,17 @@ bool is_transition_property(const exprt &expr)
     return false;
 }
 
+/// Given a transition property G Q (or sva_always Q),
+/// returns Q in LTL form.
+static exprt transition_property_q(const exprt &expr)
+{
+  if(is_SVA(expr))
+    return transition_property_q(SVA_to_LTL(expr));
+
+  PRECONDITION(expr.id() == ID_G);
+  return to_G_expr(expr).op();
+}
+
 property_checker_resultt transition_property(
   const transition_systemt &transition_system,
   const ebmc_propertiest &properties_in,
@@ -130,8 +141,9 @@ property_checker_resultt transition_property(
     if(!property.is_unknown())
       continue;
 
-    // Instantiate property, for two timeframes
-    auto obligations = ::property(property.normalized_expr, message_handler, 2);
+    // Instantiate Q (not G Q) for two timeframes
+    auto q = transition_property_q(property.normalized_expr);
+    auto obligations = ::property(q, false, message_handler, 2);
     auto constraint = not_exprt{conjunction(obligations)};
     handles[property.identifier] = solver.handle(constraint);
   }

--- a/src/trans-word-level/property.cpp
+++ b/src/trans-word-level/property.cpp
@@ -141,32 +141,6 @@ bool bmc_supports_property(const exprt &expr)
 
 /*******************************************************************\
 
-Function: sva_sequence_semantics
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-static sva_sequence_semanticst sva_sequence_semantics(irep_idt id)
-{
-  if(id == ID_sva_strong)
-    return sva_sequence_semanticst::STRONG;
-  else if(id == ID_sva_weak)
-    return sva_sequence_semanticst::WEAK;
-  else if(id == ID_sva_implicit_strong)
-    return sva_sequence_semanticst::STRONG;
-  else if(id == ID_sva_implicit_weak)
-    return sva_sequence_semanticst::WEAK;
-  else
-    PRECONDITION(false);
-}
-
-/*******************************************************************\
-
 Function: property_obligations_rec
 
   Inputs:
@@ -186,6 +160,7 @@ struct bmc_lassot
 
 static obligationst property_obligations_rec(
   const exprt &property_expr,
+  bool allow_pending_matches,
   const mp_integer &current,
   const mp_integer &no_timeframes,
   const std::optional<bmc_lassot> &lasso)
@@ -236,7 +211,8 @@ static obligationst property_obligations_rec(
 
     for(mp_integer c = from; c <= to; ++c)
     {
-      obligations.add(property_obligations_rec(phi, c, no_timeframes, lasso));
+      obligations.add(property_obligations_rec(
+        phi, allow_pending_matches, c, no_timeframes, lasso));
     }
 
     return obligations;
@@ -261,8 +237,8 @@ static obligationst property_obligations_rec(
 
     for(mp_integer u = current + from; u <= current + to; ++u)
     {
-      auto obligations_rec =
-        property_obligations_rec(op, u, no_timeframes, lasso);
+      auto obligations_rec = property_obligations_rec(
+        op, allow_pending_matches, u, no_timeframes, lasso);
       disjuncts.push_back(obligations_rec.conjunction().second);
     }
 
@@ -301,7 +277,8 @@ static obligationst property_obligations_rec(
 
     for(mp_integer j = current; j < l.end; ++j)
     {
-      auto tmp = property_obligations_rec(phi, j, no_timeframes, lasso);
+      auto tmp = property_obligations_rec(
+        phi, allow_pending_matches, j, no_timeframes, lasso);
       phi_disjuncts.push_back(tmp.conjunction().second);
     }
 
@@ -341,7 +318,8 @@ static obligationst property_obligations_rec(
     for(mp_integer c = from; c <= to; ++c)
     {
       auto tmp =
-        property_obligations_rec(s_eventually.op(), c, no_timeframes, lasso)
+        property_obligations_rec(
+          s_eventually.op(), allow_pending_matches, c, no_timeframes, lasso)
           .conjunction();
       time = std::max(time, tmp.first);
       disjuncts.push_back(tmp.second);
@@ -390,7 +368,8 @@ static obligationst property_obligations_rec(
 
     for(mp_integer c = from; c <= to; ++c)
     {
-      obligations.add(property_obligations_rec(phi, c, no_timeframes, lasso));
+      obligations.add(property_obligations_rec(
+        phi, allow_pending_matches, c, no_timeframes, lasso));
     }
 
     return obligations;
@@ -428,7 +407,8 @@ static obligationst property_obligations_rec(
         next = current + 1;
       }
 
-      return property_obligations_rec(phi, next, no_timeframes, lasso);
+      return property_obligations_rec(
+        phi, allow_pending_matches, next, no_timeframes, lasso);
     }
     else
     {
@@ -436,7 +416,8 @@ static obligationst property_obligations_rec(
 
       if(next < no_timeframes)
       {
-        return property_obligations_rec(phi, next, no_timeframes, lasso);
+        return property_obligations_rec(
+          phi, allow_pending_matches, next, no_timeframes, lasso);
       }
       else
       {
@@ -454,7 +435,8 @@ static obligationst property_obligations_rec(
     // p U q ≡ Fq ∧ (p W q)
     exprt tmp = and_exprt{F_exprt{q}, weak_U_exprt{p, q}};
 
-    return property_obligations_rec(tmp, current, no_timeframes, lasso);
+    return property_obligations_rec(
+      tmp, allow_pending_matches, current, no_timeframes, lasso);
   }
   else if(property_expr.id() == ID_sva_until || property_expr.id() == ID_weak_U)
   {
@@ -481,10 +463,12 @@ static obligationst property_obligations_rec(
 
     for(mp_integer j = start; j < end; ++j)
     {
-      auto q_rec = property_obligations_rec(q, j, no_timeframes, lasso);
+      auto q_rec = property_obligations_rec(
+        q, allow_pending_matches, j, no_timeframes, lasso);
       q_disjuncts.push_back(q_rec.conjunction().second);
 
-      auto p_rec = property_obligations_rec(p, j, no_timeframes, lasso);
+      auto p_rec = property_obligations_rec(
+        p, allow_pending_matches, j, no_timeframes, lasso);
       auto cond =
         or_exprt{p_rec.conjunction().second, disjunction(q_disjuncts)};
 
@@ -518,12 +502,14 @@ static obligationst property_obligations_rec(
 
     for(mp_integer j = start; j < end; ++j)
     {
-      auto q_rec = property_obligations_rec(q, j, no_timeframes, lasso);
+      auto q_rec = property_obligations_rec(
+        q, allow_pending_matches, j, no_timeframes, lasso);
       auto cond =
         or_exprt{q_rec.conjunction().second, disjunction(p_disjuncts)};
       obligations.add(current, cond);
 
-      auto p_rec = property_obligations_rec(p, j, no_timeframes, lasso);
+      auto p_rec = property_obligations_rec(
+        p, allow_pending_matches, j, no_timeframes, lasso);
       p_disjuncts.push_back(p_rec.conjunction().second);
     }
 
@@ -537,7 +523,8 @@ static obligationst property_obligations_rec(
     // p strongR q ≡ Fp ∧ (p R q)
     exprt tmp = and_exprt{F_exprt{q}, weak_U_exprt{p, q}};
 
-    return property_obligations_rec(tmp, current, no_timeframes, lasso);
+    return property_obligations_rec(
+      tmp, allow_pending_matches, current, no_timeframes, lasso);
   }
   else if(property_expr.id() == ID_sva_until_with)
   {
@@ -545,7 +532,8 @@ static obligationst property_obligations_rec(
     // Note that lhs and rhs are flipped.
     auto &until_with = to_sva_until_with_expr(property_expr);
     auto R = R_exprt{until_with.rhs(), until_with.lhs()};
-    return property_obligations_rec(R, current, no_timeframes, lasso);
+    return property_obligations_rec(
+      R, allow_pending_matches, current, no_timeframes, lasso);
   }
   else if(property_expr.id() == ID_sva_s_until_with)
   {
@@ -553,7 +541,8 @@ static obligationst property_obligations_rec(
     // Note that lhs and rhs are flipped.
     auto &s_until_with = to_sva_s_until_with_expr(property_expr);
     auto strong_R = strong_R_exprt{s_until_with.rhs(), s_until_with.lhs()};
-    return property_obligations_rec(strong_R, current, no_timeframes, lasso);
+    return property_obligations_rec(
+      strong_R, allow_pending_matches, current, no_timeframes, lasso);
   }
   else if(property_expr.id() == ID_and)
   {
@@ -563,8 +552,8 @@ static obligationst property_obligations_rec(
 
     for(auto &op : to_and_expr(property_expr).operands())
     {
-      obligations.add(
-        property_obligations_rec(op, current, no_timeframes, lasso));
+      obligations.add(property_obligations_rec(
+        op, allow_pending_matches, current, no_timeframes, lasso));
     }
 
     return obligations;
@@ -579,8 +568,8 @@ static obligationst property_obligations_rec(
 
     for(auto &op : to_or_expr(property_expr).operands())
     {
-      auto obligations =
-        property_obligations_rec(op, current, no_timeframes, lasso);
+      auto obligations = property_obligations_rec(
+        op, allow_pending_matches, current, no_timeframes, lasso);
       auto conjunction = obligations.conjunction();
       t = std::max(t, conjunction.first);
       disjuncts.push_back(conjunction.second);
@@ -597,14 +586,16 @@ static obligationst property_obligations_rec(
     auto tmp = and_exprt{
       implies_exprt{equal_expr.lhs(), equal_expr.rhs()},
       implies_exprt{equal_expr.rhs(), equal_expr.lhs()}};
-    return property_obligations_rec(tmp, current, no_timeframes, lasso);
+    return property_obligations_rec(
+      tmp, allow_pending_matches, current, no_timeframes, lasso);
   }
   else if(property_expr.id() == ID_implies)
   {
     // we rely on NNF
     auto &implies_expr = to_implies_expr(property_expr);
     auto tmp = or_exprt{not_exprt{implies_expr.lhs()}, implies_expr.rhs()};
-    return property_obligations_rec(tmp, current, no_timeframes, lasso);
+    return property_obligations_rec(
+      tmp, allow_pending_matches, current, no_timeframes, lasso);
   }
   else if(property_expr.id() == ID_if)
   {
@@ -612,14 +603,20 @@ static obligationst property_obligations_rec(
     auto &if_expr = to_if_expr(property_expr);
     auto cond =
       instantiate_state_predicate(if_expr.cond(), current, no_timeframes);
-    auto obligations_true =
-      property_obligations_rec(
-        if_expr.true_case(), current, no_timeframes, lasso)
-        .conjunction();
-    auto obligations_false =
-      property_obligations_rec(
-        if_expr.false_case(), current, no_timeframes, lasso)
-        .conjunction();
+    auto obligations_true = property_obligations_rec(
+                              if_expr.true_case(),
+                              allow_pending_matches,
+                              current,
+                              no_timeframes,
+                              lasso)
+                              .conjunction();
+    auto obligations_false = property_obligations_rec(
+                               if_expr.false_case(),
+                               allow_pending_matches,
+                               current,
+                               no_timeframes,
+                               lasso)
+                               .conjunction();
     return obligationst{
       std::max(obligations_true.first, obligations_false.first),
       if_exprt{cond, obligations_true.second, obligations_false.second}};
@@ -630,7 +627,11 @@ static obligationst property_obligations_rec(
   {
     // drop reduntant type casts
     return property_obligations_rec(
-      to_typecast_expr(property_expr).op(), current, no_timeframes, lasso);
+      to_typecast_expr(property_expr).op(),
+      allow_pending_matches,
+      current,
+      no_timeframes,
+      lasso);
   }
   else if(property_expr.id() == ID_not)
   {
@@ -642,14 +643,17 @@ static obligationst property_obligations_rec(
     if(op_negated_opt.has_value())
     {
       return property_obligations_rec(
-        op_negated_opt.value(), current, no_timeframes, lasso);
+        op_negated_opt.value(),
+        allow_pending_matches,
+        current,
+        no_timeframes,
+        lasso);
     }
     else if(
       op.id() == ID_sva_strong || op.id() == ID_sva_weak ||
       op.id() == ID_sva_implicit_strong || op.id() == ID_sva_implicit_weak)
     {
       auto &sequence = to_sva_sequence_property_expr_base(op).sequence();
-      auto semantics = sva_sequence_semantics(op.id());
 
       const auto matches =
         instantiate_sequence(sequence, current, no_timeframes);
@@ -658,8 +662,8 @@ static obligationst property_obligations_rec(
 
       for(auto &match : matches)
       {
-        // drop pending matches when using strong semantics
-        if(semantics == sva_sequence_semanticst::STRONG && match.is_pending())
+        // drop pending matches when not allowed
+        if(match.is_pending() && !allow_pending_matches)
           continue;
 
         // The sequence must not match.
@@ -689,7 +693,7 @@ static obligationst property_obligations_rec(
     auto implies_expr =
       implies_exprt{sva_implies_expr.lhs(), sva_implies_expr.rhs()};
     return property_obligations_rec(
-      implies_expr, current, no_timeframes, lasso);
+      implies_expr, allow_pending_matches, current, no_timeframes, lasso);
   }
   else if(property_expr.id() == ID_sva_iff)
   {
@@ -697,7 +701,8 @@ static obligationst property_obligations_rec(
     // Note that this is not an SVA sequence operator.
     auto &sva_iff_expr = to_sva_iff_expr(property_expr);
     auto equal_expr = equal_exprt{sva_iff_expr.lhs(), sva_iff_expr.rhs()};
-    return property_obligations_rec(equal_expr, current, no_timeframes, lasso);
+    return property_obligations_rec(
+      equal_expr, allow_pending_matches, current, no_timeframes, lasso);
   }
   else if(
     property_expr.id() == ID_sva_overlapped_implication ||
@@ -743,7 +748,7 @@ static obligationst property_obligations_rec(
 
       // Get obligations for RHS
       auto rhs_obligations_rec = property_obligations_rec(
-        implication.rhs(), t_rhs, no_timeframes, lasso);
+        implication.rhs(), allow_pending_matches, t_rhs, no_timeframes, lasso);
 
       for(auto &rhs_obligation : rhs_obligations_rec.map)
       {
@@ -801,10 +806,13 @@ static obligationst property_obligations_rec(
       }
       else
       {
-        auto obligations_rec =
-          property_obligations_rec(
-            followed_by.consequent(), property_start, no_timeframes, lasso)
-            .conjunction();
+        auto obligations_rec = property_obligations_rec(
+                                 followed_by.consequent(),
+                                 allow_pending_matches,
+                                 property_start,
+                                 no_timeframes,
+                                 lasso)
+                                 .conjunction();
 
         disjuncts.push_back(
           and_exprt{match.condition(), obligations_rec.second});
@@ -822,7 +830,6 @@ static obligationst property_obligations_rec(
     // match points, and evaluate to true if any of them matches
     auto &sequence =
       to_sva_sequence_property_expr_base(property_expr).sequence();
-    auto semantics = sva_sequence_semantics(property_expr.id());
 
     const auto matches = instantiate_sequence(sequence, current, no_timeframes);
     exprt::operandst disjuncts;
@@ -831,8 +838,8 @@ static obligationst property_obligations_rec(
 
     for(auto &match : matches)
     {
-      // drop pending matches when using strong semantics
-      if(semantics == sva_sequence_semanticst::STRONG && match.is_pending())
+      // drop pending matches when not allowed
+      if(match.is_pending() && !allow_pending_matches)
         continue;
 
       // empty matches are not considered
@@ -897,8 +904,10 @@ obligationst property_obligations_lasso(
   for(lasso.end = 1; lasso.end < no_timeframes; ++lasso.end)
     for(lasso.start = 0; lasso.start < lasso.end; ++lasso.start)
     {
+      // There is no need to consider pending matches on lasso-shaped
+      // traces -- the length of the trace is infinite.
       auto obligations_lasso =
-        property_obligations_rec(property_expr, 0, no_timeframes, lasso);
+        property_obligations_rec(property_expr, false, 0, no_timeframes, lasso);
 
       auto lasso_symbol = ::lasso_symbol(lasso.start, lasso.end);
 
@@ -933,6 +942,7 @@ Function: property_obligations
 
 obligationst property_obligations(
   const exprt &property_expr,
+  bool allow_pending_matches,
   message_handlert &message_handler,
   const mp_integer &no_timeframes)
 {
@@ -950,7 +960,8 @@ obligationst property_obligations(
   obligationst obligations;
 
   // Form 1 -- linear path
-  auto form_1 = property_obligations_rec(nnf, 0, no_timeframes, {});
+  auto form_1 =
+    property_obligations_rec(nnf, allow_pending_matches, 0, no_timeframes, {});
 
   // Form 2 -- lasso
   auto form_2 = property_obligations_lasso(nnf, no_timeframes);
@@ -972,14 +983,15 @@ Function: property
 
 exprt::operandst property(
   const exprt &property_expr,
+  bool allow_pending_matches,
   message_handlert &message_handler,
   std::size_t no_timeframes)
 {
   // The first element of the pair is the length of the
   // counterexample, and the second is the condition that
   // must be valid for the property to hold.
-  auto obligations =
-    property_obligations(property_expr, message_handler, no_timeframes);
+  auto obligations = property_obligations(
+    property_expr, allow_pending_matches, message_handler, no_timeframes);
 
   // Map obligations onto timeframes.
   exprt::operandst prop_handles{no_timeframes, true_exprt()};

--- a/src/trans-word-level/property.h
+++ b/src/trans-word-level/property.h
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 /// returns a vector of obligation expressions, one per timeframe
 exprt::operandst property(
   const exprt &property_expr,
+  bool allow_pending_matches,
   message_handlert &,
   std::size_t no_timeframes);
 


### PR DESCRIPTION
## Summary

Adds an `allow_pending_matches` parameter to the BMC property obligation
pipeline, controlling whether pending sequence matches (those that cannot
complete within the verification bound) are kept or dropped.

## Semantic change

In BMC we only search for counterexamples on finite paths. A pending match
is inconclusive — it neither proves nor disproves the property.

- **Universal properties (assert):** `allow_pending_matches=true`. Pending
  matches are kept as vacuously true. No counterexample was found at the
  boundary, so BMC correctly reports "PROVED up to bound".
- **Existential properties (cover):** `allow_pending_matches=false`. Pending
  matches are dropped — an incomplete match is not a witness.

Previously, the strong/weak sequence distinction controlled this: strong
sequences dropped pending matches, weak sequences kept them. This was
incorrect for BMC — the strong/weak distinction is about whether a sequence
*requires* a match to exist, which is a separate concern from how BMC handles
the finite-path boundary. The `sva_sequence_semantics` helper is removed.

Implication and followed-by antecedents continue to unconditionally drop
pending LHS matches, since a pending antecedent should not trigger the
consequent.

## Effect on tests

Properties like `assert property (strong(##[0:9] x==5))` with a bound too
low for the match to complete now report "PROVED up to bound" instead of
"REFUTED". The old REFUTED was unsound — BMC was conflating "match cannot
complete within bound" with "property is refuted".

## What was tested

- All verilog regression tests pass
- All ebmc regression tests pass