### PR TITLE
EBMC: improve error message when no input file is given

### DIFF
--- a/regression/ebmc/CLI/no-input-file.desc
+++ b/regression/ebmc/CLI/no-input-file.desc
@@ -1,0 +1,7 @@
+CORE
+
+
+^error: no input file given$
+^EXIT=6$
+^SIGNAL=0$
+--

--- a/src/ebmc/build_transition_system.cpp
+++ b/src/ebmc/build_transition_system.cpp
@@ -44,6 +44,11 @@ static std::set<std::string> file_extensions(const cmdlinet::argst &args)
 
 std::optional<transition_systemt> ebmc_languagest::transition_system()
 {
+  if(cmdline.args.empty())
+  {
+    throw ebmc_errort{} << "no input file given";
+  }
+
   auto extensions = file_extensions(cmdline.args);
   auto ext_used = [&extensions](const char *ext)
   { return extensions.find(ext) != extensions.end(); };


### PR DESCRIPTION
Previously, running `ebmc` with no input files produced the confusing error message:

```
error: no support for given input file extensions
```

This is misleading because there are no files at all. This PR adds an early check for empty command-line arguments and reports a clear message instead:

```
error: no input file given
```

**Changes:**
- `src/ebmc/build_transition_system.cpp`: added empty-args check before extension-based dispatch
- `regression/ebmc/CLI/no-input-file.desc`: regression test for the new message