### PR TITLE
SMV word-level: support reduction and replication operators

### DIFF
--- a/regression/ebmc/smv-word-level/reduction1.desc
+++ b/regression/ebmc/smv-word-level/reduction1.desc
@@ -1,16 +1,15 @@
-KNOWNBUG
+CORE
 reduction1.sv
 --smv-word-level
 ^MODULE main$
 ^INVAR a = 0uh8_A5$
-^INVAR r_and = \(\)$
-^INVAR r_or = \(\)$
-^INVAR r_xor = \(\)$
-^INVAR r_nand = \(\)$
-^INVAR r_nor = \(\)$
-^INVAR r_xnor = \(\)$
+^INVAR r_and = \(a = 0ud8_255\)$
+^INVAR r_or = \(a != 0ud8_0\)$
+^INVAR r_xor = \(bool\(a\[0:0\]\) xor bool\(a\[1:1\]\) xor bool\(a\[2:2\]\) xor bool\(a\[3:3\]\) xor bool\(a\[4:4\]\) xor bool\(a\[5:5\]\) xor bool\(a\[6:6\]\) xor bool\(a\[7:7\]\)\)$
+^INVAR r_nand = \(a != 0ud8_255\)$
+^INVAR r_nor = \(a = 0ud8_0\)$
+^INVAR r_xnor = !\(bool\(a\[0:0\]\) xor bool\(a\[1:1\]\) xor bool\(a\[2:2\]\) xor bool\(a\[3:3\]\) xor bool\(a\[4:4\]\) xor bool\(a\[5:5\]\) xor bool\(a\[6:6\]\) xor bool\(a\[7:7\]\)\)$
 ^EXIT=0$
 ^SIGNAL=0$
 --
 --
-Reduction operators (&, |, ^) produce norep output instead of proper SMV.

--- a/regression/ebmc/smv-word-level/replication1.desc
+++ b/regression/ebmc/smv-word-level/replication1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 replication1.sv
 --smv-word-level
 ^MODULE main$
@@ -9,4 +9,3 @@ replication1.sv
 ^SIGNAL=0$
 --
 --
-Replication operator ({N{x}}) produces norep output instead of concatenation.

--- a/src/smvlang/expr2smv.cpp
+++ b/src/smvlang/expr2smv.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/mathematical_types.h>
 
 #include <temporal-logic/ltl.h>
+#include <verilog/verilog_expr_lowering.h>
 
 #include "smv_expr.h"
 #include "smv_types.h"
@@ -1216,6 +1217,27 @@ expr2smvt::resultt expr2smvt::convert_rec(const exprt &src)
 
   else if(src.id() == ID_zero_extend)
     return convert_zero_extend(to_zero_extend_expr(src));
+
+  else if(src.id() == ID_reduction_and)
+    return convert_rec(lower(to_reduction_and_expr(src)));
+
+  else if(src.id() == ID_reduction_nand)
+    return convert_rec(lower(to_reduction_nand_expr(src)));
+
+  else if(src.id() == ID_reduction_or)
+    return convert_rec(lower(to_reduction_or_expr(src)));
+
+  else if(src.id() == ID_reduction_nor)
+    return convert_rec(lower(to_reduction_nor_expr(src)));
+
+  else if(src.id() == ID_reduction_xor)
+    return convert_rec(lower(to_reduction_xor_expr(src)));
+
+  else if(src.id() == ID_reduction_xnor)
+    return convert_rec(lower(to_reduction_xnor_expr(src)));
+
+  else if(src.id() == ID_replication)
+    return convert_rec(lower(to_replication_expr(src)));
 
   else // no SMV language expression for internal representation
     return convert_norep(src);

