### PR TITLE
SMV netlists: use pretty name, when available

### DIFF
--- a/regression/ebmc/smv-netlist/array_assignment.desc
+++ b/regression/ebmc/smv-netlist/array_assignment.desc
@@ -1,8 +1,8 @@
 CORE
 array_assignment.sv
 --reset rst --smv-netlist --simple-netlist
-^ASSIGN next\(Verilog\.main\.data\[0\]\):=nondet\[1\];$
-^ASSIGN next\(Verilog\.main\.data\[1\]\):=nondet\[2\];$
+^ASSIGN next\(main\.data\[0\]\):=nondet\[1\];$
+^ASSIGN next\(main\.data\[1\]\):=nondet\[2\];$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/smv-netlist/assignment.desc
+++ b/regression/ebmc/smv-netlist/assignment.desc
@@ -1,7 +1,7 @@
 CORE
 assignment.sv
 --smv-netlist --simple-netlist
-^LTLSPEC G \!nondet\[5\]$
+^LTLSPEC G \!main\.data\[1\]$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/smv-netlist/invar1.desc
+++ b/regression/ebmc/smv-netlist/invar1.desc
@@ -1,9 +1,9 @@
 CORE
 invar1.smv
 --smv-netlist
-^VAR smv\.main\.var\.x: boolean;$
-^INVAR smv\.main\.var\.x$
-^CTLSPEC AG smv\.main\.var\.x$
+^VAR x: boolean;$
+^INVAR x$
+^CTLSPEC AG x$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/smv-netlist/nondet1.desc
+++ b/regression/ebmc/smv-netlist/nondet1.desc
@@ -1,8 +1,9 @@
 CORE
 nondet1.smv
 --smv-netlist
+^VAR data: boolean;$
 ^VAR nondet: boolean;$
-^ASSIGN next\(smv\.main\.var\.data\):=nondet;$
+^ASSIGN next\(data\):=nondet;$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/smv-netlist/nondet2.desc
+++ b/regression/ebmc/smv-netlist/nondet2.desc
@@ -1,8 +1,8 @@
 CORE
 nondet2.sv
 --smv-netlist
-^VAR nondet: boolean;$
-^LTLSPEC G nondet$
+^VAR main\.some_data: boolean;$
+^LTLSPEC G main\.some_data$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/smv-netlist/smv1.desc
+++ b/regression/ebmc/smv-netlist/smv1.desc
@@ -2,11 +2,11 @@ CORE
 smv1.smv
 --smv-netlist
 ^MODULE main$
-^VAR smv\.main\.var\.x: boolean;$
-^ASSIGN next\(smv\.main\.var\.x\):=\!smv\.main\.var\.x;$
-^INIT !smv\.main\.var\.x$
-^LTLSPEC G F smv\.main\.var\.x$
-^CTLSPEC smv\.main\.var\.x <-> \!AX smv\.main\.var\.x$
+^VAR x: boolean;$
+^ASSIGN next\(x\):=\!x;$
+^INIT !x$
+^LTLSPEC G F x$
+^CTLSPEC x <-> \!AX x$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/smv-netlist/verilog1.desc
+++ b/regression/ebmc/smv-netlist/verilog1.desc
@@ -2,11 +2,11 @@ CORE
 verilog1.sv
 --smv-netlist
 ^MODULE main$
-^VAR Verilog\.main\.x: boolean;$
-^ASSIGN next\(Verilog\.main\.x\):=\!Verilog\.main\.x;$
-^INIT !Verilog\.main\.x$
+^VAR main\.x: boolean;$
+^ASSIGN next\(main\.x\):=\!main\.x;$
+^INIT !main\.x$
 ^-- Verilog::main.assert.1$
-^LTLSPEC G F Verilog\.main\.x$
+^LTLSPEC G F main\.x$
 ^-- Verilog::main.assert.2$
 ^-- not translated$
 ^EXIT=0$

--- a/regression/smv/smv-netlist/smv_netlist1.desc
+++ b/regression/smv/smv-netlist/smv_netlist1.desc
@@ -1,10 +1,10 @@
 CORE
 smv_netlist1.v
 --smv-netlist
-^VAR Verilog\.main\.my-bit: boolean;$
-^VAR Verilog\.main\.clk: boolean;$
-^ASSIGN next\(Verilog\.main\.my-bit\):=!Verilog\.main\.my-bit;$
-^INIT !Verilog\.main\.my-bit$
+^VAR main\.my-bit: boolean;$
+^VAR main\.clk: boolean;$
+^ASSIGN next\(main\.my-bit\):=!main\.my-bit;$
+^INIT !main\.my-bit$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -317,7 +317,8 @@ int ebmc_parse_optionst::doit()
       outfile.stream() << "-- Generated from "
                        << transition_system.main_symbol->name << '\n';
       outfile.stream() << '\n';
