### PR TITLE
Verilog: interface scope resolution operator

### DIFF
--- a/regression/verilog/interface/scope_resolution1.desc
+++ b/regression/verilog/interface/scope_resolution1.desc
@@ -1,0 +1,9 @@
+CORE
+scope_resolution1.sv
+--bound 1
+^\[main\.p1\] always main\.bus\.data == 171: PROVED up to bound 1
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Interface scope resolution operator (IEEE 1800-2017 25.3).

--- a/regression/verilog/interface/scope_resolution1.sv
+++ b/regression/verilog/interface/scope_resolution1.sv
@@ -1,0 +1,15 @@
+// Interface scope resolution operator (IEEE 1800-2017 25.3)
+interface bus_if;
+  typedef logic [7:0] byte_t;
+  byte_t data;
+endinterface
+
+module main;
+  bus_if bus();
+  bus_if::byte_t temp;
+  initial begin
+    temp = 8'hAB;
+    bus.data = temp;
+  end
+  p1: assert property (bus.data == 8'hAB);
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3665,6 +3665,8 @@ module_instantiation:
 // or a variable declaration. Both start with TOK_INTERFACE_IDENTIFIER followed
 // by an identifier, which is LALR(1)-ambiguous with data_type and module_identifier.
 // We handle both cases in a unified rule to avoid the conflict.
+// The scope resolution operator (interface_identifier::type) is also handled here
+// to avoid a shift/reduce conflict with the interface instantiation rule.
 interface_instantiation_or_variable_declaration:
           TOK_INTERFACE_IDENTIFIER '#' '(' list_of_parameter_assignments_opt ')' hierarchical_instance_brace ';'
                 { init($$, ID_inst);
@@ -3678,6 +3680,22 @@ interface_instantiation_or_variable_declaration:
                   stack_expr($$).set(ID_module, base_name);
                   stack_expr($$).add(ID_parameter_assignments).make_nil();
                   swapop($$, $2); }
+        | TOK_INTERFACE_IDENTIFIER "::"
+                { // enter the interface scope for type lookup
+                  init($$, ID_verilog_package_scope);
+                  auto base_name = stack_expr($1).get(ID_base_name);
+                  PARSER.scopes.enter_package_scope(base_name);
+                  mto($$, $1); }
+          type_identifier
+                { pop_scope(); }
+          packed_dimension_brace list_of_variable_decl_assignments ';'
+                { init($$, ID_decl);
+                  stack_expr($$).set(ID_class, ID_reg);
+                  // $3 is the package_scope node from the mid-rule action
+                  mto($3, $4);
+                  add_as_subtype(stack_type($6), stack_type($3));
+                  addswap($$, ID_type, $6);
+                  swapop($$, $7); }
         ;
 
 interface_instance_item_brace:

--- a/src/verilog/verilog_elaborate_type.cpp
+++ b/src/verilog/verilog_elaborate_type.cpp
@@ -206,15 +206,52 @@ typet verilog_typecheck_exprt::elaborate_package_scope_typedef(
   // look it up
   const symbolt *symbol_ptr;
 
-  if(ns.lookup(full_identifier, symbol_ptr))
-    throw errort().with_location(location)
-      << "symbol " << typedef_base_name << " not found in package";
+  if(!ns.lookup(full_identifier, symbol_ptr))
+  {
+    // must be type
+    if(!symbol_ptr->is_type)
+      throw errort().with_location(location) << "expected a type identifier";
 
-  // must be type
-  if(!symbol_ptr->is_type)
-    throw errort().with_location(location) << "expected a type identifier";
+    return symbol_ptr->type;
+  }
 
-  return symbol_ptr->type;
+  // Not found as a package symbol. Check if it's an interface.
+  auto source_identifier =
+    id2string(verilog_module_symbol(package_base_name)) + "$source";
+
+  const symbolt *source_symbol_ptr;
+  if(!ns.lookup(source_identifier, source_symbol_ptr))
+  {
+    auto &module_source = source_symbol_ptr->type.find(ID_module_source);
+
+    if(module_source.id() == ID_verilog_interface)
+    {
+      // Search through the interface's module items for the typedef
+      auto &interface_source = to_verilog_module_source(module_source);
+      for(auto &item : interface_source.module_items())
+      {
+        if(item.id() == ID_decl)
+        {
+          auto &decl = to_verilog_decl(item);
+          if(decl.get_class() == ID_typedef)
+          {
+            for(auto &declarator : decl.declarators())
+            {
+              if(declarator.base_name() == typedef_base_name)
+              {
+                // Found the typedef in the interface source.
+                // Elaborate its type.
+                return elaborate_type(declarator.merged_type(decl.type()));
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  throw errort().with_location(location)
+    << "symbol " << typedef_base_name << " not found in package";
 }
 
 /*******************************************************************\


### PR DESCRIPTION
## Summary
- Adds support for the interface scope resolution operator (`bus_if::byte_t`) per IEEE 1800-2017 section 25.3
- Parser handles `TOK_INTERFACE_IDENTIFIER "::"` in the `interface_instantiation_or_variable_declaration` rule to avoid shift/reduce conflicts with existing interface instantiation rules
- Type-checker (`elaborate_package_scope_typedef`) falls back to searching the interface source's module items when the package-style symbol lookup fails
- Promotes `regression/verilog/interface/scope_resolution1.desc` from KNOWNBUG to CORE

## Test plan
- [x] `regression/verilog/interface/scope_resolution1.desc` passes (PROVED up to bound 1)
- [x] All Verilog regression tests pass
- [x] All EBMC regression tests pass
- [x] No new parser conflicts introduced (zero shift/reduce or reduce/reduce)