### PR TITLE
BTOR2: use extractbit for 1-bit slice

### DIFF
--- a/regression/ebmc/btor/bitvec1-slice1.desc
+++ b/regression/ebmc/btor/bitvec1-slice1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 bitvec1-slice1.btor2
 --bound 0
 ^\[bad5\] : PROVED up to bound 0$
@@ -6,4 +6,3 @@ bitvec1-slice1.btor2
 ^SIGNAL=0$
 --
 --
-extractbits on a 1-bit value is silently ignored, producing an incorrect result

--- a/src/btor/btor_ebmc_language.cpp
+++ b/src/btor/btor_ebmc_language.cpp
@@ -369,7 +369,10 @@ static exprt build_op_expr(
   if(tag == "slice")
   {
     auto lower = node.uargs.at(1);
-    return extractbits_exprt{to_bv(arg(0)), lower, type};
+    if(type.id() == ID_bool)
+      return extractbit_exprt{to_bv(arg(0)), lower};
+    else
+      return extractbits_exprt{to_bv(arg(0)), lower, type};
   }
 
   // Overflow operators


### PR DESCRIPTION
This fixes the BTOR2 `slice` operator for the case when the result type is `bool` (bitvec 1).

**Fix:** Use `extractbit_exprt` when the result type is `ID_bool`.

**Testing:** The KNOWNBUG test `bitvec1-slice1` now passes and is promoted to CORE.