### PR TITLE
Fix comments for `normalize_property`

### DIFF
--- a/src/temporal-logic/normalize_property.h
+++ b/src/temporal-logic/normalize_property.h
@@ -11,12 +11,8 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include <util/expr.h>
 
-/// This applies the following rewrites:
-///
-/// -----Propositional-----
-/// ¬(a ∨ b) --> ¬a ∧ ¬b
-/// ¬(a ∧ b) --> ¬a ∨ ¬b
-/// (a -> b) --> ¬a ∨ b
+/// This applies the following rewrites, in addition to the ones
+/// done by \ref trivial_sva:
 ///
 /// -----SVA-----
 /// a|=>b --> ¬a ∨ always[1:1] b   if a is not an SVA sequence
@@ -25,22 +21,10 @@ Author: Daniel Kroening, dkr@amazon.com
 /// sva_nexttime[i] φ --> sva_always[i:i] φ
 /// sva_s_nexttime φ --> sva_always[1:1] φ
 /// sva_s_nexttime[i] φ --> sva_s_always[i:i] φ
-/// ##[0:$] φ --> s_eventually φ
-/// ##[i:$] φ --> s_nexttime[i] s_eventually φ
-/// ##[*] φ --> s_eventually φ
-/// ##[+] φ --> always[1:1] s_eventually φ
-/// strong(φ) --> φ
-/// weak(φ) --> φ
-/// ¬ sva_s_eventually φ --> sva_always ¬φ
-/// ¬ sva_always φ --> sva_s_eventually ¬φ
 /// cover φ --> sva_always_exprt ¬φ
+/// a sva_disable_iff b --> a ∨ b  unless used in cover φ
+/// a sva_disable_iff b --> ¬a ∧ b  when used in cover φ
 ///
-/// ----LTL-----
-/// ¬Xφ --> X¬φ
-/// ¬¬φ --> φ
-/// ¬Gφ --> F¬φ
-/// ¬Fφ --> G¬φ
-/// false R ψ --> G ψ
 exprt normalize_property(exprt);
 
 #endif

--- a/src/temporal-logic/trivial_sva.h
+++ b/src/temporal-logic/trivial_sva.h
@@ -20,6 +20,8 @@ Author: Daniel Kroening, dkr@amazon.com
 /// a sva_and b --> a ∧ b                     if a and b are not sequences
 /// a sva_or b --> a ∨ b                      if a and b are not sequences
 /// sva_overlapped_implication --> a -> b     if a and b are not sequences
+/// strong(φ) --> φ                           if φ is not a sequence
+/// weak(φ) --> φ                             if φ is not a sequence
 /// sva_if --> ? :
 /// sva_case --> ? :
 /// a sva_accept_on b --> a ∨ b


### PR DESCRIPTION
This updates the comments for `normalize_property` in the header file to match what the code does.