### PR TITLE
BTOR2: implement sdivo and udivo overflow operators

### DIFF
--- a/regression/ebmc/btor/div-overflow1.btor2
+++ b/regression/ebmc/btor/div-overflow1.btor2
@@ -1,0 +1,24 @@
+; Test sdivo and udivo overflow detection operators on 4-bit values
+1 sort bitvec 4
+2 sort bitvec 1
+; udivo(a, 0) == true (dividing by zero always overflows)
+3 constd 1 7
+4 zero 1
+5 udivo 2 3 4
+6 not 2 5
+7 bad 6
+; udivo(a, nonzero) == false (no overflow with nonzero divisor)
+8 constd 1 3
+9 udivo 2 3 8
+10 bad 9
+; sdivo(INT_MIN, -1) == true (signed division overflows: -8/(-1)=8 unrepresentable)
+; -8 is 0b1000 = unsigned 8 in 4 bits; -1 is 0b1111 = unsigned 15
+11 constd 1 8
+12 constd 1 15
+13 sdivo 2 11 12
+14 not 2 13
+15 bad 14
+; sdivo(INT_MIN, 1) == false (dividing by 1 does not overflow)
+16 constd 1 1
+17 sdivo 2 11 16
+18 bad 17

--- a/regression/ebmc/btor/div-overflow1.desc
+++ b/regression/ebmc/btor/div-overflow1.desc
@@ -1,0 +1,10 @@
+CORE
+div-overflow1.btor2
+--bound 0
+^\[bad7\] : PROVED up to bound 0$
+^\[bad10\] : PROVED up to bound 0$
+^\[bad15\] : PROVED up to bound 0$
+^\[bad18\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/src/btor/btor_ebmc_language.cpp
+++ b/src/btor/btor_ebmc_language.cpp
@@ -429,6 +429,24 @@ static exprt build_op_expr(
   if(tag == "smulo")
     return mult_overflow_exprt{to_signed(arg(0)), to_signed(arg(1))};
 
+  if(tag == "udivo")
+  {
+    // unsigned division overflows iff divisor is zero
+    auto b = to_bv(arg(1));
+    return equal_exprt{b, from_integer(0, b.type())};
+  }
+
+  if(tag == "sdivo")
+  {
+    // signed division overflows iff dividend == INT_MIN and divisor == -1
+    auto sa = to_signed(arg(0));
+    auto sb = to_signed(arg(1));
+    auto w = to_bitvector_type(sa.type()).get_width();
+    auto min_int = from_integer(-power(2, w - 1), sa.type());
+    auto neg_one = from_integer(-1, sb.type());
+    return and_exprt{equal_exprt{sa, min_int}, equal_exprt{sb, neg_one}};
+  }
+
   throw ebmc_errort{} << "BTOR2: unsupported operator '" << tag << "'";
 }
 


### PR DESCRIPTION
## Summary

- `sdivo` (signed division overflow) and `udivo` (unsigned division overflow) were missing from the BTOR2 operator table, causing `error: BTOR2: unsupported operator 'sdivo'` on files generated by FuzzBtor2 and other BTOR2 tools.
- Implement both:
  - `udivo(a, b)` → `b == 0` (unsigned division overflows iff divisor is zero)
  - `sdivo(a, b)` → `a == INT_MIN ∧ b == -1` (signed division overflows iff the result is unrepresentable)

## Test plan

- [ ] `div-overflow1`: verify constant-folding of all four overflow/non-overflow cases with `--bound 0`
- [ ] FuzzBtor2 campaign of 200 seeds produces zero `unsupported operator` errors
- [ ] Existing regression suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)