### PR TITLE
AIGER output: emit module outputs and input names

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,8 @@
 * Netlist: module outputs are now classified as outputs rather than
   wires (visible in --show-varmap); they remain shown in
   counterexample traces
-* --aiger outputs the model in AIGER format
+* --aiger outputs the model in AIGER format, now including module
+  outputs and input/output symbol names
 * Fix for lowering of s_until_with to LTL
 * Verilog: $root.
 * Verilog: procedural assignments to hierarchical identifiers

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # EBMC 6.1
 
+* Netlist: module outputs are now classified as outputs rather than
+  wires (visible in --show-varmap); they remain shown in
+  counterexample traces
 * --aiger outputs the model in AIGER format
 * Fix for lowering of s_until_with to LTL
 * Verilog: $root.

--- a/regression/ebmc/aiger-output/output1.desc
+++ b/regression/ebmc/aiger-output/output1.desc
@@ -1,0 +1,10 @@
+CORE
+output1.sv
+--aiger --top main
+^aag 6 4 0 2 2$
+^i0 .*a\[0\]$
+^o0 .*o\[0\]$
+^o1 .*o\[1\]$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/aiger-output/output1.sv
+++ b/regression/ebmc/aiger-output/output1.sv
@@ -1,0 +1,3 @@
+module main(input [1:0] a, input [1:0] b, output [1:0] o);
+  assign o = a & b;
+endmodule

--- a/regression/ebmc/aiger-output/output_reg1.desc
+++ b/regression/ebmc/aiger-output/output_reg1.desc
@@ -1,0 +1,11 @@
+CORE
+output_reg1.sv
+--aiger --top main
+^aag 3 2 1 0 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+^o0
+--
+An `output reg` must remain a latch in the netlist (state before
+visibility): it is exported as an AIGER latch, not as an output.

--- a/regression/ebmc/aiger-output/output_reg1.sv
+++ b/regression/ebmc/aiger-output/output_reg1.sv
@@ -1,0 +1,4 @@
+module main(input clk, input x, output reg q);
+  initial q = 0;
+  always @(posedge clk) q <= x;
+endmodule

--- a/src/ebmc/output_aiger.cpp
+++ b/src/ebmc/output_aiger.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <trans-netlist/netlist.h>
 
 #include <ostream>
+#include <string>
 
 extern "C"
 {
@@ -28,6 +29,27 @@ static unsigned to_aiger_lit(literalt l)
   if(l.is_true())
     return aiger_true;
   return ((l.var_no() + 1) << 1) | (l.sign() ? 1u : 0u);
+}
+
+/// Sanitize a string for use as an AIGER symbol name. The AIGER
+/// symbol-table format is "<type><pos> <name>\n" where the name
+/// extends to the end of the line: the reader (aiger.c) consumes
+/// characters up to '\n', and the writer asserts the name is
+/// non-empty. Spaces are therefore fine (and can occur, e.g., in
+/// VHDL extended identifiers), but an embedded newline would
+/// corrupt the symbol table, a carriage return would pollute
+/// round-trips, and an empty name would trip the writer's
+/// assertion. Replace control characters by '_' and map an empty
+/// name to "_".
+static std::string aiger_symbol_name(const std::string &src)
+{
+  std::string result = src;
+  for(auto &ch : result)
+    if(static_cast<unsigned char>(ch) < ' ')
+      ch = '_';
+  if(result.empty())
+    result = "_";
+  return result;
 }
 
 /// Get the body literal for an invariant property (G/AG/sva_always).
@@ -62,7 +84,18 @@ void output_aiger(const netlistt &netlist, std::ostream &out)
   for(auto var_no : netlist.var_map.inputs)
   {
     unsigned lit = to_aiger_lit(literalt{var_no, false});
-    aiger_add_input(aig, lit, nullptr);
+    // Name the input from the reverse map (e.g. "a[3]"), so
+    // downstream gate-level tools can check operand ordering.
+    auto it = netlist.var_map.reverse_map.find(var_no);
+    if(it != netlist.var_map.reverse_map.end())
+    {
+      std::string name = aiger_symbol_name(
+        id2string(it->second.id) + '[' + std::to_string(it->second.bit_nr) +
+        ']');
+      aiger_add_input(aig, lit, name.c_str());
+    }
+    else
+      aiger_add_input(aig, lit, nullptr);
   }
 
   // Add latches
@@ -99,6 +132,26 @@ void output_aiger(const netlistt &netlist, std::ostream &out)
     aiger_add_constraint(aig, lit, nullptr);
   }
 
+  // Add module outputs. These are circuit outputs in the AIGER
+  // sense (e.g. the product bits of a multiplier), as consumed by
+  // gate-level tools such as AMulet. Emitted per bit, LSB first,
+  // named "id[bit]". Note the bit's current literal may be negated;
+  // to_aiger_lit preserves the sign.
+  for(const auto &map_it : netlist.var_map.sorted())
+  {
+    const auto &id = map_it->first;
+    const auto &var = map_it->second;
+    if(!var.is_output())
+      continue;
+    for(std::size_t bit_nr = 0; bit_nr < var.bits.size(); bit_nr++)
+    {
+      unsigned lit = to_aiger_lit(var.bits[bit_nr].current);
+      std::string name =
+        aiger_symbol_name(id2string(id) + '[' + std::to_string(bit_nr) + ']');
+      aiger_add_output(aig, lit, name.c_str());
+    }
+  }
+
   // Add properties as bad state outputs.
   // A bad state is a state that violates the property,
   // i.e., the negation of the property body literal.
