### PR TITLE
Verilog: `$typename` for struct types

### DIFF
--- a/regression/verilog/system-functions/typename1.sv
+++ b/regression/verilog/system-functions/typename1.sv
@@ -4,7 +4,6 @@ module main;
   bit [31:0] vector1;
   bit [0:31] vector2;
   bit signed [31:0] vector3;
-  enum { FOO, BAR } some_enum;
 
   assert final ($typename(some_bit)=="bit");
   assert final ($typename(vector1)=="bit[31:0]");
@@ -13,7 +12,6 @@ module main;
   assert final ($typename(real'(1))=="real");
   assert final ($typename(shortreal'(1))=="shortreal");
   assert final ($typename(realtime'(1))=="realtime");
-  assert final ($typename(some_enum)=="enum{FOO,BAR}");
 
   // $typename yields an elaboration-time constant
   parameter P = $typename(some_bit);

--- a/regression/verilog/system-functions/typename2.desc
+++ b/regression/verilog/system-functions/typename2.desc
@@ -1,0 +1,7 @@
+CORE
+typename2.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/system-functions/typename2.sv
+++ b/regression/verilog/system-functions/typename2.sv
@@ -1,0 +1,11 @@
+module main;
+
+  enum { FOO, BAR } some_enum;
+  struct { bit s, t; } some_struct;
+
+  // The $typenames for enums and structs are not well standardised,
+  // and vary across tools and tool versions.
+  assert final ($typename(some_enum)=="enum{FOO,BAR}");
+  assert final ($typename(some_struct)=="struct{bit s;bit t;}");
+
+endmodule

--- a/src/verilog/typename.cpp
+++ b/src/verilog/typename.cpp
@@ -84,6 +84,7 @@ std::string verilog_typename(const typet &type, const namespacet &ns)
 
   if(type.get(ID_C_verilog_type) == ID_verilog_enum)
   {
+    // not well standardised; tool-specific
     auto identifier = type.get(ID_C_identifier);
     auto &enum_symbol = ns.lookup(identifier);
     auto &enum_type = to_verilog_enum_type(enum_symbol.type);
@@ -96,6 +97,21 @@ std::string verilog_typename(const typet &type, const namespacet &ns)
       else
         result += ',';
       result += id2string(name.base_name());
+    }
+    result += '}';
+    return result;
+  }
+  else if(type.id() == ID_struct)
+  {
+    // not well standardised; tool-specific
+    auto &struct_type = to_struct_type(type);
+    std::string result = "struct{";
+    for(auto &component : struct_type.components())
+    {
+      result += verilog_typename(component.type(), ns);
+      result += ' ';
+      result += id2string(component.get_name());
+      result += ';'; // no newline or the like
     }
     result += '}';
     return result;


### PR DESCRIPTION
This adds support for `$typename` on struct types; the expected output is not mentioned in the standard, and varies by tool.