### PR TITLE
BTOR2 front-end

### DIFF
--- a/regression/ebmc/btor/arithmetic1.btor2
+++ b/regression/ebmc/btor/arithmetic1.btor2
@@ -1,0 +1,40 @@
+; Test arithmetic operators on 8-bit values
+1 sort bitvec 8
+2 sort bitvec 1
+3 constd 1 10
+4 constd 1 3
+; sub(10, 3) == 7
+5 sub 1 3 4
+6 constd 1 7
+7 neq 2 5 6
+8 bad 7
+; mul(10, 3) == 30
+9 mul 1 3 4
+10 constd 1 30
+11 neq 2 9 10
+12 bad 11
+; udiv(10, 3) == 3
+13 udiv 1 3 4
+14 neq 2 13 4
+15 bad 14
+; urem(10, 3) == 1
+16 urem 1 3 4
+17 constd 1 1
+18 neq 2 16 17
+19 bad 18
+; sdiv: -6 / 3 == -2
+; Use add to verify: sdiv(-6,3)*3 + srem(-6,3) == -6
+20 constd 1 250
+21 sdiv 1 20 4
+22 mul 1 21 4
+23 srem 1 20 4
+24 add 1 22 23
+25 neq 2 24 20
+26 bad 25
+; smod: verify smod(-7,3) has sign of divisor (positive)
+; -7 smod 3: result should be 2 (since -7 = -3*3 + 2)
+27 constd 1 249
+28 smod 1 27 4
+29 constd 1 2
+30 neq 2 28 29
+31 bad 30

