### PR TITLE
error message when reset constraint cannot be parsed

### DIFF
--- a/regression/ebmc/CLI/reset4.desc
+++ b/regression/ebmc/CLI/reset4.desc
@@ -1,0 +1,9 @@
+CORE
+reset4.sv
+--reset some_unknown_identifier
+^line 1: unknown identifier some_unknown_identifier$
+^error: failed to parse reset constraint$
+^EXIT=6$
+^SIGNAL=0$
+--
+--

--- a/regression/ebmc/CLI/reset4.sv
+++ b/regression/ebmc/CLI/reset4.sv
@@ -1,0 +1,3 @@
+module main(input clk, rst);
+  // deliberately empty
+endmodule

--- a/src/verilog/verilog_ebmc_language.cpp
+++ b/src/verilog/verilog_ebmc_language.cpp
@@ -19,7 +19,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <ebmc/ebmc_error.h>
 #include <ebmc/show_modules.h>
 #include <ebmc/transition_system.h>
-#include <langapi/language_util.h>
+#include <langapi/mode.h>
 #include <trans-word-level/show_module_hierarchy.h>
 
 #include "verilog_elaborate_compilation_unit.h"
@@ -484,9 +484,19 @@ std::optional<transition_systemt> verilog_ebmc_languaget::transition_system()
   // --reset given?
   if(cmdline.isset("reset"))
   {
-    namespacet ns(transition_system.symbol_table);
-    exprt reset_constraint = to_expr(
-      ns, transition_system.main_symbol->name, cmdline.get_value("reset"));
+    auto language = get_language_from_mode(transition_system.main_symbol->mode);
+    exprt reset_constraint;
+    const namespacet ns{transition_system.symbol_table};
+
+    if(language->to_expr(
+         cmdline.get_value("reset"),
+         id2string(transition_system.main_symbol->module),
+         reset_constraint,
+         ns,
+         message_handler))
+    {
+      throw ebmc_errort{} << "failed to parse reset constraint";
+    }
 
     // true in initial state
     transt new_trans_expr = transition_system.trans_expr;


### PR DESCRIPTION
This adds an appropriate error message for the case when the given reset constraint cannot be parsed.