### PR TITLE
Verilog: support member access after bit-select

### DIFF
--- a/regression/verilog/structs/array_of_structs1.desc
+++ b/regression/verilog/structs/array_of_structs1.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE
 array_of_structs1.sv
 
 ^EXIT=0$
 ^SIGNAL=0$
 --
 --
-This does not parse.

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -4873,10 +4873,22 @@ hierarchical_identifier_select:
 
 hierarchical_identifier_bit_select_brace:
           hierarchical_variable_identifier
-        | hierarchical_identifier_bit_select_brace constant_bit_select
+        | hierarchical_identifier_bit_select_plus
+        ;
+
+// This matches when at least one bit_select has been applied,
+// allowing subsequent '.' member access without conflicting with
+// hierarchical_identifier's own '.' rule.
+hierarchical_identifier_bit_select_plus:
+          hierarchical_identifier_bit_select_brace constant_bit_select
                 { init($$, ID_verilog_bit_select);
                   mto($$, $1);
                   mto($$, $2); }
+        | hierarchical_identifier_bit_select_plus '.' identifier
+                { init($$, ID_hierarchical_identifier);
+                  stack_expr($$).reserve_operands(2);
+                  mto($$, $1);
+                  mto($$, $3); }
         ;
 
 time_literal: TOK_TIME_LITERAL


### PR DESCRIPTION
Adds parsing support for member access after array indexing, e.g., `s[0].a`, `matrix[i][j].field`, and `arr[0].sub.x`.

Introduces a `hierarchical_identifier_bit_select_plus` nonterminal that allows `'.' identifier` chaining once at least one `constant_bit_select` has been consumed. This avoids shift/reduce conflicts with the existing `hierarchical_identifier '.' identifier` rule.

The regression test `array_of_structs1` is promoted from KNOWNBUG to CORE.