### PR TITLE
SMV word-level: regression tests for Verilog operators

### DIFF
--- a/regression/ebmc/smv-word-level/arithmetic1.desc
+++ b/regression/ebmc/smv-word-level/arithmetic1.desc
@@ -1,0 +1,12 @@
+CORE
+arithmetic1.sv
+--smv-word-level
+^MODULE main$
+^INVAR a = 0ud8_10$
+^INVAR b = 0ud8_3$
+^INVAR diff = a - b$
+^INVAR neg = -a$
+^INVAR prod = a \* b$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv-word-level/arithmetic1.sv
+++ b/regression/ebmc/smv-word-level/arithmetic1.sv
@@ -1,0 +1,9 @@
+module main;
+
+  wire [7:0] a = 8'd10;
+  wire [7:0] b = 8'd3;
+  wire [7:0] diff = a - b;
+  wire [7:0] neg = -a;
+  wire [7:0] prod = a * b;
+
+endmodule

--- a/regression/ebmc/smv-word-level/bitselect1.desc
+++ b/regression/ebmc/smv-word-level/bitselect1.desc
@@ -1,0 +1,10 @@
+CORE
+bitselect1.sv
+--smv-word-level
+^MODULE main$
+^INVAR a = 0uh8_A5$
+^INVAR b0 = bool\(a\[0sd32_0:0sd32_0\]\)$
+^INVAR b7 = bool\(a\[0sd32_7:0sd32_7\]\)$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv-word-level/bitselect1.sv
+++ b/regression/ebmc/smv-word-level/bitselect1.sv
@@ -1,0 +1,7 @@
+module main;
+
+  wire [7:0] a = 8'hA5;
+  wire b0 = a[0];
+  wire b7 = a[7];
+
+endmodule

--- a/regression/ebmc/smv-word-level/bitwise1.desc
+++ b/regression/ebmc/smv-word-level/bitwise1.desc
@@ -1,0 +1,14 @@
+CORE
+bitwise1.sv
+--smv-word-level
+^MODULE main$
+^INVAR a = 0uh8_A5$
+^INVAR b = 0uh8_3C$
+^INVAR w_and = \(a & b\)$
+^INVAR w_or = \(a \| b\)$
+^INVAR w_xor = \(a xor b\)$
+^INVAR w_xnor = \(a xnor b\)$
+^INVAR w_not = !a$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv-word-level/bitwise1.sv
+++ b/regression/ebmc/smv-word-level/bitwise1.sv
@@ -1,0 +1,11 @@
+module main;
+
+  wire [7:0] a = 8'hA5;
+  wire [7:0] b = 8'h3C;
+  wire [7:0] w_and = a & b;
+  wire [7:0] w_or = a | b;
+  wire [7:0] w_xor = a ^ b;
+  wire [7:0] w_xnor = a ~^ b;
+  wire [7:0] w_not = ~a;
+
+endmodule

--- a/regression/ebmc/smv-word-level/conditional1.desc
+++ b/regression/ebmc/smv-word-level/conditional1.desc
@@ -1,0 +1,10 @@
+CORE
+conditional1.sv
+--smv-word-level
+^MODULE main$
+^INVAR a = 0ud8_10$
+^INVAR b = 0ud8_3$
+^INVAR mux = \(sel\?a:b\)$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv-word-level/conditional1.sv
+++ b/regression/ebmc/smv-word-level/conditional1.sv
@@ -1,0 +1,7 @@
+module main(input sel);
+
+  wire [7:0] a = 8'd10;
+  wire [7:0] b = 8'd3;
+  wire [7:0] mux = sel ? a : b;
+
+endmodule

--- a/regression/ebmc/smv-word-level/divmod1.desc
+++ b/regression/ebmc/smv-word-level/divmod1.desc
@@ -1,0 +1,11 @@
+CORE
+divmod1.sv
+--smv-word-level
+^MODULE main$
+^INVAR a = 0ud8_100$
+^INVAR b = 0ud8_7$
+^INVAR w_div = a / b$
+^INVAR w_mod = a mod b$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv-word-level/divmod1.sv
+++ b/regression/ebmc/smv-word-level/divmod1.sv
@@ -1,0 +1,8 @@
+module main;
+
+  wire [7:0] a = 8'd100;
+  wire [7:0] b = 8'd7;
+  wire [7:0] w_div = a / b;
+  wire [7:0] w_mod = a % b;
+
+endmodule

--- a/regression/ebmc/smv-word-level/logical1.desc
+++ b/regression/ebmc/smv-word-level/logical1.desc
@@ -1,0 +1,10 @@
+CORE
+logical1.sv
+--smv-word-level
+^MODULE main$
+^INVAR w_land = \(a & b\)$
+^INVAR w_lor = \(a \| b\)$
+^INVAR w_lnot = !a$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv-word-level/logical1.sv
+++ b/regression/ebmc/smv-word-level/logical1.sv
@@ -1,0 +1,7 @@
+module main(input a, input b);
+
+  wire w_land = a && b;
+  wire w_lor = a || b;
+  wire w_lnot = !a;
+
+endmodule

