### PR TITLE
hw-cbmc: restore mixed Verilog/C flow

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -79,6 +79,8 @@ jobs:
         run: make -C regression/smv test-z3
       - name: Run the vlindex tests
         run: make -C regression/vlindex test
+      - name: Run the hw-cbmc tests
+        run: make -C regression/hw-cbmc test
       - name: Print ccache stats
         run: ccache -s
 
@@ -149,6 +151,8 @@ jobs:
         run: make -C regression/smv test-z3
       - name: Run the vlindex tests
         run: make -C regression/vlindex test
+      - name: Run the hw-cbmc tests
+        run: make -C regression/hw-cbmc test
       - name: Print ccache stats
         run: ccache -s
       - name: Upload the ebmc binary

--- a/regression/hw-cbmc/D-flip-flop/main.v
+++ b/regression/hw-cbmc/D-flip-flop/main.v
@@ -23,10 +23,6 @@ module top(Din, En, CLK, Dout);
 endmodule
 
 module ff(input Din, CLK, output Dout);
-  input CLK;
-  input Din;
-  output Dout;
-
   reg q;
   assign Dout = q;
 

--- a/regression/hw-cbmc/Functions1/test.desc
+++ b/regression/hw-cbmc/Functions1/test.desc
@@ -1,6 +1,9 @@
-CORE
+KNOWNBUG
 harness.c
 main.v --module vmain --bound 10
 ^EXIT=0$
 ^SIGNAL=0$
 --
+--
+Constant-function localparam evaluation is tracked separately as a Verilog
+frontend bug.

--- a/regression/hw-cbmc/Inputs2/test.desc
+++ b/regression/hw-cbmc/Inputs2/test.desc
@@ -1,11 +1,13 @@
 CORE
 main.c
 main.v --module top --bound 4
+^\[main\.assertion\.1\] line \d+ assertion top\.variable == \(unsigned long int\)0: SUCCESS$
+^\[main\.assertion\.2\] line \d+ assertion top\.variable == \(unsigned long int\)10: SUCCESS$
+^\[main\.assertion\.3\] line \d+ assertion top\.variable == \(unsigned long int\)20: SUCCESS$
+^\[main\.assertion\.4\] line \d+ assertion top\.variable == \(unsigned long int\)10: SUCCESS$
+^\[main\.assertion\.5\] line \d+ assertion top\.variable == \(unsigned long int\)100: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
 ^SIGNAL=0$
-^\[main.assertion.1\] assertion top.variable == (unsigned long int)0: SUCCESS$
-^\[main.assertion.2\] assertion top.variable == (unsigned long int)10: SUCCESS$
-^\[main.assertion.3\] assertion top.variable == (unsigned long int)20: SUCCESS$
-^\[main.assertion.4\] assertion top.variable == (unsigned long int)10: SUCCESS$
-^\[main.assertion.5\] assertion top.variable == (unsigned long int)100: FAILURE$
 --
 ^warning: ignoring

--- a/regression/hw-cbmc/gen-interface/main.v
+++ b/regression/hw-cbmc/gen-interface/main.v
@@ -1,0 +1,10 @@
+module top(input clk);
+
+  reg [63:0] counter;
+
+  initial counter=0;
+
+  always @(posedge clk)
+    counter=counter+1;
+
+endmodule

--- a/regression/hw-cbmc/gen-interface/test.desc
+++ b/regression/hw-cbmc/gen-interface/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.v
+--module top --gen-interface
+^struct module_top \{$
+^  _Bool clk;$
+^  _u64 counter;$
+^\};$
+^extern struct module_top top;$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/hw-cbmc/Makefile
+++ b/src/hw-cbmc/Makefile
@@ -34,6 +34,7 @@ OBJ+= $(CPROVER_DIR)/goto-checker/goto-checker$(LIBEXT) \
       $(CPROVER_DIR)/solvers/solvers$(LIBEXT) \
       $(CPROVER_DIR)/util/util$(LIBEXT) \
       $(CPROVER_DIR)/json/json$(LIBEXT) \
+      ../ebmc/ebmc_language$(OBJEXT) \
       ../ebmc/show_modules$(OBJEXT) \
       ../temporal-logic/temporal-logic$(LIBEXT) \
       ../trans-netlist/trans_trace$(OBJEXT) \

