### PR TITLE
New IC3: report the length of the counterexample trace

### DIFF
--- a/regression/ebmc/new-ic3/refuted1.desc
+++ b/regression/ebmc/new-ic3/refuted1.desc
@@ -1,7 +1,7 @@
 CORE
 refuted1.sv
 --new-ic3 --top main
-^Property refuted$
+^Property refuted with counterexample of length 4$
 ^\[main\.p0\] always main\.cnt != 3: REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/src/new-ic3/ic3_solver.cpp
+++ b/src/new-ic3/ic3_solver.cpp
@@ -756,6 +756,9 @@ struct proof_obligationt
 {
   cubet cube;
   std::size_t level;
+  // Number of transitions from this cube to the property-violating
+  // state; used for the counterexample length when refuting.
+  std::size_t depth;
 
   bool operator>(const proof_obligationt &other) const
   {
@@ -773,7 +776,7 @@ ic3_resultt ic3_solvert::solve()
   if(initial_state_is_bad())
   {
     message.status() << "Property violated in initial state" << messaget::eom;
-    return ic3_resultt::REFUTED;
+    return ic3_resultt::refuted(1);
   }
 
   while(true)
@@ -799,11 +802,11 @@ ic3_resultt ic3_solvert::solve()
       if(!bad_cube.has_value())
         break;
 
-      obligations.push({bad_cube.value(), k});
+      obligations.push({bad_cube.value(), k, 0});
 
       while(!obligations.empty())
       {
-        auto [cube, level] = obligations.top();
+        auto [cube, level, depth] = obligations.top();
         obligations.pop();
 
         if(is_blocked(cube, level))
@@ -811,8 +814,11 @@ ic3_resultt ic3_solvert::solve()
 
         if(init_intersects(cube))
         {
-          message.status() << "Property refuted" << messaget::eom;
-          return ic3_resultt::REFUTED;
+          // The cube contains an initial state, and the bad state is
+          // depth transitions away: depth + 1 states in total.
+          message.status() << "Property refuted with counterexample of length "
+                           << depth + 1 << messaget::eom;
+          return ic3_resultt::refuted(depth + 1);
         }
 
         if(level == 0)
@@ -824,8 +830,8 @@ ic3_resultt ic3_solvert::solve()
         auto pred = solve_relative(level - 1, cube);
         if(pred.has_value())
         {
-          obligations.push({pred.value(), level - 1});
-          obligations.push({std::move(cube), level});
+          obligations.push({pred.value(), level - 1, depth + 1});
+          obligations.push({std::move(cube), level, depth});
         }
         else
         {
@@ -834,7 +840,7 @@ ic3_resultt ic3_solvert::solve()
 
           // Re-queue at level+1 to push the blocking clause higher
           if(level + 1 <= k)
-            obligations.push({std::move(cube), level + 1});
+            obligations.push({std::move(cube), level + 1, depth});
         }
       }
     } // end blocking phase
@@ -848,7 +854,7 @@ ic3_resultt ic3_solvert::solve()
         << std::setprecision(3)
         << std::chrono::duration<double>(end_time - start_time).count()
         << " seconds (" << num_queries << " queries)" << messaget::eom;
-      return ic3_resultt::PROVED;
+      return ic3_resultt::proved();
     }
   }
 }

--- a/src/new-ic3/ic3_solver.h
+++ b/src/new-ic3/ic3_solver.h
@@ -39,10 +39,32 @@ namespace IctMinisat
 class Solver;
 }
 