--- a/regression/ebmc/smv-word-level/reduction1.desc
+++ b/regression/ebmc/smv-word-level/reduction1.desc
@@ -1,0 +1,16 @@
+KNOWNBUG
+reduction1.sv
+--smv-word-level
+^MODULE main$
+^INVAR a = 0uh8_A5$
+^INVAR r_and = \(\)$
+^INVAR r_or = \(\)$
+^INVAR r_xor = \(\)$
+^INVAR r_nand = \(\)$
+^INVAR r_nor = \(\)$
+^INVAR r_xnor = \(\)$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Reduction operators (&, |, ^) produce norep output instead of proper SMV.

--- a/regression/ebmc/smv-word-level/reduction1.sv
+++ b/regression/ebmc/smv-word-level/reduction1.sv
@@ -1,0 +1,11 @@
+module main;
+
+  wire [7:0] a = 8'hA5;
+  wire r_and = &a;
+  wire r_or = |a;
+  wire r_xor = ^a;
+  wire r_nand = ~&a;
+  wire r_nor = ~|a;
+  wire r_xnor = ~^a;
+
+endmodule

--- a/regression/ebmc/smv-word-level/relational1.desc
+++ b/regression/ebmc/smv-word-level/relational1.desc
@@ -1,0 +1,14 @@
+CORE
+relational1.sv
+--smv-word-level
+^MODULE main$
+^INVAR a = 0ud8_10$
+^INVAR b = 0ud8_3$
+^INVAR w_lt = \(a < b\)$
+^INVAR w_gt = \(a > b\)$
+^INVAR w_le = \(a <= b\)$
+^INVAR w_ge = \(a >= b\)$
+^INVAR w_ne = \(a != b\)$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv-word-level/relational1.sv
+++ b/regression/ebmc/smv-word-level/relational1.sv
@@ -1,0 +1,11 @@
+module main;
+
+  wire [7:0] a = 8'd10;
+  wire [7:0] b = 8'd3;
+  wire w_lt = a < b;
+  wire w_gt = a > b;
+  wire w_le = a <= b;
+  wire w_ge = a >= b;
+  wire w_ne = a != b;
+
+endmodule

--- a/regression/ebmc/smv-word-level/replication1.desc
+++ b/regression/ebmc/smv-word-level/replication1.desc
@@ -1,0 +1,12 @@
+KNOWNBUG
+replication1.sv
+--smv-word-level
+^MODULE main$
+^INVAR a = 0uh4_A$
+^INVAR rep = a :: a$
+^INVAR rep3 = a :: a :: a$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Replication operator ({N{x}}) produces norep output instead of concatenation.

--- a/regression/ebmc/smv-word-level/replication1.sv
+++ b/regression/ebmc/smv-word-level/replication1.sv
@@ -1,0 +1,7 @@
+module main;
+
+  wire [3:0] a = 4'hA;
+  wire [7:0] rep = {2{a}};
+  wire [11:0] rep3 = {3{a}};
+
+endmodule

--- a/regression/ebmc/smv-word-level/shift1.desc
+++ b/regression/ebmc/smv-word-level/shift1.desc
@@ -1,0 +1,12 @@
+CORE
+shift1.sv
+--smv-word-level
+^MODULE main$
+^INVAR a = 0uh8_A5$
+^INVAR shl = a << 0sd32_2$
+^INVAR lshr = a >> 0sd32_2$
+^INVAR sa = -0sd8_10$
+^INVAR ashr = sa >> 0sd32_2$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/smv-word-level/shift1.sv
+++ b/regression/ebmc/smv-word-level/shift1.sv
@@ -1,0 +1,9 @@
+module main;
+
+  wire [7:0] a = 8'hA5;
+  wire [7:0] shl = a << 2;
+  wire [7:0] lshr = a >> 2;
+  wire signed [7:0] sa = -8'sd10;
+  wire signed [7:0] ashr = sa >>> 2;
+
+endmodule


### PR DESCRIPTION
Add regression tests for the `--smv-word-level` output covering Verilog operator groups that were previously untested:

**CORE tests (8 new, all passing):**
- `arithmetic1` — subtraction, unary minus, multiplication
- `bitwise1` — AND, OR, XOR, XNOR, NOT
- `shift1` — left shift, logical right shift, arithmetic right shift
- `relational1` — <, >, <=, >=, !=
- `conditional1` — ternary operator (? :)
- `divmod1` — division and modulo
- `logical1` — logical AND, OR, NOT
- `bitselect1` — single-bit extraction

**KNOWNBUG tests (2 new, documenting missing translation):**
- `reduction1` — reduction AND, OR, XOR produce norep output
- `replication1` — replication operator produces norep output

These document that `expr2smv.cpp` does not yet handle `ID_reduction_*` and `ID_replication` expressions.