### PR TITLE
Verilog: check `return` values

### DIFF
--- a/regression/verilog/functioncall/return3.desc
+++ b/regression/verilog/functioncall/return3.desc
@@ -1,0 +1,9 @@
+CORE
+return3.sv
+
+^file .* line 4: must return value$
+^EXIT=2$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/functioncall/return3.sv
+++ b/regression/verilog/functioncall/return3.sv
@@ -1,0 +1,7 @@
+module main;
+
+  function int some_int();
+    return; // error: must return value
+  endfunction
+
+endmodule

--- a/regression/verilog/functioncall/return4.desc
+++ b/regression/verilog/functioncall/return4.desc
@@ -1,0 +1,9 @@
+CORE
+return4.sv
+
+^file .* line 4: must not return value$
+^EXIT=2$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/functioncall/return4.sv
+++ b/regression/verilog/functioncall/return4.sv
@@ -1,0 +1,7 @@
+module main;
+
+  function void some_void();
+    return 123; // error: must not return value
+  endfunction
+
+endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -3240,6 +3240,11 @@ void verilog_synthesist::synth_return(const verilog_returnt &statement)
       frame.return_value.has_value(),
       "return with value requires return value symbol");
 
+    // we expect the type checker to make the types consistent
+    DATA_INVARIANT(
+      statement.value().type() == frame.return_value.value().type(),
+      "return value and symbol must have consistent types");
+
     verilog_assignt assignment{
       ID_verilog_blocking_assign,
       frame.return_value.value(),

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1309,16 +1309,40 @@ Function: verilog_typecheckt::convert_return
 
 \*******************************************************************/
 
-void verilog_typecheckt::convert_return(verilog_returnt &statement)
+void verilog_typecheckt::convert_return(verilog_returnt &return_statement)
 {
   if(function_or_task_name.empty())
   {
-    throw errort().with_location(statement.source_location())
+    throw errort().with_location(return_statement.source_location())
       << "return statement outside of function or task";
   }
 
-  if(statement.has_value())
-    convert_expr(statement.value());
+  // look up the task/function symbol
+  auto &tf_symbol = ns.lookup(function_or_task_name);
+  auto &return_type = to_code_type(tf_symbol.type).return_type();
+
+  // ID_empty is used for tasks
+  if(return_type.id() == ID_verilog_void || return_type.id() == ID_empty)
+  {
+    if(return_statement.has_value())
+    {
+      throw errort().with_location(return_statement.source_location())
+        << "must not return value";
+    }
+  }
+  else
+  {
+    if(!return_statement.has_value())
+    {
+      throw errort().with_location(return_statement.source_location())
+        << "must return value";
+    }
+
+    convert_expr(return_statement.value());
+
+    // returns are an "assignment-like context" (1800-2017 10.8)
+    assignment_conversion(return_statement.value(), return_type);
+  }
 }
 
 /*******************************************************************\


### PR DESCRIPTION
This enforces that a `void` function does not return a value using `return`, and conversely, that a non-`void` function does return a value when using `return`.