### PR TITLE
New IC3: decision-variable restriction and eager clause pushing

### DIFF
--- a/src/new-ic3/PERFORMANCE.md
+++ b/src/new-ic3/PERFORMANCE.md
@@ -105,8 +105,8 @@ intel*, 6s* and prodcellp4 families), the new engine 4.
 HWMCC'25 bit-level safety track (the latest competition, October
 2025; 142-benchmark sample — every 2nd of the 284 benchmarks with a
 definitive competition verdict — AIGER 1.9 converted to SMV with
-`aigtosmv -s`): `--new-ic3` solves 65 (48 proved, 17 refuted) in
-399 s, with all verdicts matching the competition results. These
+`aigtosmv -s`): `--new-ic3` solves 64 (47 proved, 17 refuted) in
+388 s, with all verdicts matching the competition results. These
 numbers include the invariant-constraint soundness fix of #1994;
 without it, the engine reports 15 spurious refutations on this set
 (HWMCC'08/'17 benchmarks carry no invariant constraints, HWMCC'25

--- a/src/new-ic3/PERFORMANCE.md
+++ b/src/new-ic3/PERFORMANCE.md
@@ -48,6 +48,41 @@ than ~50 frames deep).
 rIC3 remains substantially ahead of both ebmc engines; it is the source
 of several of the techniques used in the new engine.
 
+## Update: decision-variable restriction and eager clause pushing
+
+Two further optimizations (2026-07-12, measured on the same machine,
+same 49-benchmark sample, 60 s timeout):
+
+1. *Decision-variable restriction*: the per-frame MiniSAT solvers only
+   branch on latch and input variables. The AIG gates use the full
+   3-clause Tseitin encoding, so BCP totalizes any assignment of the
+   latches and inputs; models remain genuine. This removes the
+   `pickBranchLit` overhead (previously ~half of SAT search time) and
+   gives a uniform 7–22% speedup.
+2. *Eager clause pushing*: after MIC generalization, the blocking phase
+   pushes the generalized clause to the highest frame where it is still
+   relatively inductive — one SAT query per level — instead of
+   re-running a full MIC generalization each time the obligation is
+   re-queued one level higher. This is the dominant win, particularly
+   on refutations with deep counterexamples.
+
+A third experiment, VSIDS-style decay of the MIC literal-activity
+ordering, improved eijkbs3330 but caused a reproducible 15x regression
+on 139453p22 and was dropped.
+
+| tool | solved (of 49) | timeouts | total time on solved |
+|---|---:|---:|---:|
+| ebmc `--new-ic3` before | 43 | 6 | 108.3 s |
+| ebmc `--new-ic3` after | 45 | 4 | 88.9 s |
+
+139453p22 (t/o → 5.5 s) and bc57sensorsp2 (t/o → 44.6 s) are newly
+solved; on the 43 benchmarks solved before, total time drops from
+108.3 s to 38.8 s (2.8x). Largest individual improvements:
+neclaftp1001 16.0 → 1.3 s, nusmvtcasp5 24.3 → 4.7 s, 139462p24
+13.9 → 0.8 s. The only regression is csmacdp2 (1.3 → 4.7 s).
+prodcellp2 now completes (refuted) in ~110 s instead of diverging.
+All verdicts continue to match the published HWMCC08 results.
+
 ## Reproducing
 
     # ebmc engines + rIC3 + Pono, CSV output

--- a/src/new-ic3/PERFORMANCE.md
+++ b/src/new-ic3/PERFORMANCE.md
@@ -83,6 +83,38 @@ neclaftp1001 16.0 → 1.3 s, nusmvtcasp5 24.3 → 4.7 s, 139462p24
 prodcellp2 now completes (refuted) in ~110 s instead of diverging.
 All verdicts continue to match the published HWMCC08 results.
 