--- a/src/verilog/verilog_expr_lowering.h
+++ b/src/verilog/verilog_expr_lowering.h
@@ -1,0 +1,95 @@
+/*******************************************************************\
+
+Module: Verilog Expression Lowering
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+/// \file
+/// Provides lowering of Verilog expressions that have no direct SMV
+/// language equivalent, such as reduction operators and replication.
+
+#ifndef CPROVER_VERILOG_VERILOG_EXPR_LOWERING_H
+#define CPROVER_VERILOG_VERILOG_EXPR_LOWERING_H
+
+#include <util/arith_tools.h>
+#include <util/bitvector_expr.h>
+#include <util/bitvector_types.h>
+#include <util/std_expr.h>
+
+/// Lower reduction_and to equality with all-ones constant.
+/// reduction_and(a) ≡ (a = 0xFF...F)
+inline exprt lower(const reduction_and_exprt &expr)
+{
+  auto &op = expr.op();
+  return equal_exprt{op, to_bitvector_type(op.type()).all_ones_expr()};
+}
+
+/// Lower reduction_nand to inequality with all-ones constant.
+/// reduction_nand(a) ≡ (a != 0xFF...F)
+inline exprt lower(const reduction_nand_exprt &expr)
+{
+  auto &op = expr.op();
+  return notequal_exprt{op, to_bitvector_type(op.type()).all_ones_expr()};
+}
+
+/// Lower reduction_or to inequality with zero.
+/// reduction_or(a) ≡ (a != 0)
+inline exprt lower(const reduction_or_exprt &expr)
+{
+  auto &op = expr.op();
+  return notequal_exprt{op, to_bitvector_type(op.type()).all_zeros_expr()};
+}
+
+/// Lower reduction_nor to equality with zero.
+/// reduction_nor(a) ≡ (a = 0)
+inline exprt lower(const reduction_nor_exprt &expr)
+{
+  auto &op = expr.op();
+  return equal_exprt{op, to_bitvector_type(op.type()).all_zeros_expr()};
+}
+
+/// Lower reduction_xor to XOR of all individual bits.
+/// reduction_xor(a) ≡ a[0] ^ a[1] ^ ... ^ a[n-1]
+inline exprt lower(const reduction_xor_exprt &expr)
+{
+  auto &op = expr.op();
+  auto width = to_bitvector_type(op.type()).width();
+  exprt result = extractbit_exprt{op, from_integer(0, natural_typet{})};
+  for(std::size_t i = 1; i < width; i++)
+  {
+    result =
+      xor_exprt{result, extractbit_exprt{op, from_integer(i, natural_typet{})}};
+  }
+  return result;
+}
+
+/// Lower reduction_xnor to negation of XOR of all individual bits.
+/// reduction_xnor(a) ≡ !(a[0] ^ a[1] ^ ... ^ a[n-1])
+inline exprt lower(const reduction_xnor_exprt &expr)
+{
+  auto &op = expr.op();
+  auto width = to_bitvector_type(op.type()).width();
+  exprt result = extractbit_exprt{op, from_integer(0, natural_typet{})};
+  for(std::size_t i = 1; i < width; i++)
+  {
+    result =
+      xor_exprt{result, extractbit_exprt{op, from_integer(i, natural_typet{})}};
+  }
+  return not_exprt{result};
+}
+
+/// Lower replication to concatenation.
+/// {N{x}} ≡ x :: x :: ... :: x (N times)
+inline exprt lower(const replication_exprt &expr)
+{
+  auto times = numeric_cast_v<std::size_t>(expr.times());
+  exprt::operandst ops;
+  ops.reserve(times);
+  for(std::size_t i = 0; i < times; i++)
+    ops.push_back(expr.op());
+  return concatenation_exprt{std::move(ops), expr.type()};
+}
+
+#endif // CPROVER_VERILOG_VERILOG_EXPR_LOWERING_H

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -3313,6 +3313,15 @@ exprt verilog_typecheck_exprt::convert_replication_expr(replication_exprt expr)
   convert_expr(op1);
   require_vector(op1);
 
+  // The parser wraps the replicated expression in a concatenation node.
+  DATA_INVARIANT(
+    op1.id() == ID_concatenation,
+    "replication operand must be a concatenation");
+
+  // Unwrap single-element concatenations.
+  if(op1.operands().size() == 1)
+    op1 = to_unary_expr(op1).op();
+
   auto width = get_width(expr.op1().type());
 
   mp_integer op0 = convert_integer_constant_expression(expr.op0());


### PR DESCRIPTION
Add `lower()` free functions for Verilog reduction operators (and/nand/or/nor/xor/xnor) and the replication operator in a new header `src/verilog/verilog_expr_lowering.h`. Use these in `expr2smv.cpp` to produce proper SMV output instead of norep dumps.

Also fix the Verilog type checker to unwrap the single-element concatenation that the parser wraps around the replication operand.

## Changes

- **`src/verilog/verilog_expr_lowering.h`** (new): Free-standing `lower()` functions for reduction and replication expressions
- **`src/smvlang/expr2smv.cpp`**: Call `lower()` for reduction/replication operators in `convert_rec()`
- **`src/verilog/verilog_typecheck_expr.cpp`**: Unwrap single-element concatenation in replication operand
- **`regression/ebmc/smv-word-level/reduction1.desc`**: KNOWNBUG → CORE
- **`regression/ebmc/smv-word-level/replication1.desc`**: KNOWNBUG → CORE

## Testing

All smv-word-level and verilog regression tests pass.