### PR TITLE
Verilog: typecheck class declarations

### DIFF
--- a/regression/verilog/class/class1.desc
+++ b/regression/verilog/class/class1.desc
@@ -1,7 +1,8 @@
 CORE
 class1.sv
---show-parse
-^Class: myClass$
+--show-symbol-table
+^  Verilog::myClass$
+^  Verilog::myClass::my_parameter$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/class/class_constructor1.desc
+++ b/regression/verilog/class/class_constructor1.desc
@@ -1,8 +1,10 @@
 CORE
 class_constructor1.sv
---show-parse
-^Class: myClass$
-^Class: emptyClass$
+--show-symbol-table
+^  Verilog::myClass$
+^  Verilog::myClass::new$
+^  Verilog::myClass::x$
+^  Verilog::emptyClass::new$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/class/class_in_module1.desc
+++ b/regression/verilog/class/class_in_module1.desc
@@ -1,7 +1,8 @@
 CORE
 class_in_module1.sv
---show-parse
-^  \* base_name: local_class$
+--show-symbol-table
+^  Verilog::main::local_class$
+^  Verilog::main::local_class::x$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/class/class_in_package1.desc
+++ b/regression/verilog/class/class_in_package1.desc
@@ -1,8 +1,9 @@
 CORE
 class_in_package1.sv
---show-parse
-^Package: p$
-^  \* base_name: pc$
+--show-symbol-table
+^  Verilog::package::p$
+^  Verilog::p::pc$
+^  Verilog::p::pc::x$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/class/class_method1.desc
+++ b/regression/verilog/class/class_method1.desc
@@ -1,7 +1,12 @@
 CORE
 class_method1.sv
---show-parse
-^Class: myClass$
+--show-symbol-table
+^  Verilog::myClass::x$
+^  Verilog::myClass::get_x$
+^  Verilog::myClass::set_x$
+^  Verilog::myClass::double_x$
+^  Verilog::myClass::dump$
+^  Verilog::myClass::zero$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/class/class_property1.desc
+++ b/regression/verilog/class/class_property1.desc
@@ -1,7 +1,13 @@
 CORE
 class_property1.sv
---show-parse
-^Class: myClass$
+--show-symbol-table
+^  Verilog::myClass::unqualified$
+^  Verilog::myClass::max_size$
+^  Verilog::myClass::count$
+^  Verilog::myClass::hidden$
+^  Verilog::myClass::secret$
+^  Verilog::myClass::mode$
+^  Verilog::myClass::cycle$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/class/extends1.desc
+++ b/regression/verilog/class/extends1.desc
@@ -1,8 +1,10 @@
 CORE
 extends1.sv
---show-parse
-^Class: base$
-^Class: derived$
+--show-symbol-table
+^  Verilog::base$
+^  Verilog::base::new$
+^  Verilog::base::x$
+^  Verilog::derived$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/class/interface_class1.desc
+++ b/regression/verilog/class/interface_class1.desc
@@ -1,9 +1,11 @@
 CORE
 interface_class1.sv
---show-parse
-^Class: myInterface$
-^Class: myOtherInterface$
-^Class: myClass$
+--show-symbol-table
+^  Verilog::myInterface::get$
+^  Verilog::myOtherInterface::put$
+^  Verilog::myClass::x$
+^  Verilog::myClass::get$
+^  Verilog::myClass::put$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/class/interface_class2.desc
+++ b/regression/verilog/class/interface_class2.desc
@@ -1,9 +1,9 @@
 CORE
 interface_class2.sv
---show-parse
-^Class: ia$
-^Class: ib$
-^Class: ic$
+--show-symbol-table
+^  Verilog::ia::a$
+^  Verilog::ib::b$
+^  Verilog::ic::c$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/class/nested_class1.desc
+++ b/regression/verilog/class/nested_class1.desc
@@ -1,8 +1,10 @@
 CORE
 nested_class1.sv
