### PR TITLE
Verilog: convenience helpers for adding scopes

### DIFF
--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -632,7 +632,7 @@ module_identifier_with_scope:
             $$ = $1;
             auto base_name = stack_expr($1).get(ID_base_name);
             // modules go into the top scope, not into $unit
-            auto &module_scope = PARSER.scopes.top_scope.add_scope(base_name, ".", verilog_scopet::MODULE);
+            auto &module_scope = PARSER.scopes.add_module_scope(base_name);
             PARSER.scopes.enter_scope(module_scope);
           }
         ;
@@ -820,7 +820,7 @@ class_declaration:
                   auto base_name = stack_expr($2).get(ID_base_name);
                   stack_expr($$).set(ID_base_name, base_name);
                   // classes go into the top scope, not $unit
-                  auto &class_scope = PARSER.scopes.top_scope.add_scope(base_name, "::", verilog_scopet::CLASS);
+                  auto &class_scope = PARSER.scopes.add_class_scope(base_name);
                   PARSER.scopes.enter_scope(class_scope);
                 }
           class_item_brace
@@ -839,7 +839,7 @@ package_declaration:
                 {
                   // packages go into the top scope, not $unit
                   auto base_name = stack_expr($5).get(ID_base_name);
-                  auto &package_scope = PARSER.scopes.top_scope.add_scope(base_name, "::", verilog_scopet::PACKAGE);
+                  auto &package_scope = PARSER.scopes.add_package_scope(base_name);
                   PARSER.scopes.enter_scope(package_scope);
                 }
           package_item_brace

--- a/src/verilog/verilog_scope.cpp
+++ b/src/verilog/verilog_scope.cpp
@@ -15,7 +15,7 @@ Author: Daniel Kroening, dkr@amazon.com
 verilog_scopet &
 verilog_scopest::add_identifier(irep_idt _base_name, scopet::kindt kind)
 {
-  return add_scope(_base_name, std::string{}, kind);
+  return current_scope().add_scope(_base_name, std::string{}, kind);
 }
 
 verilog_scopet &verilog_scopet::add_scope(
@@ -26,6 +26,24 @@ verilog_scopet &verilog_scopet::add_scope(
   auto result = scope_map.emplace(
     base_name, verilog_scopet{base_name, separator, this, kind});
   return result.first->second;
+}
+
+verilog_scopet &verilog_scopest::add_package_scope(irep_idt base_name)
+{
+  // packages go into the top scope, not $unit
+  return top_scope.add_scope(base_name, "::", scopet::PACKAGE);
+}
+
+verilog_scopet &verilog_scopest::add_module_scope(irep_idt base_name)
+{
+  // modules go into the top scope, not into $unit
+  return top_scope.add_scope(base_name, ".", scopet::MODULE);
+}
+
+verilog_scopet &verilog_scopest::add_class_scope(irep_idt base_name)
+{
+  // classes go into the top scope, not $unit
+  return top_scope.add_scope(base_name, "::", scopet::CLASS);
 }
 
 const verilog_scopet *verilog_scopest::lookup(irep_idt base_name) const

--- a/src/verilog/verilog_scope.h
+++ b/src/verilog/verilog_scope.h
@@ -114,14 +114,9 @@ public:
 
   scopet &add_identifier(irep_idt _base_name, scopet::kindt);
 
-  // add a scope to the current scope
-  scopet &add_scope(
-    irep_idt base_name,
-    const std::string &separator,
-    scopet::kindt kind)
-  {
-    return current_scope().add_scope(base_name, separator, kind);
-  }
+  scopet &add_package_scope(irep_idt base_name);
+  scopet &add_module_scope(irep_idt base_name);
+  scopet &add_class_scope(irep_idt base_name);
 
   // Scope stack
   std::vector<scopet *> scope_stack = {&top_scope, &unit_scope};
@@ -149,7 +144,8 @@ public:
     const std::string &separator,
     scopet::kindt kind)
   {
-    enter_scope(add_scope(_base_name, separator, kind));
+    auto &scope = current_scope().add_scope(_base_name, separator, kind);
+    enter_scope(scope);
   }
 
   void pop_scope()


### PR DESCRIPTION
This adds convenience helpers for adding module, package, class scopes, moving the logic from the parser to the `verilog_scopest` class.