### PR TITLE
Verilog: $typename support for unpacked arrays

### DIFF
--- a/regression/verilog/system-functions/typename_array1.desc
+++ b/regression/verilog/system-functions/typename_array1.desc
@@ -1,9 +1,7 @@
-KNOWNBUG
+CORE
 typename_array1.sv
 
 ^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring
---
-array output is wrong

--- a/regression/verilog/system-functions/typename_array1.sv
+++ b/regression/verilog/system-functions/typename_array1.sv
@@ -3,10 +3,18 @@ module main;
   bit some_array['h10];
   bit other_array[2:20];
   bit next_array[20:2];
+  bit multi_array[3:0][7:0];
+  int array_of_int[3];
+  bit [7:0][5:0][3:0] packed3d;
+  bit [7:0][5:0][3:0] packed3d_unpacked1d [0:4];
 
   // Array sizes must be unsigned decimal; the declarator is turned into '$'
   initial assert($typename(some_array)=="bit$[0:15]");
   initial assert($typename(other_array)=="bit$[2:20]");
   initial assert($typename(next_array)=="bit$[20:2]");
+  initial assert($typename(multi_array)=="bit$[3:0][7:0]");
+  initial assert($typename(array_of_int)=="int$[0:2]");
+  initial assert($typename(packed3d)=="bit[7:0][5:0][3:0]");
+  initial assert($typename(packed3d_unpacked1d)=="bit[7:0][5:0][3:0]$[0:4]");
 
 endmodule

--- a/src/verilog/typename.cpp
+++ b/src/verilog/typename.cpp
@@ -214,6 +214,52 @@ std::string verilog_typename(const typet &type, const namespacet &ns)
   {
     return "string";
   }
+  else if(type.id() == ID_array)
+  {
+    // Collect unpacked dimensions, then packed dimensions.
+    // Emit as base_type[packed_dims][base_range]$[unpacked_dims]
+    // matching the declaration order.
+    std::string unpacked_dimensions;
+    auto *current = &type;
+    while(current->id() == ID_array &&
+          to_verilog_array_type(*current).is_unpacked())
+    {
+      unpacked_dimensions += '[' + integer2string(verilog_left(*current)) +
+                             ':' + integer2string(verilog_right(*current)) +
+                             ']';
+      current = &to_verilog_array_type(*current).element_type();
+    }
+
+    std::string packed_dimensions;
+    while(current->id() == ID_array &&
+          to_verilog_array_type(*current).is_packed())
+    {
+      packed_dimensions += '[' + integer2string(verilog_left(*current)) + ':' +
+                           integer2string(verilog_right(*current)) + ']';
+      current = &to_verilog_array_type(*current).element_type();
+    }
+
+    auto base_type = verilog_typename(*current, ns);
+
+    // The base type might already have the innermost packed array.
+    // The packed_dimensions must be inserted before the '[', if any.
+    auto bracket_pos = base_type.find('[');
+    if(bracket_pos == std::string::npos)
+    {
+      // no bracket
+      base_type += packed_dimensions;
+    }
+    else
+    {
+      base_type = base_type.substr(0, bracket_pos) + packed_dimensions +
+                  base_type.substr(bracket_pos, std::string::npos);
+    }
+
+    if(unpacked_dimensions.empty())
+      return base_type;
+    else
+      return base_type + '$' + unpacked_dimensions;
+  }
   else
     return "?";
 }


### PR DESCRIPTION
Add handling for `ID_array` in `verilog_typename()` to format unpacked arrays as `element_type$[left:right]`, matching the SystemVerilog `$typename` output format.

Changes:
- `src/verilog/typename.cpp`: Handle the `ID_array` case by recursively formatting the element type and appending the array dimension.
- `regression/verilog/system-functions/typename_array1.desc`: Promote from KNOWNBUG to CORE.