### PR TITLE
Verilog: fix strong release in word-level BMC

### DIFF
--- a/regression/verilog/SVA/strong_R1.desc
+++ b/regression/verilog/SVA/strong_R1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 strong_R1.sv
 --bound 20
 ^\[main\.p0\] .*: REFUTED$

--- a/src/trans-word-level/property.cpp
+++ b/src/trans-word-level/property.cpp
@@ -178,7 +178,8 @@ static obligationst property_obligations_rec(
     property_expr.id() == ID_sva_always)
   {
     // We want AG phi.
-    auto &phi = [](const exprt &expr) -> const exprt & {
+    auto &phi = [](const exprt &expr) -> const exprt &
+    {
       if(expr.id() == ID_AG)
         return to_AG_expr(expr).op();
       else if(expr.id() == ID_G)
@@ -521,7 +522,7 @@ static obligationst property_obligations_rec(
     auto &q = to_strong_R_expr(property_expr).rhs();
 
     // p strongR q ≡ Fp ∧ (p R q)
-    exprt tmp = and_exprt{F_exprt{q}, weak_U_exprt{p, q}};
+    exprt tmp = and_exprt{F_exprt{p}, R_exprt{p, q}};
 
     return property_obligations_rec(
       tmp, allow_pending_matches, current, no_timeframes, lasso);
@@ -887,7 +888,8 @@ obligationst property_obligations_lasso(
   {
     return expr.id() == ID_F || expr.id() == ID_AF ||
            expr.id() == ID_sva_s_eventually || expr.id() == ID_sva_s_until ||
-           expr.id() == ID_U || expr.id() == ID_strong_R;
+           expr.id() == ID_sva_s_until_with || expr.id() == ID_U ||
+           expr.id() == ID_strong_R;
   };
 
   // Does the property use a lasso? This assumes NNF.


### PR DESCRIPTION
Fixes the false proof exposed by PR #1999 in the word-level BMC property encoding.

Summary:
- Correct strong_R(p, q) to F(p) and (p R q)
- Treat s_until_with as a lasso-requiring property for the infinite-path encoding
- Promote regression/verilog/SVA/strong_R1.desc from KNOWNBUG to CORE

Testing:
- ./src/ebmc/ebmc regression/verilog/SVA/strong_R1.sv --bound 20