### PR TITLE
Verilog: $root module does not need ports

### DIFF
--- a/src/verilog/verilog_ebmc_language.cpp
+++ b/src/verilog/verilog_ebmc_language.cpp
@@ -350,7 +350,8 @@ void verilog_ebmc_languaget::create_root_module(
   auto add_result_instance = symbol_table.add(instance_symbol);
   CHECK_RETURN(!add_result_instance);
 
-  // Build a verilog_instt module item for the instantiation
+  // Build a verilog_instt module item for the instantiation.
+  // The ports of the instantiated module are left unconnected.
   verilog_instt inst;
   inst.module_base_name(top_level_module);
   verilog_inst_baset::instancet instance_expr;
@@ -360,31 +361,12 @@ void verilog_ebmc_languaget::create_root_module(
   inst.instances().push_back(std::move(instance_expr));
 
   // Create the $root module symbol with the inst as its only module item.
-  // Copy the type from the top-level module, updating port identifiers.
-  auto &top_symbol = symbol_table.lookup_ref(module_identifier);
-
-  symbolt root_symbol{root_identifier, top_symbol.type, ID_Verilog};
+  // The module has no ports, no parameters.
+  symbolt root_symbol{root_identifier, module_typet{}, ID_Verilog};
   root_symbol.base_name = verilog_root_module_name();
   root_symbol.pretty_name = verilog_root_module_name();
   root_symbol.module = root_identifier;
   root_symbol.value = verilog_module_exprt({std::move(inst)});
-
-  const std::string &module_identifier_string = id2string(module_identifier);
-
-  // Update port identifiers to reflect the $root hierarchy
-  for(auto &port : to_module_type(root_symbol.type).ports())
-  {
-    auto old_id = id2string(port.identifier());
-    // Replace Verilog::MODULE with Verilog::$root.MODULE
-    if(
-      old_id.compare(0, module_identifier.size(), module_identifier_string) ==
-      0)
-    {
-      port.identifier(
-        id2string(instance_identifier) +
-        old_id.substr(module_identifier.size()));
-    }
-  }
 
   auto add_result_root = symbol_table.add(root_symbol);
   CHECK_RETURN(!add_result_root);


### PR DESCRIPTION
This removes the ports from the `$root` module; there is no need.