### PR TITLE
KNOWNBUG: s_until_with lowered to ordinary R instead of strong release

### DIFF
--- a/regression/ebmc/SVA-LTL/s_until_with1.desc
+++ b/regression/ebmc/SVA-LTL/s_until_with1.desc
@@ -1,0 +1,12 @@
+KNOWNBUG
+s_until_with1.sv
+--bdd
+^\[main\.p0\] always \(0 s_until_with 1\): REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+sva_s_until_with is lowered to ordinary R instead of strong release in
+SVA_to_LTL (src/temporal-logic/sva_to_ltl.cpp:229). The BDD engine uses
+this path and can therefore falsely prove s_until_with properties.
+The word-level BMC engine (trans-word-level/property.cpp) is not affected
+as it correctly uses strong_R_exprt.

--- a/regression/ebmc/SVA-LTL/s_until_with1.sv
+++ b/regression/ebmc/SVA-LTL/s_until_with1.sv
@@ -1,0 +1,17 @@
+module main(input clk, input a, input b);
+
+  // s_until_with is the strong form of until_with.
+  // "a s_until_with b" means: b holds at every cycle until and including
+  // the cycle where a holds, AND a must eventually hold (the strong part).
+  //
+  // The bug: sva_to_ltl.cpp lowers s_until_with to ordinary R (release),
+  // which does NOT enforce the "a must eventually hold" requirement.
+  // It should be lowered to strong release.
+
+  // This property should be REFUTED: 0 never holds, so the strong
+  // requirement (lhs must eventually become true) is violated.
+  // With the buggy lowering to ordinary R, it is incorrectly PROVED
+  // because R allows lhs to never hold as long as rhs holds forever.
+  p0: assert property (0 s_until_with 1);
+
+endmodule


### PR DESCRIPTION
## Summary

`sva_s_until_with` is lowered to ordinary `R` (release) in `sva_to_ltl.cpp:229`, even though the rest of the code documents it as strong release with swapped operands (`sva_expr.h:787`). Engines using `SVA_to_LTL` can therefore falsely prove `s_until_with` properties.

## Test

Adds a KNOWNBUG regression test (`regression/verilog/SVA/s_until_with1`) that asserts:

```systemverilog
initial p0: assert property (counter==11 s_until_with counter<=10);
```

This should be **REFUTED** because `counter==11` never holds (violating the strong liveness requirement), but is incorrectly PROVED with the current lowering to ordinary `R`.

## Root cause

`src/temporal-logic/sva_to_ltl.cpp:229` returns `R_exprt{rec_rhs, rec_lhs}` — it should use a strong release operator instead.

## References

- `src/temporal-logic/sva_to_ltl.cpp:229`
- `src/verilog/sva_expr.h:787`