### PR TITLE
Verilog: error parameter ports without value

### DIFF
--- a/regression/verilog/modules/parameter_without_default1.desc
+++ b/regression/verilog/modules/parameter_without_default1.desc
@@ -1,9 +1,9 @@
-KNOWNBUG
+CORE
 parameter_without_default1.sv
 
+^file .* line 9: parameter port P without value$
 ^EXIT=2$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-This does not parse.

--- a/regression/verilog/modules/type_parameter_port5.desc
+++ b/regression/verilog/modules/type_parameter_port5.desc
@@ -1,0 +1,7 @@
+CORE
+type_parameter_port5.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+--

--- a/regression/verilog/modules/type_parameter_port5.sv
+++ b/regression/verilog/modules/type_parameter_port5.sv
@@ -1,0 +1,13 @@
+module sub #(parameter type T /* no default */)();
+
+  var T my_var;
+
+endmodule
+
+module main;
+
+  sub #(byte) submodule();
+
+  p1: assert final ($bits(submodule.my_var) == 8);
+
+endmodule // main

--- a/regression/verilog/modules/type_parameter_port6.desc
+++ b/regression/verilog/modules/type_parameter_port6.desc
@@ -1,0 +1,9 @@
+CORE
+type_parameter_port6.sv
+
+^file .* line 10: parameter port T without value$
+^EXIT=2$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/modules/type_parameter_port6.sv
+++ b/regression/verilog/modules/type_parameter_port6.sv
@@ -1,0 +1,12 @@
+module sub #(parameter type T /* no default */)();
+
+  var T my_var;
+
+endmodule
+
+module main;
+
+  // We forgot to assign T, which is an error.
+  sub submodule();
+
+endmodule // main

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2054,12 +2054,20 @@ list_of_param_assignments:
                 { $$=$1;    mto($$, $3); }
         ;
 
-param_assignment: param_identifier '=' constant_param_expression
+param_assignment:
+          param_identifier '=' constant_param_expression
                 { init($$, ID_parameter);
                   auto base_name = stack_expr($1).get(ID_base_name);
                   PARSER.scopes.add_identifier(base_name, verilog_scopet::PARAMETER);
                   stack_expr($$).set(ID_base_name, base_name);
                   addswap($$, ID_value, $3); }
+          /* The assignment is optional */
+        | param_identifier
+                { init($$, ID_parameter);
+                  auto base_name = stack_expr($1).get(ID_base_name);
+                  PARSER.scopes.add_identifier(base_name, verilog_scopet::PARAMETER);
+                  stack_expr($$).set(ID_base_name, base_name);
+                  stack_expr($$).set(ID_value, nil_exprt{}); }
         ;
 
 list_of_type_assignments:
@@ -2069,11 +2077,23 @@ list_of_type_assignments:
                 { $$=$1;    mto($$, $3); }
         ;
 
-type_assignment: param_identifier '=' data_type
+type_assignment:
+          param_identifier '=' data_type
                 { init($$, ID_declarator);
                   auto base_name = stack_expr($1).get(ID_base_name);
                   stack_expr($$).set(ID_base_name, base_name);
                   stack_expr($$).set(ID_value, type_exprt{stack_type($3)});
+                  stack_expr($$).type() = typet{ID_type};
+
+                  // add to the scope as a type name
+                  PARSER.scopes.add_identifier(base_name, verilog_scopet::TYPEDEF);
+                }
+          /* the assignment is optional */
+        | param_identifier
+                { init($$, ID_declarator);
+                  auto base_name = stack_expr($1).get(ID_base_name);
+                  stack_expr($$).set(ID_base_name, base_name);
+                  stack_expr($$).set(ID_value, nil_exprt{});
                   stack_expr($$).type() = typet{ID_type};
 
                   // add to the scope as a type name

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -124,9 +124,12 @@ void verilog_typecheckt::collect_symbols(
   }
   else // It's a value parameter.
   {
-    // If there's no type, parameters take the type of the
-    // value. We signal this using the special type "derive_from_value".
+    // The default value is optional, and then it's an error if it is not
+    // supplied in the instantiation.  This is checked in set_parameter_values(...).
+    PRECONDITION(declarator.value().is_not_nil());
 
+    // If there's no type, parameters take the type of the final
+    // value. We signal this using the special type "derive_from_value".
     auto symbol_type =
       to_be_elaborated_typet(type.is_nil() ? derive_from_value_typet() : type);
 

--- a/src/verilog/verilog_parameterize_module.cpp
+++ b/src/verilog/verilog_parameterize_module.cpp
@@ -134,7 +134,7 @@ std::list<exprt> verilog_typecheckt::get_parameter_values(
         << "too many parameter assignments";
     }
   }
-  
+
   return parameter_values;
 }
 
@@ -152,6 +152,7 @@ Function: verilog_typecheckt::set_parameter_values
 
 void verilog_typecheckt::set_parameter_values(
   verilog_module_sourcet &module_source,
+  const source_locationt &instance_location,
   const std::list<exprt> &parameter_values)
 {
   auto p_it=parameter_values.begin();
@@ -167,6 +168,13 @@ void verilog_typecheckt::set_parameter_values(
       // only overwrite when actually assigned
       if(p_it->is_not_nil())
         declarator.value() = *p_it;
+
+      // check that we do have a value (the default value is optional)
+      if(declarator.value().is_nil())
+      {
+        throw errort().with_location(instance_location)
+          << "parameter port " << declarator.base_name() << " without value";
+      }
 
       p_it++;
     }
@@ -248,7 +256,7 @@ irep_idt verilog_typecheckt::parameterize_module(
   verilog_module_sourcet source_copy = module_source;
 
   // set parameters
-  set_parameter_values(source_copy, parameter_values);
+  set_parameter_values(source_copy, location, parameter_values);
 
   // put symbol in symbol_table
   symbolt *new_symbol;

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -148,6 +148,7 @@ protected:
 
   void set_parameter_values(
     verilog_module_sourcet &,
+    const source_locationt &instance_location,
     const std::list<exprt> &parameter_values);
 
   // interfaces


### PR DESCRIPTION
Parameter ports need not have a default value; it is an error when not set during instantiation.