### PR TITLE
logikbench.sh: cap per-circuit virtual memory

### DIFF
--- a/benchmarking/logikbench.sh
+++ b/benchmarking/logikbench.sh
@@ -101,8 +101,12 @@ for group in "$BENCHMARKS"/*/ ; do
     total=`expr $total + 1`
 
     # Parse and elaborate only (--bound 0).  Exit code 1 indicates a
-    # front-end/elaboration error; 124 is a timeout; anything else means ebmc
-    # processed the design (0 = holds/no properties, 10 = counterexample, ...).
+    # front-end/elaboration error; 124 is a timeout; 6 is CPROVER's
+    # catch-all for an internal exception, which is also what ebmc reports
+    # for std::bad_alloc (see CPROVER_EXIT_INTERNAL_OUT_OF_MEMORY in
+    # lib/cbmc/src/util/exit_codes.h) and thus what the PER_CIRCUIT_MEM_KB
+    # cap above triggers; anything else means ebmc processed the design
+    # (0 = holds/no properties, 10 = counterexample, ...).
     ( ulimit -v $PER_CIRCUIT_MEM_KB 2>/dev/null
       $RUN ebmc $incflags --bound 0 $sources ) > logikbench.out 2>&1
     status=$?
@@ -115,6 +119,10 @@ for group in "$BENCHMARKS"/*/ ; do
       echo "  TIMEOUT $group_name/$bench_name"
       fail=`expr $fail + 1`
       css=timeout ; label="timeout"
+    elif [ "$status" = 6 ] ; then
+      echo "  OOM     $group_name/$bench_name"
+      fail=`expr $fail + 1`
+      css=oom ; label="out of memory / internal error"
     else
       echo "  FAIL    $group_name/$bench_name"
       fail=`expr $fail + 1`
@@ -155,6 +163,7 @@ echo "LogikBench summary: $pass/$total circuits elaborated ($fail failed)"
   tr.ok td:last-child { color: #1a7f37; }
   tr.fail td:last-child { color: #cf222e; }
   tr.timeout td:last-child { color: #9a6700; }
+  tr.oom td:last-child { color: #8250df; }
 </style>
 </head>
 <body>

--- a/benchmarking/logikbench.sh
+++ b/benchmarking/logikbench.sh
@@ -29,6 +29,13 @@ LOGIKBENCH_REV=main
 # `gtimeout` (coreutils on macOS, `brew install coreutils`).
 PER_CIRCUIT_TIMEOUT=${PER_CIRCUIT_TIMEOUT:-60}
 
+# Per-circuit virtual memory limit, in KB, so that a single design whose
+# elaboration blows up (e.g. an unrolled loop producing exponentially large
+# expressions) cannot exhaust all memory on the machine and take the whole
+# run down with it.  Applied via the `ulimit -v` shell builtin, which is not
+# available on macOS; the run proceeds without a memory limit there.
+PER_CIRCUIT_MEM_KB=${PER_CIRCUIT_MEM_KB:-4000000}
+
 REPORT=${1:-logikbench-report.html}
 
 if command -v timeout > /dev/null 2>&1 ; then
@@ -96,7 +103,8 @@ for group in "$BENCHMARKS"/*/ ; do
     # Parse and elaborate only (--bound 0).  Exit code 1 indicates a
     # front-end/elaboration error; 124 is a timeout; anything else means ebmc
     # processed the design (0 = holds/no properties, 10 = counterexample, ...).
-    $RUN ebmc $incflags --bound 0 $sources > logikbench.out 2>&1
+    ( ulimit -v $PER_CIRCUIT_MEM_KB 2>/dev/null
+      $RUN ebmc $incflags --bound 0 $sources ) > logikbench.out 2>&1
     status=$?
 
     if [ "$status" = 0 ] || [ "$status" = 10 ] ; then


### PR DESCRIPTION
## Summary
- The LogikBench CI job ([run 29873838090](https://github.com/diffblue/hw-cbmc/actions/runs/29873838090/job/88779864321)) died with exit code 143 ("runner has received a shutdown signal") right after `basic/bin2gray`.
- Root cause: the next circuit, `basic/bin2prio` (a 64-bit priority encoder with a `for` loop inside `always @(*)`), blows up ebmc's elaboration — reproduced locally at 16+ GB RSS within 8 seconds and still climbing. The existing 60s per-circuit `timeout` only guards against hangs, not memory exhaustion, so the GitHub-hosted runner (16 GB RAM) got OOM-killed before the timeout could fire, taking the whole job down with it.
- Fix: add a per-circuit `ulimit -v` cap (default 4 GiB) alongside the existing timeout, so such circuits fail fast and are recorded as a normal failure instead of exhausting the runner's memory. `ulimit -v` isn't available on macOS, so it degrades gracefully there (same behavior as before).

## Test plan
- [x] Verified `basic/bin2prio` reaches 16+ GB RSS locally without the cap.
- [x] Ran `logikbench.sh` locally against a small benchmark subset (`basic/band`, `basic/bin2gray`, `basic/bin2prio`); it now completes with exit 0 and correctly records the pathological circuit as a failure instead of hanging/OOMing.
- [x] `sh -n benchmarking/logikbench.sh` passes.
- [ ] Confirm the LogikBench GitHub Actions job goes green on Linux (where `ulimit -v` actually engages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)