### PR TITLE
Verilog: unconnected module ports

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # EBMC 6.0
 
+* Verilog: unconnected module ports
 * Verilog: based unsized literals now extend x/z MSB to context width
 * Verilog: identifiers given on command-line must now include module identifier
 * BMC: strong sequences that exceed the bound are no longer reported as REFUTED

--- a/regression/verilog/modules/unconnected_ports1.desc
+++ b/regression/verilog/modules/unconnected_ports1.desc
@@ -1,8 +1,13 @@
-KNOWNBUG
-unconnected_ports1.v
---bound 0
-^EXIT=0$
+CORE
+unconnected_ports1.sv
+
+^\[.*\] main\.m1\.x == 1: PROVED .*$
+^\[.*\] main\.m1\.y === 'z: REFUTED$
+^\[.*\] main\.m1\.z == 5: REFUTED$
+^\[.*\] main\.m2\.x === 'z: REFUTED$
+^\[.*\] main\.m2\.y == 1: PROVED .*$
+^\[.*\] main\.m2\.z == 5: REFUTED$
+^EXIT=10$
 ^SIGNAL=0$
 --
 --
-This fails an assertion.

--- a/regression/verilog/modules/unconnected_ports1.sv
+++ b/regression/verilog/modules/unconnected_ports1.sv
@@ -12,14 +12,14 @@ module main();
   // This is 'x for logic types.
   // However, Icarus Verilog, VCS, Questa, Xcelium use 'z.
 
-  initial assert (m1.x == 1);
-  initial assert (m1.y === 'z);
-  initial assert (m1.z == 5);
+  initial assert (m1.x == 1);   // holds
+  initial assert (m1.y === 'z); // fails
+  initial assert (m1.z == 5);   // fails
 
   my_module m2(/* blank */, 1, /* blank */);
 
-  initial assert (m2.x === 'z);
-  initial assert (m2.y == 1);
-  initial assert (m2.z == 5);
+  initial assert (m2.x === 'z); // fails
+  initial assert (m2.y == 1);   // holds
+  initial assert (m2.z == 5);   // fails
 
 endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -1406,9 +1406,15 @@ void verilog_synthesist::instantiate_ports(
 
     for(const auto &connection : inst.connections())
     {
-      DATA_INVARIANT(connection.is_not_nil(), "all ports must be connected");
-
-      instantiate_port(*p_it, connection, inst.source_location(), trans);
+      // 1800-2017 23.3.3.2 says
+      // "If left unconnected, the port shall have the default
+      // initial value corresponding to the data type."
+      // Simulators don't agree on this, and we hence leave the port
+      // unconstrained.
+      if(connection.is_not_nil())
+      {
+        instantiate_port(*p_it, connection, inst.source_location(), trans);
+      }
 
       p_it++;
     }


### PR DESCRIPTION
This allows Verilog module ports to be unconnected, leaving them unconstrained.  The standard expects these to be given the default initial value for the data type, but simulators use other behaviors, e.g., `'z`.