### PR TITLE
Verilog: fix procedural assignment to imported package variables

### DIFF
--- a/regression/verilog/packages/package_var3.desc
+++ b/regression/verilog/packages/package_var3.desc
@@ -1,9 +1,8 @@
-KNOWNBUG
+CORE
 package_var3.sv
 --module main --bound 0
+^\[main\.p0\] always my_pkg::my_var == 42: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --
-^warning: ignoring
 --
-Procedural assignment to an imported package variable is not supported.

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -661,6 +661,10 @@ void verilog_synthesist::assignment_rec(
       << "assignment to non-variable";
   }
 
+  // Ensure the symbol is in local_symbols so that synth_assignments
+  // processes it. This is needed for imported package variables.
+  local_symbols.insert(symbol.name);
+
   if(construct==constructt::ALWAYS &&
      event_guard==event_guardt::NONE)
   {


### PR DESCRIPTION
## Summary
- Adds `local_symbols.insert(symbol.name)` in `assignment_rec()` so that any symbol written in an initial/always block is tracked by `synth_assignments`
- Converts the KNOWNBUG test from #1966 to a CORE test

Previously, `initial my_var = 42` on an imported package variable was silently dropped during synthesis because the variable was never added to `local_symbols` (only module-level declarations were). The initial value was stored in the `assignments` map but never emitted into the transition system.

## Test plan
- [x] New regression test `package_var3` passes (PROVED, was REFUTED before)
- [x] Full verilog and packages regression suite passes