### PR TITLE
Fix unsound fairness handling in liveness-to-safety translation

### DIFF
--- a/regression/ebmc/liveness-to-safety/fairness_failing1.bdd.desc
+++ b/regression/ebmc/liveness-to-safety/fairness_failing1.bdd.desc
@@ -1,0 +1,9 @@
+CORE
+fairness_failing1.sv
+--bdd --liveness-to-safety
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.p0\] always s_eventually main\.x: REFUTED$
+--
+--
+See fairness_failing1.desc; this is the reproducer for issue #2007.

--- a/regression/ebmc/liveness-to-safety/fairness_failing1.desc
+++ b/regression/ebmc/liveness-to-safety/fairness_failing1.desc
@@ -1,0 +1,14 @@
+CORE
+fairness_failing1.sv
+--bound 10 --liveness-to-safety
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.p0\] always s_eventually main\.x: REFUTED$
+--
+--
+This is the reproducer for issue #2007: the translation used to turn
+each fairness assumption into the assumed safety property
+G (looped → live), enforced at every step. The loop on the stuck
+register closes one cycle after 'save', by which at most one of the
+two fairness conditions can have been observed, so every path taking
+'save' was pruned and the property was vacuously PROVED.

--- a/regression/ebmc/liveness-to-safety/fairness_failing1.sv
+++ b/regression/ebmc/liveness-to-safety/fairness_failing1.sv
@@ -1,0 +1,18 @@
+module main(input clk, input act);
+
+  reg x;
+
+  initial x=0;
+
+  always @(posedge clk)
+    x <= x;
+
+  // Two fairness assumptions that cannot be observed
+  // in the same cycle.
+  assume property (always s_eventually act);
+  assume property (always s_eventually !act);
+
+  // expected to fail: x is stuck at 0
+  p0: assert property (s_eventually x);
+
+endmodule

--- a/regression/ebmc/liveness-to-safety/fairness_passing1.bdd.desc
+++ b/regression/ebmc/liveness-to-safety/fairness_passing1.bdd.desc
@@ -1,0 +1,11 @@
+CORE
+fairness_passing1.sv
+--bdd --liveness-to-safety
+^EXIT=0$
+^SIGNAL=0$
+^\[main\.p0\] always s_eventually main\.x: PROVED$
+--
+--
+The property only holds owing to the two fairness assumptions, which
+the liveness-to-safety translation folds into the loop-closure check
+of the asserted property.

--- a/regression/ebmc/liveness-to-safety/fairness_passing1.sv
+++ b/regression/ebmc/liveness-to-safety/fairness_passing1.sv
@@ -1,0 +1,19 @@
+module main(input clk, input a, input b);
+
+  reg x, seen_a;
+
+  initial x=0;
+  initial seen_a=0;
+
+  always @(posedge clk) begin
+    if(a) seen_a <= 1;
+    if(b && seen_a) x <= 1;
+  end
+
+  assume property (always s_eventually a);
+  assume property (always s_eventually b);
+
+  // expected to pass, owing to the two fairness assumptions
+  p0: assert property (s_eventually x);
+
+endmodule

--- a/regression/ebmc/liveness-to-safety/safety_assumption1.desc
+++ b/regression/ebmc/liveness-to-safety/safety_assumption1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 safety_assumption1.sv
 --bound 10 --liveness-to-safety
 ^EXIT=0$
@@ -7,9 +7,5 @@ safety_assumption1.sv
 ^\[main\.p0\] always s_eventually main\.my_bit: PROVED up to bound 10$
 --
 --
-The liveness-to-safety translation rejects any non-disabled property it
-cannot translate, including assumed plain-safety properties
-(src/ebmc/liveness_to_safety.cpp). "assume property (always a)" alongside
-a liveness assertion yields "error: no liveness-to-safety translation for
-always main.a" and EXIT=6. The assumption needs no translation and should
-be passed through unchanged.
+The plain-safety assumption requires no liveness-to-safety translation
+and is passed through unchanged.

--- a/src/ebmc/liveness_to_safety.cpp
+++ b/src/ebmc/liveness_to_safety.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <util/invariant.h>
 #include <util/namespace.h>
 
+#include <temporal-logic/temporal_logic.h>
 #include <trans-word-level/next_symbol.h>
 #include <verilog/sva_expr.h>
 
@@ -43,6 +44,11 @@ protected:
   using propertyt = ebmc_propertiest::propertyt;
 
   void translate_GFp(propertyt &);
+  void translate_fairness(propertyt &);
+  void create_live_variable(const propertyt &);
+
+  // The 'live' variables of the fairness assumptions.
+  exprt::operandst fairness_conditions;
 
   static symbol_exprt loop_variable(const symbol_exprt &symbol_expr)
   {
@@ -105,12 +111,18 @@ protected:
     return symbol_exprt(id2string(property_identifier) + "#live", bool_typet());
   }
 
-  static exprt
-  safety_replacement(irep_idt property_identifier, const exprt &expr)
+  exprt safety_replacement(irep_idt property_identifier) const
   {
-    // G (looped → live)
-    return sva_always_exprt(
-      implies_exprt(looped_symbol(), live_symbol(property_identifier)));
+    // G (looped ∧ fair → live)
+    // The fairness conjuncts restrict the check to loops on which
+    // all fairness assumptions were observed.
+    exprt::operandst premise_conjuncts = {looped_symbol()};
+
+    for(auto &fairness_condition : fairness_conditions)
+      premise_conjuncts.push_back(fairness_condition);
+
+    return sva_always_exprt(implies_exprt(
+      conjunction(premise_conjuncts), live_symbol(property_identifier)));
   }
 };
 
