### PR TITLE
BTOR2: validate operand types and slice bounds

### DIFF
--- a/regression/ebmc/btor/redand-array1.btor2
+++ b/regression/ebmc/btor/redand-array1.btor2
@@ -1,0 +1,8 @@
+; redand applied to array-typed operand should produce an error
+1 sort bitvec 4
+2 sort bitvec 8
+3 sort array 1 2
+4 input 3
+5 sort bitvec 1
+6 redand 5 4
+7 bad 6

--- a/regression/ebmc/btor/redand-array1.desc
+++ b/regression/ebmc/btor/redand-array1.desc
@@ -1,0 +1,8 @@
+CORE
+redand-array1.btor2
+--bound 0
+^error: BTOR2: operator 'redand' requires bitvector operands$
+^EXIT=6$
+^SIGNAL=0$
+--
+--

--- a/regression/ebmc/btor/sext-array1.btor2
+++ b/regression/ebmc/btor/sext-array1.btor2
@@ -1,0 +1,10 @@
+; sext applied to array-typed operand should produce an error
+1 sort bitvec 4
+2 sort bitvec 8
+3 sort array 1 2
+4 input 3
+5 sort bitvec 12
+6 sext 5 4 4
+7 sort bitvec 1
+8 redor 7 6
+9 bad 8

--- a/regression/ebmc/btor/sext-array1.desc
+++ b/regression/ebmc/btor/sext-array1.desc
@@ -1,0 +1,8 @@
+CORE
+sext-array1.btor2
+--bound 0
+^error: BTOR2: operator 'sext' requires bitvector operands$
+^EXIT=6$
+^SIGNAL=0$
+--
+--

--- a/regression/ebmc/btor/slice-oob1.btor2
+++ b/regression/ebmc/btor/slice-oob1.btor2
@@ -1,0 +1,8 @@
+; slice with upper index exceeding bitvector width should produce an error
+1 sort bitvec 8
+2 input 1
+3 sort bitvec 4
+4 slice 3 2 100 97
+5 sort bitvec 1
+6 redor 5 4
+7 bad 6

--- a/regression/ebmc/btor/slice-oob1.desc
+++ b/regression/ebmc/btor/slice-oob1.desc
@@ -1,0 +1,8 @@
+CORE
+slice-oob1.btor2
+--bound 0
+^error: BTOR2: slice upper index 100 exceeds source width 8$
+^EXIT=6$
+^SIGNAL=0$
+--
+--

