### PR TITLE
Verilog: KNOWNBUG regression tests for `$countbits`

### DIFF
--- a/regression/verilog/system-functions/countbits1.desc
+++ b/regression/verilog/system-functions/countbits1.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+countbits1.sv
+--module main
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+$countbits is not yet implemented.

--- a/regression/verilog/system-functions/countbits1.sv
+++ b/regression/verilog/system-functions/countbits1.sv
@@ -1,0 +1,21 @@
+module main;
+
+  // $countbits counts the number of bits matching the control bit(s)
+  // Per IEEE 1800-2017 section 20.9
+
+  // count ones
+  p0: assert final ($countbits(8'b10101010, '1) == 4);
+
+  // count zeros
+  p1: assert final ($countbits(8'b10101010, '0) == 4);
+
+  // count ones in all-ones
+  p2: assert final ($countbits(8'b11111111, '1) == 8);
+
+  // count ones in all-zeros
+  p3: assert final ($countbits(8'b00000000, '1) == 0);
+
+  // count zeros in all-zeros
+  p4: assert final ($countbits(8'b00000000, '0) == 8);
+
+endmodule

--- a/regression/verilog/system-functions/countbits2.desc
+++ b/regression/verilog/system-functions/countbits2.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+countbits2.sv
+--module main
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+$countbits is not yet implemented.

--- a/regression/verilog/system-functions/countbits2.sv
+++ b/regression/verilog/system-functions/countbits2.sv
@@ -1,0 +1,22 @@
+module main;
+
+  // $countbits with multiple control bits
+  // Per IEEE 1800-2017 section 20.9
+
+  // count both ones and zeros (should equal bit width)
+  p0: assert final ($countbits(8'b10101010, '0, '1) == 8);
+
+  // count x and z bits in a four-state value
+  p1: assert final ($countbits(4'b01xz, 'x, 'z) == 2);
+
+  // count x bits only
+  p2: assert final ($countbits(4'b01xz, 'x) == 1);
+
+  // count z bits only
+  p3: assert final ($countbits(4'b01xz, 'z) == 1);
+
+  // $countbits yields an elaboration-time constant
+  parameter P = 8'b11001100;
+  parameter Q = $countbits(P, '1);
+
+endmodule

--- a/regression/verilog/system-functions/countbits3.desc
+++ b/regression/verilog/system-functions/countbits3.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+countbits3.sv
+--module main
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+$countbits is not yet implemented.

--- a/regression/verilog/system-functions/countbits3.sv
+++ b/regression/verilog/system-functions/countbits3.sv
@@ -1,0 +1,15 @@
+module main;
+
+  // If a control_bit value has a width greater than 1, only the LSB is used.
+  // Per IEEE 1800-2017 section 20.9
+
+  // 2'b01 has LSB = 1, so this counts ones
+  p0: assert final ($countbits(8'b10101010, 2'b01) == 4);
+
+  // 2'b10 has LSB = 0, so this counts zeros
+  p1: assert final ($countbits(8'b10101010, 2'b10) == 4);
+
+  // 4'b0110 has LSB = 0, so this counts zeros
+  p2: assert final ($countbits(8'b11110000, 4'b0110) == 4);
+
+endmodule


### PR DESCRIPTION
Add regression tests for the `$countbits` system function (IEEE 1800-2017 section 20.9).

## Changes

- `countbits1.sv` / `countbits1.desc`: Basic tests with a single control bit (`'1` and `'0`), including edge cases (all-ones, all-zeros).
- `countbits2.sv` / `countbits2.desc`: Tests with multiple control bits (`'0, '1` together; `'x, 'z`), and use as an elaboration-time constant.

Both tests are marked `KNOWNBUG` since `$countbits` is not yet implemented in the Verilog front-end.