### PR TITLE
BTOR2: KNOWNBUG tests for 1-bit signed operator semantics

### DIFF
--- a/regression/ebmc/btor/bitvec1-sdivo1.btor2
+++ b/regression/ebmc/btor/bitvec1-sdivo1.btor2
@@ -1,0 +1,11 @@
+; sdivo on bitvec 1
+; In 1-bit signed: value 1 represents INT_MIN (-1, which is the minimum
+; for 1-bit signed). sdivo(INT_MIN, -1) should be true (overflow).
+; Here both operands are 1 (representing -1), and -1 is INT_MIN in 1-bit.
+; sdiv(-1, -1) = 1, which cannot be represented in 1-bit signed -> overflow.
+1 sort bitvec 1
+2 one 1
+; sdivo(1, 1) on 1-bit: sdivo(INT_MIN, -1) = true (overflow)
+3 sdivo 1 2 2
+4 not 1 3
+5 bad 4

--- a/regression/ebmc/btor/bitvec1-sdivo1.desc
+++ b/regression/ebmc/btor/bitvec1-sdivo1.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+bitvec1-sdivo1.btor2
+--bound 0
+^\[bad5\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+to_signed() zero-extends 1-bit values to 2 bits, losing the sign bit.
+sdivo on 1-bit values fails to detect overflow (INT_MIN / -1).

--- a/regression/ebmc/btor/bitvec1-signed-comparison2.btor2
+++ b/regression/ebmc/btor/bitvec1-signed-comparison2.btor2
@@ -1,0 +1,18 @@
+; Signed comparisons on bitvec 1
+; In 1-bit signed: value 1 represents -1, value 0 represents 0.
+; So -1 < 0, meaning slt(1, 0) should be true.
+1 sort bitvec 1
+2 one 1
+3 zero 1
+; slt(1, 0): -1 < 0 is true
+4 slt 1 2 3
+5 not 1 4
+6 bad 5
+; sgt(0, 1): 0 > -1 is true
+7 sgt 1 3 2
+8 not 1 7
+9 bad 8
+; sgte(0, 1): 0 >= -1 is true
+10 sgte 1 3 2
+11 not 1 10
+12 bad 11

--- a/regression/ebmc/btor/bitvec1-signed-comparison2.desc
+++ b/regression/ebmc/btor/bitvec1-signed-comparison2.desc
@@ -1,0 +1,12 @@
+KNOWNBUG
+bitvec1-signed-comparison2.btor2
+--bound 0
+^\[bad6\] : PROVED up to bound 0$
+^\[bad9\] : PROVED up to bound 0$
+^\[bad12\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+to_signed() zero-extends 1-bit values to 2 bits, losing the sign bit.
+slt/sgt/sgte on 1-bit values with value 1 (representing -1) produce wrong results.

--- a/regression/ebmc/btor/bitvec1-smulo1.btor2
+++ b/regression/ebmc/btor/bitvec1-smulo1.btor2
@@ -1,0 +1,10 @@
+; smulo on bitvec 1
+; In 1-bit signed: value 1 represents -1.
+; smulo(1, 1): signed multiplication (-1) * (-1) = +1, which overflows
+; 1-bit signed (range is {-1, 0}). So smulo should be true.
+1 sort bitvec 1
+2 one 1
+; smulo(1, 1) on 1-bit: (-1) * (-1) = +1 overflows -> true
+3 smulo 1 2 2
+4 not 1 3
+5 bad 4

--- a/regression/ebmc/btor/bitvec1-smulo1.desc
+++ b/regression/ebmc/btor/bitvec1-smulo1.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+bitvec1-smulo1.btor2
+--bound 0
+^\[bad5\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+to_signed() zero-extends 1-bit values to 2 bits, losing the sign bit.
+smulo on 1-bit values fails to detect overflow of (-1) * (-1).

--- a/regression/ebmc/btor/bitvec1-sra1.btor2
+++ b/regression/ebmc/btor/bitvec1-sra1.btor2
@@ -1,0 +1,9 @@
+; sra on bitvec 1: arithmetic right shift of -1 by 1 should be -1
+; In 1-bit signed: value 1 represents -1. sra(-1, 1) should propagate
+; the sign bit, giving -1 (i.e., bit value 1).
+1 sort bitvec 1
+2 one 1
+; sra(1, 1) on 1-bit: sign bit propagates, result should be 1
+3 sra 1 2 2
+4 not 1 3
+5 bad 4

--- a/regression/ebmc/btor/bitvec1-sra1.desc
+++ b/regression/ebmc/btor/bitvec1-sra1.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+bitvec1-sra1.btor2
+--bound 0
+^\[bad5\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+to_signed() zero-extends 1-bit values to 2 bits, losing the sign bit.
+sra on 1-bit values produces wrong results: sra(-1, 1) should be -1 but gives 0.

--- a/regression/ebmc/btor/bitvec1-ssubo1.btor2
+++ b/regression/ebmc/btor/bitvec1-ssubo1.btor2
@@ -1,0 +1,12 @@
+; ssubo on bitvec 1
+; In 1-bit signed: value 0 represents 0, value 1 represents -1.
+; Range of 1-bit signed is {-1, 0}.
+; ssubo(0, 1): signed subtraction 0 - (-1) = +1, which overflows 1-bit signed.
+; So ssubo should be true.
+1 sort bitvec 1
+2 zero 1
+3 one 1
+; ssubo(0, 1) on 1-bit: 0 - (-1) = +1 overflows -> true
+4 ssubo 1 2 3
+5 not 1 4
+6 bad 5

--- a/regression/ebmc/btor/bitvec1-ssubo1.desc
+++ b/regression/ebmc/btor/bitvec1-ssubo1.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+bitvec1-ssubo1.btor2
+--bound 0
+^\[bad6\] : PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+to_signed() zero-extends 1-bit values to 2 bits, losing the sign bit.
+ssubo on 1-bit values fails to detect overflow of 0 - (-1).


### PR DESCRIPTION
The `to_signed()` helper in the BTOR2 front-end zero-extends 1-bit values to 2 bits before interpreting as signed, which loses the sign bit.

In 1-bit signed representation, value 1 represents -1 (INT_MIN). After zero-extension to 2-bit unsigned (`01`) and reinterpretation as 2-bit signed, it becomes +1. This causes incorrect results for all signed operators on `bitvec 1` operands:

- `sra`: arithmetic right shift of -1 should propagate sign, but gives 0
- `slt`/`sgt`/`sgte`: signed comparisons treating -1 as +1
- `sdiv`: signed division with incorrect operand interpretation
- `srem`: signed remainder with incorrect operand interpretation
- `sdivo`: fails to detect INT_MIN / -1 overflow on 1-bit

These KNOWNBUG tests document the issue. The fix would be to sign-extend (not zero-extend) in `to_signed()` when widening 1-bit values:

```cpp
static exprt to_signed(const exprt &e)
{
  auto a = to_bv(e);
  auto w = get_width(e);
  if(w < 2)
  {
    // Sign-extend: cast to signed first, then widen
    a = typecast_exprt{a, signedbv_typet{w}};
    a = typecast_exprt{a, signedbv_typet{2}};
    return a;
  }
  return typecast_exprt{a, signedbv_typet{w}};
}
```