### PR TITLE
reduce complexity of `sequence_repetition1.sv` test

### DIFF
--- a/regression/verilog/SVA/sequence_repetition1.desc
+++ b/regression/verilog/SVA/sequence_repetition1.desc
@@ -9,8 +9,8 @@ sequence_repetition1.sv
 ^\[main\.p5w\] main\.x == 0 \[=2\]: PROVED up to bound 10$
 ^\[main\.p4s\] strong\(main\.x == 0 \[->2\]\): PROVED up to bound 10$
 ^\[main\.p5s\] strong\(main\.x == 0 \[=2\]\): PROVED up to bound 10$
-^\[main\.c4s\] cover strong\(main\.x == 0 \[->2\]\): REFUTED up to bound 10$
-^\[main\.c5s\] cover strong\(main\.x == 0 \[=2\]\): REFUTED up to bound 10$
+^\[main\.c4s\] cover strong\(main\.x == 0 \[->2\]\): PROVED$
+^\[main\.c5s\] cover strong\(main\.x == 0 \[=2\]\): PROVED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/sequence_repetition1.sv
+++ b/regression/verilog/SVA/sequence_repetition1.sv
@@ -1,13 +1,13 @@
 module main(input clk);
 
-  reg [3:0] x = 0;
+  reg [1:0] x = 0;
 
   // 0 1 2 3 4 ...
   always_ff @(posedge clk)
     x<=x+8'd1;
 
   // 0 0 1 1 2 2 3 3 ...
-  wire [3:0] half_x = x/8'd2;
+  wire [1:0] half_x = x/2'd2;
 
   // should pass
   initial p0: assert property (half_x==0[*2]);


### PR DESCRIPTION
This reduces the number of bits in `sequence_repetition1.sv` in order to reduce the runtime of the BDD engine.  With `--buechi`, the current number of 4 bits requires 361 seconds in CI.