### PR TITLE
Verilog: remove dual-purpose use of symbolt::is_state_var

### DIFF
--- a/regression/ebmc/engine-heuristic/ct1.desc
+++ b/regression/ebmc/engine-heuristic/ct1.desc
@@ -1,0 +1,10 @@
+CORE
+ct1.sv
+
+^\[main\.a0\] always main\.x == 0: ASSUMED$
+^\[main\.p0\] always main\.out == 1: PROVED \(CT=0\)$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/ebmc/engine-heuristic/ct1.sv
+++ b/regression/ebmc/engine-heuristic/ct1.sv
@@ -1,0 +1,16 @@
+// state-less
+function [31:0] some_func(input [31:0] data_in);
+  reg [31:0] data;
+  data = data_in + 1;
+  return data;
+endfunction
+
+module main(input clk, input x);
+
+  // all stateless, hence CT=0
+  wire [31:0] out = some_func(x);
+
+  a0: assume property (@(posedge clk) x == 0);
+  p0: assert property (@(posedge clk) out == 1);
+
+endmodule

--- a/regression/ebmc/engine-heuristic/ct2.desc
+++ b/regression/ebmc/engine-heuristic/ct2.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 ct2.sv
 
 ^\[main\.a0\] always main\.x == 0: ASSUMED$
@@ -8,4 +8,3 @@ ct2.sv
 --
 ^warning: ignoring
 --
-The CT does not apply, but should.

--- a/regression/ebmc/engine-heuristic/ct2.desc
+++ b/regression/ebmc/engine-heuristic/ct2.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+ct2.sv
+
+^\[main\.a0\] always main\.x == 0: ASSUMED$
+^\[main\.p0\] always main\.out == 1: PROVED \(CT=0\)$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The CT does not apply, but should.

--- a/regression/ebmc/engine-heuristic/ct2.sv
+++ b/regression/ebmc/engine-heuristic/ct2.sv
@@ -1,0 +1,16 @@
+module main(input clk, input x);
+
+  // state-less
+  function [31:0] some_func(input [31:0] data_in);
+    reg [31:0] data;
+    data = data_in + 1;
+    return data;
+  endfunction
+
+  // all stateless, hence CT=0
+  wire [31:0] out = some_func(x);
+
+  a0: assume property (@(posedge clk) x == 0);
+  p0: assert property (@(posedge clk) out == 1);
+
+endmodule

--- a/regression/ebmc/smv-netlist/verilog_function1.desc
+++ b/regression/ebmc/smv-netlist/verilog_function1.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+verilog_function1.sv
+--smv-netlist
+^EXIT=0$
+^SIGNAL=0$
+--
+^ASSIGN next\(.*\):=.*;$
+^warning: ignoring
+--
+This yields an error.

--- a/regression/ebmc/smv-netlist/verilog_function1.sv
+++ b/regression/ebmc/smv-netlist/verilog_function1.sv
@@ -1,0 +1,16 @@
+// state-less
+function [31:0] some_func(input [31:0] data_in);
+  reg [31:0] data;
+  data = data_in + 1;
+  return data;
+endfunction
+
+module main(input clk, input x);
+
+  // all stateless
+  wire [31:0] out = some_func(x);
+
+  a0: assume property (@(posedge clk) x == 0);
+  p0: assert property (@(posedge clk) out == 1);
+
+endmodule

--- a/regression/ebmc/smv-netlist/verilog_function2.desc
+++ b/regression/ebmc/smv-netlist/verilog_function2.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 verilog_function2.sv
 --smv-netlist
 ^EXIT=0$
@@ -7,4 +7,3 @@ verilog_function2.sv
 ^ASSIGN next\(.*\):=.*;$
 ^warning: ignoring
 --
-next-state constraints are generated.

--- a/regression/ebmc/smv-netlist/verilog_function2.desc
+++ b/regression/ebmc/smv-netlist/verilog_function2.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+verilog_function2.sv
+--smv-netlist
+^EXIT=0$
+^SIGNAL=0$
+--
+^ASSIGN next\(.*\):=.*;$
+^warning: ignoring
+--
+next-state constraints are generated.