---show-parse
-^Class: outer$
-^  \* base_name: inner$
+--show-symbol-table
+^  Verilog::outer$
+^  Verilog::outer::x$
+^  Verilog::outer::inner$
+^  Verilog::outer::inner::y$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/class/parameterized_class1.desc
+++ b/regression/verilog/class/parameterized_class1.desc
@@ -1,7 +1,11 @@
 CORE
 parameterized_class1.sv
---show-parse
-^Class: stack$
+--show-symbol-table
+^  Verilog::stack$
+^  Verilog::stack::T$
+^  Verilog::stack::DEPTH$
+^  Verilog::stack::mem$
+^  Verilog::stack::top$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/class/virtual_class1.desc
+++ b/regression/verilog/class/virtual_class1.desc
@@ -1,8 +1,9 @@
 CORE
 virtual_class1.sv
---show-parse
-^Class: myBase$
-^Class: myClass$
+--show-symbol-table
+^  Verilog::myBase::area$
+^  Verilog::myClass::width$
+^  Verilog::myClass::area$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -5384,7 +5384,7 @@ cell_identifier: non_type_identifier;
 class_identifier: TOK_CLASS_IDENTIFIER
                 {
                   init($$, ID_verilog_class_type);
-                  auto base_name = stack_expr($1).id();
+                  auto base_name = stack_expr($1).get(ID_base_name);
                   stack_expr($$).set(ID_base_name, base_name);
                   stack_expr($$).set(ID_verilog_scope_prefix, PARSER.scopes.current_scope().prefix);
                 }

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
 #include <util/mathematical_types.h>
+#include <util/prefix.h>
 
 #include "verilog_typecheck.h"
 #include "verilog_types.h"
@@ -95,6 +96,37 @@ void verilog_typecheckt::collect_port_symbols(const verilog_declt &decl)
   }
 }
 
+irep_idt verilog_typecheckt::class_identifier(const irep_idt &base_name) const
+{
+  static const std::string package_prefix = "Verilog::package::";
+
+  if(!current_class_identifier.empty())
+  {
+    return id2string(current_class_identifier) + "::" + id2string(base_name);
+  }
+  else if(has_prefix(id2string(module_identifier), package_prefix))
+  {
+    auto package_name =
+      std::string{id2string(module_identifier), package_prefix.size()};
+    return verilog_package_identifier(package_name, base_name);
+  }
+  else if(!module_identifier.empty())
+  {
+    return id2string(module_identifier) + "::" + id2string(base_name);
+  }
+  else
+  {
+    return verilog_module_symbol(base_name);
+  }
+}
+
+bool verilog_typecheckt::is_class_constructor(
+  const verilog_function_or_task_declt &decl) const
+{
+  return decl.get_class() == ID_function && !current_class_identifier.empty() &&
+         decl.base_name() == "new" && decl.type().is_nil();
+}
+
 void verilog_typecheckt::collect_symbols(
   const typet &type,
   const verilog_parameter_declt::declaratort &declarator)
