### PR TITLE
Verilog: validate argument type for `$size` and related functions

### DIFF
--- a/regression/verilog/system-functions/size2.desc
+++ b/regression/verilog/system-functions/size2.desc
@@ -1,10 +1,8 @@
-KNOWNBUG
+CORE
 size2.sv
 
-^file .* line 10: $
+^file .* line 10: \$size expects an array or integral argument$
 ^EXIT=2$
 ^SIGNAL=0$
 --
 ^warning: ignoring
---
-The error message has no location and is misleading.

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1339,6 +1339,18 @@ exprt verilog_typecheck_exprt::convert_system_function(function_call_exprt expr)
         << "cannot determine the number of bits of " << to_string(arguments[0]);
     }
 
+    if(
+      base_name != "$bits" && arguments[0].type().id() != ID_unsignedbv &&
+      arguments[0].type().id() != ID_signedbv &&
+      arguments[0].type().id() != ID_verilog_unsignedbv &&
+      arguments[0].type().id() != ID_verilog_signedbv &&
+      arguments[0].type().id() != ID_bool &&
+      arguments[0].type().id() != ID_array)
+    {
+      throw errort().with_location(arguments[0].source_location())
+        << base_name << " expects an array or integral argument";
+    }
+
     // The return type is integer.
     expr.type() = integer_typet();
 


### PR DESCRIPTION
## Summary

`$size`, `$left`, `$right`, `$low`, `$high`, and `$increment` now produce a type-checking error with source location when called with a non-array, non-integral argument (e.g., `real`). Previously they silently returned 0.

## Changes

- **src/verilog/verilog_typecheck_expr.cpp**: Added type validation that rejects arguments whose type is not an array or integral (bit-vector) type.
- **regression/verilog/system-functions/size2.desc**: Promoted from `KNOWNBUG` to `CORE`.

## Testing

- `make test` in `regression/verilog` passes, including the now-CORE `size2.desc` test.
- All other system-functions tests remain passing.