@@ -108,7 +161,7 @@ void output_aiger(const netlistt &netlist, std::ostream &out)
     if(l.has_value())
     {
       unsigned bad_lit = to_aiger_lit(!l.value());
-      aiger_add_bad(aig, bad_lit, id2string(id).c_str());
+      aiger_add_bad(aig, bad_lit, aiger_symbol_name(id2string(id)).c_str());
     }
   }
 

--- a/src/trans-netlist/build_netlist_var_map.cpp
+++ b/src/trans-netlist/build_netlist_var_map.cpp
@@ -59,6 +59,8 @@ build_netlist_var_map(symbol_table_baset &symbol_table, const irep_idt &module)
       vartype = var_mapt::vart::vartypet::INPUT;
     else if(symbol.is_state_var)
       vartype = var_mapt::vart::vartypet::LATCH;
+    else if(symbol.is_output)
+      vartype = var_mapt::vart::vartypet::OUTPUT;
     else
       vartype = var_mapt::vart::vartypet::WIRE;
 

--- a/src/trans-netlist/counterexample_netlist.cpp
+++ b/src/trans-netlist/counterexample_netlist.cpp
@@ -42,8 +42,8 @@ void show_state(
   for(auto it : map.var_map.sorted())
   {
     const var_mapt::vart &var=it->second;
-    
-    if(var.is_latch() || var.is_input() || var.is_wire())
+
+    if(var.is_latch() || var.is_input() || var.is_wire() || var.is_output())
     {
       std::cout << it->first << "=";
 

--- a/src/trans-netlist/trans_to_netlist.cpp
+++ b/src/trans-netlist/trans_to_netlist.cpp
@@ -472,7 +472,7 @@ void convert_trans_to_netlistt::finalize_lhs(lhs_mapt::iterator lhs_it)
       // make it a new input
       lhs.l=lhs.bit->next=new_input();
     }
-    else if(lhs.var->is_wire())
+    else if(lhs.var->is_wire() || lhs.var->is_output())
     {
       // there needs to be _something_ as value,
       // make it a new input
@@ -542,8 +542,9 @@ void convert_trans_to_netlistt::convert_lhs_rec(
         throw ebmc_errort{} << "lhs_rec: failed to find `"
                             << bv_varid.as_string() << "' in lhs_map";
 
-      // we only need to do wires
-      if(!it->second.var->is_wire()) return;
+      // we only need to do wires and outputs
+      if(!it->second.var->is_wire() && !it->second.var->is_output())
+        return;
 
       finalize_lhs(it);
     }
@@ -711,8 +712,9 @@ void convert_trans_to_netlistt::add_equality_rec(
       lhs_entryt &lhs_entry=it->second;
       const var_mapt::vart &var=*lhs_entry.var;
 
-      if((next && !var.is_latch()) ||
-         (!next && !var.is_wire()))
+      if(
+        (next && !var.is_latch()) ||
+        (!next && !var.is_wire() && !var.is_output()))
       {
         // give up
         constraint_list.push_back(src);

--- a/src/trans-netlist/trans_trace_netlist.cpp
+++ b/src/trans-netlist/trans_trace_netlist.cpp
@@ -119,8 +119,10 @@ trans_tracet compute_trans_trace(
     {
       const var_mapt::vart &var=it->second;
 
-      // we show latches, inputs, wires      
-      if(!var.is_latch() && !var.is_input() && !var.is_wire())
+      // we show latches, inputs, wires, outputs
+      if(
+        !var.is_latch() && !var.is_input() && !var.is_wire() &&
+        !var.is_output())
         continue;
         
       const symbolt &symbol=ns.lookup(it->first);


### PR DESCRIPTION
## Summary

`ebmc --aiger` emitted properties (as bad-state signals) but never the module's outputs. For combinational circuits the outputs were lost entirely: a Verilog `assign p = a * b` module produced an AIGER file with 2n inputs and **no outputs**, and the output bits' literals stayed constant false.

Two underlying issues, fixed in two commits:

1. **Netlist: classify module outputs as OUTPUT.** `var_mapt::vartypet::OUTPUT` (and the `outputs` var-set) existed but was never assigned — symbols with `is_output` were classified as wires. Now assigned in `build_netlist_var_map` (after the state-var check, so an `output reg` remains a latch), with OUTPUT treated like WIRE wherever combinational definitions are converted or displayed (`trans_to_netlist`, counterexample display, trace computation).

2. **AIGER output: emit module outputs and input names.** One AIGER output per output bit, named `id[bit]`; inputs named the same way.

## Testing

- New regression tests: `aiger-output/output1` (combinational outputs + symbol names) and `aiger-output/output_reg1` (an `output reg` remains a latch and is not additionally emitted as an output).
- Full `regression/ebmc` and `regression/verilog` (915 tests) suites pass.
- End-to-end: `assign p = a * b` modules exported at 8–1024 bits are certified as correct multipliers by AMulet2, and differentially simulated against multiplication (1000 random vectors per width, zero mismatches).