### PR TITLE
hw-cbmc: make register_languages a proper override

### DIFF
--- a/src/hw-cbmc/Makefile
+++ b/src/hw-cbmc/Makefile
@@ -4,6 +4,9 @@ SRC = hw_cbmc_main.cpp hw_cbmc_parse_options.cpp next_timeframe.cpp \
 
 OBJ+= $(CPROVER_DIR)/goto-checker/goto-checker$(LIBEXT) \
       $(CPROVER_DIR)/cbmc/cbmc_parse_options$(OBJEXT) \
+      $(CPROVER_DIR)/cbmc/cbmc_languages$(OBJEXT) \
+      $(CPROVER_DIR)/json-symtab-language/json-symtab-language$(LIBEXT) \
+      $(CPROVER_DIR)/statement-list/statement-list$(LIBEXT) \
       $(CPROVER_DIR)/goto-instrument/cover$(OBJEXT) \
       $(CPROVER_DIR)/goto-instrument/cover_basic_blocks$(OBJEXT) \
       $(CPROVER_DIR)/goto-instrument/cover_instrument_assume$(OBJEXT) \

--- a/src/hw-cbmc/hw_cbmc_languages.cpp
+++ b/src/hw-cbmc/hw_cbmc_languages.cpp
@@ -23,11 +23,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <smvlang/smv_language.h>
 #endif
 
-#include <cbmc/cbmc_parse_options.h>
+#include "hw_cbmc_parse_options.h"
 
 /*******************************************************************\
 
-Function: cbmc_parse_optionst::register_languages
+Function: hw_cbmc_parse_optionst::register_languages
 
   Inputs:
 
@@ -37,7 +37,7 @@ Function: cbmc_parse_optionst::register_languages
 
 \*******************************************************************/
 
-void cbmc_parse_optionst::register_languages()
+void hw_cbmc_parse_optionst::register_languages()
 {
   register_language(new_ansi_c_language);
   register_language(new_cpp_language);

--- a/src/hw-cbmc/hw_cbmc_parse_options.h
+++ b/src/hw-cbmc/hw_cbmc_parse_options.h
@@ -18,9 +18,9 @@ Author: Daniel Kroening, kroening@kroening.com
 class hw_cbmc_parse_optionst:public cbmc_parse_optionst
 {
 public:
-  virtual int doit();
-  virtual void help();
-  
+  int doit() override;
+  void help() override;
+
   hw_cbmc_parse_optionst(int argc, const char **argv):
     cbmc_parse_optionst(argc, argv, HW_CBMC_OPTIONS)
   {
@@ -30,6 +30,8 @@ public:
   unsigned unwind_no_timeframes;
 
 protected:
+  void register_languages() override;
+
   virtual int get_modules(std::list<exprt> &bmc_constraints);
 
   irep_idt get_top_module();


### PR DESCRIPTION
`hw_cbmc_languages.cpp` used to define the *base class's* `cbmc_parse_optionst::register_languages`, relying on the Makefile linking `cbmc_parse_options.o` while deliberately omitting `cbmc_languages.o`. This link-time translation-unit substitution breaks silently if the CBMC submodule ever restructures those translation units.

This PR overrides the virtual `register_languages` in `hw_cbmc_parse_optionst` instead and links the submodule's `cbmc_languages.o` normally, matching the pattern used by `ebmc_parse_optionst`. That requires additionally linking the `statement-list` and `json-symtab-language` libraries the base-class definition references (link-time only — those languages are not registered by hw-cbmc, since the override is what runs).

The class's remaining virtuals (`doit`, `help`) gain the `override` keyword to satisfy `-Winconsistent-missing-override`.

No functional change. hw-cbmc builds and the `regression/hw-cbmc` suite passes, including the Verilog tests that exercise the overridden language registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)