@@ -154,6 +186,37 @@ void verilog_typecheckt::collect_symbols(
 void verilog_typecheckt::collect_symbols(
   const verilog_sequence_declarationt &declaration)
 {
+}
+
+void verilog_typecheckt::collect_symbols(const verilog_classt &class_decl)
+{
+  auto identifier = class_identifier(class_decl.base_name());
+
+  symbolt symbol{identifier, typet{ID_verilog_class_type}, mode};
+  symbol.module = verilog_root_module_identifier();
+  symbol.base_name = class_decl.base_name();
+  symbol.pretty_name = strip_verilog_root_prefix(symbol.name);
+  symbol.is_type = true;
+  symbol.location = class_decl.source_location();
+  symbol.type.set(ID_base_name, class_decl.base_name());
+  symbol.type.set(ID_identifier, identifier);
+
+  add_symbol(std::move(symbol));
+
+  const auto old_class_identifier = current_class_identifier;
+  current_class_identifier = identifier;
+
+  for(auto &parameter_port_decl : class_decl.parameter_port_decls())
+  {
+    collect_symbols(parameter_port_decl.type());
+    for(auto &declarator : parameter_port_decl.declarators())
+      collect_symbols(parameter_port_decl.type(), declarator);
+  }
+
+  for(auto &item : class_decl.module_items())
+    collect_symbols(item);
+
+  current_class_identifier = old_class_identifier;
 }
 
 void verilog_typecheckt::collect_symbols(const typet &type)
@@ -612,7 +675,12 @@ void verilog_typecheckt::collect_symbols(
   typet return_type;
 
   if(decl.get_class() == ID_function)
-    return_type = elaborate_type(decl.type());
+  {
+    if(is_class_constructor(decl))
+      return_type = typet{ID_verilog_void};
+    else
+      return_type = elaborate_type(decl.type());
+  }
   else
     return_type = empty_typet();
 
@@ -961,6 +1029,13 @@ void verilog_typecheckt::collect_symbols(
     collect_symbols(to_verilog_let(module_item));
   }
   else if(module_item.id() == ID_verilog_empty_item)
+  {
+  }
+  else if(module_item.id() == ID_verilog_class)
+  {
+    collect_symbols(to_verilog_class(module_item));
+  }
+  else if(module_item.id() == ID_verilog_constraint)
   {
   }
   else if(module_item.id() == ID_verilog_smv_using)

--- a/src/verilog/verilog_elaborate_compilation_unit.cpp
+++ b/src/verilog/verilog_elaborate_compilation_unit.cpp
@@ -109,5 +109,27 @@ void verilog_elaborate_compilation_unit(
           throw ebmc_errort{};
       }
     }
+    else if(item.id() == ID_verilog_class)
+    {
+      try
+      {
+        verilog_typecheckt verilog_typecheck(
+          parse_tree.standard,
+          warn_implicit_nets,
+          symbol_table,
+          message_handler);
+        verilog_typecheck.typecheck_class(to_verilog_class(item));
+      }
+      catch(const typecheckt::errort &error)
+      {
+        if(!error.what().empty())
+        {
+          throw ebmc_errort{}.with_location(error.source_location())
+            << error.what();
+        }
+        else
+          throw ebmc_errort{};
+      }
+    }
   }
 }

--- a/src/verilog/verilog_elaborate_type.cpp
+++ b/src/verilog/verilog_elaborate_type.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/ebmc_util.h>
 #include <util/ieee_float.h>
 #include <util/mathematical_types.h>
+#include <util/prefix.h>
 
 #include "verilog_expr.h"
 #include "verilog_typecheck_expr.h"
