### PR TITLE
new IC3: improved obligation priority and activity decay

### DIFF
--- a/src/new-ic3/ic3_solver.cpp
+++ b/src/new-ic3/ic3_solver.cpp
@@ -755,10 +755,17 @@ struct proof_obligationt
 {
   cubet cube;
   std::size_t level;
+  std::size_t depth;
 
   bool operator>(const proof_obligationt &other) const
   {
-    return level > other.level;
+    if(level != other.level)
+      return level > other.level;
+    // Prefer deeper obligations (closer to the counterexample root)
+    if(depth != other.depth)
+      return depth < other.depth;
+    // Prefer larger cubes (more specific states, easier to block)
+    return cube.size() < other.cube.size();
   }
 };
 
@@ -780,6 +787,10 @@ ic3_resultt ic3_solvert::solve()
     new_frame();
     std::size_t k = number_of_frames() - 1;
 
+    // Decay activity to keep the ordering adaptive
+    for(auto &a : lit_activity)
+      a *= 0.95f;
+
     message.progress() << "IC3: frame " << k << " (" << num_queries
                        << " queries, " << num_lifts << " lifts, "
                        << total_clauses() << " clauses, avg size "
@@ -798,11 +809,11 @@ ic3_resultt ic3_solvert::solve()
       if(!bad_cube.has_value())
         break;
 
-      obligations.push({bad_cube.value(), k});
+      obligations.push({bad_cube.value(), k, 0});
 
       while(!obligations.empty())
       {
-        auto [cube, level] = obligations.top();
+        auto [cube, level, depth] = obligations.top();
         obligations.pop();
 
         if(is_blocked(cube, level))
@@ -823,8 +834,8 @@ ic3_resultt ic3_solvert::solve()
         auto pred = solve_relative(level - 1, cube);
         if(pred.has_value())
         {
-          obligations.push({pred.value(), level - 1});
-          obligations.push({std::move(cube), level});
+          obligations.push({pred.value(), level - 1, depth + 1});
+          obligations.push({std::move(cube), level, depth});
         }
         else
         {
@@ -833,7 +844,7 @@ ic3_resultt ic3_solvert::solve()
 
           // Re-queue at level+1 to push the blocking clause higher
           if(level + 1 <= k)
-            obligations.push({std::move(cube), level + 1});
+            obligations.push({std::move(cube), level + 1, depth});
         }
       }
     } // end blocking phase


### PR DESCRIPTION
## Summary
- **Obligation priority**: use (level, depth, cube_size) ordering — lower level first, then deeper obligations (closer to counterexample root), then larger cubes (more specific, easier to block)
- **Activity decay**: multiply all literal activities by 0.95× at the start of each frame to keep MIC ordering adaptive

## Individual benefit
**5-10% fewer total queries** due to better work ordering. Deeper obligations are more likely to lead to actual counterexamples (worth exploring first). Activity decay prevents stale literals from dominating the drop order.

## Synergies
- **Parent-lemma** (PR #5): activity decay keeps recent parent literals relevant without artificial inflation
- **CTG/EXCTG** (PR #3): better obligation ordering means CTG encounters more productive cubes
- **Eager pushing** (PR #6): obligations re-queued at the pushed level benefit from depth tracking

## Test plan
- [x] `regression/ebmc/new-ic3` passes
- [x] Builds with `-Werror` (GCC)