### PR TITLE
Verilog: use standard terminology in `vtypet`

### DIFF
--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -2920,15 +2920,15 @@ typet verilog_typecheck_exprt::max_type(
     return t0;
 
   if(
-    vt0.is_string() && (vt1.is_signed() || vt1.is_unsigned() ||
-                        vt1.is_verilog_signed() || vt1.is_verilog_unsigned()))
+    vt0.is_string() && (vt1.is_signed_bit() || vt1.is_unsigned_bit() ||
+                        vt1.is_signed_logic() || vt1.is_unsigned_logic()))
   {
     return t0;
   }
 
   if(
-    (vt0.is_signed() || vt0.is_unsigned() || vt0.is_verilog_signed() ||
-     vt0.is_verilog_unsigned()) &&
+    (vt0.is_signed_bit() || vt0.is_unsigned_bit() || vt0.is_signed_logic() ||
+     vt0.is_unsigned_logic()) &&
     vt0.is_string())
   {
     return t1;
@@ -2947,23 +2947,20 @@ typet verilog_typecheck_exprt::max_type(
     return t0;
 
   // If one of the operands is a real, we return the real.
-  if(vt0.is_verilog_real())
+  if(vt0.is_real())
     return t0;
-  else if(vt1.is_verilog_real())
+  else if(vt1.is_real())
     return t1;
 
-  bool is_verilogbv=
-    vt0.is_verilog_signed() || vt0.is_verilog_unsigned() ||
-    vt1.is_verilog_signed() || vt1.is_verilog_unsigned();
+  // If one of the operands is four-valued, we return a four-valued type.
+  bool is_four_valued = vt0.is_four_valued() || vt1.is_four_valued();
 
   // The result is unsigned if any of the operands is
-  bool is_unsigned=
-    vt0.is_unsigned() || vt0.is_bool() || vt0.is_verilog_unsigned() ||
-    vt1.is_unsigned() || vt1.is_bool() || vt1.is_verilog_unsigned();
+  bool is_unsigned = vt0.is_unsigned_integral() || vt1.is_unsigned_integral();
 
   unsigned max_width=std::max(vt0.get_width(), vt1.get_width());
 
-  if(is_verilogbv)
+  if(is_four_valued)
   {
     if(is_unsigned)
       return verilog_unsignedbv_typet(max_width);

--- a/src/verilog/vtype.cpp
+++ b/src/verilog/vtype.cpp
@@ -40,12 +40,12 @@ vtypet::vtypet(const typet &type)
   }
   else if(type.id()==ID_unsignedbv)
   {
-    vtype=UNSIGNED;
+    vtype = UNSIGNED_BIT;
     width=to_unsignedbv_type(type).get_width();
   }
   else if(type.id()==ID_signedbv)
   {
-    vtype=SIGNED;
+    vtype = SIGNED_BIT;
     width=to_signedbv_type(type).get_width();
   }
   else if(type.id()==ID_bool)
@@ -55,22 +55,22 @@ vtypet::vtypet(const typet &type)
   }
   else if(type.id()==ID_verilog_signedbv)
   {
-    vtype=VERILOG_SIGNED;
+    vtype = SIGNED_LOGIC;
     width=to_verilog_signedbv_type(type).get_width();
   }
   else if(type.id()==ID_verilog_unsignedbv)
   {
-    vtype=VERILOG_UNSIGNED;
+    vtype = UNSIGNED_LOGIC;
     width=to_verilog_unsignedbv_type(type).get_width();
   }
   else if(type.id() == ID_verilog_realtime || type.id() == ID_verilog_real)
   {
-    vtype = VERILOG_REAL;
+    vtype = REAL;
     width = 64;
   }
   else if(type.id() == ID_verilog_shortreal)
   {
-    vtype = VERILOG_REAL;
+    vtype = REAL;
     width = 32;
   }
   else if(type.id() == ID_verilog_chandle)
@@ -113,23 +113,23 @@ std::ostream &operator << (std::ostream &out, const vtypet &vtype)
   {
   case vtypet::INTEGER:
     return out << "integer";
-    
-  case vtypet::UNSIGNED:
-    return out << "unsigned(" << vtype.get_width() << ")";
 
-  case vtypet::SIGNED:
-    return out << "signed(" << vtype.get_width() << ")";
-  
-  case vtypet::VERILOG_SIGNED:
-    return out << "verilog_signed(" << vtype.get_width() << ")";
+  case vtypet::UNSIGNED_BIT:
+    return out << "unsigned-bit(" << vtype.get_width() << ")";
 
-  case vtypet::VERILOG_UNSIGNED:
-    return out << "verilog_unsigned(" << vtype.get_width() << ")";
+  case vtypet::SIGNED_BIT:
+    return out << "signed-bit(" << vtype.get_width() << ")";
+
+  case vtypet::SIGNED_LOGIC:
+    return out << "signed-logic(" << vtype.get_width() << ")";
+
+  case vtypet::UNSIGNED_LOGIC:
+    return out << "unsigned-logic(" << vtype.get_width() << ")";
 
   case vtypet::BOOL:
     return out << "bool";
 
-  case vtypet::VERILOG_REAL:
+  case vtypet::REAL:
     return out << "real";
 
   case vtypet::NULL_TYPE:

--- a/src/verilog/vtype.h
+++ b/src/verilog/vtype.h
@@ -11,6 +11,9 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/type.h>
 
+/// a Verilog non-composite type, including
+/// integral types (1800 2017 6.11.1), realtime types,
+/// string
 class vtypet
 {
 public:
@@ -22,14 +25,26 @@ public:
   inline unsigned get_width() const { return width; }
   
   inline bool is_bool() const { return vtype==BOOL; }
-  inline bool is_signed() const { return vtype==SIGNED; }
-  inline bool is_unsigned() const { return vtype==UNSIGNED; }
-  inline bool is_integer() const { return vtype==INTEGER; }
-  inline bool is_verilog_signed() const { return vtype==VERILOG_SIGNED; }
-  inline bool is_verilog_unsigned() const { return vtype==VERILOG_UNSIGNED; }
-  inline bool is_verilog_real() const
+  inline bool is_signed_bit() const
   {
-    return vtype == VERILOG_REAL;
+    return vtype == SIGNED_BIT;
+  }
+  inline bool is_unsigned_bit() const
+  {
+    return vtype == UNSIGNED_BIT;
+  }
+  inline bool is_integer() const { return vtype==INTEGER; }
+  inline bool is_signed_logic() const
+  {
+    return vtype == SIGNED_LOGIC;
+  }
+  inline bool is_unsigned_logic() const
+  {
+    return vtype == UNSIGNED_LOGIC;
+  }
+  inline bool is_real() const
+  {
+    return vtype == REAL;
   }
   bool is_null() const
   {
@@ -49,17 +64,37 @@ public:
   }
   inline bool is_other() const { return vtype==OTHER; }
 
+  bool is_signed_integral() const
+  {
+    return vtype == SIGNED_BIT || vtype == SIGNED_LOGIC;
+  }
+
+  bool is_unsigned_integral() const
+  {
+    return vtype == BOOL || vtype == UNSIGNED_BIT || vtype == UNSIGNED_LOGIC;
+  }
+
+  bool is_two_valued() const
+  {
+    return vtype == BOOL || vtype == SIGNED_BIT || vtype == UNSIGNED_BIT;
+  }
+
+  bool is_four_valued() const
+  {
+    return vtype == SIGNED_LOGIC || vtype == UNSIGNED_LOGIC;
+  }
+
 protected:
   typedef enum
   {
     UNKNOWN,
     BOOL,
-    SIGNED,
-    UNSIGNED,
+    SIGNED_BIT,
+    UNSIGNED_BIT,
     INTEGER,
-    VERILOG_SIGNED,
-    VERILOG_UNSIGNED,
-    VERILOG_REAL,
+    SIGNED_LOGIC,
+    UNSIGNED_LOGIC,
+    REAL,
     NULL_TYPE,
     CHANDLE,
     EVENT,


### PR DESCRIPTION
This renames enums and methods in vtypet to use IEEE 1800 2017 terminology. Two-valued types are 'bit' types, and four-valued types are 'logic' types.