### PR TITLE
Verilog: support package-scoped sequence and property references

### DIFF
--- a/regression/verilog/packages/package_property1.desc
+++ b/regression/verilog/packages/package_property1.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE
 package_property1.sv
 
 ^EXIT=0$
 ^SIGNAL=0$
 --
 --
-fails to typecheck

--- a/regression/verilog/packages/package_property1.desc
+++ b/regression/verilog/packages/package_property1.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+package_property1.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+fails to typecheck

--- a/regression/verilog/packages/package_property1.sv
+++ b/regression/verilog/packages/package_property1.sv
@@ -1,0 +1,10 @@
+package my_pkg;
+  property is_true;
+    1
+  endproperty
+endpackage
+
+module main;
+  // holds
+  assert property (my_pkg::is_true);
+endmodule

--- a/regression/verilog/packages/package_sequence1.desc
+++ b/regression/verilog/packages/package_sequence1.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+package_sequence1.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+fails to typecheck

--- a/regression/verilog/packages/package_sequence1.desc
+++ b/regression/verilog/packages/package_sequence1.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE
 package_sequence1.sv
 
 ^EXIT=0$
 ^SIGNAL=0$
 --
 --
-fails to typecheck

--- a/regression/verilog/packages/package_sequence1.sv
+++ b/regression/verilog/packages/package_sequence1.sv
@@ -1,0 +1,10 @@
+package my_pkg;
+  sequence is_true;
+    1
+  endsequence
+endpackage
+
+module main;
+  // will be covered
+  cover sequence (my_pkg::is_true);
+endmodule

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1740,15 +1740,8 @@ exprt verilog_typecheck_exprt::convert_verilog_identifier(
       symbol->type.id() == ID_verilog_sva_named_sequence ||
       symbol->type.id() == ID_verilog_sva_named_property)
     {
-      // A named sequence or property. Create an instance expression,
-      // and then flatten it.
-      auto symbol_expr = symbol->symbol_expr().with_source_location(expr);
-      auto &declaration =
-        to_verilog_sequence_property_declaration_base(symbol->value);
-      auto instance =
-        sva_sequence_property_instance_exprt{symbol_expr, {}, declaration}
-          .with_source_location(expr);
-      return flatten_named_sequence_property(instance);
+      return instantiate_named_sequence_property(
+        *symbol, expr.source_location());
     }
     else
     {
@@ -3376,8 +3369,17 @@ exprt verilog_typecheck_exprt::convert_binary_expr(binary_exprt expr)
     }
 
     // found!
-    return symbol_exprt{full_identifier, symbol->type}.with_source_location(
-      location);
+    if(
+      symbol->type.id() == ID_verilog_sva_named_sequence ||
+      symbol->type.id() == ID_verilog_sva_named_property)
+    {
+      return instantiate_named_sequence_property(*symbol, location);
+    }
+    else
+    {
+      return symbol_exprt{full_identifier, symbol->type}.with_source_location(
+        location);
+    }
   }
   else if(expr.id()==ID_replication)
     return convert_replication_expr(to_replication_expr(expr));

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -230,6 +230,8 @@ protected:
   [[nodiscard]] exprt convert_other_sva(exprt);
   [[nodiscard]] exprt
     flatten_named_sequence_property(sva_sequence_property_instance_exprt);
+  [[nodiscard]] exprt
+  instantiate_named_sequence_property(const symbolt &, source_locationt);
 
   // system functions
   exprt bits(const exprt &);

--- a/src/verilog/verilog_typecheck_sva.cpp
+++ b/src/verilog/verilog_typecheck_sva.cpp
@@ -8,6 +8,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/arith_tools.h>
 #include <util/mathematical_types.h>
+#include <util/symbol.h>
 
 #include <temporal-logic/temporal_logic.h>
 
@@ -515,4 +516,17 @@ exprt verilog_typecheck_exprt::flatten_named_sequence_property(
     PRECONDITION(false);
 
   return instance;
+}
+
+exprt verilog_typecheck_exprt::instantiate_named_sequence_property(
+  const symbolt &symbol,
+  source_locationt location)
+{
+  auto symbol_expr = symbol.symbol_expr().with_source_location(location);
+  auto &declaration =
+    to_verilog_sequence_property_declaration_base(symbol.value);
+  auto instance =
+    sva_sequence_property_instance_exprt{symbol_expr, {}, declaration};
+  instance.add_source_location() = std::move(location);
+  return flatten_named_sequence_property(std::move(instance));
 }


### PR DESCRIPTION
## Summary
- Fix typechecking of package-scoped named sequences and properties (e.g., `my_pkg::is_true` used in `assert property` or `cover sequence`)
- The `ID_verilog_package_scope` handler in `convert_binary_expr` now creates an `sva_sequence_property_instance_exprt` and flattens it, matching what `convert_verilog_identifier` does for non-package-scoped references
- Extract shared helper `instantiate_named_sequence_property` to eliminate duplication between both call sites

Fixes the bugs exposed by #1954.

## Test plan
- [x] New regression tests `package_property1` and `package_sequence1` pass (were KNOWNBUG in #1954)
- [x] Full `regression/verilog` suite passes
- [x] Full `regression/ebmc` suite passes