### PR TITLE
new-ic3: revise diagnostic output

### DIFF
--- a/src/new-ic3/ic3_solver.cpp
+++ b/src/new-ic3/ic3_solver.cpp
@@ -22,6 +22,7 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include <algorithm>
 #include <chrono>
+#include <iomanip>
 #include <queue>
 #include <unordered_set>
 
@@ -128,10 +129,10 @@ ic3_solvert::ic3_solvert(
 {
   // Encode the netlist into CNF: one timeframe only — the next-state
   // functions are nodes in the same variable space.
-  base_cnf = std::make_unique<recording_cnft>(solver_message_handler);
+  base_cnf = std::make_unique<recording_cnft>(message_handler);
   bmc_mapt bmc_map(netlist, 1, *base_cnf);
   {
-    messaget message{solver_message_handler};
+    messaget message{message_handler};
     ::unwind(netlist, bmc_map, message, *base_cnf, false, 0);
   }
 
@@ -771,7 +772,7 @@ ic3_resultt ic3_solvert::solve()
   // Check: can initial states violate the property?
   if(initial_state_is_bad())
   {
-    message.result() << "Property violated in initial state" << messaget::eom;
+    message.status() << "Property violated in initial state" << messaget::eom;
     return ic3_resultt::REFUTED;
   }
 
@@ -810,7 +811,7 @@ ic3_resultt ic3_solvert::solve()
 
         if(init_intersects(cube))
         {
-          message.result() << "Property refuted" << messaget::eom;
+          message.status() << "Property refuted" << messaget::eom;
           return ic3_resultt::REFUTED;
         }
 
@@ -842,8 +843,9 @@ ic3_resultt ic3_solvert::solve()
     if(propagate())
     {
       auto end_time = std::chrono::steady_clock::now();
-      message.statistics()
-        << "IC3: converged at frame " << k << " in "
+      message.status()
+        << "IC3: converged at frame " << k << " in " << std::fixed
+        << std::setprecision(3)
         << std::chrono::duration<double>(end_time - start_time).count()
         << " seconds (" << num_queries << " queries)" << messaget::eom;
       return ic3_resultt::PROVED;

--- a/src/new-ic3/new_ic3_engine.cpp
+++ b/src/new-ic3/new_ic3_engine.cpp
@@ -64,6 +64,8 @@ property_checker_resultt new_ic3_engine(
     }
   }
 
+  message.progress() << "Creating netlist for IC3" << messaget::eom;
+
   const namespacet ns(transition_system.symbol_table);
 
   auto netlist =
@@ -90,19 +92,22 @@ property_checker_resultt new_ic3_engine(
     // Add the property cone to a local copy of the netlist and obtain
     // the property literal in the AIG variable space.
     netlistt prop_netlist(netlist);
-    literalt prop_lit;
+    literalt prop_lit = [&]()
     {
       aig_prop_constraintt aig_prop(prop_netlist, message_handler);
-      prop_lit = instantiate_convert(
+      return instantiate_convert(
         aig_prop,
         prop_netlist.var_map,
         to_unary_expr(property.normalized_expr).op(),
         ns,
         message_handler);
-    }
+    }();
 
     ic3_solvert solver(std::move(prop_netlist), prop_lit, message_handler);
     auto result = solver.solve();
+
+    // record the outcome produced by this engine
+    constexpr auto engine = "ic3";
 
     // For exists-path properties (cover), the normalized expression is
     // the dual safety property: a refutation is a witness trace, and a
@@ -111,15 +116,15 @@ property_checker_resultt new_ic3_engine(
     {
     case ic3_resultt::PROVED:
       if(property.is_exists_path())
-        property.refuted();
+        property.refuted(engine);
       else
-        property.proved();
+        property.proved(engine);
       break;
     case ic3_resultt::REFUTED:
       if(property.is_exists_path())
-        property.proved();
+        property.proved(engine);
       else
-        property.refuted();
+        property.refuted(engine);
       break;
     }
   }

--- a/src/trans-netlist/unwind_netlist.cpp
+++ b/src/trans-netlist/unwind_netlist.cpp
@@ -53,9 +53,10 @@ void unwind(
 
   // do transitions
   if(last)
-    message.progress() << "Transition " << t << messaget::eom;
+    message.progress() << "Unwinding transition " << t << messaget::eom;
   else
-    message.progress() << "Transition " << t << "->" << t + 1 << messaget::eom;
+    message.progress() << "Unwinding transition " << t << "->" << t + 1
+                       << messaget::eom;
 
   const bmc_mapt::timeframet &timeframe=bmc_map.timeframe_map[t];
   


### PR DESCRIPTION
This revises the diagnostic output when using the new IC3 engine, by adding a message, changing the verbosity level of existing messages, and using the given message handler instead of a `null_message_handlert`.