### PR TITLE
Verilog: support for $value$plusargs

### DIFF
--- a/regression/verilog/system-functions/test_plusargs1.desc
+++ b/regression/verilog/system-functions/test_plusargs1.desc
@@ -1,0 +1,7 @@
+CORE
+test_plusargs1.sv
+--module main --bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/system-functions/test_plusargs1.sv
+++ b/regression/verilog/system-functions/test_plusargs1.sv
@@ -1,0 +1,6 @@
+module main;
+
+  // $test$plusargs returns 0 (not found) in synthesis
+  always assert ($test$plusargs("TESTNAME") == 0);
+
+endmodule

--- a/regression/verilog/system-functions/value_plusargs1.desc
+++ b/regression/verilog/system-functions/value_plusargs1.desc
@@ -1,0 +1,7 @@
+CORE
+value_plusargs1.sv
+--module main --bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/system-functions/value_plusargs1.sv
+++ b/regression/verilog/system-functions/value_plusargs1.sv
@@ -1,0 +1,10 @@
+module main;
+
+  reg [31:0] val;
+
+  initial val = 100;
+
+  // $value$plusargs returns 0 (not found) in synthesis
+  always assert ($value$plusargs("SEED=%d", val) == 0);
+
+endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -408,6 +408,12 @@ exprt verilog_synthesist::expand_function_call(
       auto what = synth_expr(call.arguments()[0], symbol_state); // rec. call
       return popcount_exprt{what, call.type()};
     }
+    else if(base_name == "$value$plusargs")
+    {
+      // IEEE 1800-2017 section 21.6
+      // Return 0, indicating plusarg not found, keeping the default.
+      return from_integer(0, call.type()).with_source_location(call);
+    }
     else
     {
       // Attempt to constant fold.

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -414,6 +414,12 @@ exprt verilog_synthesist::expand_function_call(
       // Return 0, indicating plusarg not found, keeping the default.
       return from_integer(0, call.type()).with_source_location(call);
     }
+    else if(base_name == "$test$plusargs")
+    {
+      // IEEE 1800-2017 section 21.6
+      // Return 0, indicating plusarg not found.
+      return from_integer(0, call.type()).with_source_location(call);
+    }
     else
     {
       // Attempt to constant fold.

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1513,6 +1513,20 @@ exprt verilog_typecheck_exprt::convert_system_function(function_call_exprt expr)
 
     return std::move(expr);
   }
+  else if(base_name == "$test$plusargs")
+  {
+    // IEEE 1800-2017 section 21.6
+    if(arguments.size() != 1)
+    {
+      throw errort().with_location(expr.source_location())
+        << "$test$plusargs takes one argument";
+    }
+
+    // Returns integer: 1 if plusarg found, 0 otherwise.
+    expr.type() = integer_typet();
+
+    return std::move(expr);
+  }
   else
   {
     throw errort().with_location(expr.function().source_location())

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1499,6 +1499,20 @@ exprt verilog_typecheck_exprt::convert_system_function(function_call_exprt expr)
 
     return std::move(expr);
   }
+  else if(base_name == "$value$plusargs")
+  {
+    // IEEE 1800-2017 section 21.6
+    if(arguments.size() != 2)
+    {
+      throw errort().with_location(expr.source_location())
+        << "$value$plusargs takes two arguments";
+    }
+
+    // Returns integer: 1 if plusarg found, 0 otherwise.
+    expr.type() = integer_typet();
+
+    return std::move(expr);
+  }
   else
   {
     throw errort().with_location(expr.function().source_location())


### PR DESCRIPTION
Add support for the `$value$plusargs` system function (IEEE 1800-2017 section 21.6).

For synthesis/formal verification, the function returns 0 (plusarg not found), so the variable retains its default value. This is the behavior needed for Chisel-generated Verilog.

**Changes:**
- Type-checking: validates 2 arguments, returns integer type
- Synthesis: returns constant 0 (not found)
- Regression test verifying the return value is 0