--- a/src/btor/btor_ebmc_language.cpp
+++ b/src/btor/btor_ebmc_language.cpp
@@ -172,6 +172,13 @@ static exprt build_op_expr(
   auto arg = [&](std::size_t i) -> exprt
   { return node_to_expr(node.args.at(i), model, expr_map); };
 
+  auto require_bv = [&](const exprt &e)
+  {
+    if(e.type().id() == ID_array)
+      throw ebmc_errort{} << "BTOR2: operator '" << node.tag
+                          << "' requires bitvector operands";
+  };
+
   const auto &tag = node.tag;
 
   // Unary operators
@@ -182,28 +189,101 @@ static exprt build_op_expr(
     else
       return bitnot_exprt{arg(0)};
   }
-  if(tag == "inc")
-    return plus_exprt{to_bv(arg(0)), from_integer(1, to_bv(arg(0)).type())};
-  if(tag == "dec")
-    return minus_exprt{to_bv(arg(0)), from_integer(1, to_bv(arg(0)).type())};
-  if(tag == "neg")
-    return unary_minus_exprt{to_bv(arg(0)), to_bv(arg(0)).type()};
-  if(tag == "redand")
-    return reduction_and_exprt{to_bv(arg(0))};
-  if(tag == "redor")
-    return reduction_or_exprt{to_bv(arg(0))};
-  if(tag == "redxor")
-    return reduction_xor_exprt{to_bv(arg(0))};
 
-  // Binary operators
+  // Boolean operators
   if(tag == "iff")
     return equal_exprt{arg(0), arg(1)};
+
   if(tag == "implies")
     return implies_exprt{arg(0), arg(1)};
+
   if(tag == "eq")
     return equal_exprt{arg(0), arg(1)};
+
   if(tag == "neq")
     return notequal_exprt{arg(0), arg(1)};
+
+  // Bitwise operators
+  if(tag == "and")
+  {
+    if(type.id() == ID_bool)
+      return and_exprt{arg(0), arg(1)};
+    else
+      return bitand_exprt{arg(0), arg(1)};
+  }
+
+  if(tag == "nand")
+  {
+    if(type.id() == ID_bool)
+      return not_exprt{and_exprt{arg(0), arg(1)}};
+    else
+      return bitnand_exprt{arg(0), arg(1)};
+  }
+
+  if(tag == "nor")
+  {
+    if(type.id() == ID_bool)
+      return not_exprt{or_exprt{arg(0), arg(1)}};
+    else
+      return bitnor_exprt{arg(0), arg(1)};
+  }
+
+  if(tag == "or")
+  {
+    if(type.id() == ID_bool)
+      return or_exprt{arg(0), arg(1)};
+    else
+      return bitor_exprt{arg(0), arg(1)};
+  }
+
+  if(tag == "xnor")
+  {
+    if(type.id() == ID_bool)
+      return equal_exprt{arg(0), arg(1)};
+    else
+      return bitxnor_exprt{arg(0), arg(1)};
+  }
+
+  if(tag == "xor")
+  {
+    if(type.id() == ID_bool)
+      return notequal_exprt{arg(0), arg(1)};
+    else
+      return bitxor_exprt{arg(0), arg(1)};
+  }
+
+  // Array operations
+  if(tag == "read")
+    return index_exprt{arg(0), arg(1)};
+
+  if(tag == "write")
+    return with_exprt{arg(0), arg(1), arg(2)};
+
+  // Ternary
+  if(tag == "ite")
+    return if_exprt{arg(0), arg(1), arg(2)};
+
+  // from here onwards, all operators require all arguments to have vector type
+  for(std::size_t i = 0; i < node.args.size(); i++)
+    require_bv(arg(i));
+
+  if(tag == "inc")
+    return plus_exprt{to_bv(arg(0)), from_integer(1, to_bv(arg(0)).type())};
+
+  if(tag == "dec")
+    return minus_exprt{to_bv(arg(0)), from_integer(1, to_bv(arg(0)).type())};
+
+  if(tag == "neg")
+    return unary_minus_exprt{to_bv(arg(0)), to_bv(arg(0)).type()};
+
+  if(tag == "redand")
+    return reduction_and_exprt{to_bv(arg(0))};
+
+  if(tag == "redor")
+    return reduction_or_exprt{to_bv(arg(0))};
+
+  if(tag == "redxor")
+    return reduction_xor_exprt{to_bv(arg(0))};
 
   // Signed/unsigned comparisons
   if(tag == "sgt" || tag == "sgte" || tag == "slt" || tag == "slte")
@@ -216,94 +296,63 @@ static exprt build_op_expr(
                                       : ID_le;
     return binary_relation_exprt{sa, rel_id, sb};
   }
+
   if(tag == "ugt")
     return binary_relation_exprt{to_bv(arg(0)), ID_gt, to_bv(arg(1))};
+
   if(tag == "ugte")
     return binary_relation_exprt{to_bv(arg(0)), ID_ge, to_bv(arg(1))};
+
   if(tag == "ult")
     return binary_relation_exprt{to_bv(arg(0)), ID_lt, to_bv(arg(1))};
+
   if(tag == "ulte")
     return binary_relation_exprt{to_bv(arg(0)), ID_le, to_bv(arg(1))};
-
-  // Bitwise operators
-  if(tag == "and")
-  {
-    if(type.id() == ID_bool)
-      return and_exprt{arg(0), arg(1)};
-    else
-      return bitand_exprt{arg(0), arg(1)};
-  }
-  if(tag == "nand")
-  {
-    if(type.id() == ID_bool)
-      return not_exprt{and_exprt{arg(0), arg(1)}};
-    else
-      return bitnand_exprt{arg(0), arg(1)};
-  }
-  if(tag == "nor")
-  {
-    if(type.id() == ID_bool)
-      return not_exprt{or_exprt{arg(0), arg(1)}};
-    else
-      return bitnor_exprt{arg(0), arg(1)};
-  }
-  if(tag == "or")
-  {
-    if(type.id() == ID_bool)
-      return or_exprt{arg(0), arg(1)};
-    else
-      return bitor_exprt{arg(0), arg(1)};
-  }
-  if(tag == "xnor")
-  {
-    if(type.id() == ID_bool)
-      return equal_exprt{arg(0), arg(1)};
-    else
-      return bitxnor_exprt{arg(0), arg(1)};
-  }
-  if(tag == "xor")
-  {
-    if(type.id() == ID_bool)
-      return notequal_exprt{arg(0), arg(1)};
-    else
-      return bitxor_exprt{arg(0), arg(1)};
-  }
 
   // Shift and rotate
   if(tag == "sll")
     return shl_exprt{to_bv(arg(0)), to_bv(arg(1))};
+
   if(tag == "srl")
     return lshr_exprt{to_bv(arg(0)), to_bv(arg(1))};
+
   if(tag == "sra")
-  {
     return typecast_exprt{ashr_exprt{to_signed(arg(0)), to_bv(arg(1))}, type};
-  }
+
   if(tag == "rol")
     return shift_exprt{to_bv(arg(0)), ID_rol, to_bv(arg(1))};
+
   if(tag == "ror")
     return shift_exprt{to_bv(arg(0)), ID_ror, to_bv(arg(1))};
 
   // Arithmetic
   if(tag == "add")
     return plus_exprt{to_bv(arg(0)), to_bv(arg(1))};
+
   if(tag == "sub")
     return minus_exprt{to_bv(arg(0)), to_bv(arg(1))};
+
   if(tag == "mul")
     return mult_exprt{to_bv(arg(0)), to_bv(arg(1))};
+
   if(tag == "udiv")
     return div_exprt{to_bv(arg(0)), to_bv(arg(1))};
+
   if(tag == "sdiv")
   {
     return typecast_exprt{
       div_exprt{to_signed(arg(0)), to_signed(arg(1))}, type};
   }
+
   if(tag == "urem")
     return mod_exprt{to_bv(arg(0)), to_bv(arg(1))};
+
   if(tag == "srem")
   {
     return typecast_exprt{
       mod_exprt{to_signed(arg(0)), to_signed(arg(1))}, type};
   }
+
   if(tag == "smod")
   {
     // smod: result has sign of divisor
@@ -313,6 +362,7 @@ static exprt build_op_expr(
     auto signed_type = a.type();
     auto rem = mod_exprt{a, b};
     auto zero = from_integer(0, signed_type);
+
     // Check if signs differ: (rem < 0) != (b < 0)
     auto rem_neg = binary_relation_exprt{rem, ID_lt, zero};
     auto b_neg = binary_relation_exprt{b, ID_lt, zero};
@@ -327,16 +377,6 @@ static exprt build_op_expr(
   if(tag == "concat")
     return concatenation_exprt{to_bv(arg(0)), to_bv(arg(1)), type};
 
-  // Array operations
-  if(tag == "read")
-    return index_exprt{arg(0), arg(1)};
-  if(tag == "write")
-    return with_exprt{arg(0), arg(1), arg(2)};
-
-  // Ternary
-  if(tag == "ite")
-    return if_exprt{arg(0), arg(1), arg(2)};
-
   // Indexed operators
   if(tag == "sext")
   {
@@ -346,14 +386,24 @@ static exprt build_op_expr(
     return typecast_exprt{
       typecast_exprt{a, signedbv_typet{w}}, unsignedbv_typet{new_width}};
   }
+
   if(tag == "uext")
   {
     auto new_width = get_width(arg(0)) + node.uargs.at(0);
     return typecast_exprt{to_bv(arg(0)), unsignedbv_typet{new_width}};
   }
+
   if(tag == "slice")
   {
+    auto upper = node.uargs.at(0);
     auto lower = node.uargs.at(1);
+    auto src_width = get_width(arg(0));
+    if(upper >= src_width)
+      throw ebmc_errort{} << "BTOR2: slice upper index " << upper
+                          << " exceeds source width " << src_width;
+    if(lower > upper)
+      throw ebmc_errort{} << "BTOR2: slice lower index " << lower
+                          << " exceeds upper index " << upper;
     if(type.id() == ID_bool)
       return extractbit_exprt{to_bv(arg(0)), lower};
     else
@@ -363,14 +413,19 @@ static exprt build_op_expr(
   // Overflow operators
   if(tag == "uaddo")
     return plus_overflow_exprt{to_bv(arg(0)), to_bv(arg(1))};
+
   if(tag == "saddo")
     return plus_overflow_exprt{to_signed(arg(0)), to_signed(arg(1))};
+
   if(tag == "usubo")
     return minus_overflow_exprt{to_bv(arg(0)), to_bv(arg(1))};
+
   if(tag == "ssubo")
     return minus_overflow_exprt{to_signed(arg(0)), to_signed(arg(1))};
+
   if(tag == "umulo")
     return mult_overflow_exprt{to_bv(arg(0)), to_bv(arg(1))};
+
   if(tag == "smulo")
     return mult_overflow_exprt{to_signed(arg(0)), to_signed(arg(1))};
 


### PR DESCRIPTION
Add input validation to the BTOR2 front-end to prevent invariant violations (aborts) on malformed inputs.

## Changes

1. **Array type validation**: Reject bitvector-only operators (`sext`, `uext`, `slice`, `redand`, `redor`, shifts, arithmetic, `concat`, overflow) when given array-typed operands. Previously these caused a precondition failure in `to_bitvector_type` or `boolbv_width`.

2. **Slice bounds checking**: Validate that slice upper/lower indices are within the source bitvector width. Previously out-of-bounds indices passed through to the solver, causing an invariant violation in `convert_extractbits`.

Both now produce a clean error message with exit code 6 instead of aborting.

## Testing

- 3 new regression tests added: `sext-array1`, `redand-array1`, `slice-oob1`
- All existing BTOR2 regression tests pass
- Full `regression/ebmc` test suite passes

## How bugs were found

Fuzz testing with [FuzzBtor2](https://github.com/CoriolisSP/FuzzBtor2) combined with manually crafted edge-case BTOR2 inputs targeting type mismatches and boundary conditions.