### PR TITLE
SMV netlist: use pretty name for property identifier

### DIFF
--- a/regression/ebmc/smv-netlist/verilog1.desc
+++ b/regression/ebmc/smv-netlist/verilog1.desc
@@ -5,9 +5,9 @@ verilog1.sv
 ^VAR main\.x: boolean;$
 ^ASSIGN next\(main\.x\):=\!main\.x;$
 ^INIT !main\.x$
-^-- Verilog::main.assert.1$
+^-- main.assert.1$
 ^LTLSPEC G F main\.x$
-^-- Verilog::main.assert.2$
+^-- main.assert.2$
 ^-- not translated$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/src/trans-netlist/smv_netlist.cpp
+++ b/src/trans-netlist/smv_netlist.cpp
@@ -323,23 +323,26 @@ void smv_netlist(
 
   for(auto &[id, netlist_expr] : netlist.properties)
   {
+    auto &symbol = ns.lookup(id);
+    auto display_name = symbol.display_name();
+
     if(!netlist_expr.has_value())
     {
       // translation has failed
-      out << "-- " << id << '\n';
+      out << "-- " << display_name << '\n';
       out << "-- not translated\n";
       out << '\n';
     }
     else if(is_CTL(*netlist_expr))
     {
-      out << "-- " << id << '\n';
+      out << "-- " << display_name << '\n';
       out << "CTLSPEC ";
       print_smv(netlist, variable_names, out, *netlist_expr);
       out << '\n';
     }
     else if(is_LTL(*netlist_expr))
     {
-      out << "-- " << id << '\n';
+      out << "-- " << display_name << '\n';
       out << "LTLSPEC ";
       print_smv(netlist, variable_names, out, *netlist_expr);
       out << '\n';
@@ -352,7 +355,7 @@ void smv_netlist(
     else
     {
       // translated to something we can't print
-      out << "-- " << id << '\n';
+      out << "-- " << display_name << '\n';
       out << "-- cannot output\n";
       out << '\n';
     }


### PR DESCRIPTION
This replaces the full identifier by the pretty name when printing the name of the property in the SMV netlist as a comment.