### PR TITLE
Verilog: extract `top_level_modules` into separate file

### DIFF
--- a/regression/verilog/comments/eof-in-comment1.desc
+++ b/regression/verilog/comments/eof-in-comment1.desc
@@ -1,7 +1,7 @@
 CORE
 eof-in-comment1.v
 
-^no module found$
+^error: no module found$
 ^EXIT=1$
 ^SIGNAL=0$
 --

--- a/regression/verilog/constraints/constraint1.desc
+++ b/regression/verilog/constraints/constraint1.desc
@@ -1,7 +1,7 @@
 CORE
 constraint1.sv
 
-^no module found$
+^error: no module found$
 ^EXIT=1$
 ^SIGNAL=0$
 --

--- a/src/verilog/Makefile
+++ b/src/verilog/Makefile
@@ -2,6 +2,7 @@ SRC = aval_bval_encoding.cpp \
       convert_literals.cpp \
       expr2verilog.cpp \
       sva_expr.cpp \
+      top_level_modules.cpp \
       typename.cpp \
       verilog_bits.cpp \
       verilog_ebmc_language.cpp \

--- a/src/verilog/top_level_modules.cpp
+++ b/src/verilog/top_level_modules.cpp
@@ -1,0 +1,145 @@
+/*******************************************************************\
+
+Module: Verilog Top Level Modules
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+/// \file
+/// Verilog Top Level Modules
+
+#include "top_level_modules.h"
+
+#include <util/cmdline.h>
+
+#include <ebmc/ebmc_error.h>
+
+static void sort_alphabetically(std::vector<irep_idt> &names)
+{
+  std::sort(
+    names.begin(),
+    names.end(),
+    [](const irep_idt &a, const irep_idt &b)
+    { return id2string(a) < id2string(b); });
+}
+
+static void module_dependencies_rec(
+  const verilog_module_itemt &module_item,
+  const std::function<void(irep_idt)> &action)
+{
+  if(module_item.id() == ID_inst)
+  {
+    action(to_verilog_inst(module_item).module_base_name());
+  }
+  else if(module_item.id() == ID_generate_block)
+  {
+    for(auto &sub_item : to_verilog_generate_block(module_item).module_items())
+      module_dependencies_rec(sub_item, action);
+  }
+  else if(module_item.id() == ID_generate_if)
+  {
+    auto &generate_if = to_verilog_generate_if(module_item);
+    module_dependencies_rec(generate_if.then_case(), action);
+    if(generate_if.has_else_case())
+      module_dependencies_rec(generate_if.else_case(), action);
+  }
+  else if(module_item.id() == ID_generate_for)
+  {
+    module_dependencies_rec(
+      to_verilog_generate_for(module_item).body(), action);
+  }
+}
+
+static void module_dependencies(
+  const verilog_module_sourcet &module_source,
+  const std::function<void(irep_idt)> &action)
+{
+  for(auto &item : module_source.items())
+    module_dependencies_rec(item, action);
+}
+
+/// Determine the set of top-level modules following 1800 2017 23.3.1,
+/// given via their base names. Sorted alphabetically.
+std::vector<irep_idt> top_level_modules(
+  const std::list<verilog_parse_treet> &parse_trees,
+  const cmdlinet &cmdline)
+{
+  // start with a set of all modules, from all the files
+  std::set<irep_idt> all_modules;
+
+  for(auto &parse_tree : parse_trees)
+    for(auto &item : parse_tree.items)
+    {
+      if(item.id() == ID_verilog_module)
+      {
+        auto base_name = to_verilog_module_source(item).base_name();
+        all_modules.insert(base_name);
+      }
+    }
+
+  // Did the user specify a set of top level modules?
+  std::vector<irep_idt> given_modules;
+
+  if(cmdline.isset("module"))
+  {
+    for(auto &value : cmdline.get_values("module"))
+      given_modules.push_back(value);
+  }
+  else if(cmdline.isset("top"))
+  {
+    for(auto &value : cmdline.get_values("top"))
+      given_modules.push_back(value);
+  }
+
+  if(!given_modules.empty())
+  {
+    // first check that all the given modules exist
+    for(const auto &given_module : given_modules)
+    {
+      if(all_modules.find(given_module) == all_modules.end())
+      {
+        throw ebmc_errort{}.with_exit_code(2)
+          << "module '" << given_module << "' not found";
+      }
+    }
+
+    // now sort alphabetically
+    sort_alphabetically(given_modules);
+
+    return given_modules; // done
+  }
+
+  // No modules given. Find all modules that are not used
+  // as a submodule. Start with all modules, and then erase
+  // the ones that are used as a submodule.
+  std::set<irep_idt> top_level_modules = all_modules;
+
+  for(auto &parse_tree : parse_trees)
+  {
+    for(auto &item : parse_tree.items)
+    {
+      if(item.id() == ID_verilog_module || item.id() == ID_verilog_program)
+      {
+        auto erase = [&top_level_modules](irep_idt dependency)
+        { top_level_modules.erase(dependency); };
+        module_dependencies(to_verilog_module_source(item), erase);
+      }
+    }
+  }
+
+  if(top_level_modules.empty())
+  {
+    throw ebmc_errort{}.with_exit_code(1) << "no module found";
+  }
+
+  // sort alphabetically into a vector
+  std::vector<irep_idt> result;
+
+  for(auto &module : top_level_modules)
+    result.push_back(module);
+
+  sort_alphabetically(result);
+
+  return result; // done
+}

--- a/src/verilog/top_level_modules.h
+++ b/src/verilog/top_level_modules.h
@@ -1,0 +1,25 @@
+/*******************************************************************\
+
+Module: Verilog Top Level Modules
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+/// \file
+/// Verilog Top Level Modules
+
+#ifndef EBMC_VERILOG_TOP_LEVEL_MODULES_H
+#define EBMC_VERILOG_TOP_LEVEL_MODULES_H
+
+#include "verilog_parse_tree.h"
+
+class cmdlinet;
+
+// Returns the base_names of the top-level modules in alphabetical order.
+// Throws ebmc_errort when a given top-level module is not found,
+// or when there is no top-level module.
+std::vector<irep_idt>
+top_level_modules(const std::list<verilog_parse_treet> &, const cmdlinet &);
+
+#endif // EBMC_VERILOG_TOP_LEVEL_MODULES_H

--- a/src/verilog/verilog_ebmc_language.cpp
+++ b/src/verilog/verilog_ebmc_language.cpp
@@ -22,6 +22,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <langapi/mode.h>
 #include <trans-word-level/show_module_hierarchy.h>
 
+#include "top_level_modules.h"
 #include "verilog_elaborate_compilation_unit.h"
 #include "verilog_language.h"
 #include "verilog_parser.h"
@@ -33,15 +34,6 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <fstream>
 #include <functional>
 #include <iostream>
-
-static void sort_alphabetically(std::vector<irep_idt> &names)
-{
-  std::sort(
-    names.begin(),
-    names.end(),
-    [](const irep_idt &a, const irep_idt &b)
-    { return id2string(a) < id2string(b); });
-}
 
 void verilog_ebmc_languaget::preprocess(
   const std::filesystem::path &path,
@@ -226,129 +218,6 @@ transition_systemt verilog_ebmc_languaget::typecheck(
   }
 
   return transition_system;
-}
-
-static void module_dependencies_rec(
-  const verilog_module_itemt &module_item,
-  const std::function<void(irep_idt)> &action)
-{
-  if(module_item.id() == ID_inst)
-  {
-    action(to_verilog_inst(module_item).module_base_name());
-  }
-  else if(module_item.id() == ID_generate_block)
-  {
-    for(auto &sub_item : to_verilog_generate_block(module_item).module_items())
-      module_dependencies_rec(sub_item, action);
-  }
-  else if(module_item.id() == ID_generate_if)
-  {
-    auto &generate_if = to_verilog_generate_if(module_item);
-    module_dependencies_rec(generate_if.then_case(), action);
-    if(generate_if.has_else_case())
-      module_dependencies_rec(generate_if.else_case(), action);
-  }
-  else if(module_item.id() == ID_generate_for)
-  {
-    module_dependencies_rec(
-      to_verilog_generate_for(module_item).body(), action);
-  }
-}
-
-static void module_dependencies(
-  const verilog_module_sourcet &module_source,
-  const std::function<void(irep_idt)> &action)
-{
-  for(auto &item : module_source.items())
-    module_dependencies_rec(item, action);
-}
-
-/// Determine the set of top-level modules following 1800 2017 23.3.1,
-/// given via their base names. Sorted alphabetically.
-std::vector<irep_idt>
-verilog_ebmc_languaget::top_level_modules(const parse_treest &parse_trees) const
-{
-  // start with a set of all modules, from all the files
-  std::set<irep_idt> all_modules;
-
-  for(auto &parse_tree : parse_trees)
-    for(auto &item : parse_tree.items)
-    {
-      if(item.id() == ID_verilog_module)
-      {
-        auto base_name = to_verilog_module_source(item).base_name();
-        all_modules.insert(base_name);
-      }
-    }
-
-  // Did the user specify a set of top level modules?
-  std::vector<irep_idt> given_modules;
-
-  if(cmdline.isset("module"))
-  {
-    for(auto &value : cmdline.get_values("module"))
-      given_modules.push_back(value);
-  }
-  else if(cmdline.isset("top"))
-  {
-    for(auto &value : cmdline.get_values("top"))
-      given_modules.push_back(value);
-  }
-
-  if(!given_modules.empty())
-  {
-    // first check that all the given modules exist
-    for(const auto &given_module : given_modules)
-    {
-      if(all_modules.find(given_module) == all_modules.end())
-      {
-        messaget log{message_handler};
-        log.error() << "module '" << given_module << "' not found"
-                    << messaget::eom;
-        throw ebmc_errort{}.with_exit_code(2);
-      }
-    }
-
-    // now sort alphabetically
-    sort_alphabetically(given_modules);
-
-    return given_modules; // done
-  }
-
-  // No modules given. Find all modules that are not used
-  // as a submodule. Start with all modules, and then erase
-  // the ones that are used as a submodule.
-  std::set<irep_idt> top_level_modules = all_modules;
-
-  for(auto &parse_tree : parse_trees)
-  {
-    for(auto &item : parse_tree.items)
-    {
-      if(item.id() == ID_verilog_module || item.id() == ID_verilog_program)
-      {
-        auto erase = [&top_level_modules](irep_idt dependency)
-        { top_level_modules.erase(dependency); };
-        module_dependencies(to_verilog_module_source(item), erase);
-      }
-    }
-  }
-
-  if(top_level_modules.empty())
-  {
-    messaget log{message_handler};
-    log.error() << "no module found" << messaget::eom;
-    throw ebmc_errort{}.with_exit_code(1);
-  }
-
-  // sort alphabetically into a vector
-  std::vector<irep_idt> result;
-
-  for(auto &module : top_level_modules)
-    result.push_back(module);
-
-  sort_alphabetically(result);
-
-  return result; // done
 }
 
 /// Create a $root module instance containing the given top-level module,
@@ -563,7 +432,7 @@ std::optional<transition_systemt> verilog_ebmc_languaget::transition_system()
   //
   // determine the top-level modules
   //
-  auto top_level_modules = this->top_level_modules(parse_trees);
+  auto top_level_modules = ::top_level_modules(parse_trees, cmdline);
 
   //
   // type checking

--- a/src/verilog/verilog_ebmc_language.h
+++ b/src/verilog/verilog_ebmc_language.h
@@ -51,9 +51,6 @@ protected:
 
   void copy_parse_tree(const parse_treet &, symbol_tablet &);
 
-  // base_names of the top-level modules, alphabetical order
-  std::vector<irep_idt> top_level_modules(const parse_treest &) const;
-
   class modulet
   {
   public:


### PR DESCRIPTION
This moves the discovery of top-level Verilog modules into a separate function and separate file.