### PR TITLE
Verilog: require_vector now handles integer types

### DIFF
--- a/regression/verilog/parameters/parameter_equality1.desc
+++ b/regression/verilog/parameters/parameter_equality1.desc
@@ -1,0 +1,9 @@
+CORE
+parameter_equality1.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Parameter using $clog2 result in shift and equality expressions.

--- a/regression/verilog/parameters/parameter_equality1.sv
+++ b/regression/verilog/parameters/parameter_equality1.sv
@@ -1,0 +1,11 @@
+module main #(parameter N = 8) ();
+
+  localparam N_LG2 = $clog2(N);
+  localparam N_IS_POWER_OF_2 = (1 << N_LG2) == N;
+  localparam N_W = N_IS_POWER_OF_2 ? N_LG2 + 1 : N_LG2;
+
+  initial assert(N_LG2 == 3);
+  initial assert(N_IS_POWER_OF_2 == 1);
+  initial assert(N_W == 4);
+
+endmodule

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -679,6 +679,17 @@ void verilog_typecheck_exprt::require_vector(exprt &expr)
     // A scalar, which is a special case of a vector. Cast to unsignedbv{1}.
     expr = typecast_exprt{std::move(expr), unsignedbv_typet{1}};
   }
+  else if(expr.type().id() == ID_verilog_integer)
+  {
+    // integer is a 32-bit signed integral type (1800-2017 Sec. 6.11).
+    // Cast to signedbv{32}.
+    expr = typecast_exprt{std::move(expr), signedbv_typet{32}};
+  }
+  else if(expr.type().id() == ID_integer)
+  {
+    // Mathematical integer, e.g., from $clog2. Cast to signedbv{32}.
+    expr = typecast_exprt{std::move(expr), signedbv_typet{32}};
+  }
   else if(
     expr.type().id() == ID_verilog_unsignedbv ||
     expr.type().id() == ID_verilog_signedbv ||


### PR DESCRIPTION
The `require_vector` function rejected expressions with `integer` type (`ID_integer` from system functions like `$clog2`, and `ID_verilog_integer`). This caused failures when using `$clog2` results in shift or equality expressions within parameter/localparam declarations.

## Example that failed

```systemverilog
module main #(parameter N = 8) ();
  localparam N_LG2 = $clog2(N);
  localparam N_IS_POWER_OF_2 = (1 << N_LG2) == N;
endmodule
```

Error: `expected a vector type, but got integer`

## Fix

Cast `ID_verilog_integer` and `ID_integer` to `signedbv{32}` in `require_vector()`, consistent with how `verilog_lowering` handles these types.

## Testing

- Added regression test `regression/verilog/parameters/parameter_equality1.sv`
- Full `regression/verilog` test suite passes with no regressions