### PR TITLE
Verilog: support for let expressions with ports

### DIFF
--- a/regression/verilog/let/let_ports2.desc
+++ b/regression/verilog/let/let_ports2.desc
@@ -1,5 +1,5 @@
 CORE
-let_ports1.sv
+let_ports2.sv
 
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/verilog/let/let_ports2.sv
+++ b/regression/verilog/let/let_ports2.sv
@@ -1,0 +1,12 @@
+// SystemVerilog let with multiple ports
+
+module main;
+
+  let add(a, b) = a + b;
+  let mul(x, y) = x * y;
+
+  p0: assert final (add(3, 4) == 7);
+  p1: assert final (mul(3, 4) == 12);
+  p2: assert final (add(mul(2, 3), 1) == 7);
+
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3137,6 +3137,12 @@ let_port_list:
 let_port_item:
           attribute_instance_brace let_formal_type formal_port_identifier
           variable_dimension_brace let_port_initializer_opt
+                {
+                  init($$, ID_decl);
+                  addswap($$, ID_type, $2);
+                  stack_expr($3).id(ID_declarator);
+                  mto($$, $3);
+                }
         ;
 
 let_port_initializer_opt:

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -676,13 +676,6 @@ void verilog_typecheckt::collect_symbols(const verilog_lett &let)
   // These have one declarator.
   auto &declarator = let.declarator();
 
-  // We don't currently do let ports
-  if(declarator.type().is_not_nil())
-  {
-    throw errort().with_location(let.source_location())
-      << "let ports not supported yet";
-  }
-
   const irep_idt &base_name = declarator.base_name();
   irep_idt identifier = hierarchical_identifier(base_name);
 
@@ -698,6 +691,24 @@ void verilog_typecheckt::collect_symbols(const verilog_lett &let)
   new_symbol.value = declarator.value();
   new_symbol.base_name = base_name;
   new_symbol.pretty_name = strip_verilog_root_prefix(new_symbol.name);
+
+  // Store port names in the value expression if there are ports
+  if(declarator.type().is_not_nil())
+  {
+    auto &ports = declarator.type();
+    irept::subt port_names;
+    for(auto &port_item : ports.get_sub())
+    {
+      // Each port_item is ID_decl with a declarator operand
+      auto &port_decl = static_cast<const exprt &>(port_item);
+      if(port_decl.operands().size() >= 1)
+      {
+        auto &port_declarator = port_decl.operands()[0];
+        port_names.push_back(irept(port_declarator.get(ID_base_name)));
+      }
+    }
+    new_symbol.value.add(ID_ports).get_sub() = std::move(port_names);
+  }
 
   let_symbols.insert(new_symbol.name);
 
@@ -1087,13 +1098,26 @@ void verilog_typecheckt::elaborate_symbol_rec(irep_idt identifier)
     // Is the type derived from the value (e.g., parameters)?
     if(to_type_with_subtype(symbol.type).subtype().id() == ID_derive_from_value)
     {
-      // First elaborate the value, possibly recursively.
-      convert_expr(symbol.value);
+      // Let expressions with ports are not elaborated until call site.
+      bool is_let_with_ports =
+        is_let && symbol.value.find(ID_ports).is_not_nil();
 
-      if(!is_let)
-        symbol.value = elaborate_constant_expression_check(symbol.value);
+      if(is_let_with_ports)
+      {
+        // Use a placeholder type; the actual type is determined at the
+        // call site after argument substitution.
+        symbol.type = typet(ID_nil);
+      }
+      else
+      {
+        // First elaborate the value, possibly recursively.
+        convert_expr(symbol.value);
 
-      symbol.type = symbol.value.type();
+        if(!is_let)
+          symbol.value = elaborate_constant_expression_check(symbol.value);
+
+        symbol.type = symbol.value.type();
+      }
     }
     else
     {

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -846,6 +846,33 @@ exprt verilog_typecheck_exprt::convert_expr_rec(exprt expr)
 
 /*******************************************************************\
 
+Function: verilog_typecheck_exprt::replace_let_port
+
+  Inputs:
+
+ Outputs:
+
+ Purpose: Replace occurrences of a let port name with the argument
+
+\*******************************************************************/
+
+void verilog_typecheck_exprt::replace_let_port(
+  exprt &expr,
+  const irep_idt &port_name,
+  const exprt &arg)
+{
+  if(expr.id() == ID_verilog_identifier && expr.get(ID_base_name) == port_name)
+  {
+    expr = arg;
+    return;
+  }
+
+  for(auto &op : expr.operands())
+    replace_let_port(op, port_name, arg);
+}
+
+/*******************************************************************\
+
 Function: verilog_typecheck_exprt::convert_expr_function_call
 
   Inputs:
@@ -926,6 +953,33 @@ exprt verilog_typecheck_exprt::convert_expr_function_call(
 
   if(symbol->type.id()!=ID_code)
   {
+    // Is this a let expression with ports?
+    if(symbol->is_macro && symbol->value.find(ID_ports).is_not_nil())
+    {
+      auto &ports = symbol->value.find(ID_ports).get_sub();
+
+      if(arguments.size() != ports.size())
+      {
+        throw errort().with_location(expr.source_location())
+          << "let `" << base_name << "' expects " << ports.size()
+          << " arguments, but got " << arguments.size();
+      }
+
+      // Substitute port names with arguments in the let body
+      exprt body = symbol->value;
+      body.remove(ID_ports);
+
+      for(std::size_t i = 0; i < ports.size(); i++)
+      {
+        irep_idt port_name = ports[i].id();
+        replace_let_port(body, port_name, arguments[i]);
+      }
+
+      // Convert the substituted body
+      convert_expr(body);
+      return body;
+    }
+
     throw errort().with_location(f_op.source_location())
       << "expected function name";
   }

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -201,6 +201,7 @@ protected:
   [[nodiscard]] exprt convert_trinary_expr(ternary_exprt);
   [[nodiscard]] exprt convert_expr_concatenation(concatenation_exprt);
   [[nodiscard]] exprt convert_expr_function_call(function_call_exprt);
+  void replace_let_port(exprt &, const irep_idt &port_name, const exprt &arg);
   [[nodiscard]] exprt convert_system_function(function_call_exprt);
   [[nodiscard]] exprt convert_bit_select_expr(verilog_bit_select_exprt);
   [[nodiscard]] exprt convert_replication_expr(replication_exprt);


### PR DESCRIPTION
Implements macro-like substitution for let constructs with formal arguments (IEEE 1800-2017 A.2.12).

## Changes
- Parser: added action to `let_port_item` to capture port identifiers
- Elaboration: stores port names in the let symbol, defers body conversion to call site
- Expression typechecking: detects let calls and substitutes arguments for port names

## Testing
- Updated `let_ports1` test (single port) to expect success
- Added `let_ports2` test with multiple ports and nested let calls