### PR TITLE
BTOR2: reject duplicate sort and node IDs

### DIFF
--- a/regression/ebmc/btor/dup-node-id1.btor2
+++ b/regression/ebmc/btor/dup-node-id1.btor2
@@ -1,0 +1,5 @@
+; duplicate node ID should produce an error
+1 sort bitvec 4
+2 state 1
+3 bad 2
+3 input 1

--- a/regression/ebmc/btor/dup-node-id1.desc
+++ b/regression/ebmc/btor/dup-node-id1.desc
@@ -1,0 +1,7 @@
+CORE
+dup-node-id1.btor2
+--bound 0
+^error: BTOR2: duplicate node ID 3 on line 5$
+^EXIT=6$
+^SIGNAL=0$
+--

--- a/regression/ebmc/btor/dup-sort-id1.btor2
+++ b/regression/ebmc/btor/dup-sort-id1.btor2
@@ -1,0 +1,5 @@
+; duplicate sort ID should produce an error
+1 sort bitvec 4
+1 sort bitvec 8
+2 input 1
+3 bad 2

--- a/regression/ebmc/btor/dup-sort-id1.desc
+++ b/regression/ebmc/btor/dup-sort-id1.desc
@@ -1,0 +1,7 @@
+CORE
+dup-sort-id1.btor2
+--bound 0
+^error: BTOR2: duplicate sort ID 1 on line 3$
+^EXIT=6$
+^SIGNAL=0$
+--

--- a/src/btor/btor_parser.cpp
+++ b/src/btor/btor_parser.cpp
@@ -81,6 +81,9 @@ btor2_modelt btor2_parse(std::istream &in)
                             << "' on line " << line_number;
       }
 
+      if(model.sorts.count(id))
+        throw ebmc_errort{} << "BTOR2: duplicate sort ID " << id << " on line "
+                            << line_number;
       model.sorts[id] = sort;
       continue;
     }
@@ -196,6 +199,9 @@ btor2_modelt btor2_parse(std::istream &in)
         node.symbol = sym;
     }
 
+    if(model.nodes.count(id))
+      throw ebmc_errort{} << "BTOR2: duplicate node ID " << id << " on line "
+                          << line_number;
     model.nodes[id] = std::move(node);
   }
 


### PR DESCRIPTION
## Summary

- Reusing an ID overwrote the previous entry in `model.nodes` while keeping the original ID in `model.bad_properties` / `model.constraints` / etc.
- The third pass then called `node.args[0]` on the replacement node (which may have no arguments), causing a **segfault** (SIGSEGV, exit 139).
- Fix: detect and reject duplicate sort IDs and node IDs in the parser with a descriptive `ebmc_errort`.

## Test plan

- [ ] `dup-sort-id1`: `1 sort bitvec 4` then `1 sort bitvec 8` → `error: BTOR2: duplicate sort ID 1 on line 3`
- [ ] `dup-node-id1`: `3 bad 2` then `3 input 1` → `error: BTOR2: duplicate node ID 3 on line 5`
- [ ] Existing regression suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)