### PR TITLE
move rewrite for trivial `|=>` and `|->`

### DIFF
--- a/src/temporal-logic/normalize_property.h
+++ b/src/temporal-logic/normalize_property.h
@@ -15,8 +15,6 @@ Author: Daniel Kroening, dkr@amazon.com
 /// done by \ref trivial_sva:
 ///
 /// -----SVA-----
-/// a|=>b --> ¬a ∨ always[1:1] b   if a is not an SVA sequence
-/// a|->b --> a⇒b                  if a is not an SVA sequence
 /// sva_nexttime φ --> sva_always[1:1] φ
 /// sva_nexttime[i] φ --> sva_always[i:i] φ
 /// sva_s_nexttime φ --> sva_always[1:1] φ

--- a/src/temporal-logic/trivial_sva.cpp
+++ b/src/temporal-logic/trivial_sva.cpp
@@ -8,6 +8,8 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include "trivial_sva.h"
 
+#include <util/mathematical_types.h>
+
 #include <verilog/sva_expr.h>
 
 #include "temporal_logic.h"
@@ -35,7 +37,7 @@ exprt trivial_sva(exprt expr)
   // post-traversal
   if(expr.id() == ID_sva_overlapped_implication)
   {
-    // Same as regular implication if lhs and rhs are not sequences.
+    // Same as regular implication if lhs is not a proper sequence.
     auto &sva_implication = to_sva_overlapped_implication_expr(expr);
 
     auto lhs = is_state_predicate(sva_implication.lhs());
@@ -43,6 +45,24 @@ exprt trivial_sva(exprt expr)
 
     if(lhs.has_value() && rhs.has_value())
       expr = implies_exprt{*lhs, *rhs};
+    else if(lhs.has_value() && !rhs.has_value())
+      expr = implies_exprt{*lhs, sva_implication.rhs()};
+  }
+  else if(expr.id() == ID_sva_non_overlapped_implication)
+  {
+    // a|=>b is the same as a->always[1:1] b if lhs is not a proper sequence.
+    auto &sva_implication = to_sva_non_overlapped_implication_expr(expr);
+
+    auto lhs = is_state_predicate(sva_implication.lhs());
+
+    if(lhs.has_value())
+    {
+      auto one = natural_typet{}.one_expr();
+      auto ranged_always =
+        sva_ranged_always_exprt{one, one, sva_implication.rhs()};
+      ranged_always.type() = bool_typet{};
+      return or_exprt{not_exprt{*lhs}, ranged_always};
+    }
   }
   else if(expr.id() == ID_sva_iff)
   {

--- a/src/temporal-logic/trivial_sva.h
+++ b/src/temporal-logic/trivial_sva.h
@@ -14,6 +14,8 @@ Author: Daniel Kroening, dkr@amazon.com
 /// This applies the following rewrites, removing SVA operators
 /// that trivial in the sense that they are state predicates only.
 ///
+/// a|=>b --> ¬a ∨ always[1:1] b              if a is not a sequence
+/// a|->b --> a⇒b                             if a is not a sequence
 /// a sva_iff b --> a <-> b
 /// a sva_implies b --> a -> b
 /// sva_not a --> ¬a

--- a/unit/temporal-logic/trivial_sva.cpp
+++ b/unit/temporal-logic/trivial_sva.cpp
@@ -6,6 +6,8 @@ Author: Daniel Kroening, dkr@amazon.com
 
 \*******************************************************************/
 
+#include <util/mathematical_types.h>
+
 #include <temporal-logic/trivial_sva.h>
 #include <testing-utils/use_catch.h>
 #include <verilog/sva_expr.h>
@@ -35,6 +37,38 @@ SCENARIO("Simplifying a trivial SVA formula")
       trivial_sva(sva_and_exprt{
         sva_or_exprt{prop(p), prop(q), bool_typet{}}, prop(r), bool_typet{}}) ==
       and_exprt{or_exprt{prop(p), prop(q)}, prop(r)});
+  }
+
+  GIVEN("An overlapped implication with non-trivial rhs")
+  {
+    auto prop = [](exprt expr) {
+      return sva_boolean_exprt{std::move(expr), bool_typet{}};
+    };
+
+    // rhs is not a state predicate (e.g., sva_ranged_always)
+    auto one = natural_typet{}.one_expr();
+    auto rhs = sva_ranged_always_exprt{one, one, prop(q), bool_typet{}};
+
+    auto input = sva_overlapped_implication_exprt{prop(p), rhs, bool_typet{}};
+    auto result = trivial_sva(input);
+
+    REQUIRE(result == implies_exprt{p, rhs});
+  }
+
+  GIVEN("A non-overlapped implication with trivial lhs")
+  {
+    auto prop = [](exprt expr) {
+      return sva_boolean_exprt{std::move(expr), bool_typet{}};
+    };
+
+    auto one = natural_typet{}.one_expr();
+    auto rhs = prop(q);
+    auto input =
+      sva_non_overlapped_implication_exprt{prop(p), rhs, bool_typet{}};
+    auto result = trivial_sva(input);
+
+    auto expected_always = sva_ranged_always_exprt{one, one, rhs, bool_typet{}};
+    REQUIRE(result == or_exprt{not_exprt{p}, expected_always});
   }
 
   GIVEN("A trivial SVA formula with sequences")


### PR DESCRIPTION
This moves the trivial case of SVA `|=>` and `|->` where the LHS is not a proper sequence from `normalize_property` to `trivial_sva`.