-enum class ic3_resultt
+struct ic3_resultt
 {
-  PROVED,
-  REFUTED
+  enum class outcomet
+  {
+    PROVED,
+    REFUTED
+  } outcome;
+
+  /// When REFUTED, the number of states in the counterexample trace:
+  /// the trace has states at timeframes 0, ..., length - 1, and the
+  /// property-violating state is at timeframe length - 1.
+  /// The trace is genuine, but not guaranteed to be a shortest
+  /// counterexample: obligations are processed by frame level, not by
+  /// depth, so a longer chain of predecessors may reach an initial
+  /// state before a minimal-length one is explored.
+  std::size_t counterexample_length = 0;
+
+  static ic3_resultt proved()
+  {
+    return {outcomet::PROVED, 0};
+  }
+
+  static ic3_resultt refuted(std::size_t counterexample_length)
+  {
+    return {outcomet::REFUTED, counterexample_length};
+  }
 };
 
 /// The IC3 solver uses per-frame SAT solvers via CNF replay.
@@ -66,7 +88,8 @@ public:
 
   ~ic3_solvert();
 
-  /// Run the IC3 algorithm. Returns PROVED or REFUTED.
+  /// Run the IC3 algorithm. Returns PROVED or REFUTED; when refuted,
+  /// the result includes the length of the counterexample trace.
   ic3_resultt solve();
 
 private:

--- a/src/new-ic3/new_ic3_engine.cpp
+++ b/src/new-ic3/new_ic3_engine.cpp
@@ -112,15 +112,15 @@ property_checker_resultt new_ic3_engine(
     // For exists-path properties (cover), the normalized expression is
     // the dual safety property: a refutation is a witness trace, and a
     // proof shows that no witness exists.
-    switch(result)
+    switch(result.outcome)
     {
-    case ic3_resultt::PROVED:
+    case ic3_resultt::outcomet::PROVED:
       if(property.is_exists_path())
         property.refuted(engine);
       else
         property.proved(engine);
       break;
-    case ic3_resultt::REFUTED:
+    case ic3_resultt::outcomet::REFUTED:
       if(property.is_exists_path())
         property.proved(engine);
       else

--- a/unit/new-ic3/ic3_solver.cpp
+++ b/unit/new-ic3/ic3_solver.cpp
@@ -6,6 +6,8 @@ Author: Daniel Kroening, dkr@amazon.com
 
 \*******************************************************************/
 
+#include <util/std_types.h>
+
 #include <new-ic3/ic3_solver.h>
 #include <testing-utils/use_catch.h>
 
@@ -57,7 +59,7 @@ SCENARIO("ic3_solvert proves a trivially safe property")
 
     THEN("IC3 proves the property")
     {
-      REQUIRE(solver.solve() == ic3_resultt::PROVED);
+      REQUIRE(solver.solve().outcome == ic3_resultt::outcomet::PROVED);
     }
   }
 }
@@ -77,9 +79,11 @@ SCENARIO("ic3_solvert refutes a property violated in the initial state")
     null_message_handlert mh;
     ic3_solvert solver(std::move(netlist), prop_lit, mh);
 
-    THEN("IC3 refutes the property")
+    THEN("IC3 refutes the property with a single-state counterexample")
     {
-      REQUIRE(solver.solve() == ic3_resultt::REFUTED);
+      auto result = solver.solve();
+      REQUIRE(result.outcome == ic3_resultt::outcomet::REFUTED);
+      REQUIRE(result.counterexample_length == 1);
     }
   }
 }
@@ -100,9 +104,11 @@ SCENARIO("ic3_solvert refutes a property violated after one step")
     null_message_handlert mh;
     ic3_solvert solver(std::move(netlist), prop_lit, mh);
 
-    THEN("IC3 refutes the property")
+    THEN("IC3 refutes the property with a two-state counterexample")
     {
-      REQUIRE(solver.solve() == ic3_resultt::REFUTED);
+      auto result = solver.solve();
+      REQUIRE(result.outcome == ic3_resultt::outcomet::REFUTED);
+      REQUIRE(result.counterexample_length == 2);
     }
   }
 }
@@ -155,7 +161,7 @@ SCENARIO("ic3_solvert proves a property on a two-latch system")
 
     THEN("IC3 proves the property")
     {
-      REQUIRE(solver.solve() == ic3_resultt::PROVED);
+      REQUIRE(solver.solve().outcome == ic3_resultt::outcomet::PROVED);
     }
   }
 }
