### PR TITLE
Verilog: split type elaboration from synthesis encoding

### DIFF
--- a/regression/verilog/system-functions/typename_logic2.desc
+++ b/regression/verilog/system-functions/typename_logic2.desc
@@ -1,7 +1,7 @@
 CORE
 typename_logic2.sv
 
-^\[.*\] \$typename\(\[0:0\]\) == "logic": PROVED .*$
+^\[.*\] \$typename\(bool\) == "logic": PROVED .*$
 ^\[.*\] \$typename\(\[31:0\]\) == "logic\[31:0\]": PROVED .*$
 ^\[.*\] \$typename\(\[0:31\]\) == "logic\[0:31\]": PROVED .*$
 ^\[.*\] \$typename\(signed \[31:0\]\) == "logic signed\[31:0\]": PROVED .*$

--- a/src/verilog/typename.cpp
+++ b/src/verilog/typename.cpp
@@ -143,7 +143,10 @@ std::string verilog_typename(const typet &type, const namespacet &ns)
   }
   else if(type.id() == ID_bool)
   {
-    return "bit";
+    if(verilog_type == ID_verilog_logic)
+      return "logic";
+    else
+      return "bit";
   }
   else if(type.id() == ID_signedbv)
   {

--- a/src/verilog/verilog_elaborate.cpp
+++ b/src/verilog/verilog_elaborate.cpp
@@ -41,7 +41,8 @@ void verilog_typecheckt::collect_port_symbols(const verilog_declt &decl)
   else
   {
     // add the symbol
-    typet type = elaborate_type(declarator.merged_type(decl.type()));
+    typet type =
+      make_two_valued(elaborate_type(declarator.merged_type(decl.type())));
 
     symbolt new_symbol{identifier, type, mode};
 
@@ -435,7 +436,8 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
 
         symbol.base_name = declarator.base_name();
         symbol.location = declarator.source_location();
-        symbol.type = elaborate_type(declarator.merged_type(decl.type()));
+        symbol.type =
+          make_two_valued(elaborate_type(declarator.merged_type(decl.type())));
 
         if(symbol.base_name.empty())
         {
@@ -553,7 +555,8 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
             << "empty symbol name";
         }
 
-        symbol.type = elaborate_type(declarator.merged_type(decl.type()));
+        symbol.type =
+          make_two_valued(elaborate_type(declarator.merged_type(decl.type())));
         symbol.name = hierarchical_identifier(symbol.base_name);
         symbol.pretty_name = strip_verilog_root_prefix(symbol.name);
 
@@ -605,7 +608,8 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
 
       symbol.base_name = declarator.base_name();
       symbol.location = declarator.source_location();
-      symbol.type = elaborate_type(declarator.merged_type(decl.type()));
+      symbol.type =
+        make_two_valued(elaborate_type(declarator.merged_type(decl.type())));
 
       if(symbol.base_name.empty())
       {
@@ -672,7 +676,8 @@ void verilog_typecheckt::collect_symbols(const verilog_declt &decl)
 
       symbol.base_name = declarator.base_name();
       symbol.location = declarator.source_location();
-      symbol.type = elaborate_type(declarator.merged_type(decl.type()));
+      symbol.type =
+        make_two_valued(elaborate_type(declarator.merged_type(decl.type())));
 
       if(symbol.base_name.empty())
       {
@@ -735,7 +740,7 @@ void verilog_typecheckt::collect_symbols(
     if(is_class_constructor(decl))
       return_type = typet{ID_verilog_void};
     else
-      return_type = elaborate_type(decl.type());
+      return_type = make_two_valued(elaborate_type(decl.type()));
   }
   else
     return_type = empty_typet();
@@ -1264,8 +1269,8 @@ void verilog_typecheckt::elaborate_symbol_rec(irep_idt identifier)
     else
     {
       // No, elaborate the type.
-      auto elaborated_type =
-        elaborate_type(to_type_with_subtype(symbol.type).subtype());
+      auto elaborated_type = make_two_valued(
+        elaborate_type(to_type_with_subtype(symbol.type).subtype()));
       symbol.type = elaborated_type;
 
       // Now elaborate the value, possibly recursively, if any.

--- a/src/verilog/verilog_elaborate_type.cpp
+++ b/src/verilog/verilog_elaborate_type.cpp
@@ -37,6 +37,13 @@ static bool is_packed_type(const typet &type)
     type.id() == ID_signedbv || type.id() == ID_unsignedbv ||
     type.id() == ID_bool)
   {
+    // the 'bit' vector types
+    return true;
+  }
+  else if(
+    type.id() == ID_verilog_signedbv || type.id() == ID_verilog_unsignedbv)
+  {
+    // the 'logic' vector types
     return true;
   }
   else
@@ -253,7 +260,8 @@ typet verilog_typecheck_exprt::elaborate_type(const typet &src)
   if(src.is_nil() || src.id() == ID_reg)
   {
     // it's just a bit, unsigned, four-valued
-    auto result = bool_typet{}.with_source_location(source_location);
+    auto result =
+      verilog_unsignedbv_typet{1}.with_source_location(source_location);
     result.set(ID_C_verilog_type, ID_verilog_logic);
     return result;
   }
@@ -264,7 +272,8 @@ typet verilog_typecheck_exprt::elaborate_type(const typet &src)
     if(subtype.is_nil())
     {
       // one bit, signed, four-valued
-      auto result = signedbv_typet{1}.with_source_location(source_location);
+      auto result =
+        verilog_signedbv_typet{1}.with_source_location(source_location);
       result.set(ID_C_verilog_type, ID_verilog_logic);
       return result;
     }
@@ -287,8 +296,17 @@ typet verilog_typecheck_exprt::elaborate_type(const typet &src)
 
         return dest;
       }
-      else if(rec.id() == ID_bool)
-        return signedbv_typet{1};
+      else if(rec.id() == ID_verilog_unsignedbv)
+      {
+        typet dest =
+          verilog_signedbv_typet{to_verilog_unsignedbv_type(rec).width()};
+
+        auto verilog_type = rec.get(ID_C_verilog_type);
+        if(verilog_type != irep_idt{})
+          dest.set(ID_C_verilog_type, verilog_type);
+
+        return dest;
+      }
       else
         return rec;
     }
@@ -318,6 +336,17 @@ typet verilog_typecheck_exprt::elaborate_type(const typet &src)
         auto verilog_vector_type = rec.get(ID_C_verilog_vector_type);
         if(verilog_vector_type != irep_idt{})
           dest.set(ID_C_verilog_vector_type, verilog_vector_type);
+
+        return dest;
+      }
+      else if(rec.id() == ID_verilog_signedbv)
+      {
+        typet dest =
+          verilog_unsignedbv_typet{to_verilog_signedbv_type(rec).width()};
+
+        auto verilog_type = rec.get(ID_C_verilog_type);
+        if(verilog_type != irep_idt{})
+          dest.set(ID_C_verilog_type, verilog_type);
 
         return dest;
       }
@@ -353,17 +382,23 @@ typet verilog_typecheck_exprt::elaborate_type(const typet &src)
   else if(src.id() == ID_verilog_integer)
   {
     // four-valued type, signed
-    return signedbv_typet{32}.with_source_location(source_location);
+    auto result =
+      verilog_signedbv_typet{32}.with_source_location(source_location);
+    result.set(ID_C_verilog_type, ID_integer);
+    return result;
   }
   else if(src.id() == ID_verilog_time)
   {
     // four-valued type, unsigned
-    return unsignedbv_typet{64}.with_source_location(source_location);
+    auto result =
+      verilog_unsignedbv_typet{64}.with_source_location(source_location);
+    result.set(ID_C_verilog_type, ID_verilog_time);
+    return result;
   }
   else if(src.id() == ID_verilog_bit)
   {
     // two-valued type
-    return bool_typet().with_source_location(source_location);
+    return unsignedbv_typet{1}.with_source_location(source_location);
   }
   else if(src.id() == ID_verilog_logic)
   {
@@ -375,7 +410,8 @@ typet verilog_typecheck_exprt::elaborate_type(const typet &src)
   else if(src.id() == ID_wire)
   {
     // four-valued type
-    auto result = bool_typet{}.with_source_location(source_location);
+    auto result =
+      verilog_unsignedbv_typet{1}.with_source_location(source_location);
     result.set(ID_C_verilog_type, ID_wire);
     return result;
   }

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1606,7 +1606,7 @@ exprt verilog_typecheck_exprt::convert_nullary_expr(nullary_exprt expr)
   else if(expr.id() == ID_type)
   {
     // Used, e.g., for $bits
-    expr.type() = elaborate_type(expr.type());
+    expr.type() = make_two_valued(elaborate_type(expr.type()));
     return std::move(expr);
   }
   else if(expr.id() == ID_this)
@@ -3072,7 +3072,7 @@ exprt verilog_typecheck_exprt::convert_unary_expr(unary_exprt expr)
     // SystemVerilog has got type'(expr). This is an explicit
     // type cast. These are assignment contexts.
     convert_expr(expr.op());
-    expr.type() = elaborate_type(expr.type());
+    expr.type() = make_two_valued(elaborate_type(expr.type()));
 
     // In contrast to assignments, these can turn integers into enums
     // (1800-2017 6.19.3).
@@ -3142,7 +3142,7 @@ exprt verilog_typecheck_exprt::convert_unary_expr(unary_exprt expr)
   else if(expr.id() == ID_verilog_implicit_typecast)
   {
     // We generate implict casts during elaboration.
-    expr.type() = elaborate_type(expr.type());
+    expr.type() = make_two_valued(elaborate_type(expr.type()));
     convert_expr(expr.op());
     expr.id(ID_typecast);
   }

--- a/src/verilog/verilog_types.cpp
+++ b/src/verilog/verilog_types.cpp
@@ -76,3 +76,66 @@ constant_exprt verilog_unsignedbv_typet::all_z_expr() const
 {
   return constant_exprt{std::string(get_width(), 'z'), *this};
 }
+
+typet make_two_valued(typet src)
+{
+  if(src.id() == ID_verilog_unsignedbv)
+  {
+    // Is it [0:0]? If so, make it 'bool'
+    if(
+      to_verilog_unsignedbv_type(src).width() == 1 &&
+      src.get(ID_C_offset) == irep_idt{})
+    {
+      auto result = bool_typet{}.with_source_location(src.source_location());
+      irep_idt verilog_type = src.get(ID_C_verilog_type);
+      if(verilog_type != irep_idt{})
+        result.set(ID_C_verilog_type, verilog_type);
+      return result;
+    }
+    else
+    {
+      // replace id, preserve width and location, if any
+      src.id(ID_unsignedbv);
+      return src;
+    }
+  }
+  else if(src.id() == ID_verilog_signedbv)
+  {
+    // replace id, preserve width and location, if any
+    src.id(ID_signedbv);
+    return src;
+  }
+  else if(src.id() == ID_unsignedbv)
+  {
+    // Is it [0:0]? If so, make it 'bool'
+    if(
+      to_unsignedbv_type(src).width() == 1 &&
+      src.get(ID_C_offset) == irep_idt{})
+    {
+      auto result = bool_typet{}.with_source_location(src.source_location());
+      irep_idt verilog_type = src.get(ID_C_verilog_type);
+      if(verilog_type != irep_idt{})
+        result.set(ID_C_verilog_type, verilog_type);
+      return result;
+    }
+    else
+    {
+      // leave as is
+      return src;
+    }
+  }
+  else if(src.id() == ID_array)
+  {
+    auto &array_type = to_array_type(src);
+    array_type.element_type() = make_two_valued(array_type.element_type());
+    return src;
+  }
+  else if(src.id() == ID_struct)
+  {
+    for(auto &component : to_struct_type(src).components())
+      component.type() = make_two_valued(component.type());
+    return src;
+  }
+  else
+    return src;
+}

--- a/src/verilog/verilog_types.h
+++ b/src/verilog/verilog_types.h
@@ -998,4 +998,7 @@ public:
   }
 };
 
+/// replaces all four-valued types by their corresponding two-valued type
+typet make_two_valued(typet);
+
 #endif


### PR DESCRIPTION
The type elaboration now returns the original four-valued type as given, as opposed to replacing it by it's corresponding two-valued type.

This replacement is now done by a new function, `make_two_valued(typet)`.