### PR TITLE
Verilog preprocessor: preserve newlines in multi-line defines

### DIFF
--- a/regression/verilog/preprocessor/multi-line-define1.desc
+++ b/regression/verilog/preprocessor/multi-line-define1.desc
@@ -1,7 +1,8 @@
 CORE
 multi-line-define1.v
 --preprocess
-^A B C$
+activate-multi-line-match
+^A \nB \nC$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -207,19 +207,13 @@ void verilog_preprocessort::preprocessor()
     // the first context is the input file
     context_stack.emplace_back(false, &in, widen_if_needed(filename));
 
+    // tell the parser the file name
+    emit_line_directive(0); // 'neither'
+
     while(!context_stack.empty())
     {
       while(!tokenizer().eof())
       {
-        // Emit line directive to get parser line count
-        // back in sync with preprocessor line count.
-        if(
-          condition && context().is_file() &&
-          parser_line_no != tokenizer().line_no())
-        {
-          emit_line_directive(0); // 'neither'
-        }
-
         // Read a token.
         auto token = tokenizer().next_token();
         if(token == '`')
@@ -245,7 +239,16 @@ void verilog_preprocessort::preprocessor()
 
             // track parser line number
             if(token == '\n')
+            {
               parser_line_no++;
+
+              // Emit line directive to get parser line count
+              // back in sync with preprocessor line count.
+              if(context().is_file() && parser_line_no != tokenizer().line_no())
+              {
+                emit_line_directive(0); // 'neither'
+              }
+            }
           }
           else
           {
@@ -456,10 +459,11 @@ void verilog_preprocessort::directive()
       auto token = tokenizer().next_token();
       if(token == '\\' && tokenizer().peek() == '\n')
       {
-        // Eat the newline, which is escaped.
-        // We rely on the sync_line_no mechanism to
-        // get the parser's line count back in sync.
-        tokenizer().next_token();
+        // 1800-2017 22.5.1: "The newline character preceded by a
+        // backslash shall be replaced in the expanded macro with a
+        // newline character (but without the preceding backslash
+        // character)."
+        define.tokens.push_back(tokenizer().next_token());
       }
       else
         define.tokens.push_back(std::move(token));


### PR DESCRIPTION
1800-2017 22.5.1: "The newline character preceded by a backslash shall be replaced in the expanded macro with a newline character (but without the preceding backslash character)."

The preprocessor now stores the escaped newline in the macro text instead of discarding it, and hence macro expansions span the same number of lines as the macro definition.

The `line directive that re-synchronizes the parser's line counter is now emitted after a newline, so that it always starts on a new line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)