### PR TITLE
use existing `verilog_ebmc_languaget::typecheck_module` for `$root`

### DIFF
--- a/src/verilog/verilog_ebmc_language.cpp
+++ b/src/verilog/verilog_ebmc_language.cpp
@@ -334,8 +334,40 @@ void verilog_ebmc_languaget::create_root_module(
   verilog_standardt standard,
   symbol_tablet &symbol_table)
 {
-  auto module_identifier = verilog_module_symbol(top_level_module);
   auto root_identifier = verilog_module_symbol(verilog_root_module_name());
+
+  // create a parse tree for $root
+  verilog_module_sourcet root_source{verilog_root_module_name()};
+
+  // Build a verilog_instt module item for the instantiation
+  verilog_instt inst;
+  inst.set_module(top_level_module);
+  verilog_inst_baset::instancet instance_expr;
+  instance_expr.set(ID_base_name, top_level_module);
+  inst.instances().push_back(std::move(instance_expr));
+
+  // add the module instance for the top-level module
+  root_source.module_items().push_back(std::move(inst));
+
+  // create a symbol for the $root source
+  symbolt root_source_symbol{
+    id2string(root_identifier) + "$source",
+    typet{ID_module_source},
+    ID_Verilog};
+  root_source_symbol.base_name = verilog_root_module_name();
+  root_source_symbol.pretty_name = verilog_root_module_name();
+  root_source_symbol.module = root_source_symbol.name;
+  root_source_symbol.type.set(ID_module_source, root_source);
+
+  auto add_result = symbol_table.add(root_source_symbol);
+  CHECK_RETURN(!add_result);
+
+  verilog_ebmc_languaget::parse_treet parse_tree{standard};
+  verilog_ebmc_languaget::modulet module{root_identifier, parse_tree};
+  typecheck_module(module, symbol_table);
+
+#if 0
+  auto module_identifier = verilog_module_symbol(top_level_module);
   auto instance_identifier =
     id2string(root_identifier) + "." + id2string(top_level_module);
 
@@ -350,13 +382,6 @@ void verilog_ebmc_languaget::create_root_module(
   auto add_result_instance = symbol_table.add(instance_symbol);
   CHECK_RETURN(!add_result_instance);
 
-  // Build a verilog_instt module item for the instantiation
-  verilog_instt inst;
-  inst.set_module(module_identifier);
-  verilog_inst_baset::instancet instance_expr;
-  instance_expr.set(ID_base_name, top_level_module);
-  instance_expr.identifier(instance_identifier);
-  inst.instances().push_back(std::move(instance_expr));
 
   // Create the $root module symbol with the inst as its only module item.
   // Copy the type from the top-level module, updating port identifiers.
@@ -399,6 +424,7 @@ void verilog_ebmc_languaget::create_root_module(
     ignore_initial,
     initial_zero,
     message_handler);
+#endif
 }
 
 static bool get_main(

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -1037,6 +1037,10 @@ public:
   class instancet : public exprt
   {
   public:
+    instancet() : exprt{ID_inst}
+    {
+    }
+
     const irep_idt &base_name() const
     {
       return get(ID_base_name);

--- a/src/verilog/verilog_parameterize_module.cpp
+++ b/src/verilog/verilog_parameterize_module.cpp
@@ -213,6 +213,16 @@ irep_idt verilog_typecheckt::parameterized_module_identifier(
   if(parameter_values.empty())
     return module_identifier;
 
+#if 0
+  // All parameters nil?
+  bool all_nil = true;
+  for(const auto &pv : parameter_values)
+    if(pv.is_not_nil())
+      all_nil = false;
+  if(all_nil)
+    return module_identifier;
+#endif
+
   // Create full parameterized module name by appending a suffix
   // to the name of the instantiated module.
   std::string suffix="(";

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/expr_util.h>
 #include <util/identifier.h>
 #include <util/mathematical_types.h>
+#include <util/prefix.h>
 #include <util/simplify_expr.h>
 #include <util/std_expr.h>
 
@@ -1729,13 +1730,15 @@ void verilog_synthesist::expand_module_instance(
       std::string full_identifier =
         id2string(instance.identifier()) + identifier_without_module;
 
-      // We special-case the pretty name for identifiers under $root:
-      // it is customary to use the name of the module only as root
-      // of the hierarchical identifier.
-      new_symbol.pretty_name =
-        module == verilog_module_symbol(verilog_root_module_name())
-          ? symbol.pretty_name
-          : strip_verilog_prefix(full_identifier);
+      // Strip the Verilog:: prefix, and if present, the $root. prefix
+      // to obtain the pretty_name
+      irep_idt new_pretty_name = strip_verilog_prefix(full_identifier);
+      static const std::string root_prefix =
+        id2string(verilog_root_module_name()) + '.';
+      if(has_prefix(id2string(new_pretty_name), root_prefix))
+        new_pretty_name = id2string(new_pretty_name)
+                            .substr(root_prefix.size(), std::string::npos);
+      new_symbol.pretty_name = new_pretty_name;
       new_symbol.name=full_identifier;
 
       if(symbol_table.add(new_symbol))


### PR DESCRIPTION
This re-uses existing logic for type-checking modules in `verilog_ebmc_languaget` for `create_root_module`, avoiding duplication.