### PR TITLE
new IC3 solver: pass netlist as reference

### DIFF
--- a/src/new-ic3/ic3_solver.cpp
+++ b/src/new-ic3/ic3_solver.cpp
@@ -121,7 +121,7 @@ static void add_minisat_clause(IctMinisat::Solver &S, const bvt &clause)
 // ============================================================
 
 ic3_solvert::ic3_solvert(
-  netlistt netlist,
+  const netlistt &netlist,
   literalt prop_netlist_lit,
   message_handlert &message_handler)
   : message_handler(message_handler)

--- a/src/new-ic3/ic3_solver.h
+++ b/src/new-ic3/ic3_solver.h
@@ -60,7 +60,7 @@ class ic3_solvert
 {
 public:
   ic3_solvert(
-    netlistt netlist,
+    const netlistt &,
     literalt property_literal,
     message_handlert &message_handler);
 

--- a/src/new-ic3/new_ic3_engine.cpp
+++ b/src/new-ic3/new_ic3_engine.cpp
@@ -101,7 +101,7 @@ property_checker_resultt new_ic3_engine(
         message_handler);
     }
 
-    ic3_solvert solver(std::move(prop_netlist), prop_lit, message_handler);
+    ic3_solvert solver{prop_netlist, prop_lit, message_handler};
     auto result = solver.solve();
 
     // For exists-path properties (cover), the normalized expression is


### PR DESCRIPTION
The solver now receives the netlist as a reference, and not as a copy.