### PR TITLE
grammar for tagged union constructors with value

### DIFF
--- a/regression/verilog/unions/tagged_union1.sv
+++ b/regression/verilog/unions/tagged_union1.sv
@@ -8,4 +8,8 @@ module main;
 
   initial v = tagged Invalid;
 
+  VInt i;
+
+  initial i = tagged Valid 123;
+
 endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -578,6 +578,8 @@ int yyverilogerror(const char *error)
 %left "*" "/" "%"
 %left "**"
 %nonassoc UNARY_PLUS UNARY_MINUS "!" "~" "&~" "++" "--"
+// tagged union expressions bind stronger than anything else
+%left "tagged"
 
 // Statements
 %nonassoc LT_TOK_ELSE
@@ -4774,6 +4776,8 @@ expression:
 tagged_union_expression:
           TOK_TAGGED member_identifier
                 { init($$, ID_verilog_tagged_union); mto($$, $2); }
+        | TOK_TAGGED member_identifier expression %prec TOK_TAGGED
+                { init($$, ID_verilog_tagged_union); mto($$, $2); mto($$, $3); }
         ;
 
 inside_expression:


### PR DESCRIPTION
This adds the grammar for parsing SystemVerilog 1800 2017 11.9 tagged union expression with the optional value.

Type checker support is still missing.