### PR TITLE
Verilog: create symbol hierarchy directly

### DIFF
--- a/regression/ebmc/CLI/reset4.desc
+++ b/regression/ebmc/CLI/reset4.desc
@@ -1,7 +1,7 @@
 CORE
 reset4.sv
 --reset main.some_unknown_identifier
-^line 1: identifier `some_unknown_identifier' not found in module `main'$
+^line 1: identifier `some_unknown_identifier' not found in module `Verilog::\$root\.main'$
 ^error: failed to parse reset constraint$
 ^EXIT=6$
 ^SIGNAL=0$

--- a/regression/ebmc/smv-netlist/verilog_function1.desc
+++ b/regression/ebmc/smv-netlist/verilog_function1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 verilog_function1.sv
 --smv-netlist
 ^EXIT=0$
@@ -7,4 +7,3 @@ verilog_function1.sv
 ^ASSIGN next\(.*\):=.*;$
 ^warning: ignoring
 --
-This yields an error.

--- a/regression/verilog/checker/checker2.desc
+++ b/regression/verilog/checker/checker2.desc
@@ -1,7 +1,7 @@
 CORE
 checker2.sv
 --bound 20
-^\[main\.c\.assert\.1\] always main\.c\$module\.data != 10: REFUTED$
+^\[main\.c\.assert\.1\] always main\.c\.data != 10: REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/checker/checker7.desc
+++ b/regression/verilog/checker/checker7.desc
@@ -1,7 +1,7 @@
 CORE
 checker7.sv
 --bound 20
-^\[main\.c\.assert\.1\] always main\.c\$module\.data1 != main\.c\$module\.data2: REFUTED$
+^\[main\.c\.assert\.1\] always main\.c\.data1 != main\.c\.data2: REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/module_instance_identifier1.desc
+++ b/regression/verilog/modules/module_instance_identifier1.desc
@@ -1,7 +1,7 @@
 CORE
 module_instance_identifier1.v
 --show-symbol-table
-module: Verilog::main\.m8\$module$
+module: Verilog::\$root\.main\.m8\$module$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/port_with_value1.desc
+++ b/regression/verilog/modules/port_with_value1.desc
@@ -1,8 +1,8 @@
 CORE
 port_with_value1.sv
 
-^\[main\.m1\.eq] always main\.m1\$module.in1 == main\.m1\$module\.in2: REFUTED$
-^\[main\.m2\.eq] always main\.m2\$module\.in1 == main\.m2\$module\.in2: PROVED .*$
+^\[main\.m1\.eq] always main\.m1\.in1 == main\.m1\.in2: REFUTED$
+^\[main\.m2\.eq] always main\.m2\.in1 == main\.m2\.in2: PROVED .*$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -71,10 +71,10 @@ void verilog_typecheckt::collect_port_symbols(const verilog_declt &decl)
     else
       DATA_INVARIANT(false, "unexpected port class");
 
-    new_symbol.module = module_identifier;
+    new_symbol.module = verilog_root_module_identifier();
     new_symbol.value.make_nil();
     new_symbol.base_name = base_name;
-    new_symbol.pretty_name = strip_verilog_prefix(new_symbol.name);
+    new_symbol.pretty_name = strip_verilog_root_prefix(new_symbol.name);
 
     // When using ANSI style, input ports may have an
     // elaboration-time constant default value