--- a/regression/ebmc/smv-netlist/verilog_function2.sv
+++ b/regression/ebmc/smv-netlist/verilog_function2.sv
@@ -1,0 +1,16 @@
+module main(input clk, input x);
+
+  // state-less
+  function [31:0] some_func(input [31:0] data_in);
+    reg [31:0] data;
+    data = data_in + 1;
+    return data;
+  endfunction
+
+  // all stateless
+  wire [31:0] out = some_func(x);
+
+  a0: assume property (@(posedge clk) x == 0);
+  p0: assert property (@(posedge clk) out == 1);
+
+endmodule

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -55,7 +55,7 @@ void verilog_typecheckt::collect_port_symbols(const verilog_declt &decl)
     else if(port_class == ID_output_register)
     {
       new_symbol.is_output = true;
-      new_symbol.is_state_var = true;
+      new_symbol.is_lvalue = true;
     }
     else if(port_class == ID_inout)
     {
@@ -66,7 +66,7 @@ void verilog_typecheckt::collect_port_symbols(const verilog_declt &decl)
     {
       new_symbol.is_input = false;
       new_symbol.is_output = false;
-      new_symbol.is_state_var = true;
+      new_symbol.is_lvalue = true;
     }
     else
       DATA_INVARIANT(false, "unexpected port class");
@@ -293,7 +293,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
       else if(decl_class == ID_output_register)
       {
         symbol.is_output = true;
-        symbol.is_state_var = true;
+        symbol.is_lvalue = true;
       }
       else if(decl_class == ID_inout)
       {
@@ -351,10 +351,10 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
 
           osymbol.is_input = symbol.is_input;
           osymbol.is_output = symbol.is_output;
-          osymbol.is_state_var = symbol.is_state_var || osymbol.is_state_var;
+          osymbol.is_lvalue = symbol.is_lvalue || osymbol.is_lvalue;
 
-          // a register can't be an input as well
-          if(osymbol.is_input && osymbol.is_state_var)
+          // a variable can't be an input as well
+          if(osymbol.is_input && osymbol.is_lvalue)
           {
             throw errort().with_location(declarator.source_location())
               << "port `" << symbol.base_name
@@ -383,8 +383,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
       symbol.mode = mode;
       symbol.module = module_identifier;
       symbol.value.make_nil();
-
-      symbol.is_state_var = true;
+      symbol.is_lvalue = true; // even inputs can be assigned
 
       if(decl_class == ID_input)
       {
@@ -543,7 +542,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
     symbol.mode = mode;
     symbol.module = module_identifier;
     symbol.value = nil_exprt();
-    symbol.is_state_var = true;
+    symbol.is_lvalue = true;
 
     for(auto &declarator : decl.declarators())
     {
@@ -585,7 +584,7 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
               osymbol.type = symbol.type;
           }
 
-          osymbol.is_state_var = true;
+          osymbol.is_lvalue = true;
         }
         else
         {
@@ -644,7 +643,6 @@ void verilog_typecheckt::collect_symbols(
     to_code_type(symbol.type).return_type().id() != ID_verilog_void)
   {
     symbolt return_symbol;
-    return_symbol.is_state_var = true;
     return_symbol.is_lvalue = true;
     return_symbol.mode = symbol.mode;
     return_symbol.module = symbol.module;

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -640,11 +640,11 @@ void verilog_synthesist::assignment_rec(
     // we silently ignore these
     return;
   }
-  
-  if(!symbol.is_state_var)
+
+  if(!symbol.is_lvalue)
   {
     throw errort().with_location(lhs.source_location())
-      << "assignment to non-register";
+      << "assignment to non-variable";
   }
 
   if(construct==constructt::ALWAYS &&
@@ -2015,7 +2015,7 @@ void verilog_synthesist::synth_decl(const verilog_declt &statement) {
       auto symbol_expr = declarator.symbol_expr();
       const symbolt &symbol = ns.lookup(symbol_expr);
 
-      if(!symbol.is_state_var)
+      if(!symbol.is_lvalue)
       {
         // much like a continuous assignment
         const auto value =
@@ -2044,7 +2044,7 @@ void verilog_synthesist::synth_decl(const verilog_declt &statement) {
       auto rhs = declarator.value();
       const symbolt &symbol = ns.lookup(lhs);
 
-      if(symbol.is_state_var)
+      if(symbol.is_lvalue)
       {
         // much like: initial LHS=RHS;
         verilog_initialt initial;
@@ -2066,7 +2066,7 @@ void verilog_synthesist::synth_decl(const verilog_declt &statement) {
     {
       const symbolt &symbol = ns.lookup(lhs);
 
-      if(symbol.is_state_var)
+      if(symbol.is_lvalue)
       {
         // much like: initial LHS=0;
         auto rhs_opt = verilog_default_initializer(lhs.type());
@@ -2303,12 +2303,12 @@ void verilog_synthesist::synth_force_rec(
 
   // If the symbol is marked as a state variable,
   // turn it into a wire now.
-  if(symbol.is_state_var)
+  if(symbol.is_lvalue)
   {
     warning().source_location = symbol.location;
     warning() << "Making " << symbol.display_name() << " a wire" << eom;
     symbolt &writeable_symbol = symbol_table_lookup(symbol.name);
-    writeable_symbol.is_state_var = false;
+    writeable_symbol.is_lvalue = false;
   }
 
   auto lhs_synth = synth_expr(lhs, symbol_statet::CURRENT);
@@ -3757,7 +3757,7 @@ void verilog_synthesist::synth_assignments(
     new_value=symbol_expr(symbol, CURRENT);
   
   // see if wire is used to define itself
-  if(!symbol.is_state_var)
+  if(!symbol.is_lvalue)
   {
     post_process_wire(symbol.name, new_value);
   }
@@ -3790,8 +3790,7 @@ void verilog_synthesist::synth_assignments(transt &trans)
   {
     symbolt &symbol=symbol_table_lookup(it);
 
-    if(
-      symbol.is_state_var && !symbol.is_macro && symbol.type.id() != ID_integer)
+    if(symbol.is_lvalue && !symbol.is_macro && symbol.type.id() != ID_integer)
     {
       assignmentt &assignment=assignments[symbol.name];
 
@@ -3802,10 +3801,10 @@ void verilog_synthesist::synth_assignments(transt &trans)
       {
         warning().source_location = symbol.location;
         warning() << "Making " << symbol.display_name() << " a wire" << eom;
-        symbol.is_state_var=false;
+        symbol.is_lvalue = false;
       }
 
-      if(symbol.is_state_var)
+      if(symbol.is_lvalue)
       {
         // only state variables can be initialized
 
@@ -3817,6 +3816,9 @@ void verilog_synthesist::synth_assignments(transt &trans)
         synth_assignments(symbol, NEXT,
                           assignment.next.value,
                           trans.op2());
+
+        // This is a proper state variable
+        symbol.is_state_var = true;
       }
       else
       {
@@ -3863,7 +3865,7 @@ exprt verilog_synthesist::current_value(
   const symbolt &symbol,
   bool use_previous_assignments) const
 {
-  if(!symbol.is_state_var)
+  if(!symbol.is_lvalue)
   {
     if(use_previous_assignments)
     {

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -583,7 +583,7 @@ void verilog_typecheckt::check_lhs(
     switch(vassign)
     {
     case A_CONTINUOUS:
-      if(symbol.is_state_var)
+      if(symbol.is_lvalue)
       {
         // Continuous assignments can drive variables.
       }
@@ -596,8 +596,7 @@ void verilog_typecheckt::check_lhs(
 
     case A_BLOCKING:
     case A_NON_BLOCKING:
-      if(!symbol.is_state_var &&
-         !symbol.is_lvalue)
+      if(!symbol.is_lvalue)
       {
         throw errort().with_location(lhs.source_location())
           << "procedural assignment to a net\n"
@@ -608,7 +607,7 @@ void verilog_typecheckt::check_lhs(
       break;
 
     case A_PROCEDURAL_CONTINUOUS:
-      if(!symbol.is_state_var && !symbol.is_lvalue)
+      if(!symbol.is_lvalue)
       {
         throw errort().with_location(lhs.source_location())
           << "procedural continuous assignment to a net\n"


### PR DESCRIPTION
The type checker now uses `is_lvalue` to identify Verilog variables, instead of `is_state_var`.  This avoids using the same flag for indicating variables and state-holding elements of the transition system that is synthesised.