### PR TITLE
introduce `verilog_unit_scope_identifier`

### DIFF
--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -756,7 +756,7 @@ void verilog_typecheckt::convert_function_call_or_task_enable(
     if(ns.lookup(full_identifier, symbol))
     {
       // not there? Try compilation-unit scope.
-      full_identifier = verilog_package_identifier("$unit", base_name);
+      full_identifier = verilog_unit_scope_identifier(base_name);
 
       if(ns.lookup(full_identifier, symbol))
       {

--- a/src/verilog/verilog_typecheck_base.cpp
+++ b/src/verilog/verilog_typecheck_base.cpp
@@ -81,6 +81,23 @@ irep_idt verilog_package_identifier(
 
 /*******************************************************************\
 
+Function: verilog_unit_scope_identifier
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+irep_idt verilog_unit_scope_identifier(const irep_idt &base_name)
+{
+  return "Verilog::$unit::" + id2string(base_name);
+}
+
+/*******************************************************************\
+
 Function: strip_verilog_prefix
 
   Inputs:

--- a/src/verilog/verilog_typecheck_base.h
+++ b/src/verilog/verilog_typecheck_base.h
@@ -23,6 +23,7 @@ irep_idt verilog_package_identifier(const irep_idt &base_name);
 irep_idt verilog_package_identifier(
   const irep_idt &package_base_name,
   const irep_idt &item_base_name);
+irep_idt verilog_unit_scope_identifier(const irep_idt &item_base_name);
 irep_idt verilog_item_key(const irep_idt &identifier);
 irep_idt strip_verilog_prefix(const irep_idt &identifier);
 

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -81,7 +81,7 @@ verilog_typecheck_exprt::hierarchical_identifier(irep_idt base_name) const
   else
   {
     // not in a function/task, not in a module/checker/package etc.
-    return verilog_package_identifier("$unit", base_name);
+    return verilog_unit_scope_identifier(base_name);
   }
 }
 
@@ -864,7 +864,7 @@ exprt verilog_typecheck_exprt::convert_expr_function_call(
     if(ns.lookup(full_identifier, symbol))
     {
       // not there? Try compilation-unit scope.
-      full_identifier = "Verilog::$unit::" + id2string(base_name);
+      full_identifier = verilog_unit_scope_identifier(base_name);
 
       if(ns.lookup(full_identifier, symbol))
       {
@@ -1580,7 +1580,7 @@ const symbolt *verilog_typecheck_exprt::resolve(const irep_idt base_name)
     return symbol; // found!
 
   // compilation-unit scope?
-  full_identifier = "Verilog::$unit::" + id2string(base_name);
+  full_identifier = verilog_unit_scope_identifier(base_name);
 
   if(!ns.lookup(full_identifier, symbol))
     return symbol; // found!


### PR DESCRIPTION
This introduces a function for creating full identifiers in the `$unit` scope.