### PR TITLE
Verilog: KNOWNBUG test for constant-function localparam evaluation

### DIFF
--- a/regression/verilog/functioncall/constant_function_state1.desc
+++ b/regression/verilog/functioncall/constant_function_state1.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+constant_function_state1.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Constant localparam evaluation should accept this function call.

--- a/regression/verilog/functioncall/constant_function_state1.sv
+++ b/regression/verilog/functioncall/constant_function_state1.sv
@@ -1,0 +1,14 @@
+module main;
+
+  function [31:0] logval;
+    input [63:0] value;
+    begin
+      // the initial return value is a constant
+      logval = logval + 32'h1;
+    end
+  endfunction
+
+  // logval is an elaboration-time constant
+  localparam VAL = logval(16);
+
+endmodule


### PR DESCRIPTION
Add a minimal regression/verilog KNOWNBUG repro for constant-function evaluation through a `localparam`.