+## Broader evaluation: HWMCC'17 and HWMCC'25
+
+Same machine, 60 s timeout, run in parallel (4 workers for HWMCC'17,
+2 for HWMCC'25), engines built from this PR's sources.
+
+HWMCC'17 single-property track (all 300 AIGER benchmarks, SMV
+translations in `benchmarking/hwmcc17-single-smv/`; expected verdicts
+are the consensus of the 14 HWMCC'17 solvers, available for 242 of
+the 300):
+
+| engine | solved (of 300) | proved / refuted | total time on solved | wrong verdicts |
+|---|---:|---:|---:|---:|
+| ebmc `--ic3` | 125 | 93 / 32 | 697 s | 0 |
+| ebmc `--new-ic3` | 117 | 87 / 30 | 435 s | 0 |
+
+Of the 113 benchmarks solved by both engines, the new engine is
+faster on 91. The old engine solves 12 uniquely (among them the
+intel*, 6s* and prodcellp4 families), the new engine 4.
+
+HWMCC'25 bit-level safety track (the latest competition, October
+2025; 142-benchmark sample — every 2nd of the 284 benchmarks with a
+definitive competition verdict — AIGER 1.9 converted to SMV with
+`aigtosmv -s`): `--new-ic3` solves 65 (48 proved, 17 refuted) in
+399 s, with all verdicts matching the competition results. These
+numbers include the invariant-constraint soundness fix of #1994;
+without it, the engine reports 15 spurious refutations on this set
+(HWMCC'08/'17 benchmarks carry no invariant constraints, HWMCC'25
+ones do). For scale, on the same sample rIC3 solved 112 within 60 s
+in the competition (on different hardware); the gap is concentrated
+in the constrained instances, where the soundness fix weakens
+predecessor generalization.
+
 ## Reproducing
 
     # ebmc engines + rIC3 + Pono, CSV output

