### PR TITLE
untyped value parameters get the type of the final value

### DIFF
--- a/regression/verilog/modules/parameter_ports2.desc
+++ b/regression/verilog/modules/parameter_ports2.desc
@@ -1,7 +1,6 @@
-KNOWNBUG
+CORE
 parameter_ports2.v
 
 ^EXIT=0$
 ^SIGNAL=0$
 --
-The type of the parameter needs to be processed.

--- a/regression/verilog/modules/parameter_ports2.v
+++ b/regression/verilog/modules/parameter_ports2.v
@@ -1,11 +1,15 @@
 module sub #(parameter an_eight_bit_parameter_port = 1)();
 
+  // 1800 2017 6.20.2
+  // A parameter declaration with no type or range specification shall
+  // default to the type and range of the final value assigned to the
+  // parameter,
   always assert p1: $bits(an_eight_bit_parameter_port) == 8;
 
 endmodule
 
 module main;
 
-  sub #(123) submodule();
+  sub #(8'd123) submodule();
 
 endmodule // main

--- a/regression/verilog/modules/parameter_ports8.desc
+++ b/regression/verilog/modules/parameter_ports8.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+parameter_ports8.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+The constant folding lowers the type of the parameter.

--- a/regression/verilog/modules/parameter_ports8.sv
+++ b/regression/verilog/modules/parameter_ports8.sv
@@ -1,0 +1,12 @@
+module sub #(parameter untyped_port = 1)();
+
+  // If the expression is real, the parameter is real.
+  initial assert(untyped_port == 1.5);
+
+endmodule
+
+module main;
+
+  sub #(1.5) submodule();
+
+endmodule // main

--- a/src/verilog/verilog_elaborate_module_instances.cpp
+++ b/src/verilog/verilog_elaborate_module_instances.cpp
@@ -336,8 +336,10 @@ void verilog_typecheckt::parameterize_instantiated_modules(verilog_instt &inst)
       }
       else
       {
-        mp_integer v_int = convert_integer_constant_expression(value);
-        value = from_integer(v_int, integer_typet()).with_source_location(*it);
+        // constant-fold
+        convert_expr(value);
+        value =
+          elaborate_constant_expression_check(value).with_source_location(*it);
       }
     }
     else
@@ -348,8 +350,10 @@ void verilog_typecheckt::parameterize_instantiated_modules(verilog_instt &inst)
       }
       else
       {
-        mp_integer v_int = convert_integer_constant_expression(*it);
-        *it = from_integer(v_int, integer_typet()).with_source_location(*it);
+        // constant-fold
+        convert_expr(*it);
+        *it =
+          elaborate_constant_expression_check(*it).with_source_location(*it);
       }
     }
   }


### PR DESCRIPTION
This fixes the type used for untyped value parameters.  1800 2017 6.20.2 requires that the type is that of the final value.