### PR TITLE
Verilog: error with location for $bits on module instance

### DIFF
--- a/regression/verilog/system-functions/bits2.desc
+++ b/regression/verilog/system-functions/bits2.desc
@@ -1,10 +1,8 @@
-KNOWNBUG
+CORE
 bits2.sv
 
-^file .* line 11: $
+^file .* line 11: cannot determine the number of bits of main\.sub_inst$
 ^EXIT=2$
 ^SIGNAL=0$
 --
 ^warning: ignoring
---
-The error message has no location and is misleading.

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1295,6 +1295,15 @@ exprt verilog_typecheck_exprt::convert_system_function(function_call_exprt expr)
         << base_name << " takes one argument";
     }
 
+    // Check that the argument type is valid for these functions.
+    if(
+      base_name == "$bits" &&
+      !verilog_bits_opt(arguments[0].type()).has_value())
+    {
+      throw errort().with_location(arguments[0].source_location())
+        << "cannot determine the number of bits of " << to_string(arguments[0]);
+    }
+
     // The return type is integer.
     expr.type() = integer_typet();
 


### PR DESCRIPTION
Previously, `$bits` applied to a module instance would produce a misleading error without source location (`type 'integer' has unknown number of bits`). Now it reports `cannot determine the number of bits` with the correct file and line.

The regression test `bits2.desc` is promoted from KNOWNBUG to CORE.