### PR TITLE
BTOR2: fix to_signed() for 1-bit bitvectors

### DIFF
--- a/regression/ebmc/btor/bitvec1-sdivo1.desc
+++ b/regression/ebmc/btor/bitvec1-sdivo1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 bitvec1-sdivo1.btor2
 --bound 0
 ^\[bad5\] : PROVED up to bound 0$

--- a/regression/ebmc/btor/bitvec1-signed-comparison2.desc
+++ b/regression/ebmc/btor/bitvec1-signed-comparison2.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 bitvec1-signed-comparison2.btor2
 --bound 0
 ^\[bad6\] : PROVED up to bound 0$

--- a/regression/ebmc/btor/bitvec1-smulo1.desc
+++ b/regression/ebmc/btor/bitvec1-smulo1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 bitvec1-smulo1.btor2
 --bound 0
 ^\[bad5\] : PROVED up to bound 0$

--- a/regression/ebmc/btor/bitvec1-sra1.desc
+++ b/regression/ebmc/btor/bitvec1-sra1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 bitvec1-sra1.btor2
 --bound 0
 ^\[bad5\] : PROVED up to bound 0$

--- a/regression/ebmc/btor/bitvec1-ssubo1.desc
+++ b/regression/ebmc/btor/bitvec1-ssubo1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 bitvec1-ssubo1.btor2
 --bound 0
 ^\[bad6\] : PROVED up to bound 0$

--- a/src/btor/btor_ebmc_language.cpp
+++ b/src/btor/btor_ebmc_language.cpp
@@ -99,18 +99,10 @@ static std::size_t get_width(const exprt &e)
   return to_bitvector_type(e.type()).get_width();
 }
 
-/// Cast to signed, widening to at least 2 bits to satisfy CBMC's
-/// lt_or_le precondition (signed bitvectors need >= 2 bits).
+/// Cast to signed bitvector type.
 static exprt to_signed(const exprt &e)
 {
-  auto a = to_bv(e);
-  auto w = get_width(e);
-  if(w < 2)
-  {
-    a = typecast_exprt{a, unsignedbv_typet{2}};
-    w = 2;
-  }
-  return typecast_exprt{a, signedbv_typet{w}};
+  return typecast_exprt{to_bv(e), signedbv_typet{get_width(e)}};
 }
 
 /// Parse a binary constant string to a CBMC constant expression


### PR DESCRIPTION
The `to_signed()` helper zero-extended 1-bit values to 2 bits before interpreting as signed. In 1-bit signed representation, value 1 represents -1, but after zero-extension to 2-bit unsigned (01) and reinterpretation as 2-bit signed, it became +1.

Since `bv_utilst::lt_or_le` now handles 1-bit signed values natively, the widening is no longer needed. Simply cast to `signedbv_typet` of the original width.

This fixes `sra`, `slt`, `sgt`, `sgte`, `ssubo`, `smulo`, and `sdivo` on 1-bit signed bitvectors.

Supersedes branch `kroening/btor2-bitvec1-signed-knownbugs` — the KNOWNBUG tests are promoted to CORE.