### PR TITLE
CI: fix wasm release build

### DIFF
--- a/.github/workflows/ebmc-release.yaml
+++ b/.github/workflows/ebmc-release.yaml
@@ -263,6 +263,7 @@ jobs:
           source emsdk/emsdk_env.sh
           make -C src -j4 \
                BUILD_ENV=Unix \
+               CC="ccache emcc" \
                CXX="ccache emcc -fwasm-exceptions" \
                LINKFLAGS="-sEXPORTED_RUNTIME_METHODS=callMain -sALLOW_MEMORY_GROWTH=1" \
                LINKLIB="emar rc \$@ \$^" \


### PR DESCRIPTION
The wasm release build needs to use `emcc` for compiling C programs.