### PR TITLE
Verilog: remove module source copies from symbol table

### DIFF
--- a/src/verilog/verilog_parameterize_module.cpp
+++ b/src/verilog/verilog_parameterize_module.cpp
@@ -275,12 +275,12 @@ irep_idt verilog_typecheckt::parameterize_module(
 
   const symbolt &source_symbol = it->second;
 
-  const auto &source = source_symbol.type.find(ID_module_source);
+  // find the source
+  const auto &module_source =
+    to_verilog_module_source(source_symbol.type.find(ID_module_source));
 
   auto parameter_values = get_parameter_values(
-    to_verilog_module_source(source),
-    parameter_assignments,
-    instance_defparams);
+    module_source, parameter_assignments, instance_defparams);
 
   // Create full parameterized module name by appending a suffix
   // to the name of the instantiated module.
@@ -296,12 +296,13 @@ irep_idt verilog_typecheckt::parameterize_module(
 
   symbol.name = new_module_identifier;
   symbol.module = new_module_identifier;
-  symbol.type.id(ID_module);
+  symbol.type = typet{ID_module};
+
+  // copy the module source
+  verilog_module_sourcet source_copy = module_source;
 
   // set parameters
-  set_parameter_values(
-    to_verilog_module_source(symbol.type.add(ID_module_source)),
-    parameter_values);
+  set_parameter_values(source_copy, parameter_values);
 
   // put symbol in symbol_table
   symbolt *new_symbol;
@@ -317,7 +318,7 @@ irep_idt verilog_typecheckt::parameterize_module(
   verilog_typecheckt verilog_typecheck(
     standard, warn_implicit_nets, symbol_table, get_message_handler());
 
-  verilog_typecheck.typecheck_design_element(*new_symbol);
+  verilog_typecheck.typecheck_design_element(source_copy, *new_symbol);
 
   return new_module_identifier;
 }

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1772,12 +1772,11 @@ Function: verilog_typecheckt::typecheck_design_element
 
 \*******************************************************************/
 
-void verilog_typecheckt::typecheck_design_element(symbolt &symbol)
+void verilog_typecheckt::typecheck_design_element(
+  const verilog_module_sourcet &module_source,
+  symbolt &symbol)
 {
   module_identifier = symbol.name;
-
-  const auto &module_source =
-    to_verilog_module_source(symbol.type.find(ID_module_source));
 
   // Elaborate the named constants (parameters, enums),
   // generate constructs, and add the symbols to the symbol table.
@@ -1940,12 +1939,15 @@ bool verilog_typecheck(
   PRECONDITION(
     symbol_table.symbols.find(module_identifier) == symbol_table.symbols.end());
 
+  const auto &module_source =
+    to_verilog_module_source(source_symbol.type.find(ID_module_source));
+
   // copy the symbol
   symbolt symbol{source_symbol};
 
   symbol.name = module_identifier;
   symbol.module = module_identifier;
-  symbol.type.id(ID_module);
+  symbol.type = typet{ID_module};
 
   // put symbol in symbol_table
   symbolt *new_symbol;
@@ -1958,7 +1960,7 @@ bool verilog_typecheck(
 
   try
   {
-    verilog_typecheck.typecheck_design_element(*new_symbol);
+    verilog_typecheck.typecheck_design_element(module_source, *new_symbol);
   }
 
   catch(const typecheckt::errort &e)

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -68,7 +68,7 @@ public:
   // type checking for all "item containers", which includes
   // all "design elements" (modules, programs, interfaces,
   // checkers, packages, primitives, and configurations)
-  void typecheck_design_element(symbolt &);
+  void typecheck_design_element(const verilog_module_sourcet &, symbolt &);
 
   // type checking for compilation-unit scoped nets, variables,
   // typedefs, functions, tasks, parameters


### PR DESCRIPTION
The module source is now passed explicitly as an argument to `verilog_typecheckt::typecheck_design_element`, instead of passing the module source as an annotation on the type of the symbol.