@@ -123,10 +135,27 @@ static bool property_supported(const exprt &expr)
           to_sva_always_expr(expr).op().id() == ID_sva_s_eventually);
 }
 
+/// returns true iff the given assumption can be used as-is,
+/// without liveness-to-safety translation
+static bool assumption_supported_natively(const exprt &expr)
+{
+  if(!has_temporal_operator(expr))
+    return true;
+
+  if(
+    expr.id() == ID_sva_always &&
+    !has_temporal_operator(to_sva_always_expr(expr).op()))
+  {
+    return true;
+  }
+
+  return false;
+}
+
 static bool have_supported_property(const ebmc_propertiest &properties)
 {
   for(auto &property : properties.properties)
-    if(!property.is_disabled())
+    if(!property.is_disabled() && !property.is_assumed())
       if(property_supported(property.normalized_expr))
         return true;
 
@@ -248,25 +277,47 @@ void liveness_to_safetyt::operator()()
      std::move(saved_trans),
      std::move(loop_trans)});
 
+  // Translate the assumptions first; this sets up the fairness
+  // conditions, which are needed for the translation of the
+  // asserted properties.
   for(auto &property : properties.properties)
   {
-    if(!property.is_disabled())
+    if(property.is_disabled() || !property.is_assumed())
+      continue;
+
+    if(property_supported(property.normalized_expr))
     {
-      // We want GFp.
-      if(property_supported(property.normalized_expr))
-      {
-        translate_GFp(property);
-      }
-      else
-      {
-        throw ebmc_errort().with_location(property.location)
-          << "no liveness-to-safety translation for " << property.description;
-      }
+      // A fairness assumption GFp.
+      translate_fairness(property);
+    }
+    else if(!assumption_supported_natively(property.normalized_expr))
+    {
+      throw ebmc_errort().with_location(property.location)
+        << "no liveness-to-safety translation for assumption "
+        << property.description;
+    }
+  }
+
+  // Now translate the asserted properties.
+  for(auto &property : properties.properties)
+  {
+    if(property.is_disabled() || property.is_assumed())
+      continue;
+
+    // We want GFp.
+    if(property_supported(property.normalized_expr))
+    {
+      translate_GFp(property);
+    }
+    else
+    {
+      throw ebmc_errort().with_location(property.location)
+        << "no liveness-to-safety translation for " << property.description;
     }
   }
 }
 
-void liveness_to_safetyt::translate_GFp(propertyt &property)
+void liveness_to_safetyt::create_live_variable(const propertyt &property)
 {
   auto &p = to_unary_expr(to_unary_expr(property.normalized_expr).op()).op();
 
@@ -300,10 +351,29 @@ void liveness_to_safetyt::translate_GFp(propertyt &property)
 
   transition_system.trans_expr.trans() =
     conjunction({transition_system.trans_expr.trans(), std::move(live_trans)});
+}
+
+void liveness_to_safetyt::translate_fairness(propertyt &property)
+{
+  create_live_variable(property);
+
+  // The 'live' variable is added as a premise to the translation
+  // of the asserted properties, via safety_replacement(...).
+  fairness_conditions.push_back(live_symbol(property.name));
+
+  // The assumption is now folded into the asserted properties,
+  // and must not constrain the translated model itself: enforcing
+  // G (looped → live) at every step would exclude loops that are
+  // revisited before all fairness conditions have been observed.
+  property.normalized_expr = true_exprt{};
+}
+
+void liveness_to_safetyt::translate_GFp(propertyt &property)
+{
+  create_live_variable(property);
 
   // replace the liveness property
-  property.normalized_expr =
-    safety_replacement(property.name, property.normalized_expr);
+  property.normalized_expr = safety_replacement(property.name);
 }
 
 void liveness_to_safety(


### PR DESCRIPTION
Fixes #2007.

## The bug

The liveness-to-safety translation translated assumed `always s_eventually f` properties exactly like asserted ones, into the assumed safety property `G (looped → live_f)`, which the engines then enforce as a constraint at every time step. However, `looped` holds at *every* revisit of the saved loop state, including revisits before all fairness conditions can have been observed. With two or more fairness assumptions whose witnessing cycles cannot coincide — the issue's reproducer uses `GF act` and `GF !act` on a design whose loop closes after one cycle — every path taking `save` violates one of the assumed constraints. `looped` then becomes unreachable and false liveness properties are vacuously PROVED, on both the BMC and BDD engines.

## The fix

Fairness assumptions are now folded into the loop-closure check of the asserted properties, following Biere/Artho/Schuppan (FMICS'02): each assumed `GF f` still gets a `live` bit, but the asserted `GF p` is translated to

```
G (looped ∧ live_f1 ∧ … ∧ live_fn → live_p)
```

so a loop closure only counts once all fairness conditions have been observed since `save`. The assumption itself no longer constrains the translated model. This is sound and complete: a state satisfying the negated premise-conclusion pair yields a genuine fair lasso (the saved segment repeats, replaying the fairness witnesses), and conversely any fair lasso is found at the revisit by which all fairness bits have latched.

Additionally, assumed plain-safety properties (no temporal operator, or `always` over a non-temporal condition) are now passed through unchanged rather than rejected with "no liveness-to-safety translation"; the `safety_assumption1` test from #2012 is promoted from KNOWNBUG to CORE.

## Testing

- New `fairness_failing1` tests (the issue's reproducer) — REFUTED with both `--bound 10` and `--bdd`.
- New `fairness_passing1.bdd` test — a property that holds *only because of* two fairness assumptions is still PROVED, covering the completeness direction.
- Full `regression/ebmc` CORE suite passes.

Stacked on #2012 (contains its regression-test commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)