### PR TITLE
Verilog: KNOWNBUG tests for procedural assignments to hierarchical and package identifiers

### DIFF
--- a/regression/verilog/hierarchical_identifiers/hierarchical_identifiers4.desc
+++ b/regression/verilog/hierarchical_identifiers/hierarchical_identifiers4.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+hierarchical_identifiers4.v
+--module main --bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Procedural assignment to a hierarchical identifier is not supported.

--- a/regression/verilog/hierarchical_identifiers/hierarchical_identifiers4.v
+++ b/regression/verilog/hierarchical_identifiers/hierarchical_identifiers4.v
@@ -1,0 +1,11 @@
+module sub;
+  reg [7:0] value;
+endmodule
+
+module main;
+  sub s();
+
+  initial s.value = 8'hAB;
+
+  p0: assert property (s.value == 8'hAB);
+endmodule

--- a/regression/verilog/packages/package_var3.desc
+++ b/regression/verilog/packages/package_var3.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+package_var3.sv
+--module main --bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Procedural assignment to an imported package variable is not supported.

--- a/regression/verilog/packages/package_var3.sv
+++ b/regression/verilog/packages/package_var3.sv
@@ -1,0 +1,11 @@
+package my_pkg;
+  int my_var;
+endpackage
+
+module main;
+  import my_pkg::my_var;
+
+  initial my_var = 42;
+
+  p0: assert property (my_var == 42);
+endmodule


### PR DESCRIPTION
## Summary
- Adds a KNOWNBUG test for procedural assignment to a hierarchical identifier (`sub_instance.reg = value`), which currently fails during type-checking with "failed to get identifier on LHS hierarchical_identifier".
- Adds a KNOWNBUG test for procedural assignment to an imported package variable, which currently parses but the assignment silently has no effect (assertion is REFUTED).
- Verified that procedural assignment to struct members works correctly (no test needed).

## Test plan
- [x] `make -C regression/verilog test` shows both new tests as `[SKIPPED]` (KNOWNBUG behavior)
- [x] Manually confirmed the failure modes by running ebmc on the test inputs