### PR TITLE
Verilog: include module name in 'module not found' error

### DIFF
--- a/regression/verilog/modules/module_not_found1.desc
+++ b/regression/verilog/modules/module_not_found1.desc
@@ -1,7 +1,6 @@
 CORE
 module_not_found1.v
 --bound 1 --top main
-^file .* line 3: module not found$
+^file .* line 3: module `some_module_that_does_not_exist' not found$
 ^EXIT=2$
 ^SIGNAL=0$
---

--- a/src/verilog/verilog_elaborate_module_instances.cpp
+++ b/src/verilog/verilog_elaborate_module_instances.cpp
@@ -372,6 +372,7 @@ void verilog_typecheckt::parameterize_instantiated_modules(verilog_instt &inst)
     irep_idt new_module_identifier = parameterize_module(
       inst.source_location(),
       module_identifier,
+      inst_module,
       instance_identifier,
       parameter_assignments,
       instance_defparams);

--- a/src/verilog/verilog_parameterize_module.cpp
+++ b/src/verilog/verilog_parameterize_module.cpp
@@ -216,6 +216,7 @@ Function: verilog_typecheckt::parameterize_module
 irep_idt verilog_typecheckt::parameterize_module(
   const source_locationt &location,
   const irep_idt &module_identifier,
+  const irep_idt &module_base_name,
   const irep_idt &instance_identifier,
   const exprt::operandst &parameter_assignments,
   const std::map<irep_idt, exprt> &instance_defparams)
@@ -225,7 +226,8 @@ irep_idt verilog_typecheckt::parameterize_module(
     symbol_table.symbols.find(id2string(module_identifier) + "$source");
 
   if(it == symbol_table.symbols.end())
-    throw errort().with_location(location) << "module not found";
+    throw errort().with_location(location)
+      << "module `" << module_base_name << "' not found";
 
   const symbolt &source_symbol = it->second;
 

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -134,6 +134,7 @@ protected:
   irep_idt parameterize_module(
     const source_locationt &location,
     const irep_idt &module_identifier,
+    const irep_idt &module_base_name,
     const irep_idt &instance_identifier,
     const exprt::operandst &parameter_assignment,
     const std::map<irep_idt, exprt> &defparams);


### PR DESCRIPTION
The error message when instantiating a module that does not exist now includes the name of the module that was not found.