### PR TITLE
Verilog: support for `undefineall

### DIFF
--- a/regression/verilog/preprocessor/undefineall1.desc
+++ b/regression/verilog/preprocessor/undefineall1.desc
@@ -1,0 +1,13 @@
+CORE
+undefineall1.v
+--preprocess
+activate-multi-line-match
+`line 1 "undefineall1.v" 0
+
+
+
+PASS
+^EXIT=0$
+^SIGNAL=0$
+--
+^PREPROCESSING FAILED$

--- a/regression/verilog/preprocessor/undefineall1.v
+++ b/regression/verilog/preprocessor/undefineall1.v
@@ -1,0 +1,8 @@
+`define FOO 123
+`define BAR 456
+`undefineall
+`ifdef FOO
+FAIL
+`else
+PASS
+`endif

--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -503,6 +503,13 @@ void verilog_preprocessort::directive()
       defines.erase(it);
     }
   }
+  else if(text == "undefineall")
+  {
+    if(!condition)
+      return;
+
+    defines.clear();
+  }
   else if(text=="ifdef" || text=="ifndef")
   {
     bool ifdef = text == "ifdef";


### PR DESCRIPTION
Implements the `undefineall preprocessor directive per IEEE 1800-2017 section 22.5.2. This directive removes all previously defined text macros.

### Changes
- Handle `undefineall in the preprocessor by clearing all defines
- Regression test verifying macros are removed after `undefineall