### PR TITLE
Verilog: split up let1 test

### DIFF
--- a/regression/verilog/let/let1.sv
+++ b/regression/verilog/let/let1.sv
@@ -5,16 +5,10 @@ module main;
   let some_let = 8'd123;
   p0: assert final (some_let == 123 && $bits(some_let) == 8);
 
-  // The standard doesn't say, but we allow these to be elaboration-time
-  // constants.
-  parameter some_parameter = some_let;
-
-  p1: assert final (some_parameter == 123 && $bits(some_parameter) == 8);
-
   // May depend on state.
   wire some_wire;
   let some_let_eq_wire = some_wire;
 
-  p2: assert final (some_let_eq_wire == some_wire);
+  p1: assert final (some_let_eq_wire == some_wire);
 
 endmodule

--- a/regression/verilog/let/let_constant1.desc
+++ b/regression/verilog/let/let_constant1.desc
@@ -1,0 +1,7 @@
+CORE
+let_constant1.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/let/let_constant1.sv
+++ b/regression/verilog/let/let_constant1.sv
@@ -1,0 +1,13 @@
+module main;
+
+  let some_let = 8'd123;
+
+  // The standard doesn't say, but we allow these to be elaboration-time
+  // constants.
+  // This is errored by VCS 2025.06, but allowed by
+  // Questa 2025.2, Xcelium 25.03, Riviera Pro 2025.04.
+  parameter some_parameter = some_let;
+
+  initial assert(some_parameter == 123 && $bits(some_parameter) == 8);
+
+endmodule


### PR DESCRIPTION
This splits the existing let1 test into two parts.