@@ -113,9 +113,9 @@ void verilog_typecheckt::collect_symbols(
 
     type_symbolt symbol{full_identifier, symbol_type, mode};
 
-    symbol.module = module_identifier;
+    symbol.module = verilog_root_module_identifier();
     symbol.base_name = base_name;
-    symbol.pretty_name = strip_verilog_prefix(symbol.name);
+    symbol.pretty_name = strip_verilog_root_prefix(symbol.name);
     symbol.is_macro = true;
     symbol.value = nil_exprt{};
     symbol.location = declarator.source_location();
@@ -132,9 +132,9 @@ void verilog_typecheckt::collect_symbols(
 
     symbolt symbol{full_identifier, symbol_type, mode};
 
-    symbol.module = module_identifier;
+    symbol.module = verilog_root_module_identifier();
     symbol.base_name = base_name;
-    symbol.pretty_name = strip_verilog_prefix(symbol.name);
+    symbol.pretty_name = strip_verilog_root_prefix(symbol.name);
     symbol.is_macro = true;
     symbol.value = declarator.value();
     symbol.location = declarator.source_location();
@@ -185,8 +185,8 @@ void verilog_typecheckt::collect_symbols(const typet &type)
       const auto identifier = hierarchical_identifier(base_name);
       symbolt enum_name_symbol(identifier, tbd_type, mode);
       enum_name_symbol.pretty_name =
-        strip_verilog_prefix(enum_name_symbol.name);
-      enum_name_symbol.module = module_identifier;
+        strip_verilog_root_prefix(enum_name_symbol.name);
+      enum_name_symbol.module = verilog_root_module_identifier();
       enum_name_symbol.base_name = base_name;
       enum_name_symbol.value = std::move(value);
       enum_name_symbol.is_macro = true;
@@ -215,7 +215,7 @@ void verilog_typecheckt::collect_symbols(const typet &type)
     {
       const auto identifier = hierarchical_identifier(enum_type.base_name());
       type_symbolt enum_type_symbol(identifier, enum_type_copy, mode);
-      enum_type_symbol.module = module_identifier;
+      enum_type_symbol.module = verilog_root_module_identifier();
       enum_type_symbol.is_file_local = true;
       enum_type_symbol.location = enum_type.source_location();
       add_symbol(std::move(enum_type_symbol));
@@ -260,9 +260,9 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
 
       symbolt symbol{full_identifier, std::move(type), mode};
 
-      symbol.module = module_identifier;
+      symbol.module = verilog_root_module_identifier();
       symbol.base_name = base_name;
-      symbol.pretty_name = strip_verilog_prefix(symbol.name);
+      symbol.pretty_name = strip_verilog_root_prefix(symbol.name);
       symbol.is_macro = true;
       symbol.is_type = true;
       symbol.location = declarator.source_location();
@@ -283,7 +283,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
       symbolt symbol;
 
       symbol.mode = mode;
-      symbol.module = module_identifier;
+      symbol.module = verilog_root_module_identifier();
       symbol.value.make_nil();
 
       if(decl_class == ID_input)
@@ -322,7 +322,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
         }
 
         symbol.name = hierarchical_identifier(symbol.base_name);
-        symbol.pretty_name = strip_verilog_prefix(symbol.name);
+        symbol.pretty_name = strip_verilog_root_prefix(symbol.name);
 
         auto result = symbol_table.get_writeable(symbol.name);
 
@@ -381,7 +381,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
       bool input = false, output = false;
 
       symbol.mode = mode;
-      symbol.module = module_identifier;
+      symbol.module = verilog_root_module_identifier();
       symbol.value.make_nil();
       symbol.is_lvalue = true; // even inputs can be assigned
 
@@ -433,7 +433,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
 
         symbol.type = elaborate_type(declarator.merged_type(decl.type()));
         symbol.name = hierarchical_identifier(symbol.base_name);
-        symbol.pretty_name = strip_verilog_prefix(symbol.name);
+        symbol.pretty_name = strip_verilog_root_prefix(symbol.name);
 
         if(input || output)
         {
@@ -474,7 +474,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
     symbolt symbol;
 
     symbol.mode = mode;
-    symbol.module = module_identifier;
+    symbol.module = verilog_root_module_identifier();
     symbol.value = nil_exprt();
 
     for(auto &declarator : decl.declarators())
@@ -492,7 +492,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
       }
 
       symbol.name = hierarchical_identifier(symbol.base_name);
-      symbol.pretty_name = strip_verilog_prefix(symbol.name);
+      symbol.pretty_name = strip_verilog_root_prefix(symbol.name);
 
       auto result = symbol_table.get_writeable(symbol.name);
 
@@ -540,7 +540,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
     symbolt symbol;
 
     symbol.mode = mode;
-    symbol.module = module_identifier;
+    symbol.module = verilog_root_module_identifier();
     symbol.value = nil_exprt();
     symbol.is_lvalue = true;
 
@@ -559,7 +559,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
       }
 
       symbol.name = hierarchical_identifier(symbol.base_name);
-      symbol.pretty_name = strip_verilog_prefix(symbol.name);
+      symbol.pretty_name = strip_verilog_root_prefix(symbol.name);
 
       auto result = symbol_table.get_writeable(symbol.name);
 
@@ -619,8 +619,8 @@ void verilog_typecheckt::collect_symbols(
 
   symbol.base_name = base_name;
   symbol.location = decl.source_location();
-  symbol.pretty_name = strip_verilog_prefix(symbol.name);
-  symbol.module = module_identifier;
+  symbol.pretty_name = strip_verilog_root_prefix(symbol.name);
+  symbol.module = verilog_root_module_identifier();
   symbol.value = verilog_tf_sourcet{decl}; // copy the entire declaration
 
   add_symbol(symbol);
@@ -645,7 +645,7 @@ void verilog_typecheckt::collect_symbols(
     symbolt return_symbol;
     return_symbol.is_lvalue = true;
     return_symbol.mode = symbol.mode;
-    return_symbol.module = symbol.module;
+    return_symbol.module = verilog_root_module_identifier();
     return_symbol.base_name = symbol.base_name;
     return_symbol.value = nil_exprt();
     return_symbol.type = to_code_type(symbol.type).return_type();
@@ -653,7 +653,7 @@ void verilog_typecheckt::collect_symbols(
     return_symbol.name =
       id2string(symbol.name) + "." + id2string(symbol.base_name);
 
-    return_symbol.pretty_name = strip_verilog_prefix(return_symbol.name);
+    return_symbol.pretty_name = strip_verilog_root_prefix(return_symbol.name);
 
     symbol_table.add(return_symbol);
   }
@@ -690,11 +690,11 @@ void verilog_typecheckt::collect_symbols(const verilog_lett &let)
   // add the symbol
   symbolt new_symbol(identifier, type, mode);
 
-  new_symbol.module = module_identifier;
+  new_symbol.module = verilog_root_module_identifier();
   new_symbol.is_macro = true;
   new_symbol.value = declarator.value();
   new_symbol.base_name = base_name;
-  new_symbol.pretty_name = strip_verilog_prefix(new_symbol.name);
+  new_symbol.pretty_name = strip_verilog_root_prefix(new_symbol.name);
 
   let_symbols.insert(new_symbol.name);
 

--- a/src/verilog/verilog_elaborate_module_instances.cpp
+++ b/src/verilog/verilog_elaborate_module_instances.cpp
@@ -105,9 +105,9 @@ void verilog_typecheckt::elaborate_inst(
   symbol.base_name = op.base_name();
   symbol.type = typet{
     primitive ? ID_primitive_module_instance : ID_verilog_module_instance};
-  symbol.module = module_identifier;
+  symbol.module = verilog_root_module_identifier();
   symbol.name = hierarchical_identifier(symbol.base_name);
-  symbol.pretty_name = strip_verilog_prefix(symbol.name);
+  symbol.pretty_name = strip_verilog_root_prefix(symbol.name);
   symbol.value = verilog_module_instancet{instantiated_module_identifier};
 
   if(symbol_table.add(symbol))

--- a/src/verilog/verilog_generate.cpp
+++ b/src/verilog/verilog_generate.cpp
@@ -83,7 +83,7 @@ void verilog_typecheckt::elaborate_generate_decl(
         << "empty symbol name";
 
     symbol.name = hierarchical_identifier(symbol.base_name);
-    symbol.pretty_name = strip_verilog_prefix(symbol.name);
+    symbol.pretty_name = strip_verilog_root_prefix(symbol.name);
 
     genvars[symbol.base_name] = -1;
 

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -367,7 +367,7 @@ void verilog_typecheckt::interface_block(
     symbol.type=typet(ID_named_block);
     symbol.module=module_identifier;
     symbol.name = hierarchical_identifier(symbol.base_name);
-    symbol.pretty_name=strip_verilog_prefix(symbol.name);
+    symbol.pretty_name = strip_verilog_root_prefix(symbol.name);
     symbol.value=nil_exprt();
 
     if(symbol_table.add(symbol))

--- a/src/verilog/verilog_language.cpp
+++ b/src/verilog/verilog_language.cpp
@@ -293,7 +293,8 @@ bool verilog_languaget::to_expr(
   expr.swap(verilog_parser.parse_tree.expr);
 
   // typecheck it
-  result = verilog_typecheck(expr, module, standard, message_handler, ns);
+  result =
+    verilog_typecheck(expr, module, module, standard, message_handler, ns);
   if(result)
     return true;
 

--- a/src/verilog/verilog_parameterize_module.cpp
+++ b/src/verilog/verilog_parameterize_module.cpp
@@ -261,7 +261,8 @@ irep_idt verilog_typecheckt::parameterize_module(
   verilog_typecheckt verilog_typecheck(
     standard, warn_implicit_nets, symbol_table, get_message_handler());
 
-  verilog_typecheck.typecheck_design_element(source_copy, *new_symbol);
+  verilog_typecheck.typecheck_design_element(
+    source_copy, *new_symbol, instance_identifier);
 
   return new_module_identifier;
 }

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -969,6 +969,7 @@ void verilog_synthesist::replace_by_wire(
   new_symbol.location=base.location;
   new_symbol.value=nil_exprt();
   new_symbol.is_auxiliary=true;
+  new_symbol.pretty_name = strip_verilog_root_prefix(new_symbol.name);
 
   symbol_exprt symbol_expr(new_symbol.name, new_symbol.type);
 
@@ -1270,73 +1271,6 @@ const symbolt &verilog_synthesist::assignment_symbol(const exprt &lhs)
 
 /*******************************************************************\
 
-Function: verilog_synthesist::replace_symbols
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-bool verilog_synthesist::replace_symbols(
-  const replace_mapt &what,
-  exprt &dest)
-{
-  bool result=true;
-
-  if(dest.id()==ID_next_symbol ||
-     dest.id()==ID_symbol)
-  {
-    replace_mapt::const_iterator it=
-      what.find(dest.get(ID_identifier));
-
-    if(it!=what.end())
-    {
-      bool is_next_symbol=dest.id()==ID_next_symbol;
-      dest=it->second;      
-
-      if(is_next_symbol)
-        replace_symbols(ID_next_symbol, dest);
-
-      result=false;
-    }
-  }
-  else
-  {
-    Forall_operands(it, dest)
-      result=replace_symbols(what, *it) && result;
-  }
-
-  return result;
-}
-
-/*******************************************************************\
-
-Function: verilog_synthesist::replace_symbols
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-void verilog_synthesist::replace_symbols(
-  const irep_idt &target,
-  exprt &dest)
-{
-  if(dest.id()==ID_symbol)
-    dest.id(target);
-  else
-    Forall_operands(it, dest)
-      replace_symbols(target, *it);
-}
-
-/*******************************************************************\
-
 Function: verilog_synthesist::instantiate_port
 
   Inputs:
@@ -1350,19 +1284,10 @@ Function: verilog_synthesist::instantiate_port
 void verilog_synthesist::instantiate_port(
   const module_typet::portt &port,
   const exprt &value,
-  const replace_mapt &replace_map,
   const source_locationt &source_location,
   transt &trans)
 {
-  irep_idt port_identifier = port.identifier();
-
-  replace_mapt::const_iterator it = replace_map.find(port_identifier);
-
-  if(it==replace_map.end())
-  {
-    throw errort().with_location(source_location)
-      << "failed to find port symbol " << port_identifier << " in replace_map";
-  }
+  symbol_exprt port_symbol{port.identifier(), port.type()};
 
   // Much like
   //   always @(*) port = value for an input, and
@@ -1373,12 +1298,12 @@ void verilog_synthesist::instantiate_port(
   if(port.output())
   {
     lhs = value;
-    rhs = typecast_exprt::conditional_cast(it->second, value.type());
+    rhs = typecast_exprt::conditional_cast(port_symbol, value.type());
   }
   else
   {
-    lhs = it->second;
-    rhs = typecast_exprt::conditional_cast(value, it->second.type());
+    lhs = port_symbol;
+    rhs = typecast_exprt::conditional_cast(value, port_symbol.type());
   }
 
   verilog_forcet assignment{lhs, rhs};
@@ -1409,7 +1334,6 @@ void verilog_synthesist::instantiate_ports(
   const irep_idt &instance,
   const verilog_instt::instancet &inst,
   const symbolt &symbol,
-  const replace_mapt &replace_map,
   transt &trans)
 {
   if(inst.connections().empty())
@@ -1440,8 +1364,7 @@ void verilog_synthesist::instantiate_ports(
 
       if(value.is_not_nil())
       {
-        instantiate_port(
-          port, value, replace_map, inst.source_location(), trans);
+        instantiate_port(port, value, inst.source_location(), trans);
       }
     }
 
@@ -1464,11 +1387,7 @@ void verilog_synthesist::instantiate_ports(
           auto &port_symbol = ns.lookup(identifier);
           if(port_symbol.value.is_not_nil())
             instantiate_port(
-              port,
-              port_symbol.value,
-              replace_map,
-              inst.source_location(),
-              trans);
+              port, port_symbol.value, inst.source_location(), trans);
         }
       }
   }
@@ -1489,8 +1408,7 @@ void verilog_synthesist::instantiate_ports(
     {
       DATA_INVARIANT(connection.is_not_nil(), "all ports must be connected");
 
-      instantiate_port(
-        *p_it, connection, replace_map, inst.source_location(), trans);
+      instantiate_port(*p_it, connection, inst.source_location(), trans);
 
       p_it++;
     }
@@ -1733,81 +1651,11 @@ void verilog_synthesist::expand_module_instance(
 {
   construct=constructt::OTHER;
 
-  replace_mapt replace_map;
-
-  std::list<irep_idt> new_symbols;
-
-  const auto old_symbols = find_module_symbols(module_symbol);
-
-  for(auto &symbol_identifier : old_symbols)
-  {
-    const symbolt &symbol = ns.lookup(symbol_identifier);
-
-    if(symbol.type.id()!=ID_module)
-    {
-      // instantiate the symbol
-
-      symbolt new_symbol(symbol);
-
-      new_symbol.module=module;
-
-      // Identifier Verilog::INSTANTIATED_MODULE.X
-      // is turned into Verilog::MODULE.id.instance::X
-
-      // strip old module      
-      std::string identifier_without_module=
-        std::string(id2string(symbol.name), symbol.module.size());
-
-      std::string full_identifier =
-        id2string(instance.identifier()) + identifier_without_module;
-
-      // We special-case the pretty name for identifiers under $root:
-      // it is customary to use the name of the module only as root
-      // of the hierarchical identifier.
-      new_symbol.pretty_name =
-        module == verilog_module_symbol(verilog_root_module_name())
-          ? symbol.pretty_name
-          : strip_verilog_prefix(full_identifier);
-      new_symbol.name=full_identifier;
-
-      if(symbol_table.add(new_symbol))
-      {
-        throw errort() << "name collision during module instantiation: "
-                       << new_symbol.name;
-      }
-
-      new_symbols.push_back(new_symbol.name);
-
-      // build replace map
-
-      std::pair<irep_idt, exprt> replace_pair;
-      replace_pair.first=symbol.name;
-      replace_pair.second=symbol_expr(new_symbol, CURRENT);
-      replace_map.insert(replace_pair);
-    }
-  }
-
-  // replace identifiers in macros
-
-  for(const auto & it : new_symbols)
-  {
-    symbolt &symbol=symbol_table_lookup(it);
-    replace_symbols(replace_map, symbol.value);
-  }
-
   // do the trans of the instantiated module
+  for(std::size_t i = 0; i < 3; i++)
+    trans_dest.operands()[i].add_to_operands(trans_inst.operands()[i]);
 
-  {
-    transt tmp = trans_inst;
-
-    replace_symbols(replace_map, tmp);
-
-    for(std::size_t i = 0; i < 3; i++)
-      trans_dest.operands()[i].add_to_operands(std::move(tmp.operands()[i]));
-  }
-
-  instantiate_ports(
-    instance.base_name(), instance, module_symbol, replace_map, trans_dest);
+  instantiate_ports(instance.base_name(), instance, module_symbol, trans_dest);
 }
 
 /*******************************************************************\
@@ -2029,6 +1877,8 @@ void verilog_synthesist::synth_decl(const verilog_declt &statement) {
     DATA_INVARIANT(declarator.id() == ID_declarator, "must have declarator");
 
     auto lhs = declarator.symbol_expr();
+
+    local_symbols.insert(lhs.get_identifier());
 
     // This is reg x = ... or wire x = ...
     if(declarator.has_value())
@@ -4044,12 +3894,14 @@ void verilog_synthesist::convert_module_items(symbolt &symbol)
   assignments.clear();
   invars.clear();
 
-  // find out about symbols of this module
-
-  for(auto it=symbol_table.symbol_module_map.lower_bound(module);
-      it!=symbol_table.symbol_module_map.upper_bound(module);
-      it++)
-    local_symbols.insert(it->second);
+  // Add port-declared symbols to local_symbols, since ANSI-style
+  // port declarations do not appear as decl module items.
+  // Don't do for $root, which uses input identifiers of its submodules.
+  if(symbol.name != verilog_root_module_identifier())
+  {
+    for(const auto &port : to_module_type(symbol.type).ports())
+      local_symbols.insert(port.identifier());
+  }
 
   // now convert the module items
 

--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -343,22 +343,15 @@ protected:
   exprt
   expand_function_call(const class function_call_exprt &call, symbol_statet);
 
-  typedef std::map<irep_idt, exprt> replace_mapt;
-
   void instantiate_ports(
     const irep_idt &instance,
     const verilog_instt::instancet &inst,
     const symbolt &,
-    const replace_mapt &,
     transt &);
-
-  bool replace_symbols(const replace_mapt &what, exprt &dest);
-  void replace_symbols(const irep_idt &target, exprt &dest);
 
   void instantiate_port(
     const module_typet::portt &,
     const exprt &value,
-    const replace_mapt &,
     const source_locationt &,
     transt &);
 

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -158,8 +158,8 @@ void verilog_typecheckt::typecheck_port_connections(
 
       bool found=false;
 
-      std::string full_identifier =
-        id2string(symbol.module) + "." + id2string(base_name);
+      irep_idt full_identifier =
+        id2string(inst.identifier()) + '.' + id2string(base_name);
 
       named_port_connection.port() =
         symbol_exprt{full_identifier, typet{}}.with_source_location(
@@ -749,7 +749,7 @@ void verilog_typecheckt::convert_function_call_or_task_enable(
 
     // look it up
     irep_idt full_identifier =
-      id2string(module_identifier) + "." + id2string(base_name);
+      id2string(module_instance) + "." + id2string(base_name);
 
     const symbolt *symbol;
     if(ns.lookup(full_identifier, symbol))
@@ -903,12 +903,12 @@ void verilog_typecheckt::convert_assert_assume_cover(
 
   symbolt symbol{full_identifier, bool_typet{}, mode};
 
-  symbol.module = module_identifier;
+  symbol.module = verilog_root_module_identifier();
   symbol.value = nil_exprt{}; // set by synthesis
   symbol.base_name = base_name;
   symbol.is_property = true;
   symbol.location = module_item.find_source_location();
-  symbol.pretty_name = strip_verilog_prefix(full_identifier);
+  symbol.pretty_name = strip_verilog_root_prefix(full_identifier);
 
   symbol_table.insert(std::move(symbol));
 }
@@ -965,7 +965,7 @@ void verilog_typecheckt::convert_assert_assume_cover(
   auto full_identifier =
     statement.id() == ID_verilog_smv_assert ||
         statement.id() == ID_verilog_smv_assume
-      ? id2string(module_identifier) + ".property." + id2string(base_name)
+      ? id2string(module_instance) + ".property." + id2string(base_name)
       : hierarchical_identifier(base_name);
 
   if(symbol_table.symbols.find(full_identifier) != symbol_table.symbols.end())
@@ -976,14 +976,14 @@ void verilog_typecheckt::convert_assert_assume_cover(
 
   statement.identifier(full_identifier);
 
-  symbolt symbol{base_name, bool_typet{}, mode};
+  symbolt symbol{full_identifier, bool_typet{}, mode};
 
-  symbol.module = module_identifier;
+  symbol.module = verilog_root_module_identifier();
   symbol.value = nil_exprt{}; // set by synthesis
-  symbol.name = full_identifier;
+  symbol.base_name = base_name;
   symbol.is_property = true;
   symbol.location = statement.find_source_location();
-  symbol.pretty_name = strip_verilog_prefix(full_identifier);
+  symbol.pretty_name = strip_verilog_root_prefix(full_identifier);
 
   symbolt *new_symbol;
   symbol_table.move(symbol, new_symbol);
@@ -1658,7 +1658,7 @@ void verilog_typecheckt::convert_property_declaration(
 
   symbol.module = module_identifier;
   symbol.base_name = base_name;
-  symbol.pretty_name = strip_verilog_prefix(symbol.name);
+  symbol.pretty_name = strip_verilog_root_prefix(symbol.name);
   symbol.value = declaration;
   symbol.location = declaration.source_location();
 
@@ -1694,7 +1694,7 @@ void verilog_typecheckt::convert_sequence_declaration(
 
   symbol.module = module_identifier;
   symbol.base_name = base_name;
-  symbol.pretty_name = strip_verilog_prefix(symbol.name);
+  symbol.pretty_name = strip_verilog_root_prefix(symbol.name);
   symbol.value = declaration;
   symbol.location = declaration.source_location();
 
@@ -1738,18 +1738,18 @@ bool verilog_typecheckt::implicit_wire(
   const symbolt *&symbol_ptr,
   const typet &net_type)
 {
-  std::string full_identifier=
-    id2string(module_identifier)+"."+id2string(identifier);
+  std::string full_identifier =
+    id2string(module_instance) + '.' + id2string(identifier);
 
   symbolt symbol;
 
   symbol.mode=mode;
-  symbol.module=module_identifier;
+  symbol.module = verilog_root_module_identifier();
   symbol.value.make_nil();
   symbol.base_name=identifier;
   symbol.name=full_identifier;
   symbol.type = net_type;
-  symbol.pretty_name=strip_verilog_prefix(full_identifier);
+  symbol.pretty_name = strip_verilog_root_prefix(full_identifier);
 
   symbolt *new_symbol;
   symbol_table.move(symbol, new_symbol);
@@ -1772,9 +1772,11 @@ Function: verilog_typecheckt::typecheck_design_element
 
 void verilog_typecheckt::typecheck_design_element(
   const verilog_module_sourcet &module_source,
-  symbolt &symbol)
+  symbolt &symbol,
+  irep_idt new_module_instance)
 {
   module_identifier = symbol.name;
+  module_instance = new_module_instance;
 
   // Elaborate the named constants (parameters, enums),
   // generate constructs, and add the symbols to the symbol table.
@@ -1958,7 +1960,10 @@ bool verilog_typecheck(
 
   try
   {
-    verilog_typecheck.typecheck_design_element(module_source, *new_symbol);
+    verilog_typecheck.typecheck_design_element(
+      module_source,
+      *new_symbol,
+      "Verilog::$root." + id2string(source_symbol.base_name));
   }
 
   catch(const typecheckt::errort &e)

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -68,7 +68,10 @@ public:
   // type checking for all "item containers", which includes
   // all "design elements" (modules, programs, interfaces,
   // checkers, packages, primitives, and configurations)
-  void typecheck_design_element(const verilog_module_sourcet &, symbolt &);
+  void typecheck_design_element(
+    const verilog_module_sourcet &,
+    symbolt &,
+    irep_idt module_instance);
 
   // type checking for compilation-unit scoped nets, variables,
   // typedefs, functions, tasks, parameters

--- a/src/verilog/verilog_typecheck_base.cpp
+++ b/src/verilog/verilog_typecheck_base.cpp
@@ -23,6 +23,13 @@ irep_idt verilog_root_module_name()
   return name;
 }
 
+irep_idt verilog_root_module_identifier()
+{
+  const static irep_idt identifier =
+    verilog_module_symbol(verilog_root_module_name());
+  return identifier;
+}
+
 /*******************************************************************\
 
 Function: verilog_module_symbol
@@ -116,6 +123,34 @@ irep_idt strip_verilog_prefix(const irep_idt &identifier)
   DATA_INVARIANT(
     identifier.size() >= prefix.size(), "Verilog identifier syntax");
   return identifier.c_str()+prefix.size();
+}
+
+/*******************************************************************\
+
+Function: strip_verilog_root_prefix
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+irep_idt strip_verilog_root_prefix(const irep_idt &identifier)
+{
+  std::string result = id2string(identifier);
+
+  if(std::string(result, 0, 9) == "Verilog::")
+    result.erase(0, 9);
+
+  const static std::string root_module_prefix =
+    id2string(verilog_root_module_name()) + '.';
+
+  if(has_prefix(result, root_module_prefix))
+    result.erase(0, root_module_prefix.size());
+
+  return result;
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_typecheck_base.h
+++ b/src/verilog/verilog_typecheck_base.h
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "verilog_standard.h"
 
 irep_idt verilog_root_module_name(); // $root
+irep_idt verilog_root_module_identifier();
 
 irep_idt verilog_module_symbol(const irep_idt &base_name);
 irep_idt verilog_package_identifier(const irep_idt &base_name);
@@ -26,6 +27,7 @@ irep_idt verilog_package_identifier(
 irep_idt verilog_unit_scope_identifier(const irep_idt &item_base_name);
 irep_idt verilog_item_key(const irep_idt &identifier);
 irep_idt strip_verilog_prefix(const irep_idt &identifier);
+irep_idt strip_verilog_root_prefix(const irep_idt &identifier);
 
 class array_typet;
 

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -53,34 +53,30 @@ verilog_typecheck_exprt::hierarchical_identifier(irep_idt base_name) const
   const std::string named_block =
     named_blocks.empty() ? std::string() : id2string(named_blocks.back());
 
+  static const std::string verilog_prefix = "Verilog::";
+  static const std::string package_prefix = "Verilog::package::";
+
   if(!function_or_task_name.empty())
   {
     return id2string(function_or_task_name) + "." + named_block +
            id2string(base_name);
   }
-  else if(!module_identifier.empty())
+  else if(has_prefix(id2string(module_identifier), package_prefix))
   {
-    // used for both modules and packages
-    static const std::string verilog_prefix = "Verilog::";
-    static const std::string package_prefix = "Verilog::package::";
-
-    if(has_prefix(id2string(module_identifier), package_prefix))
-    {
-      auto package_name =
-        std::string{id2string(module_identifier), package_prefix.size()};
-      // Verilog::package_name::base_name
-      return verilog_package_identifier(package_name, base_name);
-    }
-    else
-    {
-      // Verilog::module_name.block.base_name
-      return id2string(module_identifier) + "." + named_block +
-             id2string(base_name);
-    }
+    auto package_name =
+      std::string{id2string(module_identifier), package_prefix.size()};
+    // Verilog::package_name::base_name
+    return verilog_package_identifier(package_name, base_name);
+  }
+  else if(!module_instance.empty())
+  {
+    // Verilog::instance.block.base_name
+    return id2string(module_instance) + '.' + named_block +
+           id2string(base_name);
   }
   else
   {
-    // not in a function/task, not in a module/checker/package etc.
+    // not in a function/task, not in a package, not in a module/checker
     return verilog_unit_scope_identifier(base_name);
   }
 }
@@ -853,7 +849,7 @@ exprt verilog_typecheck_exprt::convert_expr_function_call(
 
     // first look in the current module
     irep_idt full_identifier =
-      id2string(module_identifier) + "." + id2string(base_name);
+      id2string(module_instance) + "." + id2string(base_name);
 
     if(ns.lookup(full_identifier, symbol))
     {
@@ -1539,19 +1535,21 @@ const symbolt *verilog_typecheck_exprt::resolve(const irep_idt base_name)
       return symbol; // found!
   }
 
-  // determine the pacakge/module prefix, using the right separator
+  // determine the pacakge/module instance prefix, using the right separator
   std::string prefix;
   static const std::string package_prefix = "Verilog::package::";
 
   if(has_prefix(id2string(module_identifier), package_prefix))
   {
+    // In a package
     auto package_name =
       std::string{id2string(module_identifier), package_prefix.size()};
     prefix = "Verilog::" + package_name + "::";
   }
   else
   {
-    prefix = id2string(module_identifier) + '.';
+    // In a module instance
+    prefix = id2string(module_instance) + '.';
   }
 
   // try named blocks, beginning with inner one
@@ -1737,22 +1735,9 @@ exprt verilog_typecheck_exprt::convert_hierarchical_identifier(
 
   if(expr.lhs().type().id() == ID_verilog_module_instance)
   {
-    // figure out which module the lhs is
-    const symbolt *module_instance_symbol;
-    if(ns.lookup(lhs_identifier, module_instance_symbol))
-    {
-      throw errort().with_location(expr.source_location())
-        << "failed to find module instance `" << lhs_identifier
-        << "' on lhs of `.'";
-    }
-
-    const irep_idt &module =
-      to_verilog_module_instance(module_instance_symbol->value)
-        .module_identifier();
-
     // the identifier in the module
     const irep_idt full_identifier =
-      id2string(module) + "." + id2string(rhs_base_name);
+      id2string(lhs_identifier) + '.' + id2string(rhs_base_name);
 
     const symbolt *symbol;
     if(!ns.lookup(full_identifier, symbol))
@@ -1771,7 +1756,7 @@ exprt verilog_typecheck_exprt::convert_hierarchical_identifier(
     {
       throw errort().with_location(expr.source_location())
         << "identifier `" << rhs_base_name << "' not found in module `"
-        << module_instance_symbol->pretty_name << "'";
+        << lhs_identifier << '\'';
     }
 
     // We remember the identifier of the symbol.
@@ -3841,7 +3826,8 @@ Function: verilog_typecheck
 
 bool verilog_typecheck(
   exprt &expr,
-  const std::string &module_identifier,
+  const irep_idt &module_identifier,
+  const irep_idt &module_instance,
   verilog_standardt standard,
   message_handlert &message_handler,
   const namespacet &ns)
@@ -3850,7 +3836,7 @@ bool verilog_typecheck(
     message_handler.get_message_count(messaget::M_ERROR);
 
   verilog_typecheck_exprt verilog_typecheck_expr(
-    standard, true, ns, module_identifier, message_handler);
+    standard, true, ns, module_identifier, module_instance, message_handler);
 
   try
   {

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -39,10 +39,12 @@ public:
     verilog_standardt _standard,
     bool _warn_implicit_nets,
     const namespacet &_ns,
-    const std::string &_module_identifier,
+    const irep_idt &_module_identifier,
+    const irep_idt &_module_instance,
     message_handlert &_message_handler)
     : verilog_typecheck_baset(_standard, _ns, _message_handler),
       module_identifier(_module_identifier),
+      module_instance(_module_instance),
       warn_implicit_nets(_warn_implicit_nets)
   { }
 
@@ -56,7 +58,13 @@ public:
   exprt elaborate_constant_system_function_call(function_call_exprt);
 
 protected:
+  // full identifier of module
   irep_idt module_identifier;
+
+  // full identifier of instance
+  irep_idt module_instance;
+
+  // full identifier of function/task
   irep_idt function_or_task_name;
 
   // module_identifier.function.block.base_name
@@ -239,7 +247,8 @@ protected:
 
 bool verilog_typecheck(
   exprt &,
-  const std::string &module_identifier,
+  const irep_idt &module_identifier,
+  const irep_idt &module_instance,
   verilog_standardt,
   message_handlert &,
   const namespacet &);


### PR DESCRIPTION
This changes the way the Verilog typechecker processes submodule instances to create the final hierarchical instance identifiers directly.

This replaces the current approach where modules are type-checked for a given parameter assignment, and then subsequently instantiated by renaming the identifiers in the transition relation to match the instance identifier.

The key benefit is that the position in the module hierarchy is then known during type-checking, which enables upwards references.