### PR TITLE
fix parameters5 test

### DIFF
--- a/regression/verilog/modules/parameters5.desc
+++ b/regression/verilog/modules/parameters5.desc
@@ -5,3 +5,5 @@ parameters5.v
 ^SIGNAL=0$
 --
 ^warning: ignoring
+--
+The parameter definitions in the assertions are not expanded.

--- a/regression/verilog/modules/parameters5.v
+++ b/regression/verilog/modules/parameters5.v
@@ -1,5 +1,10 @@
-module my_module#(p0 = 0)();
+module my_module#(parameter p0 = 0)();
 
+  // 1800 2017 6.20.1
+  // If the declaration of a design element uses a parameter_port_list (even
+  // an empty one), then in any parameter_declaration directly contained
+  // within the declaration, the parameter keyword shall be a synonym for
+  // the localparam keyword
   localparam p1 = 1;
   parameter p2 = 2;
 
@@ -7,10 +12,10 @@ endmodule
 
 module main;
 
-  my_module #(10, 20) instance();
+  my_module #(10) my_instance();
 
-  always assert p0: instance.p0==10;
-  always assert p1: instance.p1==1;
-  always assert p2: instance.p2==20;
+  always assert p0: my_instance.p0==10;
+  always assert p1: my_instance.p1==1;
+  always assert p2: my_instance.p2==20;
 
 endmodule


### PR DESCRIPTION
This avoids the keyword `instance` and clarifies the expectation of the test.