### PR TITLE
add `verilog_inst_baset::instancet::base_name(...)`

### DIFF
--- a/src/verilog/verilog_ebmc_language.cpp
+++ b/src/verilog/verilog_ebmc_language.cpp
@@ -354,7 +354,7 @@ void verilog_ebmc_languaget::create_root_module(
   verilog_instt inst;
   inst.module_base_name(top_level_module);
   verilog_inst_baset::instancet instance_expr;
-  instance_expr.set(ID_base_name, top_level_module);
+  instance_expr.base_name(top_level_module);
   instance_expr.identifier(instance_identifier);
   instance_expr.module_identifier(module_identifier);
   inst.instances().push_back(std::move(instance_expr));

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -1064,6 +1064,11 @@ public:
       return get(ID_base_name);
     }
 
+    void base_name(irep_idt _base_name)
+    {
+      return set(ID_base_name, _base_name);
+    }
+
     // The identifier of the instance.
     const irep_idt &identifier() const
     {


### PR DESCRIPTION
This adds the setter for the `base_name` member of `verilog_inst_baset::instancet`.