--- a/src/new-ic3/ic3_solver.cpp
+++ b/src/new-ic3/ic3_solver.cpp
@@ -129,6 +129,16 @@ ic3_solvert::ic3_solvert(
   // Encode the netlist into CNF: one timeframe only — the next-state
   // functions are nodes in the same variable space.
   base_cnf = std::make_unique<recording_cnft>(solver_message_handler);
+
+  // Take the invariant constraints out of the netlist: unwind() would
+  // assert them as unit clauses in base_cnf, which every solver
+  // replays. In the lifting solver they would weaken lift()'s
+  // implication "cube ∧ inputs ∧ T ⇒ target" to hold only modulo the
+  // constraints, admitting constraint-violating states into widened
+  // cubes and hence spurious counterexample chains.
+  const auto constraints = std::move(netlist.constraints);
+  netlist.constraints.clear();
+
   bmc_mapt bmc_map(netlist, 1, *base_cnf);
   {
     messaget message{solver_message_handler};
@@ -172,12 +182,41 @@ ic3_solvert::ic3_solvert(
     }
   }
 
+  // The conjunction of the invariant constraints, as a literal at the
+  // current frame. It is asserted as a unit clause in the frame and
+  // init solvers, weakens the property (a bad state must satisfy the
+  // constraints), and is added to every lift target, so that the
+  // unsatisfiable core proves "cube ∧ inputs ⊨ target ∧ constraints"
+  // unconditionally: no widened cube can contain a
+  // constraint-violating state. Together this makes every obligation
+  // chain a genuine constraint-satisfying counterexample: the initial
+  // state satisfies the constraints via the init solver, each lifted
+  // cube via its lift core, each unlifted (full-state) cube via the
+  // constraint unit in the frame solver that produced it, and the bad
+  // state via the weakened property.
+  if(!constraints.empty())
+  {
+    literalt c_all = const_literal(true);
+    for(auto c : constraints)
+      c_all = base_cnf->land(c_all, bmc_map.translate(0, c));
+
+    if(!c_all.is_true())
+    {
+      constraint_lit = c_all;
+
+      // weaken the property: bad = c_all ∧ ¬P
+      prop_current = base_cnf->lor(!c_all, prop_current);
+    }
+  }
+
   lit_activity.resize(latches.size(), 0.0f);
 
   // Create the initial state solver.
   init_solver =
     std::make_unique<satcheck_no_simplifiert>(solver_message_handler);
   replay_base_cnf(*init_solver, true);
+  if(!constraint_lit.is_true())
+    init_solver->lcnf({constraint_lit});
 
   // Create lifting solver using IC3's MiniSAT (has releaseVar).
   lift_minisat = new_minisat_solver();
@@ -310,6 +349,8 @@ IctMinisat::Solver &ic3_solvert::get_solver(std::size_t level)
   if(!fs)
   {
     fs = new_minisat_solver();
+    if(!constraint_lit.is_true())
+      add_minisat_clause(*fs, {constraint_lit});
     if(level == 0)
       for(auto l : init_units)
         add_minisat_clause(*fs, {l});
@@ -440,7 +481,10 @@ cubet ic3_solvert::lift(
     if(l.is_true())
       return full_state;
 
-  // Activation literal for the target clause: act -> target_clause
+  // Activation literal for the target clause: act -> target_clause.
+  // The negated constraint is part of every target, so that the
+  // unsatisfiable core also proves that the lifted cube satisfies the
+  // invariant constraints — see the constructor.
   Var act_var = S.newVar();
   Lit act = mkLit(act_var, false);
   {
@@ -449,6 +493,8 @@ cubet ic3_solvert::lift(
     for(auto l : target_clause)
       if(!l.is_false())
         clause.push(to_minisat(l));
+    if(!constraint_lit.is_true())
+      clause.push(to_minisat(!constraint_lit));
     S.addClause(clause);
   }
 

--- a/src/new-ic3/ic3_solver.cpp
+++ b/src/new-ic3/ic3_solver.cpp
@@ -289,6 +289,16 @@ std::unique_ptr<IctMinisat::Solver> ic3_solvert::new_minisat_solver()
     S->newVar();
   for(const auto &clause : base_cnf->get_clauses())
     add_minisat_clause(*S, clause);
+  // Restrict decisions to latch and input variables. The AIG gates are
+  // encoded with the full 3-clause Tseitin AND encoding (both polarities),
+  // so once all latch-current and input variables are assigned, BCP
+  // implies every internal gate variable; models are thus still total.
+  for(IctMinisat::Var v = 0; v < S->nVars(); v++)
+    S->setDecisionVar(v, false);
+  for(const auto &latch : latches)
+    S->setDecisionVar(latch.current.var_no(), true);
+  for(auto l : input_lits)
+    S->setDecisionVar(l.var_no(), true);
   return S;
 }
 

--- a/src/new-ic3/ic3_solver.cpp
+++ b/src/new-ic3/ic3_solver.cpp
@@ -839,11 +839,21 @@ ic3_resultt ic3_solvert::solve()
         else
         {
           cubet generalized = generalize(level - 1, core);
-          add_clause(level, negate_cube(generalized));
 
-          // Re-queue at level+1 to push the blocking clause higher
-          if(level + 1 <= k)
-            obligations.push({std::move(cube), level + 1});
+          // Eagerly push the generalized clause to the highest frame where
+          // it is still relatively inductive: one query per level, instead
+          // of a full re-generalization when the obligation is re-queued.
+          std::size_t push_to = level;
+          while(push_to < k &&
+                relative_induction(push_to, generalized, nullptr, false))
+          {
+            push_to++;
+          }
+
+          add_clause(push_to, negate_cube(generalized));
+
+          if(push_to + 1 <= k)
+            obligations.push({std::move(cube), push_to + 1});
         }
       }
     } // end blocking phase

--- a/src/new-ic3/ic3_solver.h
+++ b/src/new-ic3/ic3_solver.h
@@ -106,6 +106,12 @@ private:
   std::unique_ptr<recording_cnft> base_cnf;
   bvt init_units;
 
+  // Conjunction of the invariant constraints at the current frame.
+  // Asserted as a unit clause in the frame and init solvers and added
+  // to every lift target, but NOT asserted in the lifting solver —
+  // see the constructor.
+  literalt constraint_lit = const_literal(true);
+
   void replay_base_cnf(cnft &dest, bool with_init);
 
   std::unique_ptr<satcheck_no_simplifiert> init_solver;


### PR DESCRIPTION
Two performance optimizations for the `--new-ic3` engine, motivated by profiling on the HWMCC08 sample from src/new-ic3/PERFORMANCE.md.

1. **Decision-variable restriction**: the per-frame MiniSAT solvers only branch on latch and input variables. The AIG gates use the full 3-clause Tseitin encoding, so BCP totalizes any assignment of latches and inputs; models remain genuine. Removes the `pickBranchLit` overhead (previously ~half of SAT search time); uniform 7–22% speedup.
2. **Eager clause pushing**: after MIC generalization, the blocking phase pushes the generalized clause to the highest frame where it is still relatively inductive — one SAT query per level — instead of re-running a full MIC generalization each time the obligation is re-queued one level higher. This fixes the engine's main weakness, refutations with deep counterexamples.

Results on the 49-benchmark HWMCC08 sample (60 s timeout, M2 Max; details added to PERFORMANCE.md):

| | solved (of 49) | timeouts | total time on solved |
|---|---:|---:|---:|
| before | 43 | 6 | 108.3 s |
| after | 45 | 4 | 88.9 s |

139453p22 (t/o → 5.5 s) and bc57sensorsp2 (t/o → 44.6 s) are newly solved; on the 43 benchmarks solved before, total time drops 108.3 s → 38.8 s (2.8x). Largest single improvements: neclaftp1001 16.0 → 1.3 s, nusmvtcasp5 24.3 → 4.7 s, 139462p24 13.9 → 0.8 s. Only regression: csmacdp2 1.3 → 4.7 s. prodcellp2 now terminates (~110 s) instead of diverging. All verdicts match the published HWMCC08 results, and the `regression/ebmc/new-ic3` tests pass.

A third experiment (VSIDS-style decay of the MIC literal-activity ordering) improved eijkbs3330 but caused a reproducible 15x regression on 139453p22 and was dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)