### PR TITLE
rename `hierarchical_identifier_exprt::module`

### DIFF
--- a/src/verilog/expr2verilog.cpp
+++ b/src/verilog/expr2verilog.cpp
@@ -1289,7 +1289,8 @@ expr2verilogt::resultt expr2verilogt::convert_hierarchical_identifier(
 {
   return {
     verilog_precedencet::MAX,
-    convert_rec(src.module()).s + '.' + src.item().get_string(ID_base_name)};
+    convert_rec(src.module_instance()).s + '.' +
+      id2string(src.item().base_name())};
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_elaborate_module_instances.cpp
+++ b/src/verilog/verilog_elaborate_module_instances.cpp
@@ -197,16 +197,17 @@ void verilog_typecheckt::process_parameter_override(
     auto &hierarchical_identifier = to_hierarchical_identifier_expr(lhs);
 
     // convert the instance
-    convert_expr(hierarchical_identifier.module());
+    convert_expr(hierarchical_identifier.module_instance());
 
-    if(hierarchical_identifier.module().id() != ID_symbol)
+    if(hierarchical_identifier.module_instance().id() != ID_symbol)
     {
       throw errort().with_location(module_item.source_location())
         << "defparam expected to have a single level identifier";
     }
 
     auto module_instance =
-      to_symbol_expr(hierarchical_identifier.module()).get_identifier();
+      to_symbol_expr(hierarchical_identifier.module_instance())
+        .get_identifier();
 
     auto parameter_base_name = hierarchical_identifier.item().base_name();
 

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -90,17 +90,17 @@ inline verilog_identifier_exprt &to_verilog_identifier_expr(exprt &expr)
   return static_cast<verilog_identifier_exprt &>(expr);
 }
 
-/// The syntax for these A.B, where A is a module identifier and B
-/// is an identifier within that module. B is given als symbol_exprt.
+/// The syntax for these A.B, where A is a module instance
+/// and B is an identifier within that module. B is given als symbol_exprt.
 class hierarchical_identifier_exprt : public binary_exprt
 {
 public:
-  const exprt &module() const
+  const exprt &module_instance() const
   {
     return op0();
   }
 
-  exprt &module()
+  exprt &module_instance()
   {
     return op0();
   }


### PR DESCRIPTION
This renames `hierarchical_identifier_exprt::module()` to `::module_instance()` in order to clarify its purpose.