### PR TITLE
Verilog: extend tests for `interface`

### DIFF
--- a/regression/verilog/interface/instance4.desc
+++ b/regression/verilog/interface/instance4.desc
@@ -1,9 +1,9 @@
-CORE
+KNOWNBUG
 instance4.sv
---bound 5
-^\[main\.p1\] always main\.ctr\.count <= 15: PROVED up to bound 5
+--bound 10
+^\[main\.p1\] always main\.ctr\.count <= 10: REFUTED$
 ^EXIT=0$
 ^SIGNAL=0$
 --
 --
-Interface instance with behavioral access and property checking.
+The behavior of the counter in the interface instance is overconstrainted.

--- a/regression/verilog/interface/instance4.sv
+++ b/regression/verilog/interface/instance4.sv
@@ -9,6 +9,7 @@ module main(input clk);
 
   always @(posedge clk) ctr.count = ctr.count + 1;
 
-  p1: assert property (@(posedge clk) ctr.count <= 15);
+  // should fail
+  p1: assert property (@(posedge clk) ctr.count <= 4'd10);
 
 endmodule

--- a/regression/verilog/interface/parameter1.desc
+++ b/regression/verilog/interface/parameter1.desc
@@ -1,8 +1,7 @@
 CORE
 parameter1.sv
 
-^no properties$
-^EXIT=10$
+^EXIT=0$
 ^SIGNAL=0$
 --
 --

--- a/regression/verilog/interface/parameter1.sv
+++ b/regression/verilog/interface/parameter1.sv
@@ -1,5 +1,6 @@
 interface myInterface #(parameter WIDTH = 8);
   logic [WIDTH-1:0] data;
+  initial assert($bits(data) == 16);
 endinterface
 
 module main;

--- a/regression/verilog/interface/port3.desc
+++ b/regression/verilog/interface/port3.desc
@@ -1,8 +1,7 @@
 CORE
 port3.sv
 --bound 5
-^\[main\.w\.p1\] always main\.w\.bus\.value == 4'b0111: PROVED up to bound 5
-^\[main\.r\.p1\] always main\.r\.bus\.value == 4'b0111: PROVED up to bound 5
+^\[main\.r\.p0\] main\.r\.bus\.value == 1 \|\| main\.r\.bus\.value == 2: PROVED up to bound 5
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/interface/port3.sv
+++ b/regression/verilog/interface/port3.sv
@@ -1,15 +1,15 @@
 // Two modules connected through a shared interface
 interface data_if;
   logic [3:0] value;
-  initial value = 4'd7;
+  initial value = 1;
 endinterface
 
 module writer(data_if bus);
-  p1: assert property (bus.value == 4'd7);
+  initial bus.value = 2;
 endmodule
 
 module reader(data_if bus);
-  p1: assert property (bus.value == 4'd7);
+  initial p0: assert(bus.value == 1 || bus.value == 2);
 endmodule
 
 module main(input clk);


### PR DESCRIPTION
This extends some of the tests in regression/verilog/nterface/ to cover additional behavior.