### PR TITLE
BDD: project inputs in EX

### DIFF
--- a/regression/ebmc/BDD/EX_input1.desc
+++ b/regression/ebmc/BDD/EX_input1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 EX_input1.smv
 --bdd
 ^\[spec1\] EX some_var = TRUE: PROVED$
@@ -6,8 +6,3 @@ EX_input1.smv
 ^SIGNAL=0$
 --
 ^warning: ignoring
---
-The BDD implementation of EX leaves current input variables in the resulting
-state set instead of projecting them away. That makes the satisfaction set for
-EX some_var depend on the current value of some_input, so the initial state is
-incorrectly classified as violating the property.

--- a/regression/smv/next/next3.desc
+++ b/regression/smv/next/next3.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 next3.smv
 --bdd
 ^\[.*\] AX x <-> !x: PROVED$
@@ -6,4 +6,3 @@ next3.smv
 ^SIGNAL=0$
 --
 --
-The BDD engine gives the wrong answer.

--- a/src/ebmc/bdd_engine.cpp
+++ b/src/ebmc/bdd_engine.cpp
@@ -777,7 +777,7 @@ void bdd_enginet::build_BDDs()
   for(const auto &v : vars)
   {
     transition_relation.variables.push_back(
-      {v.second.current_bdd, v.second.next_bdd});
+      {v.second.current_bdd, v.second.next_bdd, v.second.is_input});
   }
 
   // Add the next-state variable constraints for

--- a/src/ebmc/bdd_model_checker.cpp
+++ b/src/ebmc/bdd_model_checker.cpp
@@ -34,6 +34,17 @@ mini_bddt bdd_model_checkert::project_next(const mini_bddt &bdd) const
   return tmp;
 }
 
+mini_bddt bdd_model_checkert::project_inputs(const mini_bddt &bdd) const
+{
+  mini_bddt tmp = bdd;
+
+  for(const auto &v : transition_relation.variables)
+    if(v.is_input)
+      tmp = exists(tmp, v.current.var());
+
+  return tmp;
+}
+
 mini_bddt bdd_model_checkert::fixedpoint(
   std::function<mini_bddt(mini_bddt)> tau,
   mini_bddt x)
@@ -64,7 +75,7 @@ mini_bddt bdd_model_checkert::EX(mini_bddt f)
   for(const auto &c : transition_relation.constraint_conjuncts)
     conjunction = conjunction & c;
 
-  return project_next(conjunction);
+  return project_inputs(project_next(conjunction));
 }
 
 mini_bddt bdd_model_checkert::EF(mini_bddt f)

--- a/src/ebmc/bdd_model_checker.h
+++ b/src/ebmc/bdd_model_checker.h
@@ -23,6 +23,7 @@ struct bdd_transition_relationt
   {
     mini_bddt current;
     mini_bddt next;
+    bool is_input = false;
   };
 
   std::vector<variable_pairt> variables;
@@ -57,6 +58,7 @@ protected:
   const bdd_transition_relationt &transition_relation;
 
   mini_bddt current_to_next(const mini_bddt &) const;
+  mini_bddt project_inputs(const mini_bddt &) const;
   mini_bddt project_next(const mini_bddt &) const;
   mini_bddt fixedpoint(std::function<mini_bddt(mini_bddt)>, mini_bddt);
 };

--- a/unit/ebmc/bdd_model_checker.cpp
+++ b/unit/ebmc/bdd_model_checker.cpp
@@ -50,6 +50,25 @@ static bdd_transition_relationt make_counter_system(mini_bdd_mgrt &mgr)
   return tr;
 }
 
+/// Build a system with one Boolean input i and one Boolean state s.
+/// Transition: next(s) = i.
+/// The input is unconstrained, so every current state has a successor with
+/// s=1 and a successor with s=0.
+static bdd_transition_relationt make_input_driven_system(mini_bdd_mgrt &mgr)
+{
+  auto i = mgr.Var("i");
+  auto i_next = mgr.Var("i'");
+  auto s = mgr.Var("s");
+  auto s_next = mgr.Var("s'");
+
+  bdd_transition_relationt tr;
+  tr.variables.push_back({i, i_next, true});
+  tr.variables.push_back({s, s_next});
+  tr.transition_conjuncts.push_back(s_next == i);
+
+  return tr;
+}
+
 SCENARIO("BDD model checker EX on toggle system")
 {
   mini_bdd_mgrt mgr;
@@ -88,6 +107,27 @@ SCENARIO("BDD model checker AX on toggle system")
     THEN("AX(s) equals EX(s)")
     {
       REQUIRE((mc.AX(s) == mc.EX(s)).is_true());
+    }
+  }
+}
+
+SCENARIO("BDD model checker EX projects current inputs")
+{
+  mini_bdd_mgrt mgr;
+  auto tr = make_input_driven_system(mgr);
+  auto s = tr.variables[1].current;
+  bdd_model_checkert mc(tr);
+
+  GIVEN("An unconstrained current input determines the next state")
+  {
+    THEN("EX(s) is true for all current states")
+    {
+      REQUIRE(mc.EX(s).is_true());
+    }
+
+    THEN("EX(!s) is also true for all current states")
+    {
+      REQUIRE(mc.EX(!s).is_true());
     }
   }
 }


### PR DESCRIPTION
## Summary
Project current input variables out of the BDD EX pre-image so CTL state sets do not depend on unconstrained inputs.

Promote EX_input1 from KNOWNBUG to CORE and add a unit test that exercises the input-projection behavior directly in bdd_model_checkert.

## Testing
- src/ebmc/ebmc regression/ebmc/BDD/EX_input1.smv --bdd
- src/ebmc/ebmc regression/ebmc/BDD/EX1.smv --bdd
- make -C unit
