### PR TITLE
Verilog: extern method prototypes in interfaces

### DIFF
--- a/regression/verilog/interface/extern_method1.desc
+++ b/regression/verilog/interface/extern_method1.desc
@@ -1,0 +1,9 @@
+CORE
+extern_method1.sv
+--bound 1
+^\[main\.p1\] always main\.cif\.enable == 1: PROVED up to bound 1
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Extern method prototype in interface (IEEE 1800-2017 25.4.4).

--- a/regression/verilog/interface/extern_method1.sv
+++ b/regression/verilog/interface/extern_method1.sv
@@ -1,0 +1,16 @@
+// Extern method prototype in interface (IEEE 1800-2017 25.4.4)
+interface control_if;
+  logic enable;
+
+  extern function void set_enable(input logic val);
+endinterface
+
+function void control_if::set_enable(input logic val);
+  enable = val;
+endfunction
+
+module main;
+  control_if cif();
+  initial cif.set_enable(1);
+  p1: assert property (cif.enable == 1);
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1260,7 +1260,13 @@ interface_or_generate_item:
 
 extern_tf_declaration:
           TOK_EXTERN method_prototype ';'
+                { $$ = $2;
+                  stack_expr($$).set(ID_extern, true);
+                }
         | TOK_EXTERN TOK_FORKJOIN task_prototype ';'
+                { $$ = $3;
+                  stack_expr($$).set(ID_extern, true);
+                }
         ;
 
 interface_item_brace:
@@ -2557,6 +2563,32 @@ function_body_declaration:
                   addswap($$, ID_body, $9);
                   pop_scope();
                 }
+          // Out-of-body method definition with interface scope (1800-2017 25.4.4)
+        | function_data_type_or_implicit
+          TOK_INTERFACE_IDENTIFIER "::" non_type_identifier
+                { // Enter the interface scope and then the function scope
+                  auto interface_name = stack_expr($2).get(ID_base_name);
+                  PARSER.scopes.enter_package_scope(interface_name);
+                  auto function_name = stack_expr($4).get(ID_base_name);
+                  push_scope(function_name, ".", verilog_scopet::FUNCTION); }
+          '(' tf_port_list_opt ')' ';'
+          block_item_declaration_brace
+          function_statement_or_null_brace
+          TOK_ENDFUNCTION
+                { init($$, ID_decl);
+                  stack_expr($$).set(ID_class, ID_function);
+                  addswap($$, ID_type, $1);
+                  add_as_subtype(stack_type($1), stack_type($1));
+                  // Store the interface scope on the declarator
+                  stack_expr($4).set(ID_verilog_scope_prefix,
+                    id2string(stack_expr($2).get(ID_base_name)) + ".");
+                  mto($$, $4); // declarator (method name)
+                  addswap($$, ID_ports, $7);
+                  addswap($$, ID_verilog_declarations, $10);
+                  addswap($$, ID_body, $11);
+                  pop_scope() // pop function scope
+                  pop_scope() // pop interface scope
+                }
         ;
 
 tf_item_declaration_brace:
@@ -2576,7 +2608,20 @@ tf_item_declaration:
                 { add_attributes($2, $1); $$ = $2; }
         ;
 
-function_prototype: TOK_FUNCTION data_type_or_void function_identifier
+function_prototype:
+          TOK_FUNCTION data_type_or_void function_identifier
+                { init($$, ID_decl);
+                  stack_expr($$).set(ID_class, ID_function);
+                  addswap($$, ID_type, $2);
+                  mto($$, $3); // declarator
+                }
+        | TOK_FUNCTION data_type_or_void function_identifier '(' tf_port_list_opt ')'
+                { init($$, ID_decl);
+                  stack_expr($$).set(ID_class, ID_function);
+                  addswap($$, ID_type, $2);
+                  mto($$, $3); // declarator
+                  addswap($$, ID_ports, $5);
+                }
         ;
 
 // System Verilog standard 1800-2017
@@ -2621,7 +2666,18 @@ task_statement_or_null_brace:
                 { $$ = $1; mto($$, $2); }
         ;
 