-      smv_netlist(netlist, outfile.stream());
+      namespacet ns{transition_system.symbol_table};
+      smv_netlist(netlist, ns, outfile.stream());
       return 0;
     }
 

--- a/src/trans-netlist/smv_netlist.cpp
+++ b/src/trans-netlist/smv_netlist.cpp
@@ -129,14 +129,60 @@ void print_smv(
   out << expr2smv_netlistt{ns, netlist, variable_names}.convert(expr);
 }
 
-void smv_netlist(const netlistt &netlist, std::ostream &out)
+std::map<literalt::var_not, std::string> smv_names(
+  const std::vector<var_mapt::mapt::const_iterator> &sorted_identifiers,
+  const namespacet &ns)
+{
+  std::map<literalt::var_not, std::string> smv_names;
+
+  auto map_name = [&smv_names, &ns](var_mapt::mapt::const_iterator var_it)
+  {
+    const var_mapt::vart &var = var_it->second;
+    for(std::size_t i = 0; i < var.bits.size(); i++)
+    {
+      const symbolt *symbol_ptr;
+      irep_idt symbol_name;
+      if(!ns.lookup(var_it->first, symbol_ptr))
+        symbol_name = symbol_ptr->display_name();
+      else
+        symbol_name = var_it->first;
+
+      std::string smv_name = id2smv(symbol_name);
+      if(var_it->second.bits.size() != 1)
+        smv_name += '[' + std::to_string(i) + ']';
+
+      smv_names.emplace(var.bits[i].current.var_no(), smv_name);
+    }
+  };
+
+  for(auto &var_it : sorted_identifiers)
+  {
+    if(var_it->second.is_latch())
+      map_name(var_it);
+  }
+
+  for(auto &var_it : sorted_identifiers)
+  {
+    if(!var_it->second.is_latch())
+      map_name(var_it);
+  }
+
+  return smv_names;
+}
+
+void smv_netlist(
+  const netlistt &netlist,
+  const namespacet &ns,
+  std::ostream &out)
 {
   out << "MODULE main" << '\n';
 
   // We use the sorted var map to get deterministic output
   auto &var_map = netlist.var_map;
   const auto sorted_var_map = var_map.sorted();
-  std::map<literalt::var_not, std::string> variable_names;
+
+  // produce the SMV versions of the identifiers
+  auto variable_names = smv_names(sorted_var_map, ns);
 
   auto declare_var =
     [&variable_names](var_mapt::mapt::const_iterator var_it, std::ostream &out)
@@ -147,8 +193,10 @@ void smv_netlist(const netlistt &netlist, std::ostream &out)
       std::string name = id2smv(var_it->first);
       if(var_it->second.bits.size() != 1)
         name += '[' + std::to_string(i) + ']';
-      variable_names[var.bits[i].current.var_no()] = name;
-      out << "VAR " << name << ": boolean;" << '\n';
+      auto name_it = variable_names.find(var.bits[i].current.var_no());
+      DATA_INVARIANT(
+        name_it != variable_names.end(), "must have variable in renaming");
+      out << "VAR " << name_it->second << ": boolean;" << '\n';
     }
   };
 
@@ -214,10 +262,13 @@ void smv_netlist(const netlistt &netlist, std::ostream &out)
     {
       if(var.is_latch())
       {
-        out << "ASSIGN next(" << id2smv(var_it->first);
-        if(var.bits.size() != 1)
-          out << "[" << i << "]";
-        out << "):=";
+        std::string name = id2smv(var_it->first);
+        if(var_it->second.bits.size() != 1)
+          name += '[' + std::to_string(i) + ']';
+        auto name_it = variable_names.find(var.bits[i].current.var_no());
+        DATA_INVARIANT(
+          name_it != variable_names.end(), "must have variable in renaming");
+        out << "ASSIGN next(" << name_it->second << "):=";
         print_smv(netlist, variable_names, out, var.bits[i].next);
         out << ";" << '\n';
       }

--- a/src/trans-netlist/smv_netlist.h
+++ b/src/trans-netlist/smv_netlist.h
@@ -11,6 +11,6 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include "netlist.h"
 
-void smv_netlist(const netlistt &, std::ostream &);
+void smv_netlist(const netlistt &, const namespacet &, std::ostream &);
 
 #endif // CPROVER_TRANS_NETLIST_SMV_NETLIST_H


### PR DESCRIPTION
When printing SMV netlists use the pretty name of the symbol Instead of using the full identifier, when available.