### PR TITLE
Verilog: parameterized interface port connections

### DIFF
--- a/regression/verilog/interface/parameter_port1.desc
+++ b/regression/verilog/interface/parameter_port1.desc
@@ -1,0 +1,10 @@
+CORE
+parameter_port1.sv
+--bound 1
+^\[main\.c\.p1\] always main\.c\.bus\.data == 32'hCAFEBABE: PROVED up to bound 1
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Parameterized interface passed through a module port
+(IEEE 1800-2017 25.8).

--- a/regression/verilog/interface/parameter_port1.sv
+++ b/regression/verilog/interface/parameter_port1.sv
@@ -1,0 +1,14 @@
+// Parameterized interface passed through port (IEEE 1800-2017 25.8)
+interface param_if #(parameter W = 8);
+  logic [W-1:0] data;
+endinterface
+
+module consumer(param_if bus);
+  p1: assert property (bus.data == 32'hCAFEBABE);
+endmodule
+
+module main;
+  param_if #(32) wide();
+  initial wide.data = 32'hCAFEBABE;
+  consumer c(wide);
+endmodule

--- a/src/ebmc/ebmc_properties.cpp
+++ b/src/ebmc/ebmc_properties.cpp
@@ -8,6 +8,8 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include "ebmc_properties.h"
 
+#include <util/std_expr.h>
+
 #include <langapi/language.h>
 #include <langapi/language_util.h>
 #include <langapi/mode.h>
@@ -15,6 +17,32 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <verilog/sva_expr.h>
 
 #include "ebmc_error.h"
+
+/// Update symbol expression types in the given expression tree
+/// to match the symbol table. This is needed when interface port
+/// members have their types updated after the property was type-checked
+/// (e.g., due to parameterized interfaces).
+static void fix_symbol_types(exprt &expr, const namespacet &ns)
+{
+  for(auto &op : expr.operands())
+    fix_symbol_types(op, ns);
+
+  if(expr.id() == ID_symbol)
+  {
+    const symbolt *sym;
+    if(!ns.lookup(to_symbol_expr(expr).identifier(), sym))
+    {
+      // Only update if both types are the same kind of bitvector
+      // but differ in width (parameterized interface case).
+      if(
+        expr.type() != sym->type && expr.type().id() == sym->type.id() &&
+        expr.type().id() != ID_empty)
+      {
+        expr.type() = sym->type;
+      }
+    }
+  }
+}
 
 void ebmc_propertiest::propertyt::copy_results_from(
   const ebmc_propertiest::propertyt &src)
@@ -103,6 +131,11 @@ ebmc_propertiest ebmc_propertiest::from_transition_system(
         properties.properties.back().normalized_expr =
           normalize_property(symbol.value);
       }
+
+      // Fix symbol types that may have been updated after
+      // the property was type-checked (e.g., parameterized interfaces).
+      fix_symbol_types(properties.properties.back().normalized_expr, ns);
+      fix_symbol_types(properties.properties.back().original_expr, ns);
 
       message.debug() << "Normalized property: "
                       << from_expr(

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -1512,6 +1512,80 @@ void verilog_synthesist::synth_module_instance(
     // must be in symbol_table
     const symbolt &module_symbol = ns.lookup(module_identifier);
 
+    // For interface ports, update the port member types to match the
+    // actual bound interface instance before synthesising the submodule.
+    // The port's interface was instantiated with default parameters during
+    // type checking, but the actual interface may use different parameters.
+    {
+      auto &module_type = to_module_type(module_symbol.type);
+      auto &ports = module_type.ports();
+      auto &connections = instance.connections();
+
+      std::size_t port_index = 0;
+      for(auto &port : ports)
+      {
+        if(port.type().id() == ID_verilog_module_instance)
+        {
+          // Find the corresponding connection
+          const exprt *connection = nullptr;
+          if(instance.named_port_connections())
+          {
+            for(auto &conn : connections)
+            {
+              if(conn.id() == ID_verilog_named_port_connection)
+              {
+                auto &named = to_verilog_named_port_connection(conn);
+                if(
+                  to_symbol_expr(named.port()).identifier() ==
+                  port.identifier())
+                {
+                  connection = &named.value();
+                  break;
+                }
+              }
+            }
+          }
+          else if(port_index < connections.size())
+          {
+            connection = &connections[port_index];
+          }
+
+          if(
+            connection != nullptr && connection->is_not_nil() &&
+            connection->id() == ID_symbol)
+          {
+            auto &bound_id = to_symbol_expr(*connection).identifier();
+            auto port_prefix = id2string(port.identifier()) + ".";
+            auto bound_prefix = id2string(bound_id) + ".";
+
+            for(auto &entry : symbol_table.symbols)
+            {
+              auto id = id2string(entry.first);
+              if(
+                id.size() > port_prefix.size() &&
+                id.substr(0, port_prefix.size()) == port_prefix &&
+                id.find('.', port_prefix.size()) == std::string::npos)
+              {
+                auto member_name = id.substr(port_prefix.size());
+                auto bound_member_id = bound_prefix + member_name;
+
+                const symbolt *bound_sym;
+                if(!ns.lookup(bound_member_id, bound_sym))
+                {
+                  if(entry.second.type != bound_sym->type)
+                  {
+                    symbolt &port_member_sym = symbol_table_lookup(entry.first);
+                    port_member_sym.type = bound_sym->type;
+                  }
+                }
+              }
+            }
+          }
+        }
+        port_index++;
+      }
+    }
+
     // get the transition relation of the instantiated module
     auto trans_inst = verilog_synthesis(
       symbol_table,


### PR DESCRIPTION
## Summary
- Fixes KNOWNBUG test `regression/verilog/interface/parameter_port1.desc` which tests parameterized interfaces passed through module ports (IEEE 1800-2017 section 25.8)
- Updates port member types in the symbol table to match bound interface instances during synthesis
- Adds a property expression type fixup pass to handle cases where properties reference symbols whose types were updated after type-checking

## Test plan
- [x] New test `regression/verilog/interface/parameter_port1` passes (PROVED)
- [x] All existing `regression/verilog` tests pass
- [x] All existing `regression/ebmc` tests pass