### PR TITLE
Tests for Verilog task ports

### DIFF
--- a/regression/verilog/tasks/task_inout1.desc
+++ b/regression/verilog/tasks/task_inout1.desc
@@ -1,0 +1,7 @@
+CORE
+task_inout1.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/tasks/task_inout1.sv
+++ b/regression/verilog/tasks/task_inout1.sv
@@ -1,0 +1,18 @@
+module main;
+
+  task some_task;
+    inout [31:0] some_inout;
+    assert(some_inout == 123);
+    some_inout = 456; // overwrite x
+    assert(some_inout == 456);
+  endtask
+
+  reg [31:0] x;
+
+  initial begin
+    x = 123;
+    some_task(x);
+    assert(x == 456);
+  end
+
+endmodule

--- a/regression/verilog/tasks/task_input1.desc
+++ b/regression/verilog/tasks/task_input1.desc
@@ -1,0 +1,7 @@
+CORE
+task_input1.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/tasks/task_input1.sv
+++ b/regression/verilog/tasks/task_input1.sv
@@ -1,0 +1,18 @@
+module main;
+
+  task some_task;
+    input [31:0] some_input;
+    assert(some_input == 123);
+    some_input = 456; // won't overwrite x
+    assert(some_input == 456);
+  endtask
+
+  reg [31:0] x;
+
+  initial begin
+    x = 123;
+    some_task(x);
+    assert(x == 123);
+  end
+
+endmodule

--- a/regression/verilog/tasks/task_input2.sv
+++ b/regression/verilog/tasks/task_input2.sv
@@ -1,0 +1,17 @@
+module main;
+
+  task some_task([31:0] some_input);
+    assert(some_input == 123);
+    some_input = 456; // won't overwrite x
+    assert(some_input == 456);
+  endtask
+
+  reg [31:0] x;
+
+  initial begin
+    x = 123;
+    some_task(x);
+    assert(x == 123);
+  end
+
+endmodule

--- a/regression/verilog/tasks/task_output1.desc
+++ b/regression/verilog/tasks/task_output1.desc
@@ -1,0 +1,10 @@
+CORE
+task_output1.sv
+
+^\[.*\] main\.some_task\.some_output == 123: REFUTED$
+^\[.*\] main\.some_task\.some_output == 32'hs1C8: PROVED .*$
+^\[.*\] main\.x == 32'hs1C8: PROVED .*$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/tasks/task_output1.sv
+++ b/regression/verilog/tasks/task_output1.sv
@@ -1,0 +1,18 @@
+module main;
+
+  task some_task;
+    output [31:0] some_output;
+    assert(some_output == 123); // default initialized, fails
+    some_output = 456; // overwrite x
+    assert(some_output == 456);
+  endtask
+
+  reg [31:0] x;
+
+  initial begin
+    x = 123;
+    some_task(x);
+    assert(x == 456);
+  end
+
+endmodule

--- a/regression/verilog/tasks/task_ref1.desc
+++ b/regression/verilog/tasks/task_ref1.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+task_ref1.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This does not parse.

--- a/regression/verilog/tasks/task_ref1.sv
+++ b/regression/verilog/tasks/task_ref1.sv
@@ -1,0 +1,18 @@
+module main;
+
+  task some_task;
+    ref [31:0] some_ref;
+    assert(some_ref == 123);
+    some_ref = 456; // overwrite x
+    assert(some_ref == 456);
+  endtask
+
+  reg [31:0] x;
+
+  initial begin
+    x = 123;
+    some_task(x);
+    assert(x == 456);
+  end
+
+endmodule


### PR DESCRIPTION
This adds tests for Verilog task `input`/`output`/`inout`/`ref` ports.