### PR TITLE
SMV: error on FAIRNESS constraints

### DIFF
--- a/regression/smv/fairness/fairness1.desc
+++ b/regression/smv/fairness/fairness1.desc
@@ -1,0 +1,9 @@
+CORE
+fairness1.smv
+
+^file .* line 5: fairness constraints are not supported$
+^EXIT=2$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/smv/fairness/fairness1.smv
+++ b/regression/smv/fairness/fairness1.smv
@@ -1,0 +1,5 @@
+MODULE main
+
+VAR x : boolean;
+
+FAIRNESS x

--- a/src/smvlang/smv_typecheck.cpp
+++ b/src/smvlang/smv_typecheck.cpp
@@ -2435,12 +2435,8 @@ void smv_typecheckt::typecheck(smv_parse_treet::modulet::elementt &element)
     return;
 
   case smv_parse_treet::modulet::elementt::FAIRNESS:
-    typecheck(element.expr, OTHER);
-    convert_expr_to(element.expr, bool_typet{});
-    no_next_allowed(element.expr);
-    no_CTL_allowed(element.expr);
-    no_LTL_allowed(element.expr);
-    return;
+    throw errort().with_location(element.location)
+      << "fairness constraints are not supported";
 
   case smv_parse_treet::modulet::elementt::ASSIGN_CURRENT:
     typecheck(element.lhs(), OTHER);


### PR DESCRIPTION
EBMC does not support fairness constraints. Previously, FAIRNESS declarations were parsed and typechecked without error but silently ignored during model checking. This change rejects them at typecheck time with a clear error message.

## Changes
- `src/smvlang/smv_typecheck.cpp`: Replace the FAIRNESS typecheck logic with an error throw
- `regression/smv/fairness/fairness1.{smv,desc}`: Regression test confirming the error

## Testing
- `make -C regression/smv test` — all tests pass
- `make -C regression/smv test-z3` — all tests pass