### PR TITLE
Verilog: package-scoped task calls

### DIFF
--- a/regression/verilog/packages/package_task1.desc
+++ b/regression/verilog/packages/package_task1.desc
@@ -1,8 +1,7 @@
-KNOWNBUG
+CORE
 package_task1.sv
 
 ^EXIT=0$
 ^SIGNAL=0$
 --
 --
-This does not parse.

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -5057,11 +5057,21 @@ unsigned_number: TOK_NUMBER
 // System Verilog standard 1800-2017
 // A.8.2 Subroutine calls
 
+// We deviate from the standard by inlining ps_or_hierarchical_tf_identifier
+// here. Using ps_or_hierarchical_tf_identifier directly causes reduce/reduce
+// conflicts in statement context, where hierarchical_identifier is also the
+// start of blocking_assignment.
 tf_call:
           hierarchical_identifier list_of_arguments_paren_opt
                 { init($$, ID_function_call);
                   stack_expr($$).operands().reserve(2);
                   mto($$, $1); mto($$, $2); }
+        | package_scope tf_identifier list_of_arguments_paren_opt
+                { mto($1, $2);
+                  pop_scope();
+                  init($$, ID_function_call);
+                  stack_expr($$).operands().reserve(2);
+                  mto($$, $1); mto($$, $3); }
         ;
 
 list_of_arguments_paren:

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -850,23 +850,46 @@ void verilog_typecheckt::convert_function_call_or_task_enable(
   }
   else
   {
-    irep_idt base_name =
-      to_verilog_identifier_expr(statement.function()).base_name();
-
-    // look it up
-    irep_idt full_identifier =
-      id2string(module_instance) + "." + id2string(base_name);
-
+    irep_idt base_name;
     const symbolt *symbol;
-    if(ns.lookup(full_identifier, symbol))
+
+    if(statement.function().id() == ID_verilog_package_scope)
     {
-      // not there? Try compilation-unit scope.
-      full_identifier = verilog_unit_scope_identifier(base_name);
+      // package-scoped task call, e.g., moo::foo()
+      auto &package_scope = to_verilog_package_scope_expr(statement.function());
+
+      auto package_base = package_scope.package_base_name();
+      base_name =
+        to_verilog_identifier_expr(package_scope.identifier()).base_name();
+
+      irep_idt full_identifier =
+        verilog_package_identifier(package_base, base_name);
 
       if(ns.lookup(full_identifier, symbol))
       {
         throw errort().with_location(statement.function().source_location())
-          << "unknown function or task `" << base_name << "'";
+          << "task `" << base_name << "' not known in package `" << package_base
+          << '\'';
+      }
+    }
+    else
+    {
+      base_name = to_verilog_identifier_expr(statement.function()).base_name();
+
+      // look it up
+      irep_idt full_identifier =
+        id2string(module_instance) + "." + id2string(base_name);
+
+      if(ns.lookup(full_identifier, symbol))
+      {
+        // not there? Try compilation-unit scope.
+        full_identifier = verilog_unit_scope_identifier(base_name);
+
+        if(ns.lookup(full_identifier, symbol))
+        {
+          throw errort().with_location(statement.function().source_location())
+            << "unknown function or task `" << base_name << "'";
+        }
       }
     }
 


### PR DESCRIPTION
Support task calls with package scope (e.g., `moo::foo()`) in statement context.

**Changes:**
- `src/verilog/parser.y`: Add `package_scope tf_identifier` alternative to the `tf_call` rule (inlined rather than using `ps_or_hierarchical_tf_identifier` directly, to avoid LALR(1) reduce/reduce conflicts).
- `src/verilog/verilog_typecheck.cpp`: Extend `convert_function_call_or_task_enable` to handle `ID_verilog_package_scope`, resolving the task symbol via the package, matching the existing handling of package-scoped function calls in expression context.
- `regression/verilog/packages/package_task1.desc`: Promote from KNOWNBUG to CORE.