### PR TITLE
BTOR2: validate that 'next' first argument is a state variable

### DIFF
--- a/regression/ebmc/btor/next-nonsymbol1.btor2
+++ b/regression/ebmc/btor/next-nonsymbol1.btor2
@@ -1,0 +1,4 @@
+; next with a non-state-variable first arg should produce an error
+1 sort bitvec 4
+2 state 1
+3 next 1 -2 2

--- a/regression/ebmc/btor/next-nonsymbol1.desc
+++ b/regression/ebmc/btor/next-nonsymbol1.desc
@@ -1,0 +1,7 @@
+CORE
+next-nonsymbol1.btor2
+--bound 0
+^error: BTOR2: first argument of 'next' must be a state variable \(node 3\)$
+^EXIT=6$
+^SIGNAL=0$
+--

--- a/src/btor/btor_ebmc_language.cpp
+++ b/src/btor/btor_ebmc_language.cpp
@@ -508,6 +508,10 @@ static transition_systemt build_transition_system(const btor2_modelt &model)
       // next <sid> <state_nid> <next_value_nid>
       auto state_expr = node_to_expr(node.args[0], model, expr_map);
       auto next_value = node_to_expr(node.args[1], model, expr_map);
+      if(state_expr.id() != ID_symbol)
+        throw ebmc_errort{} << "BTOR2: first argument of 'next' must be a "
+                               "state variable (node "
+                            << id << ")";
       next_symbol_exprt next_state{to_symbol_expr(state_expr)};
       trans_exprs.push_back(equal_exprt{next_state, next_value});
     }


### PR DESCRIPTION
## Summary

- If the first argument of a `next` node was a negated reference (e.g., `-2`) or any non-state expression, `node_to_expr` returned a `bitnot_exprt` or similar — not a symbol.
- The subsequent call to `to_symbol_expr()` hit a CBMC precondition (`expr.id() == ID_symbol`) and aborted with an **invariant violation** (exit 134).
- Fix: check `state_expr.id() != ID_symbol` before calling `to_symbol_expr` and throw a descriptive `ebmc_errort`.

## Test plan

- [ ] `next-nonsymbol1`: `3 next 1 -2 2` (negated ref as state) → `error: BTOR2: first argument of 'next' must be a state variable (node 3)`
- [ ] Existing regression suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)