### PR TITLE
BTOR2: validate operand count for all operators

### DIFF
--- a/regression/ebmc/btor/missing-operand1.btor2
+++ b/regression/ebmc/btor/missing-operand1.btor2
@@ -1,0 +1,4 @@
+; binary operator with only one operand should produce an error
+1 sort bitvec 4
+2 input 1
+3 add 1 2

--- a/regression/ebmc/btor/missing-operand1.desc
+++ b/regression/ebmc/btor/missing-operand1.desc
@@ -1,0 +1,7 @@
+CORE
+missing-operand1.btor2
+--bound 0
+^error: BTOR2: operator 'add' requires at least 2 operand\(s\)$
+^EXIT=6$
+^SIGNAL=0$
+--

--- a/src/btor/btor_ebmc_language.cpp
+++ b/src/btor/btor_ebmc_language.cpp
@@ -170,7 +170,12 @@ static exprt build_op_expr(
   const std::map<std::size_t, exprt> &expr_map)
 {
   auto arg = [&](std::size_t i) -> exprt
-  { return node_to_expr(node.args.at(i), model, expr_map); };
+  {
+    if(i >= node.args.size())
+      throw ebmc_errort{} << "BTOR2: operator '" << node.tag
+                          << "' requires at least " << (i + 1) << " operand(s)";
+    return node_to_expr(node.args[i], model, expr_map);
+  };
 
   auto require_bv = [&](const exprt &e)
   {


### PR DESCRIPTION
## Summary

- The `arg()` lambda in `build_op_expr` called `vector::at(i)`, which throws `std::out_of_range` when an operator had fewer arguments than expected (e.g., `3 add 1 2` with only one operand).
- This exception propagated uncaught and the process terminated with **SIGABRT** (exit 6).
- Fix: replace `at()` with a bounds check that throws a descriptive `ebmc_errort` with the operator name and required operand count.

## Test plan

- [ ] `missing-operand1`: `3 add 1 2` (one arg instead of two) → `error: BTOR2: operator 'add' requires at least 2 operand(s)`
- [ ] Existing regression suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)