### PR TITLE
`--show-trans` now includes the list of state variables

### DIFF
--- a/regression/ebmc/CLI/show-trans1.desc
+++ b/regression/ebmc/CLI/show-trans1.desc
@@ -1,0 +1,11 @@
+CORE
+show-trans1.v
+--show-trans
+activate-multi-line-match
+^State variables:\n\n  main\.some_data\n$
+^Initial state constraints:\n\n  1\n$
+^State constraints:\n\n  main\.some_other_data == main\.some_data \+ main\.some_input\n$
+^Transition constraints:\n\n  next\(main\.some_data\) == main\.some_other_data$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/CLI/show-trans1.v
+++ b/regression/ebmc/CLI/show-trans1.v
@@ -1,0 +1,5 @@
+module main(input clk, input some_input);
+  reg [31:0] some_data;
+  always @(posedge clk) some_data = some_other_data;
+  wire [31:0] some_other_data = some_data + some_input;
+endmodule

--- a/regression/ebmc/CLI/show-trans2.desc
+++ b/regression/ebmc/CLI/show-trans2.desc
@@ -1,0 +1,11 @@
+CORE
+show-trans2.smv
+--show-trans
+activate-multi-line-match
+^State variables:\n$
+^Initial state constraints:\n\n  TRUE\n$
+^State constraints:\n\n  m\.flag = \(a\.q \| a\.p\)\n$
+^Transition constraints:\n\n  TRUE\n$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/CLI/show-trans2.smv
+++ b/regression/ebmc/CLI/show-trans2.smv
@@ -1,0 +1,15 @@
+-- from the NuSMV 2.7 manual
+
+MODULE main
+ VAR
+  a : bar;
+  m : foo(a);
+
+MODULE bar
+ VAR
+  q : boolean;
+  p : boolean;
+
+MODULE foo(c)
+ DEFINE
+  flag := c.q | c.p;

--- a/src/ebmc/transition_system.cpp
+++ b/src/ebmc/transition_system.cpp
@@ -53,11 +53,34 @@ static void output(
   }
 }
 
+static void show_state_variables(
+  const std::vector<symbol_exprt> &state_variables,
+  std::ostream &out,
+  languaget &language,
+  const namespacet &ns)
+{
+  for(auto &state_variable : state_variables)
+  {
+    std::string text;
+
+    if(language.from_expr(state_variable, text, ns))
+    {
+      throw ebmc_errort() << "failed to convert expression";
+    }
+
+    out << "  " << text << '\n' << '\n';
+  }
+}
+
 void transition_systemt::output(std::ostream &out) const
 {
   auto language = get_language_from_mode(main_symbol->mode);
 
   const namespacet ns{symbol_table};
+
+  out << "State variables:\n\n";
+
+  show_state_variables(state_variables(), out, *language, ns);
 
   out << "Initial state constraints:\n\n";
 


### PR DESCRIPTION
The output generated by `--show-trans` now includes a list of state variables.