### PR TITLE
KNOWNBUG test: liveness-to-safety rejects assumed plain-safety properties

### DIFF
--- a/regression/ebmc/liveness-to-safety/safety_assumption1.desc
+++ b/regression/ebmc/liveness-to-safety/safety_assumption1.desc
@@ -1,0 +1,15 @@
+KNOWNBUG
+safety_assumption1.sv
+--bound 10 --liveness-to-safety
+^EXIT=0$
+^SIGNAL=0$
+^\[main\.assume\.1\] always main\.a: ASSUMED$
+^\[main\.p0\] always s_eventually main\.my_bit: PROVED up to bound 10$
+--
+--
+The liveness-to-safety translation rejects any non-disabled property it
+cannot translate, including assumed plain-safety properties
+(src/ebmc/liveness_to_safety.cpp). "assume property (always a)" alongside
+a liveness assertion yields "error: no liveness-to-safety translation for
+always main.a" and EXIT=6. The assumption needs no translation and should
+be passed through unchanged.

--- a/regression/ebmc/liveness-to-safety/safety_assumption1.sv
+++ b/regression/ebmc/liveness-to-safety/safety_assumption1.sv
@@ -1,0 +1,17 @@
+module main(input clk, input a);
+
+  reg my_bit;
+
+  initial my_bit=0;
+
+  always @(posedge clk)
+    my_bit = !my_bit;
+
+  // A plain-safety assumption. It requires no liveness-to-safety
+  // translation, and should simply be kept as an assumption.
+  assume property (always a);
+
+  // expected to pass
+  p0: assert property (s_eventually my_bit);
+
+endmodule


### PR DESCRIPTION
The liveness-to-safety translation (`src/ebmc/liveness_to_safety.cpp`) throws "no liveness-to-safety translation" for any non-disabled property it cannot translate, including assumed properties. A plain-safety assumption such as

```systemverilog
assume property (always a);
```

alongside a liveness assertion therefore makes `ebmc --liveness-to-safety` exit with an error:

```
file safety_assumption1.sv line 15: error: no liveness-to-safety translation for always main.a
EXIT=6
```

The assumption requires no translation and should simply be passed through unchanged; the expected outcome is ASSUMED for the assumption and PROVED for the (true) liveness assertion, as plain BMC reports.

Observed while diagnosing #2007, which needs a rework of how the translation handles assumptions; this case should be covered by the same rework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)