### PR TITLE
BDD: ignore finite deadend branches in AG

### DIFF
--- a/regression/ebmc/BDD/AFAG_deadend1.desc
+++ b/regression/ebmc/BDD/AFAG_deadend1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 AFAG_deadend1.smv
 --bdd
 ^\[spec1\] AF AG good: PROVED$
@@ -6,9 +6,3 @@ AFAG_deadend1.smv
 ^SIGNAL=0$
 --
 ^warning: ignoring
---
-The BDD implementation of nested AG uses AG p = !EF !p over the raw
-transition relation. A finite branch into a deadend state with !p is therefore
-treated as a witness against AG p, even though the existing deadend regressions
-use conventions where finite deadend branches do not falsify universal
-properties.

--- a/regression/smv/CTL/smv_ctlspec_AFAG1.bdd.desc
+++ b/regression/smv/CTL/smv_ctlspec_AFAG1.bdd.desc
@@ -1,10 +1,8 @@
-KNOWNBUG
-smv_ltlspec_AFAG1.smv
+CORE
+smv_ctlspec_AFAG1.smv
 --bdd
 ^\[spec1\] AF AG !buechi_state: PROVED$
 ^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring
---
-The BDD engine returns the wrong answer.

--- a/src/ebmc/bdd_model_checker.cpp
+++ b/src/ebmc/bdd_model_checker.cpp
@@ -88,6 +88,14 @@ mini_bddt bdd_model_checkert::EG(mini_bddt f)
   return fixedpoint([this](mini_bddt x) { return x & EX(x); }, f);
 }
 
+mini_bddt bdd_model_checkert::AG(mini_bddt f)
+{
+  // Over non-total transition systems we quantify over infinite paths only.
+  // A finite branch into a deadend state must therefore not witness AG(!p).
+  mini_bddt live_states = EG(f | !f);
+  return !EF(live_states & !f);
+}
+
 mini_bddt bdd_model_checkert::EU(mini_bddt f1, mini_bddt f2)
 {
   return fixedpoint(

--- a/src/ebmc/bdd_model_checker.h
+++ b/src/ebmc/bdd_model_checker.h
@@ -43,13 +43,13 @@ public:
   mini_bddt EX(mini_bddt);
   mini_bddt EF(mini_bddt);
   mini_bddt EG(mini_bddt);
+  mini_bddt AG(mini_bddt);
   mini_bddt EU(mini_bddt, mini_bddt);
   mini_bddt AU(mini_bddt, mini_bddt);
 
   // clang-format off
   mini_bddt AX(mini_bddt f) { return !EX(!f); }
   mini_bddt AF(mini_bddt f) { return !EG(!f); }
-  mini_bddt AG(mini_bddt f) { return !EF(!f); }
   mini_bddt ER(mini_bddt f1, mini_bddt f2) { return !AU(!f1, !f2); }
   mini_bddt AR(mini_bddt f1, mini_bddt f2) { return !EU(!f1, !f2); }
   // clang-format on

--- a/unit/ebmc/bdd_model_checker.cpp
+++ b/unit/ebmc/bdd_model_checker.cpp
@@ -69,6 +69,21 @@ static bdd_transition_relationt make_input_driven_system(mini_bdd_mgrt &mgr)
   return tr;
 }
 
+/// Build a system with one Boolean state good.
+/// Transition: if good is true, the system may stay in good forever or move
+/// to !good. Once !good is reached there are no further successors.
+static bdd_transition_relationt make_good_or_deadend_system(mini_bdd_mgrt &mgr)
+{
+  auto good = mgr.Var("good");
+  auto good_next = mgr.Var("good'");
+
+  bdd_transition_relationt tr;
+  tr.variables.push_back({good, good_next});
+  tr.transition_conjuncts.push_back(good);
+
+  return tr;
+}
+
 SCENARIO("BDD model checker EX on toggle system")
 {
   mini_bdd_mgrt mgr;
@@ -194,6 +209,27 @@ SCENARIO("BDD model checker AG on toggle system")
     THEN("AG(true) is true")
     {
       REQUIRE(mc.AG(mgr.True()).is_true());
+    }
+  }
+}
+
+SCENARIO("BDD model checker AG ignores finite dead-end branches")
+{
+  mini_bdd_mgrt mgr;
+  auto tr = make_good_or_deadend_system(mgr);
+  auto good = tr.variables[0].current;
+  bdd_model_checkert mc(tr);
+
+  GIVEN("A live state that can also branch into a finite bad deadend")
+  {
+    THEN("AG(good) holds because all infinite paths stay in good")
+    {
+      REQUIRE(mc.AG(good).is_true());
+    }
+
+    THEN("AF(AG(good)) also holds")
+    {
+      REQUIRE(mc.AF(mc.AG(good)).is_true());
     }
   }
 }


### PR DESCRIPTION
Treat AG over non-total transition systems as quantifying over infinite paths only, so finite deadend branches do not witness a violation.
    
This fixes the minimal `AFAG_deadend1` reproducer and the SMV CTL regression `smv_ctlspec_AFAG1`, and adds unit coverage for AG on a live state with a finite bad branch.