### PR TITLE
Verilog synthesis now returns `transt`

### DIFF
--- a/src/verilog/verilog_ebmc_language.cpp
+++ b/src/verilog/verilog_ebmc_language.cpp
@@ -166,13 +166,17 @@ void verilog_ebmc_languaget::typecheck_module(
   const bool ignore_initial = cmdline.isset("ignore-initial");
   const bool initial_zero = cmdline.isset("initial-zero");
 
-  if(verilog_synthesis(
-       symbol_table,
-       module.identifier,
-       module.parse_tree.standard,
-       ignore_initial,
-       initial_zero,
-       message_handler))
+  try
+  {
+    verilog_synthesis(
+      symbol_table,
+      module.identifier,
+      module.parse_tree.standard,
+      ignore_initial,
+      initial_zero,
+      message_handler);
+  }
+  catch(ebmc_errort)
   {
     log.error() << "CONVERSION ERROR" << messaget::eom;
     throw ebmc_errort{}.with_exit_code(2);
@@ -332,8 +336,10 @@ verilog_ebmc_languaget::top_level_module(const parse_treest &parse_trees) const
 void verilog_ebmc_languaget::create_root_module(
   irep_idt top_level_module,
   verilog_standardt standard,
-  symbol_tablet &symbol_table)
+  transition_systemt &transition_system)
 {
+  auto &symbol_table = transition_system.symbol_table;
+
   auto module_identifier = verilog_module_symbol(top_level_module);
   auto root_identifier = verilog_module_symbol(verilog_root_module_name());
   auto instance_identifier =
@@ -389,38 +395,19 @@ void verilog_ebmc_languaget::create_root_module(
   auto add_result_root = symbol_table.add(root_symbol);
   CHECK_RETURN(!add_result_root);
 
+  transition_system.main_symbol = symbol_table.lookup(root_identifier);
+
   const bool ignore_initial = cmdline.isset("ignore-initial");
   const bool initial_zero = cmdline.isset("initial-zero");
 
   // Synthesize $root, which expands the top-level module instance
-  verilog_synthesis(
+  transition_system.trans_expr = verilog_synthesis(
     symbol_table,
     root_identifier,
     standard,
     ignore_initial,
     initial_zero,
     message_handler);
-}
-
-static bool get_main(
-  message_handlert &message_handler,
-  transition_systemt &transition_system)
-{
-  try
-  {
-    auto identifier = verilog_module_symbol(verilog_root_module_name());
-    auto symbol_it = transition_system.symbol_table.symbols.find(identifier);
-    CHECK_RETURN(symbol_it != transition_system.symbol_table.symbols.end());
-    transition_system.main_symbol = &symbol_it->second;
-    transition_system.trans_expr = to_trans_expr(symbol_it->second.value);
-  }
-
-  catch(int e)
-  {
-    return true;
-  }
-
-  return false;
 }
 
 static void make_next_state(exprt &expr)
@@ -538,18 +525,13 @@ std::optional<transition_systemt> verilog_ebmc_languaget::transition_system()
 
   // Create the $root module instance and synthesize it
   create_root_module(
-    top_level_module,
-    parse_trees.front().standard,
-    transition_system.symbol_table);
+    top_level_module, parse_trees.front().standard, transition_system);
 
   if(cmdline.isset("show-symbol-table"))
   {
     std::cout << transition_system.symbol_table;
     return {};
   }
-
-  if(get_main(message_handler, transition_system))
-    throw ebmc_errort{}.with_exit_code(1);
 
   if(cmdline.isset("show-module-hierarchy"))
   {

--- a/src/verilog/verilog_ebmc_language.h
+++ b/src/verilog/verilog_ebmc_language.h
@@ -73,7 +73,7 @@ protected:
   void create_root_module(
     irep_idt top_level_module,
     verilog_standardt,
-    symbol_tablet &);
+    transition_systemt &);
 };
 
 #endif // EBMC_VERILOG_LANGUAGE_H

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -19,6 +19,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/simplify_expr.h>
 #include <util/std_expr.h>
 
+#include <ebmc/ebmc_error.h>
+
 #include "aval_bval_encoding.h"
 #include "expr2verilog.h"
 #include "sva_expr.h"
@@ -1509,7 +1511,7 @@ Function: verilog_synthesist::synth_module_instance
 
 void verilog_synthesist::synth_module_instance(
   const verilog_instt &statement,
-  transt &trans)
+  transt &trans_dest)
 {
   for(auto &instance : statement.instances())
   {
@@ -1518,8 +1520,8 @@ void verilog_synthesist::synth_module_instance(
     // must be in symbol_table
     const symbolt &module_symbol = ns.lookup(module_identifier);
 
-    // make sure the module is synthesized already
-    verilog_synthesis(
+    // get the transition relation of the instantiated module
+    auto trans_inst = verilog_synthesis(
       symbol_table,
       module_identifier,
       standard,
@@ -1527,7 +1529,7 @@ void verilog_synthesist::synth_module_instance(
       initial_zero,
       get_message_handler());
 
-    expand_module_instance(module_symbol, instance, trans);
+    expand_module_instance(module_symbol, trans_inst, instance, trans_dest);
   }
 }
 
@@ -1725,8 +1727,9 @@ Function: verilog_synthesist::expand_module_instance
 
 void verilog_synthesist::expand_module_instance(
   const symbolt &module_symbol,
+  const transt &trans_inst,
   const verilog_instt::instancet &instance,
-  transt &trans)
+  transt &trans_dest)
 {
   construct=constructt::OTHER;
 
@@ -1792,25 +1795,19 @@ void verilog_synthesist::expand_module_instance(
     replace_symbols(replace_map, symbol.value);
   }
 
-  // do the trans
+  // do the trans of the instantiated module
 
   {
-    exprt tmp = module_symbol.value;
-
-    if(tmp.id()!=ID_trans || tmp.operands().size()!=3)
-    {
-      throw errort().with_location(instance.source_location())
-        << "Expected transition system, but got `" << tmp.id() << '\'';
-    }
+    transt tmp = trans_inst;
 
     replace_symbols(replace_map, tmp);
 
-    for(unsigned i=0; i<3; i++)
-      trans.operands()[i].add_to_operands(std::move(tmp.operands()[i]));
+    for(std::size_t i = 0; i < 3; i++)
+      trans_dest.operands()[i].add_to_operands(std::move(tmp.operands()[i]));
   }
 
   instantiate_ports(
-    instance.base_name(), instance, module_symbol, replace_map, trans);
+    instance.base_name(), instance, module_symbol, replace_map, trans_dest);
 }
 
 /*******************************************************************\
@@ -4095,7 +4092,7 @@ void verilog_synthesist::convert_module_items(symbolt &symbol)
 
 /*******************************************************************\
 
-Function: verilog_synthesist::typecheck
+Function: verilog_synthesist::synthesis
 
   Inputs:
 
@@ -4105,11 +4102,18 @@ Function: verilog_synthesist::typecheck
 
 \*******************************************************************/
 
-void verilog_synthesist::typecheck()
+transt verilog_synthesist::synthesis()
 {
   symbolt &symbol=symbol_table_lookup(module);
-  if(symbol.value.id()==ID_trans) return; // done already
-  convert_module_items(symbol);
+
+  // done already?
+  if(symbol.value.id() != ID_trans)
+  {
+    convert_module_items(symbol);
+    CHECK_RETURN(symbol.value.id() == ID_trans);
+  }
+
+  return to_trans_expr(symbol.value);
 }
 
 /*******************************************************************\
@@ -4124,7 +4128,7 @@ Function: verilog_synthesis
 
 \*******************************************************************/
 
-bool verilog_synthesis(
+transt verilog_synthesis(
   symbol_table_baset &symbol_table,
   const irep_idt &module,
   verilog_standardt standard,
@@ -4133,6 +4137,7 @@ bool verilog_synthesis(
   message_handlert &message_handler)
 {
   const namespacet ns(symbol_table);
+
   verilog_synthesist verilog_synthesis(
     standard,
     ignore_initial,
@@ -4141,7 +4146,25 @@ bool verilog_synthesis(
     symbol_table,
     module,
     message_handler);
-  return verilog_synthesis.typecheck_main();
+
+  try
+  {
+    return verilog_synthesis.synthesis();
+  }
+  catch(verilog_synthesist::errort error)
+  {
+    messaget message{message_handler};
+
+    if(error.what().empty())
+      message.error();
+    else
+    {
+      message.error().source_location = error.source_location();
+      message.error() << error.what() << messaget::eom;
+    }
+
+    throw ebmc_errort{};
+  }
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_synthesis.h
+++ b/src/verilog/verilog_synthesis.h
@@ -15,9 +15,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "verilog_standard.h"
 
-bool verilog_synthesis(
+class transt;
+
+transt verilog_synthesis(
   symbol_table_baset &,
-  const irep_idt &module,
+  const irep_idt &module_identifier,
   verilog_standardt,
   bool ignore_initial,
   bool initial_zero,

--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -59,7 +59,12 @@ public:
   {
   }
 
-  virtual void typecheck();
+  virtual void typecheck()
+  {
+  }
+
+  // throws errort on error
+  transt synthesis();
 
   enum class symbol_statet
   {
@@ -327,8 +332,9 @@ protected:
 
   void expand_module_instance(
     const symbolt &module_symbol,
+    const transt &trans_inst,
     const verilog_instt::instancet &,
-    transt &trans);
+    transt &trans_dest);
 
   void expand_hierarchical_identifier(
     class hierarchical_identifier_exprt &expr,


### PR DESCRIPTION
The Verilog synthesis function now returns the transition system generated, as opposed to expecting clients to pull this out of the symbol table.