### PR TITLE
new IC3: handle netlist invariant constraints

### DIFF
--- a/regression/ebmc/new-ic3/constraint_proved1.desc
+++ b/regression/ebmc/new-ic3/constraint_proved1.desc
@@ -1,0 +1,7 @@
+CORE
+constraint_proved1.smv
+--new-ic3
+^\[spec1\] AG x: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/new-ic3/constraint_proved1.smv
+++ b/regression/ebmc/new-ic3/constraint_proved1.smv
@@ -1,0 +1,15 @@
+-- A property that is only provable because of the INVAR constraint.
+-- Without INVAR x, the variable x is unconstrained and AG x would be refuted.
+
+MODULE main
+
+VAR x : boolean;
+VAR y : boolean;
+
+INVAR x
+
+ASSIGN
+  init(y) := FALSE;
+  next(y) := x & y;
+
+SPEC AG x

--- a/regression/ebmc/new-ic3/constraint_proved2.desc
+++ b/regression/ebmc/new-ic3/constraint_proved2.desc
@@ -1,0 +1,7 @@
+CORE
+constraint_proved2.smv
+--new-ic3
+^\[spec1\] AG y: PROVED$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/new-ic3/constraint_proved2.smv
+++ b/regression/ebmc/new-ic3/constraint_proved2.smv
@@ -1,0 +1,21 @@
+-- Multiple INVAR constraints that together prove a property.
+-- Each constraint alone is insufficient: we need both x and y
+-- to be constrained for the implication x -> y to hold,
+-- because y is unconstrained otherwise.
+
+MODULE main
+
+VAR x : boolean;
+VAR y : boolean;
+VAR z : boolean;
+
+-- Constrain x to TRUE and z to FALSE
+INVAR x
+INVAR !z
+
+ASSIGN
+  init(y) := TRUE;
+  next(y) := x & !z;
+
+-- y stays TRUE because x=TRUE and z=FALSE in every state
+SPEC AG y

--- a/regression/ebmc/new-ic3/constraint_refuted1.desc
+++ b/regression/ebmc/new-ic3/constraint_refuted1.desc
@@ -1,0 +1,8 @@
+CORE
+constraint_refuted1.smv
+--new-ic3
+^Property refuted with counterexample of length 4$
+^\[spec1\] AG cnt != 3: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/ebmc/new-ic3/constraint_refuted1.smv
+++ b/regression/ebmc/new-ic3/constraint_refuted1.smv
@@ -1,0 +1,19 @@
+-- A property that is refuted despite the INVAR constraint.
+-- The constraint restricts x to TRUE, but the property checks y,
+-- which counts and eventually reaches 3.
+
+MODULE main
+
+VAR x : boolean;
+VAR cnt : 0..3;
+
+INVAR x
+
+ASSIGN
+  init(cnt) := 0;
+  next(cnt) := case
+    cnt < 3 : cnt + 1;
+    TRUE    : cnt;
+  esac;
+
+SPEC AG cnt != 3

