### PR TITLE
Verilog: hierarchical function calls in interfaces

### DIFF
--- a/regression/verilog/interface/interface_function1.desc
+++ b/regression/verilog/interface/interface_function1.desc
@@ -1,0 +1,10 @@
+CORE
+interface_function1.sv
+--bound 1
+^\[main\.p1\] always main\.m\.double\(\) == 42: PROVED up to bound 1
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Calling a function defined in an interface via hierarchical identifier
+(IEEE 1800-2017 25.4).

--- a/regression/verilog/interface/interface_function1.sv
+++ b/regression/verilog/interface/interface_function1.sv
@@ -1,0 +1,14 @@
+// Function defined in interface, called via hierarchical name (IEEE 1800-2017 25.4)
+interface math_if;
+  logic [7:0] value;
+
+  function logic [7:0] double();
+    return value * 8'd2;
+  endfunction
+endinterface
+
+module main;
+  math_if m();
+  initial m.value = 8'd21;
+  p1: assert property (m.double() == 8'd42);
+endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -2496,9 +2496,18 @@ void verilog_synthesist::synth_assert_assume_cover(
     symbol.location.set_comment(to_string(cond_for_comment));
   }
 
-  construct=constructt::OTHER;
+  // Set up a combinational context to allow function call inlining
+  // in property expressions.
+  construct = constructt::ALWAYS_COMB;
+  event_guard = event_guardt::NONE;
+
+  value_mapt property_value_map;
+  DATA_INVARIANT(value_map == nullptr, "always/initial must not nest");
+  value_map = &property_value_map;
 
   auto cond = synth_expr(module_item.condition(), symbol_statet::SYMBOL);
+
+  value_map = nullptr;
 
   // defaults apply
   apply_defaults(cond);

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -850,23 +850,65 @@ void verilog_typecheckt::convert_function_call_or_task_enable(
   }
   else
   {
-    irep_idt base_name =
-      to_verilog_identifier_expr(statement.function()).base_name();
-
-    // look it up
-    irep_idt full_identifier =
-      id2string(module_instance) + "." + id2string(base_name);
-
     const symbolt *symbol;
-    if(ns.lookup(full_identifier, symbol))
+
+    if(statement.function().id() == ID_hierarchical_identifier)
     {
-      // not there? Try compilation-unit scope.
-      full_identifier = verilog_unit_scope_identifier(base_name);
+      // hierarchical task/function call, e.g., m.foo()
+      auto &hi = to_hierarchical_identifier_expr(statement.function());
+
+      convert_expr(hi.lhs());
+
+      irep_idt base_name = hi.rhs().base_name();
+
+      if(hi.lhs().type().id() != ID_verilog_module_instance)
+      {
+        throw errort().with_location(statement.function().source_location())
+          << "expected module instance on lhs of hierarchical function call";
+      }
+
+      const irep_idt &lhs_identifier = [](const exprt &lhs) -> const irep_idt &
+      {
+        if(lhs.id() == ID_symbol)
+          return to_symbol_expr(lhs).identifier();
+        else if(lhs.id() == ID_hierarchical_identifier)
+          return to_hierarchical_identifier_expr(lhs).identifier();
+        else
+        {
+          throw errort().with_location(lhs.source_location())
+            << "expected symbol or hierarchical identifier on lhs of `.'";
+        }
+      }(hi.lhs());
+
+      irep_idt full_identifier =
+        id2string(lhs_identifier) + "." + id2string(base_name);
 
       if(ns.lookup(full_identifier, symbol))
       {
         throw errort().with_location(statement.function().source_location())
-          << "unknown function or task `" << base_name << "'";
+          << "unknown function or task `" << base_name << "' in `"
+          << lhs_identifier << '\'';
+      }
+    }
+    else
+    {
+      irep_idt base_name =
+        to_verilog_identifier_expr(statement.function()).base_name();
+
+      // look it up
+      irep_idt full_identifier =
+        id2string(module_instance) + "." + id2string(base_name);
+
+      if(ns.lookup(full_identifier, symbol))
+      {
+        // not there? Try compilation-unit scope.
+        full_identifier = verilog_unit_scope_identifier(base_name);
+
+        if(ns.lookup(full_identifier, symbol))
+        {
+          throw errort().with_location(statement.function().source_location())
+            << "unknown function or task `" << base_name << "'";
+        }
       }
     }
 

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -933,6 +933,44 @@ exprt verilog_typecheck_exprt::convert_expr_function_call(
       }
     }
   }
+  else if(f_op.id() == ID_hierarchical_identifier)
+  {
+    // hierarchical function call, e.g., m.double()
+    auto &hi = to_hierarchical_identifier_expr(f_op);
+
+    convert_expr(hi.lhs());
+
+    base_name = hi.rhs().base_name();
+
+    if(hi.lhs().type().id() != ID_verilog_module_instance)
+    {
+      throw errort().with_location(f_op.source_location())
+        << "expected module instance on lhs of hierarchical function call";
+    }
+
+    const irep_idt &lhs_identifier = [](const exprt &lhs) -> const irep_idt &
+    {
+      if(lhs.id() == ID_symbol)
+        return to_symbol_expr(lhs).identifier();
+      else if(lhs.id() == ID_hierarchical_identifier)
+        return to_hierarchical_identifier_expr(lhs).identifier();
+      else
+      {
+        throw errort().with_location(lhs.source_location())
+          << "expected symbol or hierarchical identifier on lhs of `.'";
+      }
+    }(hi.lhs());
+
+    irep_idt full_identifier =
+      id2string(lhs_identifier) + "." + id2string(base_name);
+
+    if(ns.lookup(full_identifier, symbol))
+    {
+      throw errort().with_location(f_op.source_location())
+        << "unknown function `" << base_name << "' in `" << lhs_identifier
+        << '\'';
+    }
+  }
   else
   {
     throw errort().with_location(expr.source_location())


### PR DESCRIPTION
## Summary
- Support calling functions defined in interfaces via hierarchical identifiers (e.g., `m.double()` where `m` is an interface instance), per IEEE 1800-2017 section 25.4.
- Handle `hierarchical_identifier` as the function reference in both expression-level and statement-level function calls by resolving the module instance and looking up the function symbol within that instance's scope.
- Enable function call inlining in concurrent assertion property expressions (`assert property`) by setting up a combinational context in `synth_assert_assume_cover`.

## Test plan
- [x] New regression test `regression/verilog/interface/interface_function1` passes (changed from KNOWNBUG to CORE)
- [x] All existing `regression/verilog` tests pass
- [x] All existing `regression/ebmc` tests pass
- [x] Build succeeds with `-Werror`