### PR TITLE
Verilog: support `pragma preprocessor directive

### DIFF
--- a/regression/verilog/preprocessor/pragma1.desc
+++ b/regression/verilog/preprocessor/pragma1.desc
@@ -1,0 +1,7 @@
+CORE
+pragma1.sv
+--preprocess
+^EXIT=0$
+^SIGNAL=0$
+--
+^PREPROCESSING FAILED$

--- a/regression/verilog/preprocessor/pragma1.sv
+++ b/regression/verilog/preprocessor/pragma1.sv
@@ -1,0 +1,3 @@
+`pragma protect begin
+module main;
+endmodule

--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -695,6 +695,11 @@ void verilog_preprocessort::directive()
     // ignored
     tokenizer().skip_until_eol();
   }
+  else if(text == "pragma")
+  {
+    // ignored
+    tokenizer().skip_until_eol();
+  }
   else if(text == "default_nettype")
   {
     // pass through


### PR DESCRIPTION
The `pragma directive (IEEE 1800-2017 section 22.10) is now recognized and silently consumed by the preprocessor, matching the handling of other tool directives like `timescale and `celldefine.

## Changes
- Added `pragma handling in `verilog_preprocessor.cpp` (skip until end of line)
- Added regression test `preprocessor/pragma1`

## Testing
- Build passes (no warnings)
- All regression tests pass including the new test