### PR TITLE
Verilog: set up proper ports for the root module

### DIFF
--- a/src/verilog/verilog_ebmc_language.cpp
+++ b/src/verilog/verilog_ebmc_language.cpp
@@ -366,31 +366,19 @@ void verilog_ebmc_languaget::create_root_module(
   inst.instances().push_back(std::move(instance_expr));
 
   // Create the $root module symbol with the inst as its only module item.
-  // Copy the type from the top-level module, updating port identifiers.
   auto &top_symbol = symbol_table.lookup_ref(module_identifier);
 
-  symbolt root_symbol{root_identifier, top_symbol.type, ID_Verilog};
+  symbolt root_symbol{root_identifier, module_typet{}, ID_Verilog};
   root_symbol.base_name = verilog_root_module_name();
   root_symbol.pretty_name = verilog_root_module_name();
   root_symbol.module = root_identifier;
   root_symbol.value = verilog_module_exprt({std::move(inst)});
 
-  const std::string &module_identifier_string = id2string(module_identifier);
+  // Create the ports for the $root module
+  auto &root_ports = to_module_type(root_symbol.type).ports();
 
-  // Update port identifiers to reflect the $root hierarchy
-  for(auto &port : to_module_type(root_symbol.type).ports())
-  {
-    auto old_id = id2string(port.identifier());
-    // Replace Verilog::MODULE with Verilog::$root.MODULE
-    if(
-      old_id.compare(0, module_identifier.size(), module_identifier_string) ==
-      0)
-    {
-      port.identifier(
-        id2string(instance_identifier) +
-        old_id.substr(module_identifier.size()));
-    }
-  }
+  for(auto &top_port : to_module_type(top_symbol.type).ports())
+    root_ports.push_back(top_port);
 
   auto add_result_root = symbol_table.add(root_symbol);
   CHECK_RETURN(!add_result_root);

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -93,9 +93,8 @@ void verilog_typecheckt::check_module_ports(
       direction = ID_output;
     }
 
-    ports.emplace_back(identifier, port_symbol->type, direction);
+    ports.emplace_back(identifier, base_name, port_symbol->type, direction);
 
-    ports.back().set("#name", base_name);
     ports.back().set(ID_C_source_location, declarator.source_location());
 
     port_names.insert(base_name);

--- a/src/verilog/verilog_types.h
+++ b/src/verilog/verilog_types.h
@@ -210,10 +210,15 @@ public:
   class portt : public irept
   {
   public:
-    portt(irep_idt _identifier, typet _type, irep_idt _direction)
+    portt(
+      irep_idt _identifier,
+      irep_idt _base_name,
+      typet _type,
+      irep_idt _direction)
       : irept(ID_symbol)
     {
       identifier(_identifier);
+      base_name(_base_name);
       type() = std::move(_type);
       direction(_direction);
     }
@@ -226,6 +231,16 @@ public:
     const typet &type() const
     {
       return static_cast<const typet &>(find(ID_type));
+    }
+
+    irep_idt base_name() const
+    {
+      return get("#name");
+    }
+
+    void base_name(irep_idt _base_name)
+    {
+      return set("#name", _base_name);
     }
 
     irep_idt identifier() const


### PR DESCRIPTION
The ports for the `$root` module are now created explicitly.