-task_prototype: TOK_TASK task_identifier
+task_prototype:
+          TOK_TASK task_identifier
+                { init($$, ID_decl);
+                  stack_expr($$).set(ID_class, ID_task);
+                  mto($$, $2); // declarator
+                }
+        | TOK_TASK task_identifier '(' tf_port_list_opt ')'
+                { init($$, ID_decl);
+                  stack_expr($$).set(ID_class, ID_task);
+                  mto($$, $2); // declarator
+                  addswap($$, ID_ports, $4);
+                }
         ;
 
 tf_port_list_paren_opt:

--- a/src/verilog/verilog_elaborate_compilation_unit.cpp
+++ b/src/verilog/verilog_elaborate_compilation_unit.cpp
@@ -62,26 +62,94 @@ void verilog_elaborate_compilation_unit(
     }
     else if(item.id() == ID_decl)
     {
-      // compilation-unit scoped nets, variables, typedefs, functions,
-      // tasks, parameters
-      try
+      auto &decl = to_verilog_decl(item);
+      auto decl_class = decl.get_class();
+
+      // Out-of-body method definition for an interface (1800-2017 25.4.4)
+      if(
+        (decl_class == ID_function || decl_class == ID_task) &&
+        !decl.declarators().empty() &&
+        decl.declarators()[0].get_string(ID_verilog_scope_prefix) != "")
       {
-        verilog_typecheckt verilog_typecheck(
-          parse_tree.standard,
-          warn_implicit_nets,
-          symbol_table,
-          message_handler);
-        verilog_typecheck.typecheck_decl(to_verilog_decl(item));
-      }
-      catch(const typecheckt::errort &error)
-      {
-        if(!error.what().empty())
+        // Merge the out-of-body definition into the interface source.
+        auto scope_prefix =
+          decl.declarators()[0].get_string(ID_verilog_scope_prefix);
+        // Remove trailing '.' to get interface name
+        auto interface_name = scope_prefix.substr(0, scope_prefix.size() - 1);
+        auto source_symbol_id = "Verilog::" + interface_name + "$source";
+
+        auto *source_symbol = symbol_table.get_writeable(source_symbol_id);
+
+        if(source_symbol == nullptr)
         {
-          throw ebmc_errort{}.with_location(error.source_location())
-            << error.what();
+          throw ebmc_errort{}.with_location(decl.source_location())
+            << "interface `" << interface_name
+            << "' not found for out-of-body method definition";
         }
-        else
-          throw ebmc_errort{};
+
+        // Find the extern prototype in the interface items and replace it
+        // with the full definition.
+        auto &interface_source = static_cast<verilog_module_sourcet &>(
+          source_symbol->type.add(ID_module_source));
+        auto base_name = decl.declarators()[0].get(ID_base_name);
+
+        bool found_extern = false;
+        for(auto &iface_item : interface_source.module_items())
+        {
+          if(
+            iface_item.id() == ID_decl &&
+            to_verilog_decl(iface_item).get_class() == decl_class &&
+            to_verilog_decl(iface_item).get_bool(ID_extern))
+          {
+            auto &extern_decl = to_verilog_decl(iface_item);
+            if(
+              !extern_decl.declarators().empty() &&
+              extern_decl.declarators()[0].get(ID_base_name) == base_name)
+            {
+              // Replace the extern prototype with the full definition.
+              // Keep ports from the out-of-body definition and add the body.
+              iface_item = static_cast<const verilog_module_itemt &>(
+                static_cast<const exprt &>(decl));
+              // Remove the scope prefix and extern flag from the merged decl
+              auto &merged = static_cast<verilog_declt &>(iface_item);
+              merged.declarators()[0].remove(ID_verilog_scope_prefix);
+              merged.remove(ID_extern);
+              found_extern = true;
+              break;
+            }
+          }
+        }
+
+        if(!found_extern)
+        {
+          throw ebmc_errort{}.with_location(decl.source_location())
+            << "no matching extern prototype for `" << base_name
+            << "' in interface `" << interface_name << "'";
+        }
+      }
+      else
+      {
+        // compilation-unit scoped nets, variables, typedefs, functions,
+        // tasks, parameters
+        try
+        {
+          verilog_typecheckt verilog_typecheck(
+            parse_tree.standard,
+            warn_implicit_nets,
+            symbol_table,
+            message_handler);
+          verilog_typecheck.typecheck_decl(to_verilog_decl(item));
+        }
+        catch(const typecheckt::errort &error)
+        {
+          if(!error.what().empty())
+          {
+            throw ebmc_errort{}.with_location(error.source_location())
+              << error.what();
+          }
+          else
+            throw ebmc_errort{};
+        }
       }
     }
     else if(

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -156,7 +156,7 @@ void verilog_typecheckt::typecheck_port_connections(
       const irep_idt &base_name =
         to_verilog_identifier_expr(named_port_connection.port()).base_name();
 
-      bool found=false;
+      bool found = false;
 
       irep_idt full_identifier =
         id2string(inst.identifier()) + '.' + id2string(base_name);
@@ -175,7 +175,7 @@ void verilog_typecheckt::typecheck_port_connections(
       {
         if(port.identifier() == full_identifier)
         {
-          found=true;
+          found = true;
           typecheck_port_connection(value, port);
           named_port_connection.port().type() = port.type();
           break;
@@ -240,8 +240,8 @@ void verilog_typecheckt::typecheck_builtin_port_connections(
 
   inst.remove(ID_range);
 
-  typet &type=inst.type();
-  if(width==1)
+  typet &type = inst.type();
+  if(width == 1)
     type.id(ID_bool);
   else
   {
@@ -287,16 +287,16 @@ void verilog_typecheckt::convert_function_or_task(
 {
   const auto identifier = hierarchical_identifier(decl.base_name());
 
-  auto result=symbol_table.get_writeable(identifier);
+  auto result = symbol_table.get_writeable(identifier);
 
-  if(result==nullptr)
+  if(result == nullptr)
   {
     throw errort().with_location(decl.source_location())
       << "expected to find " << decl.id() << " symbol `" << identifier
       << "' in symbol_table";
   }
 
-  symbolt &symbol=*result;
+  symbolt &symbol = *result;
 
   decl.set_identifier(symbol.name);
 
@@ -308,9 +308,9 @@ void verilog_typecheckt::convert_function_or_task(
   for(auto &statement : decl.body().statements())
     convert_statement(statement);
 
-  function_or_task_name="";
+  function_or_task_name = "";
 
-  symbol.value=decl.body();
+  symbol.value = decl.body();
 }
 
 /*******************************************************************\
@@ -328,18 +328,17 @@ Function: verilog_typecheckt::elaborate_constant_function_call
 exprt verilog_typecheckt::elaborate_constant_function_call(
   const function_call_exprt &function_call)
 {
-  const function_call_exprt::argumentst &arguments=
-    function_call.arguments();
+  const function_call_exprt::argumentst &arguments = function_call.arguments();
 
   // find the function
-  if(function_call.function().id()!=ID_symbol)
+  if(function_call.function().id() != ID_symbol)
   {
     throw errort().with_location(function_call.source_location())
       << "expected function symbol, but got `"
       << to_string(function_call.function()) << '\'';
   }
 
-  const symbolt &function_symbol=
+  const symbolt &function_symbol =
     ns.lookup(to_symbol_expr(function_call.function()));
 
   verilog_function_or_task_declt::bodyt function_body;
@@ -366,13 +365,11 @@ exprt verilog_typecheckt::elaborate_constant_function_call(
       function_symbol.value);
   }
 
-  const code_typet &code_type=
-    to_code_type(function_symbol.type);
+  const code_typet &code_type = to_code_type(function_symbol.type);
 
-  const code_typet::parameterst &parameters=
-    code_type.parameters();
+  const code_typet::parameterst &parameters = code_type.parameters();
 
-  if(parameters.size()!=arguments.size())
+  if(parameters.size() != arguments.size())
   {
     throw errort().with_location(function_call.source_location())
       << "function call has wrong number of arguments";
@@ -382,7 +379,7 @@ exprt verilog_typecheckt::elaborate_constant_function_call(
 
   varst old_vars;
 
-  for(std::size_t i=0; i<arguments.size(); i++)
+  for(std::size_t i = 0; i < arguments.size(); i++)
   {
     exprt value = elaborate_constant_expression(arguments[i]);
 
@@ -392,10 +389,10 @@ exprt verilog_typecheckt::elaborate_constant_function_call(
         << "constant function argument is not constant";
     }
 
-    irep_idt p_identifier=parameters[i].get_identifier();
+    irep_idt p_identifier = parameters[i].get_identifier();
 
-    old_vars[p_identifier]=var_value(p_identifier);
-    vars[p_identifier]=value;
+    old_vars[p_identifier] = var_value(p_identifier);
+    vars[p_identifier] = value;
 
 #if 0
     status() << "ASSIGN " << p_identifier << " <- " << to_string(value) << eom;
@@ -406,12 +403,12 @@ exprt verilog_typecheckt::elaborate_constant_function_call(
   for(auto &statement : function_body.statements())
     verilog_interpreter(statement);
 
-  function_or_task_name="";
+  function_or_task_name = "";
 
   // get return value
 
-  exprt return_value=var_value(
-    id2string(function_symbol.name)+"."+
+  exprt return_value = var_value(
+    id2string(function_symbol.name) + "." +
     id2string(function_symbol.base_name));
 
   return return_value;
@@ -483,10 +480,9 @@ Function: verilog_typecheckt::convert_initial
 
 \*******************************************************************/
 
-void verilog_typecheckt::convert_initial(
-  verilog_initialt &module_item)
+void verilog_typecheckt::convert_initial(verilog_initialt &module_item)
 {
-  if(module_item.operands().size()!=1)
+  if(module_item.operands().size() != 1)
   {
     throw errort().with_location(module_item.source_location())
       << "initial statement expected to have one operand";
@@ -529,17 +525,15 @@ Function: verilog_typecheckt::check_lhs
 
 \*******************************************************************/
 
-void verilog_typecheckt::check_lhs(
-  const exprt &lhs,
-  vassignt vassign)
+void verilog_typecheckt::check_lhs(const exprt &lhs, vassignt vassign)
 {
-  if(lhs.id()==ID_index)
+  if(lhs.id() == ID_index)
   {
     check_lhs(to_index_expr(lhs).array(), vassign);
   }
-  else if(lhs.id()==ID_extractbit)
+  else if(lhs.id() == ID_extractbit)
   {
-    if(lhs.operands().size()!=2)
+    if(lhs.operands().size() != 2)
     {
       throw errort() << "extractbit takes two operands";
     }
@@ -562,16 +556,16 @@ void verilog_typecheckt::check_lhs(
     auto &part_select = to_verilog_indexed_part_select_plus_or_minus_expr(lhs);
     check_lhs(part_select.src(), vassign);
   }
-  else if(lhs.id()==ID_concatenation)
+  else if(lhs.id() == ID_concatenation)
   {
     forall_operands(it, lhs)
       check_lhs(*it, vassign);
 
     return;
   }
-  else if(lhs.id()==ID_symbol)
+  else if(lhs.id() == ID_symbol)
   {
-    const symbolt &symbol=ns.lookup(to_symbol_expr(lhs));
+    const symbolt &symbol = ns.lookup(to_symbol_expr(lhs));
 
     // check for 'const'
     if(symbol.type.get_bool(ID_C_const))
@@ -746,13 +740,13 @@ void verilog_typecheckt::convert_continuous_assign(
 {
   Forall_operands(it, module_item)
   {
-    if(it->id()!=ID_equal || it->operands().size()!=2)
+    if(it->id() != ID_equal || it->operands().size() != 2)
     {
       throw errort().with_location(it->source_location())
         << "malformed continuous assignment";
     }
 
-    it->type()=bool_typet();
+    it->type() = bool_typet();
 
     exprt &lhs = to_binary_expr(*it).lhs();
     exprt &rhs = to_binary_expr(*it).rhs();
@@ -795,6 +789,87 @@ void verilog_typecheckt::convert_function_call_or_task_enable(
   {
     // we ignore all of these
   }
+  else if(statement.function().id() == ID_hierarchical_identifier)
+  {
+    // Hierarchical function/task call, e.g., interface_instance.method()
+    auto &hier_id = to_hierarchical_identifier_expr(statement.function());
+    convert_expr(hier_id.module_instance());
+
+    const irep_idt &method_name = hier_id.rhs().base_name();
+
+    const symbolt *symbol = nullptr;
+
+    if(hier_id.module_instance().type().id() == ID_verilog_module_instance)
+    {
+      // Get the module/interface identifier from the instance
+      irep_idt lhs_identifier;
+      if(hier_id.module_instance().id() == ID_symbol)
+        lhs_identifier =
+          to_symbol_expr(hier_id.module_instance()).get_identifier();
+      else
+        lhs_identifier =
+          to_hierarchical_identifier_expr(hier_id.module_instance())
+            .identifier();
+
+      // First try instance-local lookup
+      irep_idt full_identifier =
+        id2string(lhs_identifier) + "." + id2string(method_name);
+      ns.lookup(full_identifier, symbol);
+
+      if(symbol == nullptr)
+      {
+        // Try on the interface/module type itself
+        const symbolt *instance_symbol;
+        if(
+          !ns.lookup(lhs_identifier, instance_symbol) &&
+          instance_symbol->value.id() == ID_verilog_module_instance)
+        {
+          auto module_id = to_verilog_module_instance(instance_symbol->value)
+                             .module_identifier();
+          full_identifier = id2string(module_id) + "." + id2string(method_name);
+          ns.lookup(full_identifier, symbol);
+        }
+      }
+
+      if(symbol == nullptr)
+      {
+        throw errort().with_location(statement.function().source_location())
+          << "unknown function or task `" << method_name << "'";
+      }
+    }
+    else
+    {
+      throw errort().with_location(statement.function().source_location())
+        << "expected module/interface instance for hierarchical function call";
+    }
+
+    if(symbol->type.id() != ID_code)
+    {
+      throw errort().with_location(statement.source_location())
+        << "expected task or function name";
+    }
+
+    const code_typet &code_type = to_code_type(symbol->type);
+
+    // check arguments
+    const code_typet::parameterst &parameter_types = code_type.parameters();
+    exprt::operandst &arguments = statement.arguments();
+
+    if(parameter_types.size() != arguments.size())
+    {
+      throw errort().with_location(statement.source_location())
+        << "wrong number of arguments";
+    }
+
+    for(unsigned i = 0; i < arguments.size(); i++)
+    {
+      convert_expr(arguments[i]);
+      assignment_conversion(arguments[i], parameter_types[i].type());
+    }
+
+    statement.function() =
+      symbol->symbol_expr().with_source_location(statement.function());
+  }
   else
   {
     irep_idt base_name =
@@ -826,16 +901,16 @@ void verilog_typecheckt::convert_function_call_or_task_enable(
     const code_typet &code_type = to_code_type(symbol->type);
 
     // check arguments
-    const code_typet::parameterst &parameter_types=code_type.parameters();
-    exprt::operandst &arguments=statement.arguments();
+    const code_typet::parameterst &parameter_types = code_type.parameters();
+    exprt::operandst &arguments = statement.arguments();
 
-    if(parameter_types.size()!=arguments.size())
+    if(parameter_types.size() != arguments.size())
     {
       throw errort().with_location(statement.source_location())
         << "wrong number of arguments";
     }
 
-    for(unsigned i=0; i<arguments.size(); i++)
+    for(unsigned i = 0; i < arguments.size(); i++)
     {
       convert_expr(arguments[i]);
       assignment_conversion(arguments[i], parameter_types[i].type());
@@ -860,8 +935,8 @@ Function: verilog_typecheckt::convert_assign
 
 void verilog_typecheckt::convert_force(verilog_forcet &statement)
 {
-  exprt &lhs=statement.lhs();
-  exprt &rhs=statement.rhs();
+  exprt &lhs = statement.lhs();
+  exprt &rhs = statement.rhs();
 
   convert_expr(lhs);
   convert_expr(rhs);
@@ -886,7 +961,7 @@ void verilog_typecheckt::convert_assign(
   verilog_assignt &statement,
   bool blocking)
 {
-  if(statement.operands().size()!=2)
+  if(statement.operands().size() != 2)
   {
     throw errort().with_location(statement.source_location())
       << "assign statement expected to have two operands";
@@ -897,7 +972,7 @@ void verilog_typecheckt::convert_assign(
 
   convert_expr(lhs);
   convert_expr(rhs);
-  check_lhs(lhs, blocking?A_BLOCKING:A_NON_BLOCKING);
+  check_lhs(lhs, blocking ? A_BLOCKING : A_NON_BLOCKING);
   assignment_conversion(rhs, lhs.type());
 }
 
@@ -1167,16 +1242,15 @@ Function: verilog_typecheckt::convert_event_guard
 
 \*******************************************************************/
 
-void verilog_typecheckt::convert_event_guard(
-  verilog_event_guardt &statement)
+void verilog_typecheckt::convert_event_guard(verilog_event_guardt &statement)
 {
-  if(statement.operands().size()!=2)
+  if(statement.operands().size() != 2)
   {
     throw errort().with_location(statement.source_location())
       << "event_guard expected to have two operands";
   }
 
-  exprt &guard=statement.guard();
+  exprt &guard = statement.guard();
 
   convert_expr(guard);
   make_boolean(guard);
@@ -1198,7 +1272,7 @@ Function: verilog_typecheckt::convert_delay
 
 void verilog_typecheckt::convert_delay(verilog_delayt &statement)
 {
-  if(statement.operands().size()!=2)
+  if(statement.operands().size() != 2)
   {
     throw errort().with_location(statement.source_location())
       << "delay expected to have two operands";
@@ -1221,7 +1295,7 @@ Function: verilog_typecheckt::convert_for
 
 void verilog_typecheckt::convert_for(verilog_fort &statement)
 {
-  if(statement.operands().size()!=4)
+  if(statement.operands().size() != 4)
   {
     throw errort().with_location(statement.source_location())
       << "for expected to have four operands";
@@ -1233,7 +1307,7 @@ void verilog_typecheckt::convert_for(verilog_fort &statement)
   for(auto &init : statement.initialization())
     convert_statement(init);
 
-  exprt &condition=statement.condition();
+  exprt &condition = statement.condition();
   convert_expr(condition);
   make_boolean(condition);
 
@@ -1282,7 +1356,7 @@ Function: verilog_typecheckt::convert_prepostincdec
 
 void verilog_typecheckt::convert_prepostincdec(verilog_statementt &statement)
 {
-  if(statement.operands().size()!=1)
+  if(statement.operands().size() != 1)
   {
     throw errort().with_location(statement.source_location())
       << statement.id() << " expected to have one operand";
@@ -1303,16 +1377,15 @@ Function: verilog_typecheckt::convert_while
 
 \*******************************************************************/
 
-void verilog_typecheckt::convert_while(
-  verilog_whilet &statement)
+void verilog_typecheckt::convert_while(verilog_whilet &statement)
 {
-  if(statement.operands().size()!=2)
+  if(statement.operands().size() != 2)
   {
     throw errort().with_location(statement.source_location())
       << "while expected to have two operands";
   }
 
-  exprt &condition=statement.condition();
+  exprt &condition = statement.condition();
   convert_expr(condition);
   make_boolean(condition);
 
@@ -1331,16 +1404,15 @@ Function: verilog_typecheckt::convert_repeat
 
 \*******************************************************************/
 
-void verilog_typecheckt::convert_repeat(
-  verilog_repeatt &statement)
+void verilog_typecheckt::convert_repeat(verilog_repeatt &statement)
 {
-  if(statement.operands().size()!=2)
+  if(statement.operands().size() != 2)
   {
     throw errort().with_location(statement.source_location())
       << "repeat expected to have two operands";
   }
 
-  exprt &condition=statement.condition();
+  exprt &condition = statement.condition();
   convert_expr(condition);
   make_boolean(condition);
 
@@ -1359,10 +1431,9 @@ Function: verilog_typecheckt::convert_forever
 
 \*******************************************************************/
 
-void verilog_typecheckt::convert_forever(
-  verilog_forevert &statement)
+void verilog_typecheckt::convert_forever(verilog_forevert &statement)
 {
-  if(statement.operands().size()!=1)
+  if(statement.operands().size() != 1)
   {
     throw errort().with_location(statement.source_location())
       << "forever expected to have one operand";
@@ -1383,10 +1454,9 @@ Function: verilog_typecheckt::convert_statement
 
 \*******************************************************************/
 
-void verilog_typecheckt::convert_statement(
-  verilog_statementt &statement)
+void verilog_typecheckt::convert_statement(verilog_statementt &statement)
 {
-  if(statement.id()==ID_block)
+  if(statement.id() == ID_block)
     convert_block(to_verilog_block(statement));
   else if(
     statement.id() == ID_verilog_case || statement.id() == ID_verilog_casex ||
@@ -1438,32 +1508,31 @@ void verilog_typecheckt::convert_statement(
   }
   else if(statement.id() == ID_verilog_non_blocking_assign)
     convert_assign(to_verilog_assign(statement), false);
-  else if(statement.id()==ID_if)
+  else if(statement.id() == ID_if)
     convert_if(to_verilog_if(statement));
-  else if(statement.id()==ID_event_guard)
+  else if(statement.id() == ID_event_guard)
     convert_event_guard(to_verilog_event_guard(statement));
-  else if(statement.id()==ID_delay)
+  else if(statement.id() == ID_delay)
     convert_delay(to_verilog_delay(statement));
-  else if(statement.id()==ID_for)
+  else if(statement.id() == ID_for)
     convert_for(to_verilog_for(statement));
-  else if(statement.id()==ID_while)
+  else if(statement.id() == ID_while)
     convert_while(to_verilog_while(statement));
-  else if(statement.id()==ID_repeat)
+  else if(statement.id() == ID_repeat)
     convert_repeat(to_verilog_repeat(statement));
-  else if(statement.id()==ID_forever)
+  else if(statement.id() == ID_forever)
     convert_forever(to_verilog_forever(statement));
-  else if(statement.id()==ID_skip)
+  else if(statement.id() == ID_skip)
   {
     // do nothing
   }
-  else if(statement.id()==ID_preincrement ||
-          statement.id()==ID_predecrement ||
-          statement.id()==ID_postincrement ||
-          statement.id()==ID_postdecrement)
+  else if(
+    statement.id() == ID_preincrement || statement.id() == ID_predecrement ||
+    statement.id() == ID_postincrement || statement.id() == ID_postdecrement)
     convert_prepostincdec(statement);
-  else if(statement.id()==ID_function_call)
+  else if(statement.id() == ID_function_call)
     convert_function_call_or_task_enable(to_verilog_function_call(statement));
-  else if(statement.id()==ID_decl)
+  else if(statement.id() == ID_decl)
   {
     auto decl_class = to_verilog_decl(statement).get_class();
     if(decl_class == ID_function || decl_class == ID_task)
@@ -1472,7 +1541,7 @@ void verilog_typecheckt::convert_statement(
     else
       convert_decl(to_verilog_decl(statement));
   }
-  else if(statement.id()==ID_force)
+  else if(statement.id() == ID_force)
     convert_force(to_verilog_force(statement));
   else if(statement.id() == ID_verilog_label_statement)
   {
@@ -1528,13 +1597,12 @@ Function: verilog_typecheckt::convert_module_item
 
 \*******************************************************************/
 
-void verilog_typecheckt::convert_module_item(
-  verilog_module_itemt &module_item)
+void verilog_typecheckt::convert_module_item(verilog_module_itemt &module_item)
 {
-  if(module_item.id()==ID_specify)
+  if(module_item.id() == ID_specify)
   {
   }
-  else if(module_item.id()==ID_decl)
+  else if(module_item.id() == ID_decl)
   {
     auto decl_class = to_verilog_decl(module_item).get_class();
 
@@ -1548,8 +1616,9 @@ void verilog_typecheckt::convert_module_item(
   else if(module_item.id() == ID_verilog_generate_decl)
   {
   }
-  else if(module_item.id()==ID_parameter_decl ||
-          module_item.id()==ID_local_parameter_decl)
+  else if(
+    module_item.id() == ID_parameter_decl ||
+    module_item.id() == ID_local_parameter_decl)
   {
   }
   else if(module_item.id() == ID_parameter_override)
@@ -1580,17 +1649,17 @@ void verilog_typecheckt::convert_module_item(
     convert_assert_assume_cover(
       to_verilog_assertion_item(module_item).statement());
   }
-  else if(module_item.id()==ID_initial)
+  else if(module_item.id() == ID_initial)
     convert_initial(to_verilog_initial(module_item));
-  else if(module_item.id()==ID_continuous_assign)
+  else if(module_item.id() == ID_continuous_assign)
     convert_continuous_assign(to_verilog_continuous_assign(module_item));
-  else if(module_item.id()==ID_inst)
+  else if(module_item.id() == ID_inst)
   {
   }
-  else if(module_item.id()==ID_inst_builtin)
+  else if(module_item.id() == ID_inst_builtin)
   {
   }
-  else if(module_item.id()==ID_generate_block)
+  else if(module_item.id() == ID_generate_block)
   {
     // these introduce a scope, much like a named block
     auto &generate_block = to_verilog_generate_block(module_item);
@@ -1612,7 +1681,7 @@ void verilog_typecheckt::convert_module_item(
     for(auto &var : variables)
       genvars[id2string(var.first)] = string2integer(var.second.id_string());
 
-    if(module_item.operands().size()!=1)
+    if(module_item.operands().size() != 1)
     {
       throw errort() << "set_genvars expects one operand";
     }
@@ -1847,17 +1916,17 @@ bool verilog_typecheckt::implicit_wire(
 
   symbolt symbol;
 
-  symbol.mode=mode;
+  symbol.mode = mode;
   symbol.module = verilog_root_module_identifier();
   symbol.value.make_nil();
-  symbol.base_name=identifier;
-  symbol.name=full_identifier;
+  symbol.base_name = identifier;
+  symbol.name = full_identifier;
   symbol.type = net_type;
   symbol.pretty_name = strip_verilog_root_prefix(full_identifier);
 
   symbolt *new_symbol;
   symbol_table.move(symbol, new_symbol);
-  symbol_ptr=new_symbol;
+  symbol_ptr = new_symbol;
 
   return false;
 }
@@ -1998,7 +2067,7 @@ symbolt &copy_module_source(
 
   symbol.base_name = base_name;
   symbol.pretty_name = base_name;
-  symbol.module=symbol.name;
+  symbol.module = symbol.name;
   symbol.location = verilog_module_source.source_location();
 
   symbol.type.add(ID_module_source) = verilog_module_source;


### PR DESCRIPTION
## Summary
- Implements IEEE 1800-2017 section 25.4.4 for extern method prototypes in SystemVerilog interfaces
- Enables declaring a method prototype with `extern` inside an interface and providing the out-of-body definition using the `interface_name::method_name` syntax
- Adds support for hierarchical function/task calls on interface instances (e.g., `instance.method(args)`)

## Changes
- **Parser** (`src/verilog/parser.y`):
  - Extend `function_prototype` and `task_prototype` rules to accept optional parameter lists (per IEEE 1800-2017 A.2.6)
  - Add semantic actions to `extern_tf_declaration` to produce a proper declaration node with the `extern` flag
  - Add `function_body_declaration` alternative for interface-scoped out-of-body method definitions (`TOK_INTERFACE_IDENTIFIER "::" identifier`)
- **Elaboration** (`src/verilog/verilog_elaborate_compilation_unit.cpp`):
  - Detect out-of-body method definitions (with `verilog_scope_prefix`) and merge them into the interface source before type-checking, replacing the extern prototype
- **Type-checker** (`src/verilog/verilog_typecheck.cpp`):
  - Handle hierarchical function/task calls on interface instances by resolving through the interface type when the instance-local lookup fails

## Test plan
- [x] New regression test `regression/verilog/interface/extern_method1` passes (changed from KNOWNBUG to CORE)
- [x] All existing verilog regression tests pass
- [x] All ebmc regression tests pass
- [x] All SMV regression tests pass