### PR TITLE
Verilog: name instantiated modules after instance identifier

### DIFF
--- a/regression/verilog/checker/checker2.desc
+++ b/regression/verilog/checker/checker2.desc
@@ -1,7 +1,7 @@
 CORE
 checker2.sv
 --bound 20
-^\[main\.c\.assert\.1\] always myChecker\.data != 10: REFUTED$
+^\[main\.c\.assert\.1\] always main\.c\$module\.data != 10: REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/checker/checker7.desc
+++ b/regression/verilog/checker/checker7.desc
@@ -1,7 +1,7 @@
 CORE
 checker7.sv
 --bound 20
-^\[main\.c\.assert\.1\] always myChecker\.data1 != myChecker\.data2: REFUTED$
+^\[main\.c\.assert\.1\] always main\.c\$module\.data1 != main\.c\$module\.data2: REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/module_instance_identifier1.desc
+++ b/regression/verilog/modules/module_instance_identifier1.desc
@@ -1,7 +1,7 @@
 CORE
 module_instance_identifier1.v
 --show-symbol-table
-module: Verilog::my_module\(8\)$
+module: Verilog::main\.m8\$module$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/modules/port_with_value1.desc
+++ b/regression/verilog/modules/port_with_value1.desc
@@ -1,8 +1,8 @@
 CORE
 port_with_value1.sv
 
-^\[main\.m1\.eq] always M1\.in1 == M1\.in2: REFUTED$
-^\[main\.m2\.eq] always M1\.in1 == M1\.in2: PROVED .*$
+^\[main\.m1\.eq] always main\.m1\$module.in1 == main\.m1\$module\.in2: REFUTED$
+^\[main\.m2\.eq] always main\.m2\$module\.in1 == main\.m2\$module\.in2: PROVED .*$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/src/verilog/verilog_elaborate_module_instances.cpp
+++ b/src/verilog/verilog_elaborate_module_instances.cpp
@@ -362,17 +362,17 @@ void verilog_typecheckt::parameterize_instantiated_modules(verilog_instt &inst)
     const irep_idt instance_identifier =
       hierarchical_identifier(instance_base_name);
 
-    instance.identifier(instance_identifier);
-
     // add relevant defparam assignments
     auto &instance_defparams = defparams[instance_identifier];
 
     irep_idt new_module_identifier = parameterize_module(
       inst.source_location(),
       module_identifier,
+      instance_identifier,
       parameter_assignments,
       instance_defparams);
 
+    instance.identifier(instance_identifier);
     instance.module_identifier(new_module_identifier);
 
     symbolt &instance_symbol = symbol_table_lookup(instance_identifier);

--- a/src/verilog/verilog_parameterize_module.cpp
+++ b/src/verilog/verilog_parameterize_module.cpp
@@ -195,61 +195,6 @@ void verilog_typecheckt::set_parameter_values(
 
 /*******************************************************************\
 
-Function: verilog_typecheckt::parameterized_module_identifier
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-irep_idt verilog_typecheckt::parameterized_module_identifier(
-  const irep_idt &module_identifier,
-  const std::list<exprt> &parameter_values) const
-{
-  // No actual parameters? No suffix!
-  if(parameter_values.empty())
-    return module_identifier;
-
-  // Create full parameterized module name by appending a suffix
-  // to the name of the instantiated module.
-  std::string suffix="(";
-  
-  bool first=true;
-
-  for(const auto &pv : parameter_values)
-  {
-    if(first)
-      first = false;
-    else
-      suffix += ",";
-
-    if(pv.is_not_nil())
-    {
-      if(pv.id() == ID_type)
-      {
-        suffix += verilog_typename(to_type_expr(pv).type());
-      }
-      else if(pv.id() == ID_constant)
-      {
-        mp_integer i = numeric_cast_v<mp_integer>(to_constant_expr(pv));
-        suffix += integer2string(i);
-      }
-      else
-        DATA_INVARIANT(
-          false, "parameter value expected to be type or constant");
-    }
-  }
-
-  suffix+=')';
-
-  return id2string(module_identifier) + suffix;
-}
-
-/*******************************************************************\
-
 Function: verilog_typecheckt::parameterize_module
 
   Inputs:
@@ -263,6 +208,7 @@ Function: verilog_typecheckt::parameterize_module
 irep_idt verilog_typecheckt::parameterize_module(
   const source_locationt &location,
   const irep_idt &module_identifier,
+  const irep_idt &instance_identifier,
   const exprt::operandst &parameter_assignments,
   const std::map<irep_idt, exprt> &instance_defparams)
 {
@@ -282,14 +228,14 @@ irep_idt verilog_typecheckt::parameterize_module(
   auto parameter_values = get_parameter_values(
     module_source, parameter_assignments, instance_defparams);
 
-  // Create full parameterized module name by appending a suffix
-  // to the name of the instantiated module.
-  auto new_module_identifier =
-    parameterized_module_identifier(module_identifier, parameter_values);
+  // Create full parameterized module name by appending "$module"
+  // to the name of the module instance.
+  auto new_module_identifier = id2string(instance_identifier) + "$module";
 
-  if(symbol_table.symbols.find(new_module_identifier)!=
-     symbol_table.symbols.end())
-    return new_module_identifier; // done already
+  DATA_INVARIANT(
+    symbol_table.symbols.find(new_module_identifier) ==
+      symbol_table.symbols.end(),
+    "instantiated module symbol must not yet exist");
 
   // copy the symbol
   symbolt symbol{source_symbol};
@@ -307,11 +253,8 @@ irep_idt verilog_typecheckt::parameterize_module(
   // put symbol in symbol_table
   symbolt *new_symbol;
 
-  if(symbol_table.move(symbol, new_symbol))
-  {
-    throw errort().with_location(location)
-      << "duplicate definition of parameterized module " << symbol.base_name;
-  }
+  bool move_return = symbol_table.move(symbol, new_symbol);
+  CHECK_RETURN(!move_return);
 
   // recursive call
 

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -131,12 +131,9 @@ protected:
   irep_idt parameterize_module(
     const source_locationt &location,
     const irep_idt &module_identifier,
+    const irep_idt &instance_identifier,
     const exprt::operandst &parameter_assignment,
     const std::map<irep_idt, exprt> &defparams);
-
-  irep_idt parameterized_module_identifier(
-    const irep_idt &module_identifier,
-    const std::list<exprt> &parameter_values) const;
 
   std::vector<verilog_parameter_declt::declaratort>
   get_parameter_declarators(const verilog_module_sourcet &);


### PR DESCRIPTION
This changes the pattern used for instantiated modules to use the instance identifier, as opposed to a suffix on the module name that encodes the parameter values.

The instance identifier is unique of a set of parameter values.