--- a/src/hw-cbmc/gen_interface.cpp
+++ b/src/hw-cbmc/gen_interface.cpp
@@ -41,7 +41,8 @@ protected:
   const symbolt &lookup(const irep_idt &identifier);
   std::string gen_declaration(const symbolt &symbol);
 
-  void gen_module(const symbolt &module, std::ostream& os);
+  irep_idt find_instance(const symbolt &module) const;
+  void gen_module(const symbolt &module, std::ostream &os);
 
   std::string type_to_string(const typet& type);
 };
@@ -191,7 +192,34 @@ std::string gen_interfacet::type_to_string(const typet& type)
 
 /*******************************************************************\
 
-Function: gen_interfacet::module_struct
+Function: gen_interfacet::find_instance
+
+  Inputs:
+
+ Outputs:
+
+ Purpose: Find the elaborated instance for a module type symbol.
+
+\*******************************************************************/
+
+irep_idt gen_interfacet::find_instance(const symbolt &module) const
+{
+  const std::string &name = id2string(module.name);
+  const std::string suffix = "$module";
+
+  if(
+    name.size() > suffix.size() &&
+    name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0)
+  {
+    return name.substr(0, name.size() - suffix.size());
+  }
+
+  return "Verilog::$root." + id2string(module.base_name);
+}
+
+/*******************************************************************\
+
+Function: gen_interfacet::gen_module
 
   Inputs:
 
@@ -218,45 +246,63 @@ void gen_interfacet::gen_module(
   std::set<irep_idt>::iterator
     in_progress_it=modules_in_progress.insert(module.name).first;
 
-  for(auto it=symbol_table.symbol_module_map.lower_bound(module.name);
-           it!=symbol_table.symbol_module_map.upper_bound(module.name);
-           it++)
+  irep_idt instance_name = find_instance(module);
+  std::string instance_prefix = id2string(instance_name) + ".";
+
+  // First pass: recurse into sub-module instances
+  for(const auto &entry : symbol_table.symbols)
   {
-    const symbolt &symbol=lookup(it->second);
+    const symbolt &symbol = entry.second;
+    const std::string &name = id2string(entry.first);
+
+    if(name.substr(0, instance_prefix.size()) != instance_prefix)
+      continue;
+
+    // Only direct children (no further dots)
+    if(name.find('.', instance_prefix.size()) != std::string::npos)
+      continue;
 
     if(symbol.type.id() == ID_verilog_module_instance)
     {
-      const symbolt &module_symbol=lookup(symbol.value.get(ID_module));
-      gen_module(module_symbol, os);
+      irep_idt sub_module_name = id2string(entry.first) + "$module";
+      if(symbol_table.has_symbol(sub_module_name))
+      {
+        const symbolt &module_symbol = lookup(sub_module_name);
+        gen_module(module_symbol, os);
+      }
     }
   }
 
   os << "// Module " << module.name << '\n'
       << "\n";
 
-  os << "struct module_" << module.base_name << " {\n";    
+  os << "struct module_" << module.base_name << " {\n";
 
-  for(auto it=symbol_table.symbol_module_map.lower_bound(module.name);
-           it!=symbol_table.symbol_module_map.upper_bound(module.name);
-           it++)
+  for(const auto &entry : symbol_table.symbols)
   {
-    const symbolt &symbol=lookup(it->second);
-    
-    if(symbol.is_auxiliary)
+    const symbolt &symbol = entry.second;
+    const std::string &name = id2string(entry.first);
+
+    if(name.substr(0, instance_prefix.size()) != instance_prefix)
       continue;
-    
-    if(symbol.name!=id2string(module.name)+"."+id2string(symbol.base_name))
+
+    // Only direct children
+    if(name.find('.', instance_prefix.size()) != std::string::npos)
+      continue;
+
+    if(symbol.is_auxiliary)
       continue;
 
     if(symbol.type.id() == ID_verilog_module_instance)
     {
-      const symbolt &module_symbol=lookup(symbol.value.get(ID_module));
-
-      os << "  struct module_"
-         << module_symbol.base_name
-         << " " << symbol.base_name;
-
-      os << ";\n";
+      irep_idt sub_module_name = id2string(entry.first) + "$module";
+      if(symbol_table.has_symbol(sub_module_name))
+      {
+        const symbolt &module_symbol = lookup(sub_module_name);
+        os << "  struct module_" << module_symbol.base_name << " "
+           << symbol.base_name;
+        os << ";\n";
+      }
     }
     else if(symbol.type.id()==ID_primitive_module_instance)
     {

--- a/src/hw-cbmc/hw_cbmc_parse_options.cpp
+++ b/src/hw-cbmc/hw_cbmc_parse_options.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************\
 
-Module: Main Module 
+Module: Main Module
 
 Author: Daniel Kroening, kroening@kroening.com
 
@@ -8,30 +8,387 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "hw_cbmc_parse_options.h"
 
+#include <util/cmdline.h>
 #include <util/config.h>
+#include <util/ebmc_util.h>
 #include <util/exit_codes.h>
+#include <util/find_symbols.h>
 #include <util/get_module.h>
+#include <util/invariant.h>
+#include <util/std_code.h>
+#include <util/std_expr.h>
 #include <util/string2int.h>
 #include <util/unicode.h>
 #include <util/version.h>
 
+#include <goto-programs/initialize_goto_model.h>
+#include <goto-programs/loop_ids.h>
+#include <goto-programs/read_goto_binary.h>
 #include <goto-programs/set_properties.h>
+#include <goto-programs/show_goto_functions.h>
 #include <goto-programs/show_properties.h>
+#include <goto-programs/show_symbol_table.h>
 
 #include <ansi-c/goto-conversion/goto_convert_functions.h>
 #include <ebmc/show_modules.h>
+#include <ebmc/transition_system.h>
 #include <goto-checker/all_properties_verifier_with_trace_storage.h>
 #include <goto-checker/goto_verifier.h>
 #include <goto-checker/multi_path_symex_checker.h>
-#include <goto-checker/solver_factory.h>
+#include <langapi/language_file.h>
 #include <langapi/mode.h>
+#include <linking/static_lifetime_init.h>
+#include <trans-word-level/instantiate_word_level.h>
 #include <trans-word-level/trans_trace_word_level.h>
 #include <trans-word-level/unwind.h>
+#include <verilog/verilog_ebmc_language.h>
 
 #include "gen_interface.h"
 #include "map_vars.h"
 
 #include <iostream>
+
+/*******************************************************************\
+
+Function: is_verilog_file
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static bool is_verilog_file(const std::string &file_name)
+{
+  const auto extension = std::filesystem::path(file_name).extension().string();
+  return extension == ".v" || extension == ".sv";
+}
+
+/*******************************************************************\
+
+Function: disable_default_hw_cbmc_checks
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static void
+disable_default_hw_cbmc_checks(const cmdlinet &cmdline, optionst &options)
+{
+  // This restores the defaults that hw-cbmc used to have,
+  // as opposed to the new defaults that came with cbmc 6.0.
+  // This will be removed eventually.
+
+  if(!cmdline.isset("bounds-check") && !cmdline.isset("no-bounds-check"))
+    options.set_option("bounds-check", false);
+
+  if(!cmdline.isset("pointer-check") && !cmdline.isset("no-pointer-check"))
+    options.set_option("pointer-check", false);
+
+  if(
+    !cmdline.isset("pointer-primitive-check") &&
+    !cmdline.isset("no-pointer-primitive-check"))
+  {
+    options.set_option("pointer-primitive-check", false);
+  }
+
+  if(
+    !cmdline.isset("div-by-zero-check") &&
+    !cmdline.isset("no-div-by-zero-check"))
+  {
+    options.set_option("div-by-zero-check", false);
+  }
+
+  if(
+    !cmdline.isset("signed-overflow-check") &&
+    !cmdline.isset("no-signed-overflow-check"))
+  {
+    options.set_option("signed-overflow-check", false);
+  }
+
+  if(
+    !cmdline.isset("undefined-shift-check") &&
+    !cmdline.isset("no-undefined-shift-check"))
+  {
+    options.set_option("undefined-shift-check", false);
+  }
+
+  if(
+    !cmdline.isset("unwinding-assertions") &&
+    !cmdline.isset("no-unwinding-assertions"))
+  {
+    options.set_option("unwinding-assertions", false);
+    options.set_option("paths-symex-explore-all", false);
+  }
+
+  config.ansi_c.malloc_may_fail = false;
+  config.ansi_c.malloc_failure_mode =
+    configt::ansi_ct::malloc_failure_modet::malloc_failure_mode_none;
+}
+
+/*******************************************************************\
+
+Function: merge_symbol_tables
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static void merge_symbol_tables(
+  symbol_table_baset &dest,
+  const symbol_tablet &src,
+  message_handlert &message_handler)
+{
+  messaget log(message_handler);
+
+  for(const auto &entry : src)
+  {
+    auto insert_result = dest.insert(entry.second);
+    if(!insert_result.second)
+    {
+      log.error() << "failed to merge symbol `" << entry.first << "'"
+                  << messaget::eom;
+      throw 0;
+    }
+  }
+}
+
+/*******************************************************************\
+
+Function: get_hw_cbmc_entry_function
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static symbolt &get_hw_cbmc_entry_function(
+  symbol_table_baset &symbol_table,
+  const optionst &options,
+  message_handlert &message_handler)
+{
+  irep_idt entry_function = ID_main;
+
+  if(options.is_set("function"))
+    entry_function = options.get_option("function");
+  else if(config.main.has_value())
+    entry_function = *config.main;
+
+  auto matches = symbol_table.match_name_or_base_name(entry_function);
+
+  for(auto it = matches.begin(); it != matches.end();)
+  {
+    if((*it)->second.type.id() != ID_code || (*it)->second.is_property)
+      it = matches.erase(it);
+    else
+      ++it;
+  }
+
+  messaget log(message_handler);
+
+  if(matches.empty())
+  {
+    log.error() << "entry function `" << entry_function << "' not found"
+                << messaget::eom;
+    throw 0;
+  }
+
+  if(matches.size() >= 2)
+  {
+    log.error() << "entry function `" << entry_function << "' is ambiguous"
+                << messaget::eom;
+    throw 0;
+  }
+
+  return symbol_table.get_writeable_ref(matches.front()->first);
+}
+
+/*******************************************************************\
+
+Function: build_hw_cbmc_assumptions
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static code_blockt build_hw_cbmc_assumptions(
+  const symbol_table_baset &symbol_table,
+  const irep_idt &unwind_module,
+  const unsigned unwind_no_timeframes,
+  const std::list<exprt> &constraints)
+{
+  code_blockt assumptions;
+
+  for(const auto &entry : symbol_table)
+  {
+    const auto &symbol = entry.second;
+
+    if(symbol.value.id() != ID_index)
+      continue;
+
+    const auto &index_expr = to_index_expr(symbol.value);
+    if(index_expr.array().id() != ID_symbol)
+      continue;
+
+    const auto &array_identifier =
+      to_symbol_expr(index_expr.array()).get_identifier();
+    if(array_identifier != id2string(symbol.name) + "_array")
+      continue;
+
+    mp_integer index_value;
+    if(
+      to_integer_non_constant(index_expr.index(), index_value) ||
+      index_value != 0)
+    {
+      continue;
+    }
+
+    assumptions.add(
+      code_assumet(equal_exprt(symbol.symbol_expr(), symbol.value)));
+  }
+
+  if(!unwind_module.empty() && unwind_no_timeframes != 0)
+  {
+    const namespacet ns(symbol_table);
+    const symbolt &symbol = ns.lookup(unwind_module);
+    const transt &trans = to_trans_expr(symbol.value);
+
+    if(!trans.invar().is_true())
+    {
+      for(std::size_t timeframe = 0; timeframe < unwind_no_timeframes;
+          ++timeframe)
+      {
+        assumptions.add(code_assumet(
+          instantiate(trans.invar(), timeframe, unwind_no_timeframes)));
+      }
+    }
+
+    if(!trans.init().is_true())
+    {
+      assumptions.add(
+        code_assumet(instantiate(trans.init(), 0, unwind_no_timeframes)));
+    }
+
+    if(!trans.trans().is_true())
+    {
+      for(std::size_t timeframe = 0; timeframe < unwind_no_timeframes;
+          ++timeframe)
+      {
+        assumptions.add(code_assumet(
+          instantiate(trans.trans(), timeframe, unwind_no_timeframes)));
+      }
+    }
+  }
+
+  for(const auto &constraint : constraints)
+    assumptions.add(code_assumet(constraint));
+
+  return assumptions;
+}
+
+/*******************************************************************\
+
+Function: add_timeframe_symbols
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static void add_timeframe_symbols(
+  symbol_table_baset &symbol_table,
+  const code_blockt &assumptions)
+{
+  find_symbols_sett identifiers;
+
+  for(const auto &statement : assumptions.statements())
+    find_symbols(statement, identifiers);
+
+  for(const auto &identifier : identifiers)
+  {
+    if(symbol_table.has_symbol(identifier))
+      continue;
+
+    const std::string identifier_string = id2string(identifier);
+    const auto separator_pos = identifier_string.rfind('@');
+    if(separator_pos == std::string::npos)
+      continue;
+
+    const irep_idt base_identifier = identifier_string.substr(0, separator_pos);
+    if(!symbol_table.has_symbol(base_identifier))
+      continue;
+
+    symbolt symbol = symbol_table.lookup_ref(base_identifier);
+    symbol.name = identifier;
+    symbol.base_name = identifier;
+    symbol.pretty_name = identifier;
+    symbol.is_static_lifetime = true;
+    symbol.is_lvalue = true;
+    symbol.value = nondet_symbol_exprt(identifier, symbol.type);
+
+    (void)symbol_table.insert(std::move(symbol));
+  }
+}
+
+/*******************************************************************\
+
+Function: instrument_entry_function_with_assumptions
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static void instrument_entry_function_with_assumptions(
+  symbol_table_baset &symbol_table,
+  const optionst &options,
+  message_handlert &message_handler,
+  const irep_idt &unwind_module,
+  const unsigned unwind_no_timeframes,
+  const std::list<exprt> &constraints)
+{
+  code_blockt assumptions = build_hw_cbmc_assumptions(
+    symbol_table, unwind_module, unwind_no_timeframes, constraints);
+
+  if(assumptions.operands().empty())
+    return;
+
+  add_timeframe_symbols(symbol_table, assumptions);
+
+  symbolt &entry_function =
+    get_hw_cbmc_entry_function(symbol_table, options, message_handler);
+
+  PRECONDITION(entry_function.value.id() == ID_code);
+
+  code_blockt instrumented_body;
+  for(const auto &statement : assumptions.statements())
+    instrumented_body.add(statement);
+  instrumented_body.add(to_code(entry_function.value));
+  entry_function.value = std::move(instrumented_body);
+}
 
 /*******************************************************************\
 
@@ -59,9 +416,13 @@ int hw_cbmc_parse_optionst::doit()
 
   optionst options;
   get_command_line_options(options);
+  disable_default_hw_cbmc_checks(cmdline, options);
 
   messaget::eval_verbosity(cmdline.get_value("verbosity"),
                            messaget::M_STATISTICS, ui_message_handler);
+
+  if(cmdline.isset("vcd"))
+    options.set_option("vcd", cmdline.get_value("vcd"));
 
   //
   // Print a banner
@@ -76,60 +437,144 @@ int hw_cbmc_parse_optionst::doit()
     return 0;
   }
 
-  if(cmdline.isset("vcd"))
-    options.set_option("vcd", cmdline.get_value("vcd"));
+  if(cmdline.args.empty())
+  {
+    log.error() << "Please provide a program to verify" << messaget::eom;
+    return CPROVER_EXIT_INCORRECT_TASK;
+  }
 
-  std::unique_ptr<goto_verifiert> verifier = nullptr;
-  verifier = std::make_unique<
-    all_properties_verifier_with_trace_storaget<multi_path_symex_checkert>>(
-    options, ui_message_handler, goto_model);
+  std::list<std::string> binaries, sources;
+  std::vector<std::string> verilog_sources;
 
-  // TODO : implement custom goto-checker/verifier that would support
-  // do-unwind-module and add-constraints (see below)
+  for(const auto &arg : cmdline.args)
+  {
+    if(is_goto_binary(arg, ui_message_handler))
+      binaries.push_back(arg);
+    else if(is_verilog_file(arg))
+      verilog_sources.push_back(arg);
+    else
+      sources.push_back(arg);
+  }
 
-  int get_goto_program_ret =
-      get_goto_program(goto_model, options, cmdline, ui_message_handler);
-  if (get_goto_program_ret != -1)
-    return get_goto_program_ret;
+  language_filest language_files;
+
+  initialize_from_source_files(
+    sources,
+    options,
+    language_files,
+    goto_model.symbol_table,
+    ui_message_handler);
+
+  if(read_objects_and_link(binaries, goto_model, ui_message_handler))
+    return CPROVER_EXIT_INTERNAL_ERROR;
+
+  set_up_custom_entry_point(
+    language_files,
+    goto_model.symbol_table,
+    [this](const irep_idt &identifier)
+    { return goto_model.unload(identifier); },
+    options,
+    true,
+    ui_message_handler);
+
+  if(language_files.final(goto_model.symbol_table))
+  {
+    log.error() << "FINAL STAGE CONVERSION ERROR" << messaget::eom;
+    return CPROVER_EXIT_INCORRECT_TASK;
+  }
+
+  if(!verilog_sources.empty())
+  {
+    cmdlinet verilog_cmdline = cmdline;
+    verilog_cmdline.args.assign(verilog_sources.begin(), verilog_sources.end());
+
+    verilog_ebmc_languaget verilog_language(
+      verilog_cmdline, ui_message_handler);
+    auto transition_system = verilog_language.transition_system();
+
+    if(!transition_system.has_value())
+      return CPROVER_EXIT_SUCCESS;
+
+    merge_symbol_tables(
+      goto_model.symbol_table,
+      transition_system->symbol_table,
+      ui_message_handler);
+  }
 
   std::list<exprt> constraints;
-  int get_modules_ret = get_modules(constraints);
-  if (get_modules_ret != -1)
-    return get_modules_ret;
 
-  goto_convert(goto_model.symbol_table, goto_model.goto_functions,
-               ui_message_handler);
-  if (cbmc_parse_optionst::process_goto_program(goto_model, options, log))
-    return CPROVER_EXIT_INTERNAL_ERROR;
+  int get_modules_ret = get_modules(constraints);
+  if(get_modules_ret != -1)
+    return get_modules_ret;
 
   unwind_no_timeframes = get_bound();
   unwind_module = get_top_module();
 
-  // TODO : reimplement `do_module_unwind` inside the new custom verifier
+  if(!constraints.empty() || !unwind_module.empty())
+  {
+    log.status() << "Encoding hardware constraints" << messaget::eom;
+    instrument_entry_function_with_assumptions(
+      goto_model.symbol_table,
+      options,
+      ui_message_handler,
+      unwind_module,
+      unwind_no_timeframes,
+      constraints);
+  }
 
-  // the 'extra constraints'
-  if (!constraints.empty()) {
-    log.status() << "converting constraints" << messaget::eom;
+  if(cmdline.isset("show-symbol-table"))
+  {
+    show_symbol_table(goto_model.symbol_table, ui_message_handler);
+    return CPROVER_EXIT_SUCCESS;
+  }
 
-    for (const auto &constraint : constraints) {
-      // TODO : include the extra constraints using the new custom verifier
-      // interface
-      (void)constraint;
-    }
+  goto_convert(
+    goto_model.symbol_table, goto_model.goto_functions, ui_message_handler);
+
+  recreate_initialize_function(goto_model, ui_message_handler);
+
+  update_max_malloc_size(goto_model, ui_message_handler);
+
+  if(cbmc_parse_optionst::process_goto_program(goto_model, options, log))
+    return CPROVER_EXIT_INTERNAL_ERROR;
+
+  if(cmdline.isset("validate-goto-model"))
+    goto_model.validate();
+
+  if(cmdline.isset("show-loops"))
+  {
+    show_loop_ids(ui_message_handler.get_ui(), goto_model);
+    return CPROVER_EXIT_SUCCESS;
+  }
+
+  if(
+    cmdline.isset("show-goto-functions") ||
+    cmdline.isset("list-goto-functions"))
+  {
+    show_goto_functions(
+      goto_model, ui_message_handler, cmdline.isset("list-goto-functions"));
+    return CPROVER_EXIT_SUCCESS;
   }
 
   label_properties(goto_model.goto_functions);
 
-  if (cmdline.isset("show-properties")) {
+  if(cmdline.isset("show-properties"))
+  {
     show_properties(goto_model, ui_message_handler);
     return 0;
   }
-  if (set_properties())
+
+  if(set_properties())
     return 7;
+
+  std::unique_ptr<goto_verifiert> verifier = std::make_unique<
+    all_properties_verifier_with_trace_storaget<multi_path_symex_checkert>>(
+    options, ui_message_handler, goto_model);
 
   // do actual BMC
   const resultt result = (*verifier)();
   verifier->report();
+
   return result_to_exit_code(result);
 }
 
@@ -225,7 +670,7 @@ int hw_cbmc_parse_optionst::get_modules(std::list<exprt> &bmc_constraints) {
 
         return 0; // done
       }
-      
+
       //
       // map HDL variables to C variables
       //
@@ -250,7 +695,7 @@ int hw_cbmc_parse_optionst::get_modules(std::list<exprt> &bmc_constraints) {
       .plain_text(std::cout);
     return 0; // done
   }
-    
+
   return -1; // continue
 }
 

--- a/src/hw-cbmc/map_vars.cpp
+++ b/src/hw-cbmc/map_vars.cpp
@@ -6,6 +6,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
+#include "map_vars.h"
+
 #include <util/c_types.h>
 #include <util/config.h>
 #include <util/ebmc_util.h>
@@ -15,8 +17,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <langapi/language_util.h>
 #include <trans-word-level/instantiate_word_level.h>
+#include <verilog/verilog_types.h>
 
-#include "map_vars.h"
 #include "next_timeframe.h"
 #include "set_inputs.h"
 
@@ -180,14 +182,39 @@ void map_varst::set_transition(exprt &expr, std::size_t transition)
       index_expr.array().id() == ID_symbol,
       "must have index into array symbol");
 
-    symbol_exprt &symbol=to_symbol_expr(index_expr.array());
-
-    // rename that symbol!
-    symbol.set_identifier(
-      id2string(symbol.get_identifier())+"#0");
-
-    index_expr.index()=from_integer(transition, index_expr.index().type());
+    index_expr.index() = from_integer(transition, index_expr.index().type());
   }
+}
+
+exprt normalise_verilog_array_expr(const exprt &expr)
+{
+  if(
+    expr.type().id() != ID_array ||
+    expr.type().get(ID_C_verilog_type) != ID_verilog_unpacked_array ||
+    expr.type().get_bool(ID_C_increasing))
+  {
+    return expr;
+  }
+
+  mp_integer size;
+  if(to_integer_non_constant(to_array_type(expr.type()).size(), size))
+    return expr;
+
+  const auto &array_type = to_array_type(expr.type());
+  const auto index_type = to_verilog_array_type(expr.type()).index_type();
+
+  exprt::operandst operands;
+  operands.reserve(numeric_cast_v<std::size_t>(size));
+
+  for(mp_integer i = 0; i < size; ++i)
+  {
+    exprt element = index_exprt(
+      expr, from_integer(size - i - 1, index_type), array_type.element_type());
+    operands.push_back(normalise_verilog_array_expr(element));
+  }
+
+  return array_exprt(std::move(operands), array_type)
+    .with_source_location(expr);
 }
 
 /*******************************************************************\
@@ -400,7 +427,8 @@ void map_varst::map_var(
   namespacet ns(symbol_table);
   ns.follow_macros(e2);
   instantiate_symbol(e2, transition);
-  
+  e2 = normalise_verilog_array_expr(e2);
+
   add_constraint_rec(e1, e2);
 }
 
@@ -420,7 +448,10 @@ const symbolt &map_varst::add_array(symbolt &symbol)
 {
   const namespacet ns(symbol_table);
 
-  const typet &full_type = symbol.type;
+  const typet &full_type = symbol.type.id() == ID_struct_tag
+                             ? static_cast<const typet &>(
+                                 ns.follow_tag(to_struct_tag_type(symbol.type)))
+                             : symbol.type;
 
   if(full_type.id()==ID_incomplete_array)
   {
@@ -508,7 +539,10 @@ void map_varst::map_var_rec(
   const irep_idt &prefix)
 {
   const namespacet ns(symbol_table);
-  const typet &expr_type = expr.type();
+  const typet &expr_type = expr.type().id() == ID_struct_tag
+                             ? static_cast<const typet &>(
+                                 ns.follow_tag(to_struct_tag_type(expr.type())))
+                             : expr.type();
   const struct_typet &struct_type=to_struct_type(expr_type);
   const struct_typet::componentst &components=struct_type.components();
 
@@ -529,7 +563,8 @@ void map_varst::map_var_rec(
     else
       base_name=name;
 
-    bool module_instance = c_it->type().id() == ID_struct;
+    bool module_instance =
+      c_it->type().id() == ID_struct || c_it->type().id() == ID_struct_tag;
 
     irep_idt full_name=id2string(prefix)+"."+id2string(base_name);
 
@@ -660,6 +695,7 @@ void map_varst::map_vars(const irep_idt &top_module)
 
     timeframe_symbol.base_name="timeframe";
     timeframe_symbol.name="hw-cbmc::timeframe";
+    timeframe_symbol.mode = ID_C;
     timeframe_symbol.type = c_index_type();
     timeframe_symbol.is_static_lifetime=true;
     timeframe_symbol.is_lvalue=true;
@@ -669,7 +705,18 @@ void map_varst::map_vars(const irep_idt &top_module)
   }
 
   const symbolt &top_module_symbol=lookup(top_module);
-  
+  irep_idt mapping_module = top_module_symbol.name;
+
+  for(const auto &symbol :
+      symbol_table.match_name_or_base_name(top_module_symbol.base_name))
+  {
+    if(symbol->second.type.id() == ID_verilog_module_instance)
+    {
+      mapping_module = symbol->first;
+      break;
+    }
+  }
+
   irep_idt struct_symbol;
 
   for (auto &entry : symbol_table) {
@@ -705,6 +752,9 @@ void map_varst::map_vars(const irep_idt &top_module)
       throw 0;
     }
 
+    if(s.type.id() == ID_struct_tag)
+      s.type = ns.follow_tag(to_struct_tag_type(s.type));
+
     const symbolt &array_symbol=add_array(s);
 
     symbol_exprt symbol_expr(array_symbol.type);
@@ -719,7 +769,7 @@ void map_varst::map_vars(const irep_idt &top_module)
 
     top_level_inputs.clear();
 
-    map_var_rec(top_module_symbol.name, expr, id2string(top_module_symbol.name));
+    map_var_rec(mapping_module, expr, id2string(mapping_module));
   }
 
   for (const auto &entry : symbol_table) {
@@ -727,7 +777,7 @@ void map_varst::map_vars(const irep_idt &top_module)
       const irep_idt &base_name = entry.second.base_name;
       symbolt &symbol = symbol_table.get_writeable_ref(entry.first);
       if (symbol.type.id() == ID_struct_tag)
-        symbol.type = symbol.type;
+        symbol.type = ns.follow_tag(to_struct_tag_type(symbol.type));
       if (base_name == "next_timeframe" && symbol.type.id() == ID_code) {
         namespacet ns(symbol_table);
         add_next_timeframe(symbol, struct_symbol, top_level_inputs, ns);

--- a/src/hw-cbmc/next_timeframe.cpp
+++ b/src/hw-cbmc/next_timeframe.cpp
@@ -50,7 +50,12 @@ void add_next_timeframe(
   code_blockt block;
   block.add(assignment_increase);
 
-  const struct_typet &struct_type = to_struct_type(struct_symbol.type);
+  const typet &struct_symbol_type =
+    struct_symbol.type.id() == ID_struct_tag
+      ? static_cast<const typet &>(
+          ns.follow_tag(to_struct_tag_type(struct_symbol.type)))
+      : struct_symbol.type;
+  const struct_typet &struct_type = to_struct_type(struct_symbol_type);
 
   // now assign the non-inputs in the module symbol
   const index_exprt index_expr(array_symbol.symbol_expr(),

--- a/src/hw-cbmc/set_inputs.cpp
+++ b/src/hw-cbmc/set_inputs.cpp
@@ -39,7 +39,12 @@ void add_set_inputs(
   const symbolt &array_symbol=ns.lookup(id2string(struct_identifier)+"_array");
   const symbolt &timeframe_symbol=ns.lookup("hw-cbmc::timeframe");
 
-  const struct_typet &struct_type = to_struct_type(struct_symbol.type);
+  const typet &struct_symbol_type =
+    struct_symbol.type.id() == ID_struct_tag
+      ? static_cast<const typet &>(
+          ns.follow_tag(to_struct_tag_type(struct_symbol.type)))
+      : struct_symbol.type;
+  const struct_typet &struct_type = to_struct_type(struct_symbol_type);
 
   // We now assume current input values to be equal,
   // with the goal of adding assumptions on inputs.


### PR DESCRIPTION
Load C sources with CBMC's generic frontend, load Verilog with `verilog_ebmc_languaget`, and restore the hw-cbmc-specific mapping and constraint instrumentation needed by the regression suite.

Issue #1955.
