### PR TITLE
Verilog: event control with hierarchical event expression

### DIFF
--- a/regression/verilog/events/guard1.desc
+++ b/regression/verilog/events/guard1.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE
 guard1.sv
 
 ^EXIT=10$
 ^SIGNAL=0$
 --
 --
-This does not parse.

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3993,7 +3993,7 @@ delay_control:
         ;
 
 event_control:
-          '@' event_identifier
+          '@' hierarchical_identifier
                 { init($$, ID_event_guard); mto($$, $2); }
         | '@' '(' ored_event_expression ')'
                 { init($$, ID_event_guard); mto($$, $3); }


### PR DESCRIPTION
Per IEEE 1800-2017, `event_control` accepts a `hierarchical_event_identifier` without parentheses (e.g., `@s.field`). Changed the `event_control` rule to use `hierarchical_identifier` instead of `event_identifier`.

Fixes the parsing failure exposed by the test in a624f4893a5c.