### PR TITLE
SMV netlist: escape SMV keywords in identifiers

### DIFF
--- a/regression/ebmc/smv-netlist/smv_keyword1.desc
+++ b/regression/ebmc/smv-netlist/smv_keyword1.desc
@@ -1,0 +1,8 @@
+CORE
+smv_keyword1.sv
+--smv-netlist
+^VAR main\.\\MODULE: boolean;$
+^EXIT=0$
+^SIGNAL=0$
+--
+--

--- a/regression/ebmc/smv-netlist/smv_keyword1.sv
+++ b/regression/ebmc/smv-netlist/smv_keyword1.sv
@@ -1,0 +1,13 @@
+module main(input clk);
+
+  // MODULE is an SMV keyword
+  reg MODULE;
+
+  initial MODULE = 0;
+
+  always @(posedge clk)
+    MODULE = !MODULE;
+
+  assert property (always s_eventually MODULE);
+
+endmodule

--- a/src/trans-netlist/smv_netlist.cpp
+++ b/src/trans-netlist/smv_netlist.cpp
@@ -10,8 +10,10 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <smvlang/expr2smv_class.h>
 
 #include <util/namespace.h>
+#include <util/string_utils.h>
 #include <util/symbol_table.h>
 
+#include <smvlang/smv_keywords.h>
 #include <solvers/prop/literal_expr.h>
 #include <temporal-logic/temporal_logic.h>
 #include <verilog/sva_expr.h>
@@ -20,6 +22,7 @@ std::string id2smv(const irep_idt &id)
 {
   std::string result;
 
+  // replace characters that are not allowed in SMV identifiers
   for(std::size_t i = 0; i < id.size(); i++)
   {
     const bool first = i == 0;
@@ -44,7 +47,25 @@ std::string id2smv(const irep_idt &id)
     }
   }
 
-  return result;
+  // escape any dot-separated components that are SMV keywords
+  auto components = split_string(result, '.');
+  std::string escaped;
+  bool first = true;
+
+  for(auto &component : components)
+  {
+    if(first)
+      first = false;
+    else
+      escaped += '.';
+
+    if(is_smv_keyword(component))
+      escaped += '\\';
+
+    escaped += component;
+  }
+
+  return escaped;
 }
 
 void print_smv(

--- a/src/trans-netlist/smv_netlist.h
+++ b/src/trans-netlist/smv_netlist.h
@@ -9,7 +9,13 @@ Author: Daniel Kroening, dkr@amazon.com
 #ifndef CPROVER_TRANS_NETLIST_SMV_NETLIST_H
 #define CPROVER_TRANS_NETLIST_SMV_NETLIST_H
 
+#include <util/irep.h>
+
 #include "netlist.h"
+
+#include <string>
+
+std::string id2smv(const irep_idt &);
 
 void smv_netlist(const netlistt &, const namespacet &, std::ostream &);
 

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -15,6 +15,7 @@ SRC += ebmc/bdd_model_checker.cpp \
        temporal-logic/nnf.cpp \
        temporal-logic/trivial_sva.cpp \
        trans-netlist/aig.cpp \
+       trans-netlist/id2smv.cpp \
        verilog/indexed_part_select.cpp \
        verilog/typename.cpp \
        # Empty last line

--- a/unit/trans-netlist/id2smv.cpp
+++ b/unit/trans-netlist/id2smv.cpp
@@ -1,0 +1,43 @@
+/*******************************************************************\
+
+Module: id2smv Unit Tests
+
+Author: Daniel Kroening, Amazon, dkr@amazon.com
+
+\*******************************************************************/
+
+#include <testing-utils/use_catch.h>
+#include <trans-netlist/smv_netlist.h>
+
+SCENARIO("id2smv")
+{
+  GIVEN("A plain identifier")
+  {
+    REQUIRE(id2smv("abc") == "abc");
+  }
+
+  GIVEN("An identifier with :: scope separator")
+  {
+    REQUIRE(id2smv("module::signal") == "module.signal");
+  }
+
+  GIVEN("An identifier with a dot")
+  {
+    REQUIRE(id2smv("a.b") == "a.b");
+  }
+
+  GIVEN("An identifier with a special character")
+  {
+    REQUIRE(id2smv("a@b") == "a$64$b");
+  }
+
+  GIVEN("An identifier that is an SMV keyword")
+  {
+    REQUIRE(id2smv("next") == "\\next");
+  }
+
+  GIVEN("A dotted identifier with a keyword component")
+  {
+    REQUIRE(id2smv("a.next") == "a.\\next");
+  }
+}


### PR DESCRIPTION
When a Verilog signal name coincides with an SMV keyword (e.g., MODULE), the generated SMV netlist must escape it with a backslash prefix to produce valid SMV syntax.

This adds a post-processing step to `id2smv()` that checks each dot-separated component against `is_smv_keyword()` and prefixes matches with `\`, producing e.g., `main.\MODULE`.