### PR TITLE
Verilog: ANSI port list for interfaces

### DIFF
--- a/regression/verilog/interface/ansi_ports1.desc
+++ b/regression/verilog/interface/ansi_ports1.desc
@@ -1,0 +1,9 @@
+CORE
+ansi_ports1.sv
+
+^no properties$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Interface with ANSI port list (IEEE 1800-2017 25.3).

--- a/regression/verilog/interface/ansi_ports1.sv
+++ b/regression/verilog/interface/ansi_ports1.sv
@@ -1,0 +1,15 @@
+// Interface with ANSI port list (IEEE 1800-2017 25.3)
+interface bus_if(
+  input wire clk,
+  input wire rst
+);
+  logic [7:0] data;
+
+  always @(posedge clk)
+    if (rst) data <= 0;
+endinterface
+
+module main(input clk, input rst);
+  bus_if bif(clk, rst);
+  initial bif.data = 8'hAB;
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -738,19 +738,39 @@ interface_declaration:
                     stack_expr($2));              // module_items
                   stack_expr($$).id(ID_verilog_interface);
                 }
+        | interface_ansi_header
+          interface_item_brace
+          TOK_ENDINTERFACE
+                {
+                  pop_scope();
+                  init($$);
+                  stack_expr($$) = verilog_parse_treet::create_module(
+                    stack_expr($1).operands()[0], // attributes
+                    stack_expr($1).operands()[1], // module_keyword (interface)
+                    stack_expr($1).operands()[2], // name
+                    stack_expr($1).operands()[3], // parameter_port_list
+                    stack_expr($1).operands()[4], // ports
+                    stack_expr($2));              // module_items
+                  stack_expr($$).id(ID_verilog_interface);
+                }
+        ;
+
+interface_identifier_with_scope:
+          interface_identifier
+                {
+                  $$ = $1;
+                  // interfaces go into the top scope
+                  auto base_name = stack_expr($1).get(ID_base_name);
+                  auto &interface_scope = PARSER.scopes.top_scope.add_scope(base_name, ".", verilog_scopet::INTERFACE);
+                  PARSER.scopes.enter_scope(interface_scope);
+                }
         ;
 
 interface_nonansi_header:
           attribute_instance_brace
           TOK_INTERFACE
           lifetime_opt
-          interface_identifier
-                {
-                  // interfaces go into the top scope
-                  auto base_name = stack_expr($4).get(ID_base_name);
-                  auto &interface_scope = PARSER.scopes.top_scope.add_scope(base_name, ".", verilog_scopet::INTERFACE);
-                  PARSER.scopes.enter_scope(interface_scope);
-                }
+          interface_identifier_with_scope
           package_import_declaration_brace
           parameter_port_list_opt
           list_of_ports_opt
@@ -760,8 +780,27 @@ interface_nonansi_header:
                   stack_expr($$).operands()[0].swap(stack_expr($1));
                   stack_expr($$).operands()[1].swap(stack_expr($2));
                   stack_expr($$).operands()[2].swap(stack_expr($4));
-                  stack_expr($$).operands()[3].swap(stack_expr($7));
-                  stack_expr($$).operands()[4].swap(stack_expr($8));
+                  stack_expr($$).operands()[3].swap(stack_expr($6));
+                  stack_expr($$).operands()[4].swap(stack_expr($7));
+                }
+        ;
+
+interface_ansi_header:
+          attribute_instance_brace
+          TOK_INTERFACE
+          lifetime_opt
+          interface_identifier_with_scope
+          package_import_declaration_brace
+          parameter_port_list_opt
+          list_of_port_declarations
+          ';'
+                {
+                  init($$); stack_expr($$).operands().resize(5);
+                  stack_expr($$).operands()[0].swap(stack_expr($1));
+                  stack_expr($$).operands()[1].swap(stack_expr($2));
+                  stack_expr($$).operands()[2].swap(stack_expr($4));
+                  stack_expr($$).operands()[3].swap(stack_expr($6));
+                  stack_expr($$).operands()[4].swap(stack_expr($7));
                 }
         ;
 


### PR DESCRIPTION
## Summary
- Add `interface_ansi_header` grammar rule to allow ANSI-style port declarations in SystemVerilog interfaces (IEEE 1800-2017 section 25.3)
- Introduce `interface_identifier_with_scope` rule to avoid reduce/reduce conflicts caused by mid-rule actions
- Promote the `ansi_ports1` regression test from KNOWNBUG to CORE

## Test plan
- [x] `src/ebmc/ebmc regression/verilog/interface/ansi_ports1.sv --bound 1` outputs "no properties" with exit 10
- [x] All existing interface regression tests still pass
- [x] No bison reduce/reduce conflicts in the generated parser