### PR TITLE
hw-cbmc: remove dead transition-system trace code

### DIFF
--- a/src/hw-cbmc/Makefile
+++ b/src/hw-cbmc/Makefile
@@ -37,7 +37,6 @@ OBJ+= $(CPROVER_DIR)/goto-checker/goto-checker$(LIBEXT) \
       ../ebmc/ebmc_language$(OBJEXT) \
       ../ebmc/show_modules$(OBJEXT) \
       ../temporal-logic/temporal-logic$(LIBEXT) \
-      ../trans-netlist/trans_trace$(OBJEXT) \
       ../trans-word-level/trans-word-level$(LIBEXT)
 
 include ../config.inc

--- a/src/hw-cbmc/hw_cbmc_parse_options.cpp
+++ b/src/hw-cbmc/hw_cbmc_parse_options.cpp
@@ -39,8 +39,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <langapi/mode.h>
 #include <linking/static_lifetime_init.h>
 #include <trans-word-level/instantiate_word_level.h>
-#include <trans-word-level/trans_trace_word_level.h>
-#include <trans-word-level/unwind.h>
 #include <verilog/verilog_ebmc_language.h>
 
 #include "gen_interface.h"
@@ -726,56 +724,4 @@ void hw_cbmc_parse_optionst::help()
     " --gen-interface              print C for interface to module\n"
     " --vcd file                   dump error trace in VCD format\n"
     "\n";
-}
-
-void hw_cbmc_parse_optionst::do_unwind_module(prop_convt &prop_conv) {
-  if (unwind_module == "" || unwind_no_timeframes == 0)
-    return;
-
-  namespacet ns{goto_model.symbol_table};
-  const symbolt &symbol = ns.lookup(unwind_module);
-
-  log.status() << "Unwinding transition system `" << symbol.name << "' with "
-               << unwind_no_timeframes << " time frames" << messaget::eom;
-
-  //  auto dp= get_decision_procedure();
-
-  ::unwind(to_trans_expr(symbol.value), ui_message_handler, prop_conv,
-           unwind_no_timeframes, ns, true);
-
-  log.status() << "Unwinding transition system done" << messaget::eom;
-}
-
-void hw_cbmc_parse_optionst::show_unwind_trace(const optionst &options,
-                                               const prop_convt &prop_conv) {
-  if (unwind_module == "" || unwind_no_timeframes == 0)
-    return;
-
-  namespacet ns{goto_model.symbol_table};
-  auto trans_trace =
-    compute_trans_trace(prop_conv, unwind_no_timeframes, ns, unwind_module);
-
-  if (options.get_option("vcd") != "") {
-    if (options.get_option("vcd") == "-")
-      show_trans_trace_vcd(trans_trace, log, ns, std::cout);
-    else {
-      std::ofstream out(widen_if_needed(options.get_option("vcd")));
-      show_trans_trace_vcd(trans_trace, log, ns, out);
-    }
-  }
-
-  switch(ui_message_handler.get_ui())
-  {
-  case ui_message_handlert::uit::PLAIN:
-    show_trans_trace(trans_trace, log, ns, std::cout);
-    break;
-
-  case ui_message_handlert::uit::XML_UI:
-    show_trans_trace_xml(trans_trace, log, ns, std::cout);
-    break;
-
-  case ui_message_handlert::uit::JSON_UI:
-    show_trans_trace_json(trans_trace, log, ns, std::cout);
-    break;
-  }
 }

--- a/src/hw-cbmc/hw_cbmc_parse_options.h
+++ b/src/hw-cbmc/hw_cbmc_parse_options.h
@@ -29,16 +29,6 @@ public:
   irep_idt unwind_module;
   unsigned unwind_no_timeframes;
 
-  virtual void do_unwind_module(prop_convt &prop_conv);
-
-  virtual void show_unwind_trace(const optionst &options,
-                                 const prop_convt &prop_conv);
-
-  virtual void error_trace(const optionst &options,
-                           const prop_convt &prop_conv) {
-    show_unwind_trace(options, prop_conv);
-  }
-
 protected:
   virtual int get_modules(std::list<exprt> &bmc_constraints);
 


### PR DESCRIPTION
`hw_cbmc_parse_optionst::do_unwind_module`, `show_unwind_trace` and `error_trace` overrode virtual hooks that were removed from `cbmc_parse_optionst` with the CBMC 6 goto-checker refactoring; nothing calls them anymore, so the VCD/trace output they implement is unreachable.

This removes the three methods, the `trans-word-level/unwind.h` and `trans-word-level/trans_trace_word_level.h` includes that only they used, and the `trans-netlist/trans_trace` object from the link line, which was only needed for these functions.

No functional change. hw-cbmc builds and the `regression/hw-cbmc` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)