### PR TITLE
hw-cbmc: use CPROVER_EXIT_* constants instead of magic exit codes

### DIFF
--- a/src/hw-cbmc/hw_cbmc_parse_options.cpp
+++ b/src/hw-cbmc/hw_cbmc_parse_options.cpp
@@ -407,7 +407,7 @@ int hw_cbmc_parse_optionst::doit()
   if(cmdline.isset("version"))
   {
     std::cout << CBMC_VERSION << std::endl;
-    return 0;
+    return CPROVER_EXIT_SUCCESS;
   }
 
   //
@@ -434,7 +434,7 @@ int hw_cbmc_parse_optionst::doit()
   if(cmdline.isset("preprocess"))
   {
     preprocessing(options);
-    return 0;
+    return CPROVER_EXIT_SUCCESS;
   }
 
   if(cmdline.args.empty())
@@ -561,11 +561,11 @@ int hw_cbmc_parse_optionst::doit()
   if(cmdline.isset("show-properties"))
   {
     show_properties(goto_model, ui_message_handler);
-    return 0;
+    return CPROVER_EXIT_SUCCESS;
   }
 
   if(set_properties())
-    return 7;
+    return CPROVER_EXIT_SET_PROPERTIES_FAILED;
 
   std::unique_ptr<goto_verifiert> verifier = std::make_unique<
     all_properties_verifier_with_trace_storaget<multi_path_symex_checkert>>(
@@ -660,7 +660,7 @@ int hw_cbmc_parse_optionst::get_modules(std::list<exprt> &bmc_constraints) {
           if(!out)
           {
             log.error() << "failed to open given outfile" << messaget::eom;
-            return 6;
+            return CPROVER_EXIT_INCORRECT_TASK;
           }
 
           gen_interface(goto_model.symbol_table, symbol, true, out, std::cerr);
@@ -668,7 +668,7 @@ int hw_cbmc_parse_optionst::get_modules(std::list<exprt> &bmc_constraints) {
         else
           gen_interface(goto_model.symbol_table, symbol, true, std::cout, std::cerr);
 
-        return 0; // done
+        return CPROVER_EXIT_SUCCESS; // done
       }
 
       //
@@ -681,19 +681,22 @@ int hw_cbmc_parse_optionst::get_modules(std::list<exprt> &bmc_constraints) {
                ui_message_handler, get_bound());
     }
 
-    catch(int e) { return 6; }
+    catch(int e)
+    {
+      return CPROVER_EXIT_EXCEPTION;
+    }
   }
   else if(cmdline.isset("gen-interface"))
   {
     log.error() << "must specify top module name for gen-interface"
                 << messaget::eom;
-    return 6;
+    return CPROVER_EXIT_INCORRECT_TASK;
   }
   else if(cmdline.isset("show-modules"))
   {
     show_modulest::from_symbol_table(goto_model.symbol_table)
       .plain_text(std::cout);
-    return 0; // done
+    return CPROVER_EXIT_SUCCESS; // done
   }
 
   return -1; // continue


### PR DESCRIPTION
Replaces the bare `return 0`, `return 6` and `return 7` exit codes in `hw_cbmc_parse_optionst::doit()` and `get_modules()` with the named `CPROVER_EXIT_*` constants from `util/exit_codes.h`, matching upstream `cbmc_parse_optionst`.

The numeric values are unchanged, so this is a pure readability change:

* `0` → `CPROVER_EXIT_SUCCESS`
* `7` → `CPROVER_EXIT_SET_PROPERTIES_FAILED`
* `6` → `CPROVER_EXIT_INCORRECT_TASK` (unopenable `--outfile`, missing `--top` for `--gen-interface`) and `CPROVER_EXIT_EXCEPTION` (the `catch(int)` handler)

Arguably the missing-`--top` case is a usage error, but `CPROVER_EXIT_USAGE_ERROR` is `1`, and this PR deliberately avoids changing observable exit codes.

hw-cbmc builds and the `regression/hw-cbmc` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)