@@ -512,6 +513,51 @@ typet verilog_typecheck_exprt::elaborate_type(const typet &src)
   }
   else if(src.id() == ID_verilog_class_type)
   {
+    auto identifier = src.get(ID_identifier);
+
+    if(identifier.empty())
+    {
+      const auto base_name = src.get(ID_base_name);
+
+      std::vector<irep_idt> candidates;
+      static const std::string package_prefix = "Verilog::package::";
+
+      if(!current_class_identifier.empty())
+        candidates.emplace_back(
+          id2string(current_class_identifier) + "::" + id2string(base_name));
+
+      if(has_prefix(id2string(module_identifier), package_prefix))
+      {
+        auto package_name =
+          std::string{id2string(module_identifier), package_prefix.size()};
+        candidates.push_back(
+          verilog_package_identifier(package_name, base_name));
+      }
+      else if(!module_identifier.empty())
+      {
+        candidates.emplace_back(
+          id2string(module_identifier) + "::" + id2string(base_name));
+      }
+
+      candidates.push_back(verilog_module_symbol(base_name));
+
+      for(const auto &candidate : candidates)
+      {
+        const symbolt *symbol;
+        if(
+          !ns.lookup(candidate, symbol) &&
+          symbol->type.id() == ID_verilog_class_type)
+        {
+          auto result = symbol->type;
+          result.add_source_location() = source_location;
+          return result;
+        }
+      }
+
+      throw errort{}.with_location(source_location)
+        << "unknown class `" << base_name << '\'';
+    }
+
     return src;
   }
   else if(src.id() == ID_verilog_interface)

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -2820,8 +2820,34 @@ class verilog_classt : public verilog_item_containert
 {
 public:
   explicit verilog_classt(irep_idt _base_name)
-    : verilog_item_containert(ID_verilog_module, _base_name)
+    : verilog_item_containert(ID_verilog_class, _base_name)
   {
+  }
+
+  using parameter_port_declst = std::vector<verilog_parameter_declt>;
+
+  const parameter_port_declst &parameter_port_decls() const
+  {
+    return (const parameter_port_declst &)(find(ID_verilog_parameter_port_decls)
+                                             .get_sub());
+  }
+
+  parameter_port_declst &parameter_port_decls()
+  {
+    return (
+      parameter_port_declst &)(add(ID_verilog_parameter_port_decls).get_sub());
+  }
+
+  using module_itemst = itemst;
+
+  const module_itemst &module_items() const
+  {
+    return items();
+  }
+
+  module_itemst &module_items()
+  {
+    return items();
   }
 
   void show(std::ostream &) const;

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -291,6 +291,9 @@ void verilog_typecheckt::interface_module_item(
   else if(module_item.id() == ID_verilog_empty_item)
   {
   }
+  else if(module_item.id() == ID_verilog_class)
+  {
+  }
   else if(module_item.id() == ID_verilog_smv_using)
   {
   }

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -3605,6 +3605,10 @@ void verilog_synthesist::synth_module_item(
   else if(module_item.id() == ID_verilog_empty_item)
   {
   }
+  else if(module_item.id() == ID_verilog_class)
+  {
+    // Class declarations are front-end metadata only.
+  }
   else if(module_item.id() == ID_verilog_package_import)
   {
     // done already

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -315,6 +315,59 @@ void verilog_typecheckt::convert_function_or_task(
 
 /*******************************************************************\
 
+Function: verilog_typecheckt::convert_class
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void verilog_typecheckt::convert_class(verilog_classt &class_decl)
+{
+  const auto old_class_identifier = current_class_identifier;
+  current_class_identifier = class_identifier(class_decl.base_name());
+
+  for(auto &item : class_decl.module_items())
+  {
+    if(item.id() == ID_decl)
+    {
+      auto &decl = to_verilog_decl(item);
+
+      if(decl.get_class() == ID_function || decl.get_class() == ID_task)
+        convert_function_or_task(to_verilog_function_or_task_decl(item));
+      else
+        convert_decl(decl);
+    }
+    else if(
+      item.id() == ID_parameter_decl || item.id() == ID_local_parameter_decl)
+    {
+      // already elaborated
+    }
+    else if(item.id() == ID_verilog_class)
+    {
+      convert_class(to_verilog_class(item));
+    }
+    else if(
+      item.id() == ID_verilog_constraint ||
+      item.id() == ID_verilog_covergroup || item.id() == ID_verilog_empty_item)
+    {
+      // accepted by the parser, but not semantically processed yet
+    }
+    else
+    {
+      throw errort().with_location(item.source_location())
+        << "unexpected class item: " << item.id();
+    }
+  }
+
+  current_class_identifier = old_class_identifier;
+}
+
+/*******************************************************************\
+
 Function: verilog_typecheckt::elaborate_constant_function_call
 
   Inputs:
@@ -1632,6 +1685,10 @@ void verilog_typecheckt::convert_module_item(
   else if(module_item.id() == ID_verilog_empty_item)
   {
   }
+  else if(module_item.id() == ID_verilog_class)
+  {
+    convert_class(to_verilog_class(module_item));
+  }
   else if(module_item.id() == ID_verilog_smv_using)
   {
   }
@@ -1967,6 +2024,30 @@ void verilog_typecheckt::typecheck_parameter_decl(
 
   for(auto identifier : symbols_added)
     elaborate_symbol_rec(identifier);
+}
+
+/*******************************************************************\
+
+Function: verilog_typecheckt::typecheck_class
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void verilog_typecheckt::typecheck_class(const verilog_classt &class_decl)
+{
+  auto class_copy = class_decl;
+
+  collect_symbols(class_copy);
+
+  for(auto identifier : symbols_added)
+    elaborate_symbol_rec(identifier);
+
+  convert_class(class_copy);
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -77,6 +77,7 @@ public:
   // typedefs, functions, tasks, parameters
   void typecheck_decl(const verilog_declt &);
   void typecheck_parameter_decl(const verilog_module_itemt &);
+  void typecheck_class(const verilog_classt &);
 
 protected:
   const namespacet ns;
@@ -106,6 +107,7 @@ protected:
   void collect_symbols(const verilog_module_itemt &);
   void collect_symbols(const verilog_declt &);
   void collect_symbols(const verilog_function_or_task_declt &);
+  void collect_symbols(const verilog_classt &);
   void collect_symbols(const verilog_lett &);
   void collect_symbols(const verilog_statementt &);
   void collect_symbols(const verilog_property_declarationt &);
@@ -196,6 +198,7 @@ protected:
   // module items
   void convert_decl(class verilog_declt &);
   void convert_function_or_task(class verilog_function_or_task_declt &);
+  void convert_class(class verilog_classt &);
   void convert_always_base(class verilog_always_baset &);
   void convert_initial(class verilog_initialt &);
   void convert_continuous_assign(class verilog_continuous_assignt &);
@@ -227,6 +230,9 @@ protected:
 
   bool replace_symbols(const replace_mapt &what, exprt &dest);
   void replace_symbols(const std::string &target, exprt &dest);
+
+  irep_idt class_identifier(const irep_idt &base_name) const;
+  bool is_class_constructor(const verilog_function_or_task_declt &) const;
 
   // to be overridden
   virtual void convert_statements(verilog_module_exprt &);

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -61,6 +61,10 @@ verilog_typecheck_exprt::hierarchical_identifier(irep_idt base_name) const
     return id2string(function_or_task_name) + "." + named_block +
            id2string(base_name);
   }
+  else if(!current_class_identifier.empty())
+  {
+    return id2string(current_class_identifier) + "::" + id2string(base_name);
+  }
   else if(has_prefix(id2string(module_identifier), package_prefix))
   {
     auto package_name =
@@ -1632,6 +1636,16 @@ const symbolt *verilog_typecheck_exprt::resolve(const irep_idt base_name)
 
     auto full_identifier =
       id2string(function_or_task_name) + "." + id2string(base_name);
+
+    const symbolt *symbol;
+    if(!ns.lookup(full_identifier, symbol))
+      return symbol; // found!
+  }
+
+  if(!current_class_identifier.empty())
+  {
+    auto full_identifier =
+      id2string(current_class_identifier) + "::" + id2string(base_name);
 
     const symbolt *symbol;
     if(!ns.lookup(full_identifier, symbol))

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -64,6 +64,9 @@ protected:
   // full identifier of instance
   irep_idt module_instance;
 
+  // full identifier of the enclosing class, if any
+  irep_idt current_class_identifier;
+
   // full identifier of function/task
   irep_idt function_or_task_name;
 


### PR DESCRIPTION
## Summary
Implement the Verilog front-end class slice on top of #1842 by collecting and typechecking class declarations, resolving class types canonically across scopes, and accepting class declarations during elaboration and synthesis.

## Testing
- make -C src/verilog -j4
- make -C src/ebmc -j4
- perl ../../lib/cbmc/regression/test.pl -e -p -c ../../../src/ebmc/ebmc class