### PR TITLE
Verilog: fix unsigned/signed parameter without explicit range

### DIFF
--- a/regression/verilog/parameters/signed_parameter1.desc
+++ b/regression/verilog/parameters/signed_parameter1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 signed_parameter1.sv
 
 ^EXIT=0$
@@ -6,4 +6,3 @@ signed_parameter1.sv
 --
 ^warning: ignoring
 --
-The width is wrong.

--- a/regression/verilog/parameters/unsigned_parameter1.desc
+++ b/regression/verilog/parameters/unsigned_parameter1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 unsigned_parameter1.sv
 
 ^EXIT=0$
@@ -6,4 +6,3 @@ unsigned_parameter1.sv
 --
 ^warning: ignoring
 --
-The width is wrong.

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -1123,6 +1123,35 @@ void verilog_typecheckt::elaborate_symbol_rec(irep_idt identifier)
 
       symbol.type = symbol.value.type();
     }
+    else if(
+      (to_type_with_subtype(symbol.type).subtype().id() == ID_unsigned ||
+       to_type_with_subtype(symbol.type).subtype().id() == ID_signed) &&
+      to_type_with_subtype(to_type_with_subtype(symbol.type).subtype())
+        .subtype()
+        .is_nil())
+    {
+      // A signing keyword without an explicit range.
+      // Derive the width from the value, then apply the signedness.
+      auto is_unsigned =
+        to_type_with_subtype(symbol.type).subtype().id() == ID_unsigned;
+
+      convert_expr(symbol.value);
+
+      if(!is_let)
+        symbol.value = elaborate_constant_expression_check(symbol.value);
+
+      auto value_type = symbol.value.type();
+
+      if(value_type.id() == ID_signedbv || value_type.id() == ID_unsignedbv)
+      {
+        auto width = to_bitvector_type(value_type).get_width();
+        symbol.type = is_unsigned ? typet{unsignedbv_typet{width}}
+                                  : typet{signedbv_typet{width}};
+        symbol.value = typecast_exprt{symbol.value, symbol.type};
+      }
+      else
+        symbol.type = value_type;
+    }
     else
     {
       // No, elaborate the type.


### PR DESCRIPTION
When a parameter is declared with only a signing keyword and no explicit range (e.g., `parameter unsigned P = 8'shff`), the width should be derived from the value and only the signedness adjusted.

Previously, this was incorrectly elaborated as a 1-bit type, because `elaborate_type(ID_unsigned)` with nil subtype defaults to `unsignedbv_typet{1}`.

**Changes:**
- `src/verilog/verilog_elaborate.cpp`: Handle unsigned/signed with nil subtype in `elaborate_symbol_rec` by deriving width from the value, then applying the signedness.
- `regression/verilog/parameters/unsigned_parameter1.desc`: Changed from KNOWNBUG to CORE.