### PR TITLE
Verilog preprocessor: comments ending in backslash continue defines

### DIFF
--- a/regression/verilog/preprocessor/define-with-comment1.desc
+++ b/regression/verilog/preprocessor/define-with-comment1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 define-with-comment1.v
 --preprocess
 activate-multi-line-match

--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -454,6 +454,10 @@ void verilog_preprocessort::directive()
     // but note that \n can be escaped with a backslash.
     // Note that any defines in this sequence
     // are not expanded at this point.
+    // One-line comments ending in a backslash also continue
+    // the macro text on the next line (1800-2017 22.5.1).
+    tokenizer().in_macro_text = true;
+
     while(!tokenizer().eof() && tokenizer().peek() != '\n')
     {
       auto token = tokenizer().next_token();
@@ -468,6 +472,8 @@ void verilog_preprocessort::directive()
       else
         define.tokens.push_back(std::move(token));
     }
+
+    tokenizer().in_macro_text = false;
 
 #ifdef DEBUG
     std::cout << "DEFINE: >" << identifier << "< = >";

--- a/src/verilog/verilog_preprocessor_tokenizer.h
+++ b/src/verilog/verilog_preprocessor_tokenizer.h
@@ -64,6 +64,11 @@ public:
   void skip_ws();
   void skip_until_eol();
 
+  // 1800-2017 22.5.1: While reading `define macro text, a one-line
+  // comment ending in a backslash continues the macro text on the
+  // next line.
+  bool in_macro_text = false;
+
   // get the next token from the stream
   const tokent &next_token();
 

--- a/src/verilog/verilog_preprocessor_tokenizer.l
+++ b/src/verilog/verilog_preprocessor_tokenizer.l
@@ -37,6 +37,22 @@ String		\"(\\.|[^"\\])*\"
 <INITIAL>{Identifier}	{ TOKENIZER.text(yytext, yyleng); return tokent::IDENTIFIER; }
 <INITIAL>.|\n		{ TOKENIZER.text(yytext[0]); return yytext[0]; /* anything else */ }
 <SLCOMMENT>\n		{ BEGIN INITIAL; TOKENIZER.text('\n'); return '\n'; }
+<SLCOMMENT>\\\n		{
+			  /* 1800-2017 22.5.1: a one-line comment ending in a
+			     backslash continues a `define on the next line */
+			  if(TOKENIZER.in_macro_text)
+			  {
+			    yyless(1); /* return the \n to the input */
+			    TOKENIZER.text('\\');
+			    return '\\';
+			  }
+			  else
+			  {
+			    BEGIN INITIAL;
+			    TOKENIZER.text('\n');
+			    return '\n';
+			  }
+			}
 <SLCOMMENT>.		{ /* just eat up */ }
 <SLCOMMENT><<EOF>>      { /* we allow that */ BEGIN INITIAL; }
 <MLCOMMENT>\n		{ TOKENIZER.text('\n'); return '\n'; }


### PR DESCRIPTION
1800-2017 22.5.1: "A one-line comment (that is, a comment specified with the characters //) shall not be included in the substituted text. If a one-line comment ends in a backslash, the macro definition continues on the next line."

The tokenizer still excludes the comment from the macro text, but now returns the trailing backslash as a token while macro text is read, so that the `define continues on the next line.

This is on top of #1958 and #1957, and turns the KNOWNBUG test from #1957 into CORE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)