### PR TITLE
Verilog: rename parameterize_module to instantiate_module

### DIFF
--- a/src/verilog/Makefile
+++ b/src/verilog/Makefile
@@ -11,13 +11,13 @@ SRC = aval_bval_encoding.cpp \
       verilog_elaborate_type.cpp \
       verilog_expr.cpp \
       verilog_generate.cpp \
+      verilog_instantiate_module.cpp \
       verilog_initializer.cpp \
       verilog_interfaces.cpp \
       verilog_interpreter.cpp \
       verilog_language.cpp \
       verilog_lex.yy.cpp \
       verilog_lowering.cpp \
-      verilog_parameterize_module.cpp \
       verilog_parse_tree.cpp \
       verilog_parser.cpp \
       verilog_preprocessor.cpp \

--- a/src/verilog/verilog_elaborate_module_instances.cpp
+++ b/src/verilog/verilog_elaborate_module_instances.cpp
@@ -369,7 +369,7 @@ void verilog_typecheckt::parameterize_instantiated_modules(verilog_instt &inst)
     // add relevant defparam assignments
     auto &instance_defparams = defparams[instance_identifier];
 
-    irep_idt new_module_identifier = parameterize_module(
+    irep_idt new_module_identifier = instantiate_module(
       inst.source_location(),
       module_identifier,
       inst_module,

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -1077,8 +1077,8 @@ public:
   class instancet : public exprt
   {
   public:
-    // The full identifier of the module/primitive/checker that is instantiated.
-    // This may be different for each instance, owing to defparam.
+    // The full identifier of the module/primitive/checker that is specialised
+    // to the instance.  This is unique per instance.
     irep_idt module_identifier() const
     {
       return get(ID_module_identifier);

--- a/src/verilog/verilog_instantiate_module.cpp
+++ b/src/verilog/verilog_instantiate_module.cpp
@@ -203,7 +203,7 @@ void verilog_typecheckt::set_parameter_values(
 
 /*******************************************************************\
 
-Function: verilog_typecheckt::parameterize_module
+Function: verilog_typecheckt::instantiate_module
 
   Inputs:
 
@@ -213,7 +213,7 @@ Function: verilog_typecheckt::parameterize_module
 
 \*******************************************************************/
 
-irep_idt verilog_typecheckt::parameterize_module(
+irep_idt verilog_typecheckt::instantiate_module(
   const source_locationt &location,
   const irep_idt &module_identifier,
   const irep_idt &module_base_name,

--- a/src/verilog/verilog_instantiate_module.cpp
+++ b/src/verilog/verilog_instantiate_module.cpp
@@ -75,16 +75,17 @@ std::list<exprt> verilog_typecheckt::get_parameter_values(
 
   // Are the parameter values given with the instantiation
   // statement named or ordered?
-  if(!parameter_assignment.empty() &&
-     parameter_assignment.front().id()==ID_named_parameter_assignment)
+  if(
+    !parameter_assignment.empty() &&
+    parameter_assignment.front().id() == ID_named_parameter_assignment)
   {
     // named
     std::map<irep_idt, exprt> map; // base name to values
 
     forall_expr(it, parameter_assignment)
     {
-      irep_idt parameter=it->get(ID_parameter);
-      map[parameter]=static_cast<const exprt &>(it->find(ID_value));
+      irep_idt parameter = it->get(ID_parameter);
+      map[parameter] = static_cast<const exprt &>(it->find(ID_value));
     }
 
     for(auto &decl : parameter_declarators)
@@ -107,7 +108,7 @@ std::list<exprt> verilog_typecheckt::get_parameter_values(
   else
   {
     // ordered
-    exprt::operandst::const_iterator p_it=parameter_assignment.begin();
+    exprt::operandst::const_iterator p_it = parameter_assignment.begin();
 
     for(auto &decl : parameter_declarators)
     {
@@ -128,7 +129,7 @@ std::list<exprt> verilog_typecheckt::get_parameter_values(
       parameter_values.push_back(value);
     }
 
-    if(p_it!=parameter_assignment.end())
+    if(p_it != parameter_assignment.end())
     {
       throw errort().with_location(p_it->source_location())
         << "too many parameter assignments";
@@ -155,7 +156,7 @@ void verilog_typecheckt::set_parameter_values(
   const source_locationt &instance_location,
   const std::list<exprt> &parameter_values)
 {
-  auto p_it=parameter_values.begin();
+  auto p_it = parameter_values.begin();
 
   auto &parameter_port_decls = module_source.parameter_port_decls();
 
@@ -187,9 +188,10 @@ void verilog_typecheckt::set_parameter_values(
       for(auto &declarator :
           to_verilog_parameter_decl(module_item).declarators())
       {
-        if(p_it!=parameter_values.end())
+        if(p_it != parameter_values.end())
         {
-          DATA_INVARIANT(p_it != parameter_values.end(), "have enough parameter values");
+          DATA_INVARIANT(
+            p_it != parameter_values.end(), "have enough parameter values");
 
           // only overwrite when actually assigned
           if(p_it->is_not_nil())

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -131,7 +131,9 @@ protected:
 
   void elaborate_module_instances(const verilog_module_itemt &);
 
-  irep_idt parameterize_module(
+  // Specialize a module to a given instance identifier
+  // and parameter assignment
+  irep_idt instantiate_module(
     const source_locationt &location,
     const irep_idt &module_identifier,
     const irep_idt &module_base_name,


### PR DESCRIPTION
The method `verilog_typecheckt::parameterize_module` is renamed to `instantiate_module`.
    
The new name is more accurate, as the instantiation not only depends on the parameters, but also the specific name of the instance.