### PR TITLE
SMV: KNOWNBUG test for bare section headers

### DIFF
--- a/regression/smv/syntax-errors/bare_section_headers1.desc
+++ b/regression/smv/syntax-errors/bare_section_headers1.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+bare_section_headers1.smv
+--bound 1
+^EXIT=1$
+^SIGNAL=0$
+--
+Bare TRANS/INIT/INVAR/FAIRNESS/SPEC/CTLSPEC/LTLSPEC headers are accepted
+as empty sections (parser.y:447). Truncated or malformed SMV input can
+silently weaken the model instead of failing with a parse error.

--- a/regression/smv/syntax-errors/bare_section_headers1.smv
+++ b/regression/smv/syntax-errors/bare_section_headers1.smv
@@ -1,0 +1,14 @@
+-- Bare section headers with no formula should be rejected.
+-- Truncated or malformed input can silently weaken the model.
+
+MODULE main
+
+VAR x : boolean;
+
+TRANS
+INIT
+INVAR
+FAIRNESS
+SPEC
+CTLSPEC
+LTLSPEC


### PR DESCRIPTION
Bare `TRANS`/`INIT`/`INVAR`/`FAIRNESS`/`SPEC`/`CTLSPEC`/`LTLSPEC` headers are accepted as empty sections (`parser.y:447`). Truncated or malformed SMV input can silently weaken the model instead of failing with a parse error.

This adds a `KNOWNBUG` regression test documenting the issue. The parser currently silently accepts these bare keywords, which means a truncated or accidentally incomplete SMV file will parse successfully but with missing constraints/properties — potentially making verification unsound.