### PR TITLE
KNOWNBUG test for incorrect strong_R encoding

### DIFF
--- a/regression/verilog/SVA/strong_R1.desc
+++ b/regression/verilog/SVA/strong_R1.desc
@@ -1,0 +1,14 @@
+KNOWNBUG
+strong_R1.sv
+--bound 20
+^\[main\.p0\] .*: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The encoding of ID_strong_R in src/trans-word-level/property.cpp is incorrect.
+The comment says strong_R(p, q) = Fp ∧ (p R q), but the implementation builds
+F(q) ∧ (p W q), which weakens strong release. In this test, the s_until_with
+lhs can never hold (counter never exceeds 14), so the property should be
+REFUTED, but due to the bug it is incorrectly PROVED.

--- a/regression/verilog/SVA/strong_R1.sv
+++ b/regression/verilog/SVA/strong_R1.sv
@@ -1,0 +1,27 @@
+// Test for incorrect encoding of strong release (strong_R / s_until_with).
+//
+// "a s_until_with b" maps to strong_R(b, a), which should mean:
+// F(b) ∧ (b R a), i.e., b eventually holds, and a holds at every step
+// up to and including the step when b first holds.
+//
+// The bug in property.cpp encodes strong_R(p, q) as F(q) ∧ (p W q)
+// instead of the correct F(p) ∧ (p R q).
+//
+// p0: The lhs of s_until_with never holds (counter never exceeds 14
+//     since it saturates at 10), so the property should be REFUTED by
+//     the strong eventuality requirement.
+
+module main(input clk);
+
+  reg [3:0] counter = 0;
+
+  always_ff @(posedge clk)
+    if(counter < 10)
+      counter <= counter + 1;
+
+  // "1 s_until_with (counter > 14)" should be REFUTED:
+  // counter never exceeds 10, so the strong requirement that the lhs
+  // (counter > 14) eventually holds is not met.
+  initial p0: assert property (1 s_until_with (counter > 4'd14));
+
+endmodule


### PR DESCRIPTION
Add a regression test exposing the incorrect encoding of `ID_strong_R` in `src/trans-word-level/property.cpp` (line ~518).

## Bug

The comment says `strong_R(p, q) = Fp ∧ (p R q)`, but the implementation builds `F(q) ∧ (p W q)`, which weakens strong release.

## Test

The test uses `1 s_until_with (counter > 14)` where the counter saturates at 10. Since the lhs can never hold, the strong eventuality requirement fails and the property should be **REFUTED**. Due to the bug, it is incorrectly PROVED.

Marked as KNOWNBUG until the encoding is fixed.