### PR TITLE
BDD: add EX input reproducer

### DIFF
--- a/regression/ebmc/BDD/EX_input1.desc
+++ b/regression/ebmc/BDD/EX_input1.desc
@@ -1,0 +1,13 @@
+KNOWNBUG
+EX_input1.smv
+--bdd
+^\[spec1\] EX some_var = TRUE: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The BDD implementation of EX leaves current input variables in the resulting
+state set instead of projecting them away. That makes the satisfaction set for
+EX some_var depend on the current value of some_input, so the initial state is
+incorrectly classified as violating the property.

--- a/regression/ebmc/BDD/EX_input1.smv
+++ b/regression/ebmc/BDD/EX_input1.smv
@@ -1,0 +1,10 @@
+MODULE main
+
+IVAR some_input : boolean;
+VAR some_var : boolean;
+
+ASSIGN init(some_var) := FALSE;
+ASSIGN next(some_var) := some_input;
+
+-- There exists a successor with some_var = TRUE when some_input = TRUE.
+SPEC EX some_var = TRUE


### PR DESCRIPTION
## Summary
Add a minimal KNOWNBUG regression that isolates the BDD EX bug with unconstrained current inputs.

## Testing
- src/ebmc/ebmc regression/ebmc/BDD/EX_input1.smv --bdd
  - currently reports REFUTED, reproducing the bug