@@ -247,7 +253,67 @@ SCENARIO("ic3_solvert proves a property requiring inductive strengthening")
 
     THEN("IC3 proves the property (requires inductive strengthening)")
     {
-      REQUIRE(solver.solve() == ic3_resultt::PROVED);
+      REQUIRE(solver.solve().outcome == ic3_resultt::outcomet::PROVED);
+    }
+  }
+}
+
+SCENARIO("ic3_solvert reports the length of a deeper counterexample")
+{
+  GIVEN("A 2-bit counter that increments every cycle, property = counter != 3")
+  {
+    netlistt netlist;
+
+    // Node 0: bit 0 of counter
+    literalt b0 = netlist.new_input();
+    // Node 1: bit 1 of counter
+    literalt b1 = netlist.new_input();
+
+    // The counter increments unconditionally:
+    // next_b0 = !b0
+    literalt next_b0 = !b0;
+
+    // next_b1 = b1 XOR b0, built with AND nodes
+    literalt b1_and_not_b0 = netlist.new_and_node(b1, !b0);
+    literalt not_b1_and_b0 = netlist.new_and_node(!b1, b0);
+    literalt next_b1 = !netlist.new_and_node(!b1_and_not_b0, !not_b1_and_b0);
+
+    // Register latches
+    var_mapt::vart var_b0;
+    var_b0.vartype = var_mapt::vart::vartypet::LATCH;
+    var_b0.type = bool_typet{};
+    var_b0.bits.resize(1);
+    var_b0.bits[0].current = b0;
+    var_b0.bits[0].next = next_b0;
+    netlist.var_map.map.emplace("b0", var_b0);
+    netlist.var_map.add("b0", 0, var_b0);
+
+    var_mapt::vart var_b1;
+    var_b1.vartype = var_mapt::vart::vartypet::LATCH;
+    var_b1.type = bool_typet{};
+    var_b1.bits.resize(1);
+    var_b1.bits[0].current = b1;
+    var_b1.bits[0].next = next_b1;
+    netlist.var_map.map.emplace("b1", var_b1);
+    netlist.var_map.add("b1", 0, var_b1);
+
+    // Init: counter = 0
+    netlist.initial.push_back(!b0);
+    netlist.initial.push_back(!b1);
+
+    // Property: counter != 3, i.e., !(b0 AND b1)
+    literalt prop_lit = !netlist.new_and_node(b0, b1);
+
+    null_message_handlert mh;
+    ic3_solvert solver(std::move(netlist), prop_lit, mh);
+
+    THEN("IC3 refutes the property with a four-state counterexample")
+    {
+      // The system is deterministic with a unique initial state, so
+      // the only counterexample is 0, 1, 2, 3: four states.
+      auto result = solver.solve();
+      REQUIRE(result.outcome == ic3_resultt::outcomet::REFUTED);
+      REQUIRE(result.counterexample_length == 4);
     }
   }
 }


### PR DESCRIPTION
When the property is refuted, the IC3 solver now returns the length of the counterexample trace, counted in states: the trace has states at timeframes 0, ..., length − 1, with the property-violating state at timeframe length − 1.

- `ic3_resultt` is now a struct carrying the outcome and `counterexample_length`.
- Each proof obligation tracks its distance (in transitions) to the property-violating state; the frame level alone is not a reliable measure, since obligations are re-queued at higher levels.
- The trace is genuine, but not guaranteed to be a shortest counterexample: obligations are processed by frame level, not by depth (documented in the header).
- The refutation message now reads `Property refuted with counterexample of length N`; the `refuted1` regression test checks the reported length.
- Unit tests are adjusted to the new result struct; the refutation scenarios check the reported length, including a new deterministic 2-bit counter scenario whose only counterexample has four states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)