### PR TITLE
SMV: error on duplicate module names

### DIFF
--- a/regression/smv/modules/duplicate_module1.desc
+++ b/regression/smv/modules/duplicate_module1.desc
@@ -1,0 +1,7 @@
+CORE
+duplicate_module1.smv
+
+^file .* line 10: duplicate module name `main'$
+^EXIT=2$
+^SIGNAL=0$
+--

--- a/regression/smv/modules/duplicate_module1.smv
+++ b/regression/smv/modules/duplicate_module1.smv
@@ -1,0 +1,12 @@
+MODULE main
+
+VAR x : boolean;
+
+MODULE other
+
+VAR y : boolean;
+
+-- duplicate of main
+MODULE main
+
+VAR z : boolean;

--- a/src/smvlang/smv_typecheck.cpp
+++ b/src/smvlang/smv_typecheck.cpp
@@ -28,6 +28,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cassert>
 #include <set>
 #include <stack>
+#include <unordered_set>
 
 class smv_typecheckt:public typecheckt
 {
@@ -80,6 +81,8 @@ protected:
   smv_indext index;
   const std::string &module_identifier;
 
+  static void
+  check_duplicate_module_names(const smv_parse_treet::module_listt &);
   void check_type(typet &);
   smv_ranget convert_type(const typet &) const;
 
@@ -3195,6 +3198,32 @@ void smv_typecheckt::convert(smv_parse_treet::modulet &smv_module)
 
 /*******************************************************************\
 
+Function: smv_typecheckt::check_duplicate_module_names
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void smv_typecheckt::check_duplicate_module_names(
+  const smv_parse_treet::module_listt &module_list)
+{
+  std::unordered_set<irep_idt, irep_id_hash> module_names;
+  for(const auto &module : module_list)
+  {
+    if(!module_names.insert(module.base_name).second)
+    {
+      throw errort().with_location(module.source_location)
+        << "duplicate module name `" << module.base_name << "'";
+    }
+  }
+}
+
+/*******************************************************************\
+
 Function: smv_typecheckt::typecheck
 
   Inputs:
@@ -3209,6 +3238,9 @@ void smv_typecheckt::typecheck()
 {
   if(module_identifier != "smv::main")
     return;
+
+  // check for duplicate module names
+  check_duplicate_module_names(smv_parse_tree.module_list);
 
   // build the index
   index = smv_indext{smv_parse_tree};


### PR DESCRIPTION
Duplicate `MODULE` declarations with the same name silently overwrote earlier entries in the module map, causing the analyzed module to potentially differ from the source.

This adds an error diagnostic that reports the duplicate at the second occurrence's source location. 

**Changes:**
- `src/smvlang/smv_typecheck.cpp`: Check for duplicate module names before building the index
- `regression/smv/modules/duplicate_module1.smv`: Test input with `MODULE main` declared twice
- `regression/smv/modules/duplicate_module1.desc`: Expects error with exit code 2