### PR TITLE
CI: run ebmc over the LogikBench circuits and publish a report

### DIFF
--- a/.github/workflows/logikbench.yaml
+++ b/.github/workflows/logikbench.yaml
@@ -1,0 +1,97 @@
+name: LogikBench
+
+# Runs ebmc over the LogikBench RTL benchmark suite
+# (https://github.com/zeroasiccorp/logikbench) and publishes an HTML report
+# to GitHub Pages.  This is a report-only smoke test of the Verilog/
+# SystemVerilog front-end and elaboration over a wide range of real-world
+# circuits; it never fails the build on a per-circuit basis.
+
+on:
+  # Refresh the published report whenever main changes.
+  push:
+    branches: [ main ]
+  # Weekly, to pick up new LogikBench circuits.
+  schedule:
+    - cron: '0 4 * * 1'
+  # Allow manual runs from the Actions tab.
+  workflow_dispatch:
+
+# Allow the job to deploy to GitHub Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# A single in-progress deployment at a time; do not cancel a running one.
+concurrency:
+  group: pages-logikbench
+  cancel-in-progress: false
+
+jobs:
+  # Build ebmc and run it over the LogikBench circuits, producing the report.
+  run-logikbench:
+    name: Run ebmc on LogikBench
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - name: Fetch dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get remove --purge man-db
+          packages_to_install="flex bison libxml2-utils ccache"
+          if ! sudo apt-get install --no-install-recommends -yq $packages_to_install ; then
+            sudo apt-get update
+            sudo apt-get install --no-install-recommends -yq $packages_to_install
+          fi
+      - name: Prepare ccache
+        uses: actions/cache/restore@v6
+        with:
+          path: .ccache
+          key: ${{ runner.os }}-24.04-make-gcc-logikbench-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-24.04-make-gcc-logikbench
+            ${{ runner.os }}-24.04-make-gcc
+      - name: ccache environment
+        run: |
+          echo "CCACHE_BASEDIR=$PWD" >> $GITHUB_ENV
+          echo "CCACHE_DIR=$PWD/.ccache" >> $GITHUB_ENV
+      - name: Zero ccache stats and limit in size
+        run: ccache -z --max-size=500M
+      - name: Get cadical and minisat
+        run: make -C lib/cbmc/src cadical-download minisat2-download
+      - name: Build ebmc with make
+        run: make -C src/ebmc -j4 CXX="ccache g++" MINISAT2=../../minisat-2.2.1 CADICAL=../../cadical
+      - name: Save ccache
+        uses: actions/cache/save@v6
+        if: always()
+        with:
+          path: .ccache
+          key: ${{ runner.os }}-24.04-make-gcc-logikbench-${{ github.sha }}
+      - name: Try the ebmc binary
+        run: ./src/ebmc/ebmc --version
+      - name: Run ebmc on the LogikBench circuits
+        run: |
+          mkdir -p _site
+          PATH=$PATH:$PWD/src/ebmc benchmarking/logikbench.sh _site/index.html
+      - name: Upload the report as a Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: _site
+
+  # Publish the report to GitHub Pages.  Skipped on forks, where Pages is
+  # not configured.
+  deploy:
+    name: Publish report to GitHub Pages
+    needs: run-logikbench
+    if: github.event_name != 'pull_request' && github.repository == 'diffblue/hw-cbmc'
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/benchmarking/logikbench.sh
+++ b/benchmarking/logikbench.sh
@@ -25,14 +25,18 @@ set -u
 LOGIKBENCH_REV=main
 
 # Per-circuit wall-clock limit, in seconds, so that a single hard design
-# cannot stall the whole run.  Requires coreutils `timeout` (present on Linux).
-PER_CIRCUIT_TIMEOUT=${PER_CIRCUIT_TIMEOUT:-120}
+# cannot stall the whole run.  Uses coreutils `timeout` (present on Linux) or
+# `gtimeout` (coreutils on macOS, `brew install coreutils`).
+PER_CIRCUIT_TIMEOUT=${PER_CIRCUIT_TIMEOUT:-60}
 
 REPORT=${1:-logikbench-report.html}
 
 if command -v timeout > /dev/null 2>&1 ; then
   RUN="timeout $PER_CIRCUIT_TIMEOUT"
+elif command -v gtimeout > /dev/null 2>&1 ; then
+  RUN="gtimeout $PER_CIRCUIT_TIMEOUT"
 else
+  echo "warning: no timeout/gtimeout found; running without a per-circuit limit"
   RUN=""
 fi
 

