### PR TITLE
Verilog: modport port expressions

### DIFF
--- a/regression/verilog/interface/modport_expression1.desc
+++ b/regression/verilog/interface/modport_expression1.desc
@@ -1,0 +1,9 @@
+CORE
+modport_expression1.sv
+--bound 1
+^\[main\.c\.p1\] always main\.c\.port\.data\[7:4\] == 4'b1010: PROVED up to bound 1
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Modport port expressions (IEEE 1800-2017 25.5.2).

--- a/regression/verilog/interface/modport_expression1.sv
+++ b/regression/verilog/interface/modport_expression1.sv
@@ -1,0 +1,16 @@
+// Modport expressions (IEEE 1800-2017 25.5.2)
+interface data_if;
+  logic [7:0] data;
+
+  modport split(input .upper_half(data[7:4]), input .lower_half(data[3:0]));
+endinterface
+
+module consumer(data_if.split port);
+  p1: assert property (port.upper_half == 4'hA);
+endmodule
+
+module main;
+  data_if dif();
+  initial dif.data = 8'hAB;
+  consumer c(dif);
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2718,6 +2718,8 @@ modport_ports_declaration_brace:
 // port name (starting a new group) or just a port name (continuing the
 // previous direction group). We flatten into single items to avoid a
 // shift/reduce conflict between the inner and outer comma-separated lists.
+// Per IEEE 1800-2017 25.5.2, modport port expressions use the form:
+//   port_direction . port_identifier ( expression )
 modport_ports_declaration:
           port_direction non_type_identifier
                 { $$ = $1;
@@ -2725,6 +2727,10 @@ modport_ports_declaration:
         | non_type_identifier
                 { init($$, ID_nil);
                   mto($$, $1); }
+        | port_direction '.' non_type_identifier '(' expression ')'
+                { $$ = $1;
+                  stack_expr($3).add(ID_value).swap(stack_expr($5));
+                  mto($$, $3); }
         ;
 
 // System Verilog standard 1800-2017

--- a/src/verilog/verilog_elaborate_type.cpp
+++ b/src/verilog/verilog_elaborate_type.cpp
@@ -520,6 +520,10 @@ typet verilog_typecheck_exprt::elaborate_type(const typet &src)
     auto result =
       verilog_module_instance_typet{}.with_source_location(source_location);
     result.set(ID_base_name, src.get(ID_base_name));
+    // Preserve modport name if specified (IEEE 1800-2017 25.5)
+    auto modport = src.get(ID_verilog_modport);
+    if(!modport.empty())
+      result.set(ID_verilog_modport, modport);
     return result;
   }
   else if(src.id() == ID_verilog_package_scope)

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -6,15 +6,16 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-#include <set>
-
 #include <util/ebmc_util.h>
 #include <util/mathematical_types.h>
 #include <util/std_types.h>
 
-#include "verilog_typecheck.h"
 #include "verilog_expr.h"
+#include "verilog_typecheck.h"
+#include "verilog_typecheck_expr.h"
 #include "verilog_types.h"
+
+#include <set>
 
 /*******************************************************************\
 
@@ -185,6 +186,128 @@ void verilog_typecheckt::instantiate_interface_ports(
     symbolt &port_sym = symbol_table_lookup(port_identifier);
     port_sym.value =
       verilog_module_instancet{id2string(port_identifier) + "$module"};
+
+    // Handle modport port expressions (IEEE 1800-2017 25.5.2)
+    irep_idt modport_name = port_symbol->type.get(ID_verilog_modport);
+    if(!modport_name.empty())
+    {
+      instantiate_modport_port_expressions(
+        port_identifier, interface_module_id, modport_name);
+    }
+  }
+}
+
+/*******************************************************************\
+
+Function: verilog_typecheckt::instantiate_modport_port_expressions
+
+  Inputs:
+
+ Outputs:
+
+ Purpose: For modport port expressions (IEEE 1800-2017 25.5.2),
+          create wire symbols that alias the named ports to
+          their underlying expressions. The expression is stored
+          in the symbol's value; the type is resolved by
+          type-checking the expression in the interface context.
+
+\*******************************************************************/
+
+void verilog_typecheckt::instantiate_modport_port_expressions(
+  const irep_idt &port_identifier,
+  const irep_idt &interface_module_id,
+  const irep_idt &modport_name)
+{
+  // Find the interface source
+  auto source_it =
+    symbol_table.symbols.find(id2string(interface_module_id) + "$source");
+
+  if(source_it == symbol_table.symbols.end())
+    return;
+
+  const auto &interface_source =
+    to_verilog_module_source(source_it->second.type.find(ID_module_source));
+
+  // The instantiated module identifier for the interface under this port
+  irep_idt instantiated_module_id = id2string(port_identifier) + "$module";
+
+  // Search through module items for the modport declaration
+  for(auto &item : interface_source.module_items())
+  {
+    if(item.id() != ID_verilog_modport_declaration)
+      continue;
+
+    // Each operand is a modport_item
+    for(auto &modport_item : item.operands())
+    {
+      if(modport_item.get(ID_base_name) != modport_name)
+        continue;
+
+      // Found the matching modport item. Process its port declarations.
+      for(auto &port_decl : modport_item.operands())
+      {
+        // Each port_decl is a direction node (ID_input, ID_output, etc.)
+        // with identifiers as operands.
+        for(auto &port_id : port_decl.operands())
+        {
+          // Check if this is a port expression (has ID_value)
+          const auto &value_irep = port_id.find(ID_value);
+          if(value_irep.is_nil())
+            continue;
+
+          // This is a modport port expression:
+          //   .port_name(expression)
+          irep_idt port_expr_name = port_id.get(ID_base_name);
+          if(port_expr_name.empty())
+            continue;
+
+          irep_idt full_identifier =
+            id2string(port_identifier) + "." + id2string(port_expr_name);
+
+          // Skip if the symbol already exists
+          if(
+            symbol_table.symbols.find(full_identifier) !=
+            symbol_table.symbols.end())
+            continue;
+
+          // Type-check the expression in the interface instance context
+          // to determine its type.
+          exprt value_expr = static_cast<const exprt &>(value_irep);
+
+          verilog_typecheck_exprt expr_checker(
+            standard,
+            warn_implicit_nets,
+            ns,
+            instantiated_module_id,
+            port_identifier,
+            get_message_handler());
+
+          expr_checker.convert_expr(value_expr);
+
+          // Create a wire symbol for the port expression
+          symbolt symbol{full_identifier, value_expr.type(), ID_Verilog};
+
+          symbol.base_name = port_expr_name;
+          symbol.module = module_identifier;
+          symbol.pretty_name = strip_verilog_root_prefix(full_identifier);
+          symbol.is_state_var = true;
+          symbol.is_lvalue = true;
+          symbol.value = value_expr;
+
+          if(port_decl.id() == ID_input)
+            symbol.is_input = true;
+          else if(port_decl.id() == ID_output)
+            symbol.is_output = true;
+          else if(port_decl.id() == ID_inout)
+          {
+            symbol.is_input = true;
+            symbol.is_output = true;
+          }
+
+          symbol_table.add(symbol);
+        }
+      }
+    }
   }
 }
 

--- a/src/verilog/verilog_typecheck.h
+++ b/src/verilog/verilog_typecheck.h
@@ -157,6 +157,10 @@ protected:
   // interfaces
   void check_module_ports(const verilog_module_sourcet &);
   void instantiate_interface_ports(const verilog_module_sourcet &);
+  void instantiate_modport_port_expressions(
+    const irep_idt &port_identifier,
+    const irep_idt &interface_module_id,
+    const irep_idt &modport_name);
   void interface_module_item(const class verilog_module_itemt &);
   void interface_block(const class verilog_blockt &);
   void interface_generate_block(const class verilog_generate_blockt &);

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1853,6 +1853,19 @@ exprt verilog_typecheck_exprt::convert_hierarchical_identifier(
       }
       else
       {
+        // Modport port expressions (IEEE 1800-2017 25.5.2) have
+        // a type-checked expression stored in their value. Return
+        // that expression directly so the expression tree contains
+        // the underlying signal reference.
+        if(
+          symbol->value.is_not_nil() &&
+          symbol->value.id() != ID_verilog_module_instance &&
+          symbol->value.id() != ID_trans &&
+          symbol->value.id() != ID_verilog_tf_source)
+        {
+          return symbol->value;
+        }
+
         expr.type()=symbol->type;
       }
     }


### PR DESCRIPTION
## Summary
- Implements IEEE 1800-2017 25.5.2 modport port expressions (`input .name(expr)`)
- Extends the parser to accept the modport port expression syntax
- Creates symbols for modport port expressions during interface port instantiation, with the expression type-checked in the interface context
- Resolves hierarchical accesses (e.g., `port.upper_half`) to the underlying expression at type-check time

## Test plan
- [x] Regression test `regression/verilog/interface/modport_expression1.desc` changed from KNOWNBUG to CORE and passes
- [x] All existing Verilog regression tests pass (`make -C regression/verilog test`)
- [x] All EBMC regression tests pass (`make -C regression/ebmc test`)
- [x] All SMV regression tests pass (`make -C regression/smv test`)