--- a/src/new-ic3/ic3_solver.cpp
+++ b/src/new-ic3/ic3_solver.cpp
@@ -129,6 +129,11 @@ ic3_solvert::ic3_solvert(
   // Encode the netlist into CNF: one timeframe only — the next-state
   // functions are nodes in the same variable space.
   base_cnf = std::make_unique<recording_cnft>(solver_message_handler);
+
+  // Take invariant constraints out of the netlist before encoding.
+  const auto constraints = std::move(netlist.constraints);
+  netlist.constraints.clear();
+
   bmc_mapt bmc_map(netlist, 1, *base_cnf);
   {
     messaget message{solver_message_handler};
@@ -136,6 +141,20 @@ ic3_solvert::ic3_solvert(
   }
 
   prop_current = bmc_map.translate(0, prop_netlist_lit);
+
+  // Build the constraint literal from the saved constraints.
+  if(!constraints.empty())
+  {
+    literalt c_all = const_literal(true);
+    for(auto c : constraints)
+      c_all = base_cnf->land(c_all, bmc_map.translate(0, c));
+    if(!c_all.is_true())
+    {
+      constraint_lit = c_all;
+      // Weaken the property: bad = constraints ∧ ¬P
+      prop_current = base_cnf->lor(!c_all, prop_current);
+    }
+  }
 
   // The initial state constraint, as unit clauses.
   for(auto n : netlist.initial)
@@ -178,6 +197,8 @@ ic3_solvert::ic3_solvert(
   init_solver =
     std::make_unique<satcheck_no_simplifiert>(solver_message_handler);
   replay_base_cnf(*init_solver, true);
+  if(!constraint_lit.is_true())
+    init_solver->lcnf({constraint_lit});
 
   // Create lifting solver using IC3's MiniSAT (has releaseVar).
   lift_minisat = new_minisat_solver();
@@ -300,6 +321,8 @@ IctMinisat::Solver &ic3_solvert::get_solver(std::size_t level)
   if(!fs)
   {
     fs = new_minisat_solver();
+    if(!constraint_lit.is_true())
+      add_minisat_clause(*fs, {constraint_lit});
     if(level == 0)
       for(auto l : init_units)
         add_minisat_clause(*fs, {l});
@@ -430,7 +453,7 @@ cubet ic3_solvert::lift(
     if(l.is_true())
       return full_state;
 
-  // Activation literal for the target clause: act -> target_clause
+  // Activation literal for the target clause: act -> target_clause ∨ ¬constraint
   Var act_var = S.newVar();
   Lit act = mkLit(act_var, false);
   {
@@ -439,6 +462,8 @@ cubet ic3_solvert::lift(
     for(auto l : target_clause)
       if(!l.is_false())
         clause.push(to_minisat(l));
+    if(!constraint_lit.is_true())
+      clause.push(to_minisat(!constraint_lit));
     S.addClause(clause);
   }
 

--- a/src/new-ic3/ic3_solver.cpp
+++ b/src/new-ic3/ic3_solver.cpp
@@ -130,6 +130,11 @@ ic3_solvert::ic3_solvert(
   // Encode the netlist into CNF: one timeframe only — the next-state
   // functions are nodes in the same variable space.
   base_cnf = std::make_unique<recording_cnft>(message_handler);
+
+  // Take invariant constraints out of the netlist before encoding.
+  const auto constraints = std::move(netlist.constraints);
+  netlist.constraints.clear();
+
   bmc_mapt bmc_map(netlist, 1, *base_cnf);
   {
     messaget message{message_handler};
@@ -137,6 +142,20 @@ ic3_solvert::ic3_solvert(
   }
 
   prop_current = bmc_map.translate(0, prop_netlist_lit);
+
+  // Build the constraint literal from the saved constraints.
+  if(!constraints.empty())
+  {
+    literalt c_all = const_literal(true);
+    for(auto c : constraints)
+      c_all = base_cnf->land(c_all, bmc_map.translate(0, c));
+    if(!c_all.is_true())
+    {
+      constraint_lit = c_all;
+      // Weaken the property: bad = constraints ∧ ¬P
+      prop_current = base_cnf->lor(!c_all, prop_current);
+    }
+  }
 
   // The initial state constraint, as unit clauses.
   for(auto n : netlist.initial)
@@ -179,6 +198,8 @@ ic3_solvert::ic3_solvert(
   init_solver =
     std::make_unique<satcheck_no_simplifiert>(solver_message_handler);
   replay_base_cnf(*init_solver, true);
+  if(!constraint_lit.is_true())
+    init_solver->lcnf({constraint_lit});
 
   // Create lifting solver using IC3's MiniSAT (has releaseVar).
   lift_minisat = new_minisat_solver();
@@ -301,6 +322,8 @@ IctMinisat::Solver &ic3_solvert::get_solver(std::size_t level)
   if(!fs)
   {
     fs = new_minisat_solver();
+    if(!constraint_lit.is_true())
+      add_minisat_clause(*fs, {constraint_lit});
     if(level == 0)
       for(auto l : init_units)
         add_minisat_clause(*fs, {l});
@@ -431,7 +454,7 @@ cubet ic3_solvert::lift(
     if(l.is_true())
       return full_state;
 
-  // Activation literal for the target clause: act -> target_clause
+  // Activation literal for the target clause: act -> target_clause ∨ ¬constraint
   Var act_var = S.newVar();
   Lit act = mkLit(act_var, false);
   {
@@ -440,6 +463,8 @@ cubet ic3_solvert::lift(
     for(auto l : target_clause)
       if(!l.is_false())
         clause.push(to_minisat(l));
+    if(!constraint_lit.is_true())
+      clause.push(to_minisat(!constraint_lit));
     S.addClause(clause);
   }
 

--- a/src/new-ic3/ic3_solver.cpp
+++ b/src/new-ic3/ic3_solver.cpp
@@ -122,7 +122,7 @@ static void add_minisat_clause(IctMinisat::Solver &S, const bvt &clause)
 // ============================================================
 
 ic3_solvert::ic3_solvert(
-  const netlistt &netlist,
+  netlistt &netlist,
   literalt prop_netlist_lit,
   message_handlert &message_handler)
   : message_handler(message_handler)

--- a/src/new-ic3/ic3_solver.h
+++ b/src/new-ic3/ic3_solver.h
@@ -106,6 +106,9 @@ private:
   std::unique_ptr<recording_cnft> base_cnf;
   bvt init_units;
 
+  // Conjunction of invariant constraints at the current frame.
+  literalt constraint_lit = const_literal(true);
+
   void replay_base_cnf(cnft &dest, bool with_init);
 
   std::unique_ptr<satcheck_no_simplifiert> init_solver;

--- a/src/new-ic3/ic3_solver.h
+++ b/src/new-ic3/ic3_solver.h
@@ -82,7 +82,7 @@ class ic3_solvert
 {
 public:
   ic3_solvert(
-    const netlistt &,
+    netlistt &,
     literalt property_literal,
     message_handlert &message_handler);
 

--- a/src/new-ic3/ic3_solver.h
+++ b/src/new-ic3/ic3_solver.h
@@ -129,6 +129,9 @@ private:
   std::unique_ptr<recording_cnft> base_cnf;
   bvt init_units;
 
+  // Conjunction of invariant constraints at the current frame.
+  literalt constraint_lit = const_literal(true);
+
   void replay_base_cnf(cnft &dest, bool with_init);
 
   std::unique_ptr<satcheck_no_simplifiert> init_solver;


### PR DESCRIPTION
## Summary
- Extract invariant constraints from the netlist before CNF encoding and conjoin them into a single constraint literal
- Assert constraint in init solver and all frame solvers
- Include in lift targets (bad = constraints ∧ ¬P)

**This is a correctness fix** — without it, designs with invariant constraints (common in HWMCC benchmarks) produce spurious counterexamples or fail to prove valid properties.

## Individual benefit
Required for correctness on constrained designs. Prerequisite for all other optimizations on HWMCC'25 benchmarks.

## Synergies
Prerequisite for all other IC3 PRs when running on constrained netlists.

## Test plan
- [x] `regression/ebmc/new-ic3` passes
- [x] Builds with `-Werror` (GCC)