--- a/regression/ebmc/btor/arithmetic1.desc
+++ b/regression/ebmc/btor/arithmetic1.desc
@@ -1,0 +1,12 @@
+CORE
+arithmetic1.btor2
+--bound 0
+^\[bad8\] : PROVED up to bound 0$
+^\[bad12\] : PROVED up to bound 0$
+^\[bad15\] : PROVED up to bound 0$
+^\[bad19\] : PROVED up to bound 0$
+^\[bad26\] : PROVED up to bound 0$
+^\[bad31\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/array-trace1.btor2
+++ b/regression/ebmc/btor/array-trace1.btor2
@@ -1,0 +1,15 @@
+; Minimal reproducer for bv_get_cache crash during array trace extraction.
+; An array state with write, where eq(write, write) feeds a bool state's next.
+1 sort bitvec 4
+2 sort bitvec 1
+3 sort array 2 1
+4 zero 2
+5 state 2
+6 init 2 5 4
+7 state 3
+8 state 1
+9 write 3 7 5 8
+10 eq 2 9 9
+11 next 2 5 10
+12 next 3 7 9
+13 bad 5

--- a/regression/ebmc/btor/array-trace1.desc
+++ b/regression/ebmc/btor/array-trace1.desc
@@ -1,0 +1,9 @@
+KNOWNBUG broken-smt-backend
+array-trace1.btor2
+--bound 1
+^\[bad13\] : REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+bv_get_cache invariant failure during counterexample trace extraction for arrays

--- a/regression/ebmc/btor/array1.btor2
+++ b/regression/ebmc/btor/array1.btor2
@@ -1,0 +1,14 @@
+; Test array read and write
+1 sort bitvec 4
+2 sort bitvec 8
+3 sort array 1 2
+4 sort bitvec 1
+; Create an input array, write 42 at index 3, read it back
+5 input 3 arr
+6 constd 1 3
+7 constd 2 42
+8 write 3 5 6 7
+; read(write(arr, 3, 42), 3) should be 42
+9 read 2 8 6
+10 neq 4 9 7
+11 bad 10

--- a/regression/ebmc/btor/array1.desc
+++ b/regression/ebmc/btor/array1.desc
@@ -1,0 +1,7 @@
+CORE
+array1.btor2
+--bound 0
+^\[bad11\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/bitvec1-arithmetic1.btor2
+++ b/regression/ebmc/btor/bitvec1-arithmetic1.btor2
@@ -1,0 +1,16 @@
+; Arithmetic and unary operators on bitvec 1
+1 sort bitvec 1
+2 zero 1
+3 one 1
+; neg(0) should be 0
+4 neg 1 2
+5 bad 4
+; add(1, 1) on 1-bit wraps to 0
+6 add 1 3 3
+7 bad 6
+; sub(0, 0) should be 0
+8 sub 1 2 2
+9 bad 8
+; smod(1, 1) should be 0
+10 smod 1 3 3
+11 bad 10

--- a/regression/ebmc/btor/bitvec1-arithmetic1.desc
+++ b/regression/ebmc/btor/bitvec1-arithmetic1.desc
@@ -1,0 +1,10 @@
+CORE
+bitvec1-arithmetic1.btor2
+--bound 0
+^\[bad5\] : PROVED up to bound 0$
+^\[bad7\] : PROVED up to bound 0$
+^\[bad9\] : PROVED up to bound 0$
+^\[bad11\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/bitvec1-constd-negative1.btor2
+++ b/regression/ebmc/btor/bitvec1-constd-negative1.btor2
@@ -1,0 +1,6 @@
+; constd with negative value on bitvec 1
+; constd 1 -1 should be treated as 1 (LSB of -1)
+1 sort bitvec 1
+2 constd 1 -1
+; -1 masked to 1 bit is 1, so bad should fire
+3 bad 2

--- a/regression/ebmc/btor/bitvec1-constd-negative1.desc
+++ b/regression/ebmc/btor/bitvec1-constd-negative1.desc
@@ -1,0 +1,7 @@
+CORE
+bitvec1-constd-negative1.btor2
+--bound 0
+^\[bad3\] : REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/bitvec1-sext1.btor2
+++ b/regression/ebmc/btor/bitvec1-sext1.btor2
@@ -1,0 +1,10 @@
+; Sign extension from bitvec 1
+1 sort bitvec 1
+2 sort bitvec 4
+3 one 1
+; sext of 1-bit value 1 to 4 bits: sign-extends to 1111 = 15 unsigned
+4 sext 2 3 3
+5 constd 2 15
+6 eq 1 4 5
+7 not 1 6
+8 bad 7

--- a/regression/ebmc/btor/bitvec1-sext1.desc
+++ b/regression/ebmc/btor/bitvec1-sext1.desc
@@ -1,0 +1,7 @@
+CORE
+bitvec1-sext1.btor2
+--bound 0
+^\[bad8\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/bitvec1-signed-comparison1.btor2
+++ b/regression/ebmc/btor/bitvec1-signed-comparison1.btor2
@@ -1,0 +1,6 @@
+; Signed comparison on bitvec 1
+; sgt(0, 0) on 1-bit should be false (property holds)
+1 sort bitvec 1
+2 zero 1
+3 sgt 1 2 2
+4 bad 3

--- a/regression/ebmc/btor/bitvec1-signed-comparison1.desc
+++ b/regression/ebmc/btor/bitvec1-signed-comparison1.desc
@@ -1,0 +1,7 @@
+CORE
+bitvec1-signed-comparison1.btor2
+--bound 0
+^\[bad4\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/bitvec1-slice1.btor2
+++ b/regression/ebmc/btor/bitvec1-slice1.btor2
@@ -1,0 +1,7 @@
+; slice of a 1-bit value: slice(1, 0, 0) should be identity
+; The result is incorrectly ignored, yielding a wrong answer.
+1 sort bitvec 1
+2 one 1
+3 slice 1 2 0 0
+4 not 1 3
+5 bad 4

--- a/regression/ebmc/btor/bitvec1-slice1.desc
+++ b/regression/ebmc/btor/bitvec1-slice1.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+bitvec1-slice1.btor2
+--bound 0
+^\[bad5\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+extractbits on a 1-bit value is silently ignored, producing an incorrect result

--- a/regression/ebmc/btor/bitwise1.btor2
+++ b/regression/ebmc/btor/bitwise1.btor2
@@ -1,0 +1,29 @@
+; Test binary bitwise operators on 4-bit values
+; 0xA = 1010, 0x5 = 0101
+1 sort bitvec 4
+2 sort bitvec 1
+3 constd 1 10
+4 constd 1 5
+; or(0xA, 0x5) == 0xF
+5 or 1 3 4
+6 constd 1 15
+7 neq 2 5 6
+8 bad 7
+; nand(0xF, 0xA) == 0x5
+9 constd 1 15
+10 nand 1 9 3
+11 neq 2 10 4
+12 bad 11
+; nor(0xA, 0x5) == 0x0
+13 nor 1 3 4
+14 zero 1
+15 neq 2 13 14
+16 bad 15
+; xor(0xA, 0x5) == 0xF
+17 xor 1 3 4
+18 neq 2 17 6
+19 bad 18
+; xnor(0xA, 0xA) == 0xF
+20 xnor 1 3 3
+21 neq 2 20 6
+22 bad 21

--- a/regression/ebmc/btor/bitwise1.desc
+++ b/regression/ebmc/btor/bitwise1.desc
@@ -1,0 +1,11 @@
+CORE
+bitwise1.btor2
+--bound 0
+^\[bad8\] : PROVED up to bound 0$
+^\[bad12\] : PROVED up to bound 0$
+^\[bad16\] : PROVED up to bound 0$
+^\[bad19\] : PROVED up to bound 0$
+^\[bad22\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/boolean1.btor2
+++ b/regression/ebmc/btor/boolean1.btor2
@@ -1,0 +1,18 @@
+; Test iff and implies on 1-bit values
+1 sort bitvec 1
+; iff(1, 1) should be 1
+2 one 1
+3 iff 1 2 2
+4 not 1 3
+5 bad 4
+; iff(0, 1) should be 0
+6 zero 1
+7 iff 1 6 2
+8 bad 7
+; implies(0, 0) should be 1
+9 implies 1 6 6
+10 not 1 9
+11 bad 10
+; implies(1, 0) should be 0
+12 implies 1 2 6
+13 bad 12

--- a/regression/ebmc/btor/boolean1.desc
+++ b/regression/ebmc/btor/boolean1.desc
@@ -1,0 +1,10 @@
+CORE
+boolean1.btor2
+--bound 0
+^\[bad5\] : PROVED up to bound 0$
+^\[bad8\] : PROVED up to bound 0$
+^\[bad11\] : PROVED up to bound 0$
+^\[bad13\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/comparison1.btor2
+++ b/regression/ebmc/btor/comparison1.btor2
@@ -1,0 +1,39 @@
+; Test comparison operators
+; Using 4-bit values: 3, 5, and 0xE (14 unsigned, -2 signed)
+1 sort bitvec 4
+2 sort bitvec 1
+3 constd 1 3
+4 constd 1 5
+5 constd 1 14
+; neq(3, 5) should be 1
+6 neq 2 3 4
+7 not 2 6
+8 bad 7
+; ugt(5, 3) should be 1
+9 ugt 2 4 3
+10 not 2 9
+11 bad 10
+; ugte(5, 5) should be 1
+12 ugte 2 4 4
+13 not 2 12
+14 bad 13
+; ulte(3, 5) should be 1
+15 ulte 2 3 4
+16 not 2 15
+17 bad 16
+; slt(14, 3) should be 1 (14 is -2 signed, -2 < 3)
+18 slt 2 5 3
+19 not 2 18
+20 bad 19
+; sgt(3, 14) should be 1 (3 > -2 signed)
+21 sgt 2 3 5
+22 not 2 21
+23 bad 22
+; sgte(3, 3) should be 1
+24 sgte 2 3 3
+25 not 2 24
+26 bad 25
+; slte(14, 14) should be 1
+27 slte 2 5 5
+28 not 2 27
+29 bad 28

--- a/regression/ebmc/btor/comparison1.desc
+++ b/regression/ebmc/btor/comparison1.desc
@@ -1,0 +1,14 @@
+CORE
+comparison1.btor2
+--bound 0
+^\[bad8\] : PROVED up to bound 0$
+^\[bad11\] : PROVED up to bound 0$
+^\[bad14\] : PROVED up to bound 0$
+^\[bad17\] : PROVED up to bound 0$
+^\[bad20\] : PROVED up to bound 0$
+^\[bad23\] : PROVED up to bound 0$
+^\[bad26\] : PROVED up to bound 0$
+^\[bad29\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/constants1.btor2
+++ b/regression/ebmc/btor/constants1.btor2
@@ -1,0 +1,22 @@
+; Test constant formats: const (binary), consth (hex), ones
+1 sort bitvec 8
+2 sort bitvec 1
+; const 10101010 == 170
+3 const 1 10101010
+4 constd 1 170
+5 neq 2 3 4
+6 bad 5
+; consth FF == 255
+7 consth 1 FF
+8 constd 1 255
+9 neq 2 7 8
+10 bad 9
+; ones (8-bit) == 255
+11 ones 1
+12 neq 2 11 8
+13 bad 12
+; consth a5 == 165
+14 consth 1 a5
+15 constd 1 165
+16 neq 2 14 15
+17 bad 16

--- a/regression/ebmc/btor/constants1.desc
+++ b/regression/ebmc/btor/constants1.desc
@@ -1,0 +1,10 @@
+CORE
+constants1.btor2
+--bound 0
+^\[bad6\] : PROVED up to bound 0$
+^\[bad10\] : PROVED up to bound 0$
+^\[bad13\] : PROVED up to bound 0$
+^\[bad17\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/constraint1.btor2
+++ b/regression/ebmc/btor/constraint1.btor2
@@ -1,0 +1,18 @@
+; 2-bit counter constrained to values 0 and 1
+; Without constraint, counter reaches 3 (bad). With constraint, safe.
+1 sort bitvec 2
+2 sort bitvec 1
+3 zero 1
+4 one 1
+5 state 1 cnt
+6 init 1 5 3
+7 add 1 5 4
+8 next 1 5 7
+; constraint: cnt < 2
+9 constd 1 2
+10 ult 2 5 9
+11 constraint 10
+; bad: cnt == 3
+12 constd 1 3
+13 eq 2 5 12
+14 bad 13

--- a/regression/ebmc/btor/constraint1.desc
+++ b/regression/ebmc/btor/constraint1.desc
@@ -1,0 +1,7 @@
+CORE
+constraint1.btor2
+--bound 5
+^\[bad14\] : PROVED up to bound 5$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/justice1.btor2
+++ b/regression/ebmc/btor/justice1.btor2
@@ -1,0 +1,14 @@
+; Test justice property: conjunction of two fairness conditions
+; Two toggle bits in sync, justice requires both true infinitely often
+1 sort bitvec 1
+2 zero 1
+3 state 1 a
+4 init 1 3 2
+5 not 1 3
+6 next 1 3 5
+7 state 1 b
+8 init 1 7 2
+9 not 1 7
+10 next 1 7 9
+; justice: both a and b must be true infinitely often
+11 justice 2 3 7

--- a/regression/ebmc/btor/justice1.desc
+++ b/regression/ebmc/btor/justice1.desc
@@ -1,0 +1,7 @@
+CORE
+justice1.btor2
+--bound 10
+^\[justice11\] : PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/liveness-fail1.btor2
+++ b/regression/ebmc/btor/liveness-fail1.btor2
@@ -1,0 +1,8 @@
+; Stuck bit stays false forever
+; Liveness: G(F(stuck)) — fails because stuck is always false
+1 sort bitvec 1
+2 zero 1
+3 state 1 stuck
+4 init 1 3 2
+5 next 1 3 3
+6 fair 3

--- a/regression/ebmc/btor/liveness-fail1.desc
+++ b/regression/ebmc/btor/liveness-fail1.desc
@@ -1,0 +1,7 @@
+CORE
+liveness-fail1.btor2
+--bound 10
+^\[fair6\] : REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/liveness1.btor2
+++ b/regression/ebmc/btor/liveness1.btor2
@@ -1,0 +1,9 @@
+; Toggle bit alternates 0/1 each cycle
+; Liveness: G(F(toggle)) — toggle is true infinitely often
+1 sort bitvec 1
+2 zero 1
+3 state 1 toggle
+4 init 1 3 2
+5 not 1 3
+6 next 1 3 5
+7 fair 3

--- a/regression/ebmc/btor/liveness1.desc
+++ b/regression/ebmc/btor/liveness1.desc
@@ -1,0 +1,7 @@
+CORE
+liveness1.btor2
+--bound 10
+^\[fair7\] : PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/liveness2.btor2
+++ b/regression/ebmc/btor/liveness2.btor2
@@ -1,0 +1,15 @@
+; 3-bit counter mod 5 (wraps 0..4), liveness: counter reaches 4 infinitely often
+1 sort bitvec 3
+2 sort bitvec 1
+3 zero 1
+4 one 1
+5 state 1 cnt
+6 init 1 5 3
+; next = (cnt == 4) ? 0 : cnt + 1
+7 constd 1 4
+8 eq 2 5 7
+9 add 1 5 4
+10 ite 1 8 3 9
+11 next 1 5 10
+; liveness: cnt == 4 infinitely often
+12 fair 8

--- a/regression/ebmc/btor/liveness2.desc
+++ b/regression/ebmc/btor/liveness2.desc
@@ -1,0 +1,7 @@
+CORE
+liveness2.btor2
+--bound 10
+^\[fair12\] : PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/misc1.btor2
+++ b/regression/ebmc/btor/misc1.btor2
@@ -1,0 +1,32 @@
+; Test concat, ite, sext, uext
+1 sort bitvec 4
+2 sort bitvec 8
+3 sort bitvec 1
+; concat(0xA, 0x5) == 0xA5
+4 constd 1 10
+5 constd 1 5
+6 concat 2 4 5
+7 constd 2 165
+8 neq 3 6 7
+9 bad 8
+; ite(1, 10, 5) == 10
+10 one 3
+11 ite 1 10 4 5
+12 neq 3 11 4
+13 bad 12
+; ite(0, 10, 5) == 5
+14 zero 3
+15 ite 1 14 4 5
+16 neq 3 15 5
+17 bad 16
+; uext(0x5, 4) == 0x05 (4-bit to 8-bit zero extension)
+18 uext 2 5 4
+19 constd 2 5
+20 neq 3 18 19
+21 bad 20
+; sext(0xF, 4) == 0xFF (4-bit -1 sign-extended to 8-bit)
+22 constd 1 15
+23 sext 2 22 4
+24 constd 2 255
+25 neq 3 23 24
+26 bad 25

--- a/regression/ebmc/btor/misc1.desc
+++ b/regression/ebmc/btor/misc1.desc
@@ -1,0 +1,11 @@
+CORE
+misc1.btor2
+--bound 0
+^\[bad9\] : PROVED up to bound 0$
+^\[bad13\] : PROVED up to bound 0$
+^\[bad17\] : PROVED up to bound 0$
+^\[bad21\] : PROVED up to bound 0$
+^\[bad26\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/overflow1.btor2
+++ b/regression/ebmc/btor/overflow1.btor2
@@ -1,0 +1,38 @@
+; Test overflow operators on 4-bit values
+1 sort bitvec 4
+2 sort bitvec 1
+; uaddo(15, 1) should overflow (unsigned)
+3 constd 1 15
+4 constd 1 1
+5 uaddo 2 3 4
+6 not 2 5
+7 bad 6
+; uaddo(7, 1) should NOT overflow
+8 constd 1 7
+9 uaddo 2 8 4
+10 bad 9
+; saddo(7, 1) should overflow (signed: 7+1=8 overflows 4-bit signed max=7)
+11 saddo 2 8 4
+12 not 2 11
+13 bad 12
+; usubo(0, 1) should overflow (unsigned: 0-1 wraps)
+14 zero 1
+15 usubo 2 14 4
+16 not 2 15
+17 bad 16
+; ssubo(8, 1) should overflow (signed: -8-1 overflows 4-bit signed min=-8)
+; 8 unsigned = -8 signed in 4 bits
+18 constd 1 8
+19 ssubo 2 18 4
+20 not 2 19
+21 bad 20
+; umulo(8, 2) should overflow (unsigned: 8*2=16 > 15)
+22 constd 1 2
+23 umulo 2 18 22
+24 not 2 23
+25 bad 24
+; smulo(4, 4) should overflow (signed: 4*4=16 overflows 4-bit signed)
+26 constd 1 4
+27 smulo 2 26 26
+28 not 2 27
+29 bad 28

--- a/regression/ebmc/btor/overflow1.desc
+++ b/regression/ebmc/btor/overflow1.desc
@@ -1,0 +1,13 @@
+CORE
+overflow1.btor2
+--bound 0
+^\[bad7\] : PROVED up to bound 0$
+^\[bad10\] : PROVED up to bound 0$
+^\[bad13\] : PROVED up to bound 0$
+^\[bad17\] : PROVED up to bound 0$
+^\[bad21\] : PROVED up to bound 0$
+^\[bad25\] : PROVED up to bound 0$
+^\[bad29\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/safe1.btor2
+++ b/regression/ebmc/btor/safe1.btor2
@@ -1,0 +1,12 @@
+; 1-bit state that toggles, constraint keeps it at 0
+1 sort bitvec 1
+2 zero 1
+3 one 1
+4 input 1 clk
+5 state 1 bit
+6 init 1 5 2
+7 not 1 5
+8 next 1 5 7
+; bit AND (NOT bit) is always false
+9 and 1 5 7
+10 bad 9

--- a/regression/ebmc/btor/safe1.desc
+++ b/regression/ebmc/btor/safe1.desc
@@ -1,0 +1,7 @@
+CORE
+safe1.btor2
+--bound 5
+^\[bad10\] : PROVED up to bound 5$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/shift1.btor2
+++ b/regression/ebmc/btor/shift1.btor2
@@ -1,0 +1,35 @@
+; Test shift and rotate operators on 8-bit values
+1 sort bitvec 8
+2 sort bitvec 1
+3 constd 1 5
+4 constd 1 2
+; sll(5, 2) == 20
+5 sll 1 3 4
+6 constd 1 20
+7 neq 2 5 6
+8 bad 7
+; srl(20, 2) == 5
+9 srl 1 6 4
+10 neq 2 9 3
+11 bad 10
+; sra(0xF0, 2) == 0xFC: arithmetic right shift of -16 by 2
+; 0xF0 = 240 unsigned = -16 signed, shifted right 2 = -4 = 252
+12 constd 1 240
+13 sra 1 12 4
+14 constd 1 252
+15 neq 2 13 14
+16 bad 15
+; rol(0x81, 1) == 0x03: rotate left
+; 10000001 rotated left 1 = 00000011
+17 constd 1 129
+18 constd 1 1
+19 rol 1 17 18
+20 constd 1 3
+21 neq 2 19 20
+22 bad 21
+; ror(0x81, 1) == 0xC0: rotate right
+; 10000001 rotated right 1 = 11000000 = 192
+23 ror 1 17 18
+24 constd 1 192
+25 neq 2 23 24
+26 bad 25

--- a/regression/ebmc/btor/shift1.desc
+++ b/regression/ebmc/btor/shift1.desc
@@ -1,0 +1,11 @@
+CORE
+shift1.btor2
+--bound 0
+^\[bad8\] : PROVED up to bound 0$
+^\[bad11\] : PROVED up to bound 0$
+^\[bad16\] : PROVED up to bound 0$
+^\[bad22\] : PROVED up to bound 0$
+^\[bad26\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/show-parse1.desc
+++ b/regression/ebmc/btor/show-parse1.desc
@@ -1,0 +1,12 @@
+CORE
+unsafe1.btor2
+--show-parse
+^BTOR2 model$
+^  Sorts: 1$
+^  Nodes: 9$
+^  Bad properties: 1$
+^  Sort 1: bitvec 2$
+^  4 state sort=1 'cnt'$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/trace1.desc
+++ b/regression/ebmc/btor/trace1.desc
@@ -1,0 +1,10 @@
+CORE
+unsafe1.btor2
+--bound 5 --numbered-trace
+^\[bad10\] : REFUTED$
+^Counterexample with 4 states:$
+^cnt@0 = 0$
+^cnt@3 = 3$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/unary1.btor2
+++ b/regression/ebmc/btor/unary1.btor2
@@ -1,0 +1,36 @@
+; Test unary operators on 4-bit values
+; inc(5) == 6, dec(5) == 4, neg(1) == 15 (two's complement)
+; redand(0xF) == 1, redor(0) == 0, redxor(3) == 0
+1 sort bitvec 4
+2 sort bitvec 1
+; inc(5) should be 6
+3 constd 1 5
+4 inc 1 3
+5 constd 1 6
+6 neq 2 4 5
+7 bad 6
+; dec(5) should be 4
+8 dec 1 3
+9 constd 1 4
+10 neq 2 8 9
+11 bad 10
+; neg(1) should be 15 (two's complement of 1 in 4 bits)
+12 constd 1 1
+13 neg 1 12
+14 constd 1 15
+15 neq 2 13 14
+16 bad 15
+; redand(0xF) should be 1
+17 constd 1 15
+18 redand 2 17
+19 zero 2
+20 eq 2 18 19
+21 bad 20
+; redor(0) should be 0
+22 zero 1
+23 redor 2 22
+24 bad 23
+; redxor(0b0011) should be 0 (even number of 1s)
+25 constd 1 3
+26 redxor 2 25
+27 bad 26

--- a/regression/ebmc/btor/unary1.desc
+++ b/regression/ebmc/btor/unary1.desc
@@ -1,0 +1,12 @@
+CORE
+unary1.btor2
+--bound 0
+^\[bad7\] : PROVED up to bound 0$
+^\[bad11\] : PROVED up to bound 0$
+^\[bad16\] : PROVED up to bound 0$
+^\[bad21\] : PROVED up to bound 0$
+^\[bad24\] : PROVED up to bound 0$
+^\[bad27\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/unsafe1.btor2
+++ b/regression/ebmc/btor/unsafe1.btor2
@@ -1,0 +1,11 @@
+; 2-bit counter, bad state when counter == 3
+1 sort bitvec 2
+2 zero 1
+3 one 1
+4 state 1 cnt
+5 init 1 4 2
+6 add 1 4 3
+7 next 1 4 6
+8 constd 1 3
+9 eq 1 4 8
+10 bad 9

--- a/regression/ebmc/btor/unsafe1.desc
+++ b/regression/ebmc/btor/unsafe1.desc
@@ -1,0 +1,7 @@
+CORE
+unsafe1.btor2
+--bound 5
+^\[bad10\] : REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/word-level1.btor2
+++ b/regression/ebmc/btor/word-level1.btor2
@@ -1,0 +1,17 @@
+; Test word-level ops: slice, concat, ite
+; 4-bit counter, extract low 2 bits, check if they reach 3
+1 sort bitvec 4
+2 sort bitvec 2
+3 sort bitvec 1
+4 zero 1
+5 one 1
+6 state 1 cnt
+7 init 1 6 4
+8 add 1 6 5
+9 next 1 6 8
+; slice low 2 bits
+10 slice 2 6 1 0
+; bad: low bits == 3
+11 constd 2 3
+12 eq 3 10 11
+13 bad 12

--- a/regression/ebmc/btor/word-level1.desc
+++ b/regression/ebmc/btor/word-level1.desc
@@ -1,0 +1,7 @@
+CORE
+word-level1.btor2
+--bound 5
+^\[bad13\] : REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 DIRS = ebmc hw-cbmc temporal-logic trans-word-level trans-netlist \
-       verilog vhdl smvlang ic3 aiger vlindex
+       verilog vhdl smvlang ic3 aiger btor vlindex
 
 CPROVER_DIR:=../lib/cbmc/src
 
@@ -15,7 +15,7 @@ $(patsubst %, %.dir, $(DIRS)):
 vhdl.dir: cprover.dir
 
 ebmc.dir: trans-word-level.dir trans-netlist.dir verilog.dir vhdl.dir \
-      smvlang.dir aiger.dir temporal-logic.dir cprover.dir
+      smvlang.dir aiger.dir btor.dir temporal-logic.dir cprover.dir
 
 ifneq ($(BUILD_ENV),MSVC)
 ebmc.dir: ic3.dir

--- a/src/btor/Makefile
+++ b/src/btor/Makefile
@@ -1,0 +1,16 @@
+SRC = btor_language.cpp \
+      btor_parser.cpp \
+      btor_ebmc_language.cpp \
+      #empty line
+
+include ../config.inc
+include ../common
+
+CLEANFILES = btor$(LIBEXT)
+
+all: btor$(LIBEXT)
+
+###############################################################################
+
+btor$(LIBEXT): $(OBJ)
+	$(LINKLIB)

--- a/src/btor/btor_ebmc_language.cpp
+++ b/src/btor/btor_ebmc_language.cpp
@@ -1,0 +1,670 @@
+/*******************************************************************\
+
+Module: BTOR2 Language Interface
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+/// \file
+/// BTOR2 Language Interface
+
+#include "btor_ebmc_language.h"
+
+#include <util/arith_tools.h>
+#include <util/bitvector_expr.h>
+#include <util/bitvector_types.h>
+#include <util/cmdline.h>
+#include <util/mathematical_expr.h>
+#include <util/message.h>
+#include <util/std_expr.h>
+
+#include <ebmc/ebmc_error.h>
+#include <ebmc/transition_system.h>
+#include <temporal-logic/ltl.h>
+#include <trans-word-level/next_symbol.h>
+
+#include "btor_parser.h"
+
+#include <fstream>
+#include <iostream>
+
+/// Convert a BTOR2 sort ID to a CBMC type
+static typet sort_to_type(std::size_t sort_id, const btor2_modelt &model)
+{
+  auto it = model.sorts.find(sort_id);
+  if(it == model.sorts.end())
+    throw ebmc_errort{} << "BTOR2: unknown sort " << sort_id;
+
+  auto &sort = it->second;
+  if(sort.kind == btor2_sortt::kindt::BITVEC)
+  {
+    if(sort.width == 1)
+      return bool_typet{};
+    else
+      return unsignedbv_typet{sort.width};
+  }
+  else
+  {
+    // array
+    auto index_type = sort_to_type(sort.index_sort, model);
+    auto element_type = sort_to_type(sort.element_sort, model);
+    return array_typet{element_type, infinity_exprt{index_type}};
+  }
+}
+
+/// Convert a BTOR2 node reference to an exprt.
+/// Negative references mean bitwise negation.
+static exprt node_to_expr(
+  std::ptrdiff_t nid,
+  const btor2_modelt &model,
+  const std::map<std::size_t, exprt> &expr_map)
+{
+  bool negated = nid < 0;
+  auto abs_nid = static_cast<std::size_t>(negated ? -nid : nid);
+
+  auto it = expr_map.find(abs_nid);
+  if(it == expr_map.end())
+    throw ebmc_errort{} << "BTOR2: undefined node " << abs_nid;
+
+  exprt result = it->second;
+
+  if(negated)
+  {
+    if(result.type().id() == ID_bool)
+      return not_exprt{result};
+    else
+      return bitnot_exprt{result};
+  }
+
+  return result;
+}
+
+/// Cast a bool expression to unsignedbv[1] if needed.
+/// Many BTOR2 operators (arithmetic, shifts, signed comparisons) require
+/// a bitvector operand, but bitvec 1 is mapped to bool_typet.
+static exprt to_bv(const exprt &e)
+{
+  if(e.type().id() == ID_bool)
+    return typecast_exprt{e, unsignedbv_typet{1}};
+  return e;
+}
+
+/// Get the width of a bitvector or bool expression.
+static std::size_t get_width(const exprt &e)
+{
+  if(e.type().id() == ID_bool)
+    return 1;
+  return to_bitvector_type(e.type()).get_width();
+}
+
+/// Cast to signed, widening to at least 2 bits to satisfy CBMC's
+/// lt_or_le precondition (signed bitvectors need >= 2 bits).
+static exprt to_signed(const exprt &e)
+{
+  auto a = to_bv(e);
+  auto w = get_width(e);
+  if(w < 2)
+  {
+    a = typecast_exprt{a, unsignedbv_typet{2}};
+    w = 2;
+  }
+  return typecast_exprt{a, signedbv_typet{w}};
+}
+
+/// Parse a binary constant string to a CBMC constant expression
+static constant_exprt
+binary_to_const(const std::string &bits, const typet &type)
+{
+  mp_integer value = 0;
+  for(char c : bits)
+  {
+    value *= 2;
+    if(c == '1')
+      value += 1;
+  }
+  if(type.id() == ID_bool)
+    return from_integer(value.is_odd() ? 1 : 0, type);
+  return from_integer(value, type);
+}
+
+/// Parse a decimal constant string to a CBMC constant expression
+static constant_exprt
+decimal_to_const(const std::string &dec, const typet &type)
+{
+  mp_integer value;
+  if(dec[0] == '-')
+    value = -string2integer(dec.substr(1));
+  else
+    value = string2integer(dec);
+  if(type.id() == ID_bool)
+    return from_integer(value.is_odd() ? 1 : 0, type);
+  return from_integer(value, type);
+}
+
+/// Parse a hex constant string to a CBMC constant expression
+static constant_exprt hex_to_const(const std::string &hex, const typet &type)
+{
+  mp_integer value = 0;
+  for(char c : hex)
+  {
+    value *= 16;
+    if(c >= '0' && c <= '9')
+      value += c - '0';
+    else if(c >= 'a' && c <= 'f')
+      value += c - 'a' + 10;
+    else if(c >= 'A' && c <= 'F')
+      value += c - 'A' + 10;
+  }
+  if(type.id() == ID_bool)
+    return from_integer(value.is_odd() ? 1 : 0, type);
+  return from_integer(value, type);
+}
+
+/// Build a CBMC expression for a BTOR2 operator node
+static exprt build_op_expr(
+  const btor2_linet &node,
+  const typet &type,
+  const btor2_modelt &model,
+  const std::map<std::size_t, exprt> &expr_map)
+{
+  auto arg = [&](std::size_t i) -> exprt
+  { return node_to_expr(node.args.at(i), model, expr_map); };
+
+  const auto &tag = node.tag;
+
+  // Unary operators
+  if(tag == "not")
+  {
+    if(type.id() == ID_bool)
+      return not_exprt{arg(0)};
+    else
+      return bitnot_exprt{arg(0)};
+  }
+  if(tag == "inc")
+    return plus_exprt{to_bv(arg(0)), from_integer(1, to_bv(arg(0)).type())};
+  if(tag == "dec")
+    return minus_exprt{to_bv(arg(0)), from_integer(1, to_bv(arg(0)).type())};
+  if(tag == "neg")
+    return unary_minus_exprt{to_bv(arg(0)), to_bv(arg(0)).type()};
+  if(tag == "redand")
+  {
+    auto a = to_bv(arg(0));
+    auto width = to_bitvector_type(a.type()).get_width();
+    return equal_exprt{a, from_integer(power(2, width) - 1, a.type())};
+  }
+  if(tag == "redor")
+  {
+    auto a = to_bv(arg(0));
+    return notequal_exprt{a, from_integer(0, a.type())};
+  }
+  if(tag == "redxor")
+  {
+    // XOR reduction: parity of all bits
+    auto a = to_bv(arg(0));
+    auto width = to_bitvector_type(a.type()).get_width();
+    exprt result = extractbit_exprt{a, from_integer(0, a.type())};
+    for(std::size_t i = 1; i < width; i++)
+      result =
+        xor_exprt{result, extractbit_exprt{a, from_integer(i, a.type())}};
+    return result;
+  }
+
+  // Binary operators
+  if(tag == "iff")
+    return equal_exprt{arg(0), arg(1)};
+  if(tag == "implies")
+    return implies_exprt{arg(0), arg(1)};
+  if(tag == "eq")
+    return equal_exprt{arg(0), arg(1)};
+  if(tag == "neq")
+    return notequal_exprt{arg(0), arg(1)};
+
+  // Signed/unsigned comparisons
+  if(tag == "sgt" || tag == "sgte" || tag == "slt" || tag == "slte")
+  {
+    auto sa = to_signed(arg(0));
+    auto sb = to_signed(arg(1));
+    irep_idt rel_id = tag == "sgt"    ? ID_gt
+                      : tag == "sgte" ? ID_ge
+                      : tag == "slt"  ? ID_lt
+                                      : ID_le;
+    return binary_relation_exprt{sa, rel_id, sb};
+  }
+  if(tag == "ugt")
+    return binary_relation_exprt{to_bv(arg(0)), ID_gt, to_bv(arg(1))};
+  if(tag == "ugte")
+    return binary_relation_exprt{to_bv(arg(0)), ID_ge, to_bv(arg(1))};
+  if(tag == "ult")
+    return binary_relation_exprt{to_bv(arg(0)), ID_lt, to_bv(arg(1))};
+  if(tag == "ulte")
+    return binary_relation_exprt{to_bv(arg(0)), ID_le, to_bv(arg(1))};
+
+  // Bitwise operators
+  if(tag == "and")
+  {
+    if(type.id() == ID_bool)
+      return and_exprt{arg(0), arg(1)};
+    else
+      return bitand_exprt{arg(0), arg(1)};
+  }
+  if(tag == "nand")
+  {
+    if(type.id() == ID_bool)
+      return not_exprt{and_exprt{arg(0), arg(1)}};
+    else
+      return bitnand_exprt{arg(0), arg(1)};
+  }
+  if(tag == "nor")
+  {
+    if(type.id() == ID_bool)
+      return not_exprt{or_exprt{arg(0), arg(1)}};
+    else
+      return bitnor_exprt{arg(0), arg(1)};
+  }
+  if(tag == "or")
+  {
+    if(type.id() == ID_bool)
+      return or_exprt{arg(0), arg(1)};
+    else
+      return bitor_exprt{arg(0), arg(1)};
+  }
+  if(tag == "xnor")
+  {
+    if(type.id() == ID_bool)
+      return equal_exprt{arg(0), arg(1)};
+    else
+      return bitxnor_exprt{arg(0), arg(1)};
+  }
+  if(tag == "xor")
+  {
+    if(type.id() == ID_bool)
+      return notequal_exprt{arg(0), arg(1)};
+    else
+      return bitxor_exprt{arg(0), arg(1)};
+  }
+
+  // Shift and rotate
+  if(tag == "sll")
+    return shl_exprt{to_bv(arg(0)), to_bv(arg(1))};
+  if(tag == "srl")
+    return lshr_exprt{to_bv(arg(0)), to_bv(arg(1))};
+  if(tag == "sra")
+  {
+    return typecast_exprt{ashr_exprt{to_signed(arg(0)), to_bv(arg(1))}, type};
+  }
+  if(tag == "rol")
+    return shift_exprt{to_bv(arg(0)), ID_rol, to_bv(arg(1))};
+  if(tag == "ror")
+    return shift_exprt{to_bv(arg(0)), ID_ror, to_bv(arg(1))};
+
+  // Arithmetic
+  if(tag == "add")
+    return plus_exprt{to_bv(arg(0)), to_bv(arg(1))};
+  if(tag == "sub")
+    return minus_exprt{to_bv(arg(0)), to_bv(arg(1))};
+  if(tag == "mul")
+    return mult_exprt{to_bv(arg(0)), to_bv(arg(1))};
+  if(tag == "udiv")
+    return div_exprt{to_bv(arg(0)), to_bv(arg(1))};
+  if(tag == "sdiv")
+  {
+    return typecast_exprt{
+      div_exprt{to_signed(arg(0)), to_signed(arg(1))}, type};
+  }
+  if(tag == "urem")
+    return mod_exprt{to_bv(arg(0)), to_bv(arg(1))};
+  if(tag == "srem")
+  {
+    return typecast_exprt{
+      mod_exprt{to_signed(arg(0)), to_signed(arg(1))}, type};
+  }
+  if(tag == "smod")
+  {
+    // smod: result has sign of divisor
+    // smod(a,b) = srem(a,b)==0 ? 0 : (sign(srem)!=sign(b) ? srem+b : srem)
+    auto a = to_signed(arg(0));
+    auto b = to_signed(arg(1));
+    auto signed_type = a.type();
+    auto rem = mod_exprt{a, b};
+    auto zero = from_integer(0, signed_type);
+    // Check if signs differ: (rem < 0) != (b < 0)
+    auto rem_neg = binary_relation_exprt{rem, ID_lt, zero};
+    auto b_neg = binary_relation_exprt{b, ID_lt, zero};
+    auto signs_differ = notequal_exprt{rem_neg, b_neg};
+    auto rem_nonzero = notequal_exprt{rem, zero};
+    auto adjust = and_exprt{rem_nonzero, signs_differ};
+    auto result = if_exprt{adjust, plus_exprt{rem, b}, rem};
+    return typecast_exprt{result, type};
+  }
+
+  // Concatenation
+  if(tag == "concat")
+    return concatenation_exprt{to_bv(arg(0)), to_bv(arg(1)), type};
+
+  // Array operations
+  if(tag == "read")
+    return index_exprt{arg(0), arg(1)};
+  if(tag == "write")
+    return with_exprt{arg(0), arg(1), arg(2)};
+
+  // Ternary
+  if(tag == "ite")
+    return if_exprt{arg(0), arg(1), arg(2)};
+
+  // Indexed operators
+  if(tag == "sext")
+  {
+    auto a = to_bv(arg(0));
+    auto w = get_width(arg(0));
+    auto new_width = w + node.uargs.at(0);
+    return typecast_exprt{
+      typecast_exprt{a, signedbv_typet{w}}, unsignedbv_typet{new_width}};
+  }
+  if(tag == "uext")
+  {
+    auto new_width = get_width(arg(0)) + node.uargs.at(0);
+    return typecast_exprt{to_bv(arg(0)), unsignedbv_typet{new_width}};
+  }
+  if(tag == "slice")
+  {
+    auto lower = node.uargs.at(1);
+    return extractbits_exprt{to_bv(arg(0)), lower, type};
+  }
+
+  // Overflow operators
+  if(tag == "uaddo")
+    return plus_overflow_exprt{to_bv(arg(0)), to_bv(arg(1))};
+  if(tag == "saddo")
+    return plus_overflow_exprt{to_signed(arg(0)), to_signed(arg(1))};
+  if(tag == "usubo")
+    return minus_overflow_exprt{to_bv(arg(0)), to_bv(arg(1))};
+  if(tag == "ssubo")
+    return minus_overflow_exprt{to_signed(arg(0)), to_signed(arg(1))};
+  if(tag == "umulo")
+    return mult_overflow_exprt{to_bv(arg(0)), to_bv(arg(1))};
+  if(tag == "smulo")
+    return mult_overflow_exprt{to_signed(arg(0)), to_signed(arg(1))};
+
+  throw ebmc_errort{} << "BTOR2: unsupported operator '" << tag << "'";
+}
+
+/// Build the transition system from a parsed BTOR2 model
+static transition_systemt build_transition_system(const btor2_modelt &model)
+{
+  const irep_idt mode = "BTOR2";
+  const irep_idt module_id = "btor2::main";
+
+  transition_systemt result;
+
+  // Map from BTOR2 node ID to CBMC expression
+  std::map<std::size_t, exprt> expr_map;
+
+  // First pass: create symbols for inputs and states
+  for(auto &[id, node] : model.nodes)
+  {
+    if(node.tag == "input")
+    {
+      auto type = sort_to_type(node.sort_id, model);
+      std::string name =
+        node.symbol.empty() ? "input" + std::to_string(id) : node.symbol;
+      irep_idt sym_id = id2string(module_id) + "::" + name;
+
+      symbolt symbol{sym_id, type, mode};
+      symbol.base_name = name;
+      symbol.pretty_name = name;
+      symbol.module = module_id;
+      symbol.is_input = true;
+      symbol.is_state_var = false;
+
+      result.symbol_table.add(symbol);
+      expr_map[id] = symbol_exprt{sym_id, type};
+    }
+    else if(node.tag == "state")
+    {
+      auto type = sort_to_type(node.sort_id, model);
+      std::string name =
+        node.symbol.empty() ? "state" + std::to_string(id) : node.symbol;
+      irep_idt sym_id = id2string(module_id) + "::" + name;
+
+      symbolt symbol{sym_id, type, mode};
+      symbol.base_name = name;
+      symbol.pretty_name = name;
+      symbol.module = module_id;
+      symbol.is_input = false;
+      symbol.is_state_var = true;
+
+      result.symbol_table.add(symbol);
+      expr_map[id] = symbol_exprt{sym_id, type};
+    }
+  }
+
+  // Second pass: build expressions for all nodes in order
+  for(auto &[id, node] : model.nodes)
+  {
+    if(expr_map.count(id))
+      continue; // already handled (input/state)
+
+    if(
+      node.tag == "bad" || node.tag == "constraint" || node.tag == "fair" ||
+      node.tag == "output" || node.tag == "justice" || node.tag == "init" ||
+      node.tag == "next")
+    {
+      continue; // handled in later passes
+    }
+
+    auto type = sort_to_type(node.sort_id, model);
+
+    // Constants
+    if(node.tag == "zero")
+    {
+      expr_map[id] = from_integer(0, type);
+      continue;
+    }
+    if(node.tag == "one")
+    {
+      expr_map[id] = from_integer(1, type);
+      continue;
+    }
+    if(node.tag == "ones")
+    {
+      if(type.id() == ID_bool)
+        expr_map[id] = true_exprt{};
+      else
+      {
+        auto width = to_bitvector_type(type).get_width();
+        expr_map[id] = from_integer(power(2, width) - 1, type);
+      }
+      continue;
+    }
+    if(node.tag == "const")
+    {
+      expr_map[id] = binary_to_const(node.symbol, type);
+      continue;
+    }
+    if(node.tag == "constd")
+    {
+      expr_map[id] = decimal_to_const(node.symbol, type);
+      continue;
+    }
+    if(node.tag == "consth")
+    {
+      expr_map[id] = hex_to_const(node.symbol, type);
+      continue;
+    }
+
+    // Operators
+    auto op_result = build_op_expr(node, type, model, expr_map);
+    // Cast unsignedbv[1] back to bool when the node's sort is bitvec 1
+    if(type.id() == ID_bool && op_result.type().id() != ID_bool)
+      op_result = typecast_exprt{op_result, bool_typet{}};
+    expr_map[id] = std::move(op_result);
+  }
+
+  // Third pass: build init and trans constraints
+  exprt::operandst invar_exprs;
+  exprt::operandst init_exprs;
+  exprt::operandst trans_exprs;
+
+  for(auto &[id, node] : model.nodes)
+  {
+    if(node.tag == "init")
+    {
+      // init <sid> <state_nid> <value_nid>
+      auto state_expr = node_to_expr(node.args[0], model, expr_map);
+      auto value_expr = node_to_expr(node.args[1], model, expr_map);
+      init_exprs.push_back(equal_exprt{state_expr, value_expr});
+    }
+    else if(node.tag == "next")
+    {
+      // next <sid> <state_nid> <next_value_nid>
+      auto state_expr = node_to_expr(node.args[0], model, expr_map);
+      auto next_value = node_to_expr(node.args[1], model, expr_map);
+      next_symbol_exprt next_state{to_symbol_expr(state_expr)};
+      trans_exprs.push_back(equal_exprt{next_state, next_value});
+    }
+  }
+
+  // Constraints become invariants
+  for(auto constraint_id : model.constraints)
+  {
+    auto &node = model.nodes.at(constraint_id);
+    auto constraint_expr = node_to_expr(node.args[0], model, expr_map);
+    // If not bool, convert to bool (non-zero means true)
+    if(constraint_expr.type().id() != ID_bool)
+    {
+      constraint_expr = notequal_exprt{
+        constraint_expr, from_integer(0, constraint_expr.type())};
+    }
+    invar_exprs.push_back(constraint_expr);
+  }
+
+  // Bad state properties: G(!bad)
+  for(auto bad_id : model.bad_properties)
+  {
+    auto &node = model.nodes.at(bad_id);
+    auto bad_expr = node_to_expr(node.args[0], model, expr_map);
+
+    if(bad_expr.type().id() != ID_bool)
+      bad_expr = notequal_exprt{bad_expr, from_integer(0, bad_expr.type())};
+
+    std::string name =
+      node.symbol.empty() ? "bad" + std::to_string(bad_id) : node.symbol;
+    irep_idt prop_id = id2string(module_id) + "::spec::" + name;
+
+    symbolt prop_symbol{prop_id, bool_typet(), mode};
+    prop_symbol.base_name = name;
+    prop_symbol.pretty_name = name;
+    prop_symbol.module = module_id;
+    prop_symbol.is_property = true;
+    prop_symbol.value = G_exprt{not_exprt{bad_expr}};
+
+    result.symbol_table.add(prop_symbol);
+  }
+
+  // Fair properties: G(F(fair))
+  for(auto fair_id : model.fair_properties)
+  {
+    auto &node = model.nodes.at(fair_id);
+    auto fair_expr = node_to_expr(node.args[0], model, expr_map);
+
+    if(fair_expr.type().id() != ID_bool)
+      fair_expr = notequal_exprt{fair_expr, from_integer(0, fair_expr.type())};
+
+    std::string name =
+      node.symbol.empty() ? "fair" + std::to_string(fair_id) : node.symbol;
+    irep_idt prop_id = id2string(module_id) + "::spec::" + name;
+
+    symbolt prop_symbol{prop_id, bool_typet(), mode};
+    prop_symbol.base_name = name;
+    prop_symbol.pretty_name = name;
+    prop_symbol.module = module_id;
+    prop_symbol.is_property = true;
+    prop_symbol.value = G_exprt{F_exprt{fair_expr}};
+
+    result.symbol_table.add(prop_symbol);
+  }
+
+  // Justice properties: G(F(conjunction))
+  for(auto justice_id : model.justice_properties)
+  {
+    auto &node = model.nodes.at(justice_id);
+
+    exprt::operandst conjuncts;
+    for(auto arg : node.args)
+    {
+      auto e = node_to_expr(arg, model, expr_map);
+      if(e.type().id() != ID_bool)
+        e = notequal_exprt{e, from_integer(0, e.type())};
+      conjuncts.push_back(e);
+    }
+
+    std::string name = "justice" + std::to_string(justice_id);
+    irep_idt prop_id = id2string(module_id) + "::spec::" + name;
+
+    symbolt prop_symbol{prop_id, bool_typet(), mode};
+    prop_symbol.base_name = name;
+    prop_symbol.pretty_name = name;
+    prop_symbol.module = module_id;
+    prop_symbol.is_property = true;
+    prop_symbol.value = G_exprt{F_exprt{conjunction(conjuncts)}};
+
+    result.symbol_table.add(prop_symbol);
+  }
+
+  // Module symbol
+  typet module_type(ID_module);
+
+  symbolt module_symbol{module_id, module_type, mode};
+  module_symbol.base_name = "main";
+  module_symbol.pretty_name = "main";
+  module_symbol.module = module_id;
+  module_symbol.value = transt{
+    ID_trans,
+    conjunction(invar_exprs),
+    conjunction(init_exprs),
+    conjunction(trans_exprs),
+    module_type};
+
+  result.symbol_table.add(module_symbol);
+
+  result.main_symbol = &result.symbol_table.lookup_ref(module_id);
+  result.trans_expr = to_trans_expr(result.main_symbol->value);
+
+  return result;
+}
+
+std::optional<transition_systemt> btor_ebmc_languaget::transition_system()
+{
+  if(cmdline.args.empty())
+    throw ebmc_errort{} << "no file name given";
+
+  if(cmdline.args.size() >= 2)
+    throw ebmc_errort{}.with_exit_code(1) << "BTOR2 only uses a single file";
+
+  const auto &file_name = cmdline.args.front();
+
+  std::ifstream in(file_name);
+  if(!in)
+  {
+    throw ebmc_errort{}.with_exit_code(1) << "failed to open " << file_name;
+  }
+
+  auto model = btor2_parse(in);
+
+  if(cmdline.isset("show-parse"))
+  {
+    btor2_show_parse(model, std::cout);
+    return {};
+  }
+
+  auto result = build_transition_system(model);
+
+  if(cmdline.isset("show-symbol-table"))
+  {
+    std::cout << result.symbol_table;
+    return {};
+  }
+
+  return result;
+}

--- a/src/btor/btor_ebmc_language.h
+++ b/src/btor/btor_ebmc_language.h
@@ -1,0 +1,30 @@
+/*******************************************************************\
+
+Module: BTOR2 Language Interface
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+/// \file
+/// BTOR2 Language Interface
+
+#ifndef CPROVER_BTOR_EBMC_LANGUAGE_H
+#define CPROVER_BTOR_EBMC_LANGUAGE_H
+
+#include <ebmc/ebmc_language.h>
+
+class btor_ebmc_languaget : public ebmc_languaget
+{
+public:
+  btor_ebmc_languaget(
+    const cmdlinet &_cmdline,
+    message_handlert &_message_handler)
+    : ebmc_languaget(_cmdline, _message_handler)
+  {
+  }
+
+  std::optional<transition_systemt> transition_system() override;
+};
+
+#endif // CPROVER_BTOR_EBMC_LANGUAGE_H

--- a/src/btor/btor_language.cpp
+++ b/src/btor/btor_language.cpp
@@ -1,0 +1,64 @@
+/*******************************************************************\
+
+Module: BTOR2 Language Registration
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#include "btor_language.h"
+
+#include <util/arith_tools.h>
+#include <util/bitvector_types.h>
+#include <util/std_expr.h>
+#include <util/symbol_table.h>
+
+bool btor_languaget::from_expr(
+  const exprt &expr,
+  std::string &code,
+  const namespacet &ns)
+{
+  if(expr.is_true())
+    code = "TRUE";
+  else if(expr.is_false())
+    code = "FALSE";
+  else if(expr.is_constant())
+  {
+    auto &type = expr.type();
+    if(type.id() == ID_unsignedbv || type.id() == ID_signedbv)
+    {
+      auto value = numeric_cast_v<mp_integer>(to_constant_expr(expr));
+      code = integer2string(value);
+    }
+    else
+      code = expr.pretty();
+  }
+  else if(expr.id() == ID_symbol)
+    code = id2string(to_symbol_expr(expr).get_identifier());
+  else if(expr.id() == ID_not)
+  {
+    std::string op_code;
+    from_expr(to_not_expr(expr).op(), op_code, ns);
+    code = "!" + op_code;
+  }
+  else
+    code = expr.pretty();
+  return false;
+}
+
+bool btor_languaget::from_type(
+  const typet &type,
+  std::string &code,
+  const namespacet &)
+{
+  if(type.id() == ID_unsignedbv)
+    code = "bitvec " + std::to_string(to_unsignedbv_type(type).get_width());
+  else
+    code = type.pretty();
+  return false;
+}
+
+std::unique_ptr<languaget> new_btor_language()
+{
+  return std::make_unique<btor_languaget>();
+}

--- a/src/btor/btor_language.h
+++ b/src/btor/btor_language.h
@@ -1,0 +1,98 @@
+/*******************************************************************\
+
+Module: BTOR2 Language Registration
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_BTOR_LANGUAGE_H
+#define CPROVER_BTOR_LANGUAGE_H
+
+#include <langapi/language.h>
+
+/// Minimal languaget for BTOR2, used for language mode registration
+/// (from_expr, from_type). The actual front-end is btor_ebmc_languaget.
+class btor_languaget : public languaget
+{
+public:
+  bool preprocess(
+    std::istream &,
+    const std::string &,
+    std::ostream &,
+    message_handlert &) override
+  {
+    return true;
+  }
+
+  bool parse(std::istream &, const std::string &, message_handlert &) override
+  {
+    return true;
+  }
+
+  void dependencies(const std::string &, std::set<std::string> &) override
+  {
+  }
+
+  void modules_provided(std::set<std::string> &) override
+  {
+  }
+
+  bool interfaces(symbol_table_baset &, message_handlert &) override
+  {
+    return false;
+  }
+
+  bool typecheck(symbol_table_baset &, const std::string &, message_handlert &)
+    override
+  {
+    return true;
+  }
+
+  void show_parse(std::ostream &, message_handlert &) override
+  {
+  }
+
+  bool from_expr(const exprt &, std::string &, const namespacet &) override;
+  bool from_type(const typet &, std::string &, const namespacet &) override;
+
+  bool to_expr(
+    const std::string &,
+    const std::string &,
+    exprt &,
+    const namespacet &,
+    message_handlert &) override
+  {
+    return true;
+  }
+
+  bool
+  generate_support_functions(symbol_table_baset &, message_handlert &) override
+  {
+    return false;
+  }
+
+  std::unique_ptr<languaget> new_language() override
+  {
+    return std::make_unique<btor_languaget>();
+  }
+
+  std::string id() const override
+  {
+    return "BTOR2";
+  }
+
+  std::string description() const override
+  {
+    return "BTOR2";
+  }
+
+  std::set<std::string> extensions() const override
+  {
+    return {"btor", "btor2"};
+  }
+};
+
+std::unique_ptr<languaget> new_btor_language();
+
+#endif // CPROVER_BTOR_LANGUAGE_H

--- a/src/btor/btor_parser.cpp
+++ b/src/btor/btor_parser.cpp
@@ -1,0 +1,239 @@
+/*******************************************************************\
+
+Module: BTOR2 Parser
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#include "btor_parser.h"
+
+#include <ebmc/ebmc_error.h>
+
+#include <iostream>
+#include <set>
+#include <sstream>
+
+/// Tags that take no sort and a single nid argument
+static const std::set<std::string> signal_tags =
+  {"bad", "constraint", "fair", "output"};
+
+/// Tags that take a sort and two nid arguments
+static const std::set<std::string> init_next_tags = {"init", "next"};
+
+/// Indexed operators (take sort, nid, then one or two uint indices)
+static const std::set<std::string> indexed_op_tags = {"sext", "uext", "slice"};
+
+/// Tags that declare a node with a sort
+static const std::set<std::string> input_tags =
+  {"input", "one", "ones", "zero", "const", "constd", "consth", "state"};
+
+btor2_modelt btor2_parse(std::istream &in)
+{
+  btor2_modelt model;
+  std::string line;
+  std::size_t line_number = 0;
+
+  while(std::getline(in, line))
+  {
+    line_number++;
+
+    // skip empty lines and comments
+    if(line.empty() || line[0] == ';')
+      continue;
+
+    std::istringstream ss(line);
+
+    std::size_t id;
+    std::string tag;
+
+    if(!(ss >> id >> tag))
+    {
+      throw ebmc_errort{} << "BTOR2 parse error on line " << line_number;
+    }
+
+    // Sort declaration: <sid> sort (bitvec <width> | array <sid> <sid>)
+    if(tag == "sort")
+    {
+      std::string sort_kind;
+      if(!(ss >> sort_kind))
+        throw ebmc_errort{} << "BTOR2: expected sort kind on line "
+                            << line_number;
+
+      btor2_sortt sort;
+      if(sort_kind == "bitvec")
+      {
+        sort.kind = btor2_sortt::kindt::BITVEC;
+        if(!(ss >> sort.width))
+          throw ebmc_errort{} << "BTOR2: expected width on line "
+                              << line_number;
+      }
+      else if(sort_kind == "array")
+      {
+        sort.kind = btor2_sortt::kindt::ARRAY;
+        if(!(ss >> sort.index_sort >> sort.element_sort))
+          throw ebmc_errort{} << "BTOR2: expected array sorts on line "
+                              << line_number;
+      }
+      else
+      {
+        throw ebmc_errort{} << "BTOR2: unknown sort kind '" << sort_kind
+                            << "' on line " << line_number;
+      }
+
+      model.sorts[id] = sort;
+      continue;
+    }
+
+    btor2_linet node;
+    node.id = id;
+    node.tag = tag;
+
+    if(signal_tags.count(tag))
+    {
+      // <nid> bad/constraint/fair/output <nid>
+      std::ptrdiff_t arg;
+      if(!(ss >> arg))
+        throw ebmc_errort{} << "BTOR2: expected argument on line "
+                            << line_number;
+      node.args.push_back(arg);
+
+      if(tag == "bad")
+        model.bad_properties.push_back(id);
+      else if(tag == "constraint")
+        model.constraints.push_back(id);
+      else if(tag == "fair")
+        model.fair_properties.push_back(id);
+      else if(tag == "output")
+        model.outputs.push_back(id);
+    }
+    else if(tag == "justice")
+    {
+      // <nid> justice <num> (<nid>)+
+      std::size_t count;
+      if(!(ss >> count))
+        throw ebmc_errort{} << "BTOR2: expected count on line " << line_number;
+      for(std::size_t i = 0; i < count; i++)
+      {
+        std::ptrdiff_t arg;
+        if(!(ss >> arg))
+          throw ebmc_errort{} << "BTOR2: expected justice arg on line "
+                              << line_number;
+        node.args.push_back(arg);
+      }
+      model.justice_properties.push_back(id);
+    }
+    else if(input_tags.count(tag))
+    {
+      // <nid> (input|state|one|ones|zero) <sid>
+      // <nid> const <sid> <binary>
+      // <nid> constd <sid> <decimal>
+      // <nid> consth <sid> <hex>
+      if(!(ss >> node.sort_id))
+        throw ebmc_errort{} << "BTOR2: expected sort on line " << line_number;
+
+      if(tag == "const" || tag == "constd" || tag == "consth")
+      {
+        // Store the constant value as the symbol
+        std::string val;
+        if(!(ss >> val))
+          throw ebmc_errort{} << "BTOR2: expected value on line "
+                              << line_number;
+        node.symbol = val;
+      }
+    }
+    else if(init_next_tags.count(tag))
+    {
+      // <nid> init/next <sid> <nid> <nid>
+      std::ptrdiff_t arg1, arg2;
+      if(!(ss >> node.sort_id >> arg1 >> arg2))
+        throw ebmc_errort{} << "BTOR2: expected args on line " << line_number;
+      node.args.push_back(arg1);
+      node.args.push_back(arg2);
+    }
+    else if(indexed_op_tags.count(tag))
+    {
+      // <nid> sext/uext <sid> <nid> <uint>
+      // <nid> slice <sid> <nid> <uint> <uint>
+      std::ptrdiff_t arg;
+      if(!(ss >> node.sort_id >> arg))
+        throw ebmc_errort{} << "BTOR2: expected args on line " << line_number;
+      node.args.push_back(arg);
+
+      std::size_t idx1;
+      if(!(ss >> idx1))
+        throw ebmc_errort{} << "BTOR2: expected index on line " << line_number;
+      node.uargs.push_back(idx1);
+
+      if(tag == "slice")
+      {
+        std::size_t idx2;
+        if(!(ss >> idx2))
+          throw ebmc_errort{} << "BTOR2: expected index on line "
+                              << line_number;
+        node.uargs.push_back(idx2);
+      }
+    }
+    else
+    {
+      // Generic operator: <nid> <op> <sid> <nid> [<nid> [<nid>]]
+      if(!(ss >> node.sort_id))
+        throw ebmc_errort{} << "BTOR2: expected sort on line " << line_number;
+
+      std::ptrdiff_t arg;
+      while(ss >> arg)
+        node.args.push_back(arg);
+    }
+
+    // Read optional symbol (for input/state nodes that haven't
+    // consumed the rest of the line)
+    if(
+      node.symbol.empty() && input_tags.count(tag) && tag != "const" &&
+      tag != "constd" && tag != "consth")
+    {
+      std::string sym;
+      if(ss >> sym && !sym.empty() && sym[0] != ';')
+        node.symbol = sym;
+    }
+
+    model.nodes[id] = std::move(node);
+  }
+
+  return model;
+}
+
+void btor2_show_parse(const btor2_modelt &model, std::ostream &out)
+{
+  out << "BTOR2 model\n";
+  out << "  Sorts: " << model.sorts.size() << '\n';
+  out << "  Nodes: " << model.nodes.size() << '\n';
+  out << "  Bad properties: " << model.bad_properties.size() << '\n';
+  out << "  Constraints: " << model.constraints.size() << '\n';
+  out << "  Fair properties: " << model.fair_properties.size() << '\n';
+  out << "  Outputs: " << model.outputs.size() << '\n';
+  out << "  Justice properties: " << model.justice_properties.size() << '\n';
+
+  for(auto &[id, sort] : model.sorts)
+  {
+    out << "  Sort " << id << ": ";
+    if(sort.kind == btor2_sortt::kindt::BITVEC)
+      out << "bitvec " << sort.width;
+    else
+      out << "array " << sort.index_sort << " " << sort.element_sort;
+    out << '\n';
+  }
+
+  for(auto &[id, node] : model.nodes)
+  {
+    out << "  " << id << " " << node.tag;
+    if(node.sort_id != 0)
+      out << " sort=" << node.sort_id;
+    for(auto arg : node.args)
+      out << " " << arg;
+    for(auto u : node.uargs)
+      out << " [" << u << "]";
+    if(!node.symbol.empty())
+      out << " '" << node.symbol << "'";
+    out << '\n';
+  }
+}

--- a/src/btor/btor_parser.h
+++ b/src/btor/btor_parser.h
@@ -1,0 +1,61 @@
+/*******************************************************************\
+
+Module: BTOR2 Parser
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_BTOR_PARSER_H
+#define CPROVER_BTOR_PARSER_H
+
+#include <cstddef>
+#include <iosfwd>
+#include <map>
+#include <string>
+#include <vector>
+
+/// A parsed BTOR2 line
+struct btor2_linet
+{
+  std::size_t id = 0;
+  std::string tag;
+  std::size_t sort_id = 0;
+  std::vector<std::ptrdiff_t> args; // signed: negative means negated
+  std::vector<std::size_t> uargs;   // unsigned args (for indexed ops)
+  std::string symbol;
+};
+
+/// Sort declaration
+struct btor2_sortt
+{
+  enum class kindt
+  {
+    BITVEC,
+    ARRAY
+  };
+  kindt kind;
+  std::size_t width = 0;        // for bitvec
+  std::size_t index_sort = 0;   // for array
+  std::size_t element_sort = 0; // for array
+};
+
+/// Parsed BTOR2 model
+struct btor2_modelt
+{
+  std::map<std::size_t, btor2_sortt> sorts;
+  std::map<std::size_t, btor2_linet> nodes;
+  std::vector<std::size_t> bad_properties;
+  std::vector<std::size_t> constraints;
+  std::vector<std::size_t> fair_properties;
+  std::vector<std::size_t> outputs;
+  std::vector<std::size_t> justice_properties;
+};
+
+/// Parse a BTOR2 file. Throws ebmc_errort on failure.
+btor2_modelt btor2_parse(std::istream &);
+
+/// Print parsed model for --show-parse
+void btor2_show_parse(const btor2_modelt &, std::ostream &);
+
+#endif // CPROVER_BTOR_PARSER_H

--- a/src/ebmc/Makefile
+++ b/src/ebmc/Makefile
@@ -55,6 +55,7 @@ OBJ+= $(CPROVER_DIR)/util/util$(LIBEXT) \
       ../trans-netlist/trans-netlist$(LIBEXT) \
       ../trans-word-level/trans-word-level$(LIBEXT) \
       ../aiger/aiger$(LIBEXT) \
+      ../btor/btor$(LIBEXT) \
       ../smvlang/smvlang$(LIBEXT) \
       ../verilog/verilog$(LIBEXT)
 

--- a/src/ebmc/build_transition_system.cpp
+++ b/src/ebmc/build_transition_system.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #ifndef _MSC_VER
 #  include <aiger/aiger_ebmc_language.h>
 #endif
+#include <btor/btor_ebmc_language.h>
 #include <smvlang/smv_ebmc_language.h>
 #include <verilog/verilog_ebmc_language.h>
 
@@ -56,7 +57,12 @@ std::optional<transition_systemt> ebmc_languagest::transition_system()
   bool have_aiger = false;
 #endif
 
-  if((have_smv ? 1 : 0) + (have_verilog ? 1 : 0) + (have_aiger ? 1 : 0) > 1)
+  bool have_btor = ext_used("btor") || ext_used("btor2");
+
+  if(
+    (have_smv ? 1 : 0) + (have_verilog ? 1 : 0) + (have_aiger ? 1 : 0) +
+      (have_btor ? 1 : 0) >
+    1)
   {
     throw ebmc_errort{} << "no support for mixed-language models";
   }
@@ -74,6 +80,10 @@ std::optional<transition_systemt> ebmc_languagest::transition_system()
 #ifndef _MSC_VER
     return aiger_ebmc_languaget{cmdline, message_handler}.transition_system();
 #endif
+  }
+  else if(have_btor)
+  {
+    return btor_ebmc_languaget{cmdline, message_handler}.transition_system();
   }
   else
   {

--- a/src/ebmc/ebmc_languages.cpp
+++ b/src/ebmc/ebmc_languages.cpp
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #endif
 
 #include <aiger/aiger_language.h>
+#include <btor/btor_language.h>
 
 #include "ebmc_parse_options.h"
 
@@ -43,5 +44,7 @@ void ebmc_parse_optionst::register_languages()
   #endif
   
   register_language(new_aiger_language);
+
+  register_language(new_btor_language);
 }
 


### PR DESCRIPTION
Add a BTOR2 front-end to EBMC, enabling verification of hardware models in the BTOR2 format used by the Hardware Model Checking Competition (HWMCC).

## Changes

New directory `src/btor/` with:
- **btor_parser**: Line-based BTOR2 parser producing a structured model
- **btor_languaget**: Language registration for `.btor`/`.btor2` files
- **btor_ebmc_languaget**: Transition system builder converting parsed BTOR2 into EBMC's word-level representation

Integration:
- Registered in `ebmc_languages.cpp` and dispatched in `build_transition_system.cpp`
- Added to build system (`src/Makefile`, `src/ebmc/Makefile`)

## Supported BTOR2 features

- **Sorts**: bitvec, array
- **Constants**: zero, one, ones, const, constd, consth
- **Operators**: all unary (not, inc, dec, neg, redand, redor, redxor), binary (bitwise, arithmetic, comparison, shift/rotate, concat, read), ternary (ite, write), indexed (sext, uext, slice), overflow
- **State**: input, state, init, next
- **Properties**: bad, constraint, fair, justice, output

## Testing

20 regression tests in `regression/ebmc/btor/` covering all operators, safety/liveness properties, constraints, traces, and `--show-parse`.