### PR TITLE
Verilog: support procedural assignment to hierarchical identifiers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# EBMC 6.1
+
+* Verilog: procedural assignments to hierarchical identifiers
+
 # EBMC 6.0
 
 * Verilog: unconnected module ports

--- a/regression/verilog/hierarchical_identifiers/hierarchical_identifiers4.desc
+++ b/regression/verilog/hierarchical_identifiers/hierarchical_identifiers4.desc
@@ -1,9 +1,9 @@
-KNOWNBUG
-hierarchical_identifiers4.v
+CORE
+hierarchical_identifiers4.sv
 --module main --bound 0
+^\[main\.p0\] always main\.s\.value == 171: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-Procedural assignment to a hierarchical identifier is not supported.

--- a/regression/verilog/hierarchical_identifiers/hierarchical_identifiers4.sv
+++ b/regression/verilog/hierarchical_identifiers/hierarchical_identifiers4.sv
@@ -1,0 +1,9 @@
+module sub;
+  reg [7:0] value;
+endmodule
+
+module main;
+  sub s();
+  initial s.value = 8'hAB;
+  p0: assert property (s.value == 8'hAB);
+endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -277,6 +277,13 @@ exprt verilog_synthesist::synth_lhs_expr(exprt expr)
     member_expr.struct_op() = synth_lhs_expr(member_expr.struct_op());
     return expr;
   }
+  else if(expr.id() == ID_hierarchical_identifier)
+  {
+    expand_hierarchical_identifier(
+      to_hierarchical_identifier_expr(expr), symbol_statet::CURRENT);
+    local_symbols.insert(to_symbol_expr(expr).identifier());
+    return expr;
+  }
   else if(expr.id() == ID_typecast)
   {
     auto &typecast_expr = to_typecast_expr(expr);

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -618,6 +618,54 @@ void verilog_typecheckt::check_lhs(
       break;
     }
   }
+  else if(lhs.id() == ID_hierarchical_identifier)
+  {
+    auto &hi = to_hierarchical_identifier_expr(lhs);
+    const symbolt &symbol = ns.lookup(hi.identifier());
+
+    if(symbol.type.get_bool(ID_C_const))
+    {
+      throw errort().with_location(lhs.source_location())
+        << "assignment to const";
+    }
+
+    switch(vassign)
+    {
+    case A_CONTINUOUS:
+      if(symbol.is_lvalue)
+      {
+      }
+      else if(symbol.is_input && !symbol.is_output)
+      {
+        throw errort().with_location(lhs.source_location())
+          << "continuous assignment to input";
+      }
+      break;
+
+    case A_BLOCKING:
+    case A_NON_BLOCKING:
+      if(!symbol.is_lvalue)
+      {
+        throw errort().with_location(lhs.source_location())
+          << "procedural assignment to a net\n"
+          << "Identifier " << symbol.display_name() << " is declared as "
+          << to_string(symbol.type) << " on line " << symbol.location.get_line()
+          << '.';
+      }
+      break;
+
+    case A_PROCEDURAL_CONTINUOUS:
+      if(!symbol.is_lvalue)
+      {
+        throw errort().with_location(lhs.source_location())
+          << "procedural continuous assignment to a net\n"
+          << "Identifier " << symbol.display_name() << " is declared as "
+          << to_string(symbol.type) << " on line " << symbol.location.get_line()
+          << '.';
+      }
+      break;
+    }
+  }
   else if(lhs.id() == ID_member)
   {
     check_lhs(to_member_expr(lhs).struct_op(), vassign);


### PR DESCRIPTION
## Summary
- Adds handling for `ID_hierarchical_identifier` in `check_lhs()` (type-checking) to validate assignments to module instance members
- Adds handling for `ID_hierarchical_identifier` in `synth_lhs_expr()` (synthesis) to convert hierarchical identifiers to symbol expressions on the LHS of assignments
- Converts the KNOWNBUG test from #1966 to a CORE test

Previously, `initial sub_instance.reg = value` failed with "failed to get identifier on LHS hierarchical_identifier" during type-checking.

## Test plan
- [x] New regression test `hierarchical_identifiers4` passes (PROVED)
- [x] All existing hierarchical_identifiers tests pass
- [x] Full verilog regression suite passes