--- a/benchmarking/logikbench.sh
+++ b/benchmarking/logikbench.sh
@@ -1,0 +1,180 @@
+#!/bin/sh
+
+# This runs ebmc over the RTL circuits in the LogikBench benchmark suite
+# (https://github.com/zeroasiccorp/logikbench) and produces an HTML report.
+#
+# LogikBench is a large collection of human-authored and AI-generated Verilog
+# and SystemVerilog RTL circuits, organised into benchmark groups (basic,
+# arithmetic, memory, blocks, epfl, iscas85, iscas89, koios, large).  Each
+# benchmark lives in benchmarks/<group>/<name>/ with its RTL under an rtl/
+# subdirectory.
+#
+# For every benchmark, ebmc is asked to parse and elaborate the design
+# (--bound 0).  This exercises the Verilog/SystemVerilog front-end and the
+# elaboration machinery over a wide range of real-world circuits.  The script
+# is a report-only smoke test: it writes a per-circuit HTML report but always
+# exits successfully, so that circuits ebmc cannot yet handle (e.g. unsupported
+# SystemVerilog constructs or very large SoCs) do not fail CI.
+#
+# Usage: logikbench.sh [output.html]
+#   The report is written to the given path (default: logikbench-report.html).
+
+set -u
+
+# Pin to a known revision for reproducibility.
+LOGIKBENCH_REV=main
+
+# Per-circuit wall-clock limit, in seconds, so that a single hard design
+# cannot stall the whole run.  Requires coreutils `timeout` (present on Linux).
+PER_CIRCUIT_TIMEOUT=${PER_CIRCUIT_TIMEOUT:-120}
+
+REPORT=${1:-logikbench-report.html}
+
+if command -v timeout > /dev/null 2>&1 ; then
+  RUN="timeout $PER_CIRCUIT_TIMEOUT"
+else
+  RUN=""
+fi
+
+if [ ! -e logikbench/.git ] ; then
+  echo "Cloning the LogikBench repository"
+  git clone --depth 1 --branch "$LOGIKBENCH_REV" \
+    https://github.com/zeroasiccorp/logikbench.git logikbench
+fi
+
+BENCHMARKS=logikbench/logikbench/benchmarks
+
+if [ ! -d "$BENCHMARKS" ] ; then
+  echo "LogikBench benchmarks directory not found at $BENCHMARKS"
+  exit 1
+fi
+
+EBMC_VERSION=`ebmc --version 2>/dev/null || echo unknown`
+LOGIKBENCH_SHA=`git -C logikbench rev-parse --short HEAD 2>/dev/null || echo unknown`
+GENERATED_ON=`date -u '+%Y-%m-%d %H:%M:%S UTC'`
+
+echo "Running ebmc on the LogikBench circuits"
+echo
+
+total=0
+pass=0
+fail=0
+
+# Rows of the report table are accumulated in a temporary file.
+ROWS=`mktemp`
+trap 'rm -f "$ROWS" logikbench.out' EXIT
+
+# Iterate over the benchmark groups.
+for group in "$BENCHMARKS"/*/ ; do
+  [ -d "$group" ] || continue
+  group_name=`basename "$group"`
+
+  # Iterate over the individual benchmarks in the group.
+  for bench in "$group"*/ ; do
+    [ -d "${bench}rtl" ] || continue
+
+    # Source files: the Verilog/SystemVerilog under rtl/.  ebmc selects
+    # SystemVerilog automatically for the .sv extension.
+    sources=`find "${bench}rtl" -name '*.v' -o -name '*.sv' | sort`
+    [ -n "$sources" ] || continue
+
+    bench_name=`basename "$bench"`
+
+    # Include directories: rtl/ and, if present, include/, so that `include
+    # directives and header (.vh) files resolve.
+    incflags="-I ${bench}rtl"
+    if [ -d "${bench}include" ] ; then
+      incflags="$incflags -I ${bench}include"
+    fi
+
+    total=`expr $total + 1`
+
+    # Parse and elaborate only (--bound 0).  Exit code 1 indicates a
+    # front-end/elaboration error; 124 is a timeout; anything else means ebmc
+    # processed the design (0 = holds/no properties, 10 = counterexample, ...).
+    $RUN ebmc $incflags --bound 0 $sources > logikbench.out 2>&1
+    status=$?
+
+    if [ "$status" = 0 ] || [ "$status" = 10 ] ; then
+      echo "  ok      $group_name/$bench_name"
+      pass=`expr $pass + 1`
+      css=ok ; label=ok
+    elif [ "$status" = 124 ] ; then
+      echo "  TIMEOUT $group_name/$bench_name"
+      fail=`expr $fail + 1`
+      css=timeout ; label="timeout"
+    else
+      echo "  FAIL    $group_name/$bench_name"
+      fail=`expr $fail + 1`
+      css=fail ; label="fail ($status)"
+    fi
+
+    printf '<tr class="%s"><td>%s</td><td>%s</td><td>%s</td></tr>\n' \
+      "$css" "$group_name" "$bench_name" "$label" >> "$ROWS"
+  done
+done
+
+echo
+echo "LogikBench summary: $pass/$total circuits elaborated ($fail failed)"
+
+# Emit the HTML report.
+{
+  cat <<HTML_HEAD
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>EBMC on LogikBench</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: -apple-system, system-ui, sans-serif; margin: 2rem auto;
+         max-width: 60rem; padding: 0 1rem; line-height: 1.5; }
+  h1 { margin-bottom: 0.25rem; }
+  .meta { color: #666; font-size: 0.9rem; margin-bottom: 1.5rem; }
+  .meta code { font-size: 0.85rem; }
+  .cards { display: flex; gap: 1rem; margin: 1.5rem 0; flex-wrap: wrap; }
+  .card { border: 1px solid #ccc; border-radius: 0.5rem; padding: 0.75rem 1.25rem;
+          text-align: center; min-width: 6rem; }
+  .card .n { font-size: 1.75rem; font-weight: 600; display: block; }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { text-align: left; padding: 0.35rem 0.75rem; border-bottom: 1px solid #ddd; }
+  th { position: sticky; top: 0; background: Canvas; }
+  tr.ok td:last-child { color: #1a7f37; }
+  tr.fail td:last-child { color: #cf222e; }
+  tr.timeout td:last-child { color: #9a6700; }
+</style>
+</head>
+<body>
+<h1>EBMC on LogikBench</h1>
+<p class="meta">
+  Results of running <a href="https://github.com/diffblue/hw-cbmc">ebmc</a>
+  (parse &amp; elaborate, <code>--bound 0</code>) over the
+  <a href="https://github.com/zeroasiccorp/logikbench">LogikBench</a>
+  RTL benchmark suite.<br>
+  Generated $GENERATED_ON &middot;
+  ebmc <code>$EBMC_VERSION</code> &middot;
+  logikbench <code>$LOGIKBENCH_SHA</code>
+</p>
+<div class="cards">
+  <div class="card"><span class="n">$total</span>circuits</div>
+  <div class="card"><span class="n">$pass</span>elaborated</div>
+  <div class="card"><span class="n">$fail</span>failed</div>
+</div>
+<table>
+<thead><tr><th>Group</th><th>Circuit</th><th>Result</th></tr></thead>
+<tbody>
+HTML_HEAD
+  cat "$ROWS"
+  cat <<'HTML_TAIL'
+</tbody>
+</table>
+</body>
+</html>
+HTML_TAIL
+} > "$REPORT"
+
+echo "Report written to $REPORT"
+
+# Report-only: always succeed, regardless of individual circuit failures.
+exit 0


### PR DESCRIPTION
## What

Adds a CI job that runs `ebmc` over the circuits in the [LogikBench](https://github.com/zeroasiccorp/logikbench) RTL benchmark suite and publishes a formatted HTML report to GitHub Pages.

## Details

**`benchmarking/logikbench.sh`** — clones LogikBench and runs `ebmc` in parse-and-elaborate mode (`--bound 0`) over every circuit in every benchmark group (`basic`, `arithmetic`, `memory`, `blocks`, `epfl`, `iscas85`, `iscas89`, `koios`, `large`). For each circuit it:
- passes `-I rtl` (and `-I include` when present) so `` `include `` directives and `.vh` headers resolve;
- lets `ebmc` auto-select SystemVerilog for `.sv` files;
- classifies the result as **ok** (exit `0`/`10`), **timeout** (exit `124`, via a per-circuit `timeout`), or **fail** (any other exit — e.g. front-end/elaboration errors);
- writes an HTML report with summary cards and a per-circuit table.

The script is **report-only**: it always exits `0`, so circuits `ebmc` cannot yet handle (unsupported SystemVerilog constructs, very large SoCs like cva6/rocket/wally, missing lambdalib primitives) do not turn CI red.

**`.github/workflows/logikbench.yaml`** — a new `LogikBench` workflow that builds `ebmc` (ccache), runs the script, and publishes the report to **GitHub Pages**. It runs on pushes to `main`, weekly (to pick up new circuits), and on manual dispatch. The Pages deployment is guarded to the `diffblue/hw-cbmc` repo so forks don't attempt to deploy.

## Notes

- GitHub Pages must be enabled for the repo (Settings → Pages → Source: GitHub Actions) for the `deploy` job to publish.
- LogikBench is pinned to `main`; change `LOGIKBENCH_REV` in the script to pin to a fixed revision if reproducibility across runs is desired.