### PR TITLE
IC3: accept AG and G properties

### DIFF
--- a/regression/ebmc/ic3/no_latches1.desc
+++ b/regression/ebmc/ic3/no_latches1.desc
@@ -1,0 +1,7 @@
+CORE
+no_latches1.smv
+--ic3
+^\[.*\] AG TRUE: FAILURE: no latches -- not supported by the IC3 engine$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/ebmc/ic3/no_latches1.smv
+++ b/regression/ebmc/ic3/no_latches1.smv
@@ -1,0 +1,4 @@
+MODULE main
+
+-- no latches in this design
+SPEC AG 1

--- a/regression/ebmc/ic3/not_supported2.desc
+++ b/regression/ebmc/ic3/not_supported2.desc
@@ -1,7 +1,7 @@
 CORE
 not_supported2.smv
 --ic3
-^\[.*\] AG TRUE: FAILURE: property not supported by IC3 engine$
+^\[.*\] AF x: FAILURE: property not supported by IC3 engine$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/ebmc/ic3/not_supported2.smv
+++ b/regression/ebmc/ic3/not_supported2.smv
@@ -1,4 +1,9 @@
 MODULE main
 
+VAR x : boolean;
+
+ASSIGN init(x) := FALSE;
+ASSIGN next(x) := TRUE;
+
 -- not yet supported by IC3
-SPEC AG 1
+SPEC AF x

--- a/regression/ebmc/ic3/smv_ag1.desc
+++ b/regression/ebmc/ic3/smv_ag1.desc
@@ -1,0 +1,7 @@
+CORE
+smv_ag1.smv
+--ic3
+^\[spec1\] AG !x: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/ic3/smv_ag1.smv
+++ b/regression/ebmc/ic3/smv_ag1.smv
@@ -1,0 +1,8 @@
+MODULE main
+
+VAR x : boolean;
+
+ASSIGN init(x) := FALSE;
+ASSIGN next(x) := x;
+
+SPEC AG !x

--- a/regression/ebmc/ic3/smv_g1.desc
+++ b/regression/ebmc/ic3/smv_g1.desc
@@ -1,0 +1,7 @@
+CORE
+smv_g1.smv
+--ic3
+^\[spec1\] G !x: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/ic3/smv_g1.smv
+++ b/regression/ebmc/ic3/smv_g1.smv
@@ -1,0 +1,8 @@
+MODULE main
+
+VAR x : boolean;
+
+ASSIGN init(x) := FALSE;
+ASSIGN next(x) := x;
+
+LTLSPEC G !x

--- a/src/ic3/m1ain.cc
+++ b/src/ic3/m1ain.cc
@@ -62,9 +62,10 @@ bool ic3_supports_property(const exprt &expr)
 {
   if(!is_temporal_operator(expr))
     return false;
-  else if(expr.id() == ID_sva_always)
+  else if(
+    expr.id() == ID_sva_always || expr.id() == ID_AG || expr.id() == ID_G)
   {
-    return !has_temporal_operator(to_sva_always_expr(expr).op());
+    return !has_temporal_operator(to_unary_expr(expr).op());
   }
   else
     return false;
@@ -134,6 +135,15 @@ property_checker_resultt ic3_enginet::operator()()
 
     if(number_of_properties == 0)
       return property_checker_resultt{properties};
+
+    // The engine below cannot handle designs without latches.
+    if(netlist.var_map.latches.empty())
+    {
+      for(auto &property : properties.properties)
+        if(property.is_unknown())
+          property.failure("no latches -- not supported by the IC3 engine");
+      return property_checker_resultt{properties};
+    }
 
     const0 = false;
     const1 = false;

--- a/src/ic3/r1ead_input.cc
+++ b/src/ic3/r1ead_input.cc
@@ -40,7 +40,9 @@ void ic3_enginet::find_prop_lit()
   bool found = find_prop(Prop);
 
   assert(found);
-  assert(Prop.normalized_expr.id() == ID_sva_always);
+  assert(
+    Prop.normalized_expr.id() == ID_sva_always ||
+    Prop.normalized_expr.id() == ID_AG || Prop.normalized_expr.id() == ID_G);
 
   exprt Oper = to_unary_expr(Prop.normalized_expr).op();
 


### PR DESCRIPTION
The IC3 engine now accepts CTL `AG` and LTL `G` properties with a non-temporal operand, in addition to `sva_always`; all three denote the same safety property over the netlist. This enables `--ic3` on SMV models, e.g. the HWMCC08 SMV translations.

Designs without latches, which the engine cannot handle, now yield a property FAILURE instead of `exit(100)` without a verdict.

The `not_supported2` test now uses an `AF` property, which remains unsupported; new tests cover `AG`, `G`, and the no-latches case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)