### PR TITLE
Verilog: reject implicit conversion of unpacked arrays to integral types

### DIFF
--- a/regression/verilog/arrays/unpacked_array2.desc
+++ b/regression/verilog/arrays/unpacked_array2.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
+CORE
 unpacked_array2.sv
 
+^file .* line 7: failed to convert `unpacked array \[32\] of bool' to `signed \[31:0\]'$
 ^EXIT=2$
 ^SIGNAL=0$
 --
 --
-This should fail during typechecking.

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -420,12 +420,30 @@ void verilog_typecheck_exprt::assignment_conversion(
       << to_string(lhs_type) << "'";
   }
 
+  if(
+    lhs_type.id() == ID_array &&
+    lhs_type.get(ID_C_verilog_type) == ID_verilog_unpacked_array)
+  {
+    // assignment of a non-matching type to unpacked array
+    throw errort().with_location(rhs.source_location())
+      << "failed to convert `" << to_string(original_rhs_type) << "' to `"
+      << to_string(lhs_type) << "'";
+  }
+
   // do enum, union and struct decay
   decay_to_vector(rhs);
 
   if(rhs.type().id() == ID_struct || rhs.type().id() == ID_union)
   {
     // not decayed, not equal
+    throw errort().with_location(rhs.source_location())
+      << "failed to convert `" << to_string(original_rhs_type) << "' to `"
+      << to_string(lhs_type) << "'";
+  }
+
+  if(rhs.type().id() == ID_array)
+  {
+    // Unpacked arrays do not decay to integral types.
     throw errort().with_location(rhs.source_location())
       << "failed to convert `" << to_string(original_rhs_type) << "' to `"
       << to_string(lhs_type) << "'";
@@ -2753,7 +2771,9 @@ void verilog_typecheck_exprt::array_decay(exprt &expr) const
   // 1800-2017 7.4.3
   // Packed arrays can be "treated as an integer in an expression"
   auto &type = expr.type();
-  if(type.id() == ID_array)
+  if(
+    type.id() == ID_array &&
+    type.get(ID_C_verilog_type) == ID_verilog_packed_array)
   {
     auto new_type =
       unsignedbv_typet{numeric_cast_v<std::size_t>(get_width(type))};


### PR DESCRIPTION
Per IEEE 1800-2017 section 7.4.3, only packed arrays can be treated as integers. Unpacked arrays must not implicitly decay to integral types.

## Changes

- `array_decay` now only decays packed arrays (those with `ID_C_verilog_type == ID_verilog_packed_array`), not unpacked arrays.
- `assignment_conversion` rejects assignments where the LHS is an unpacked array with a non-matching RHS, or where the RHS is an undecayed (unpacked) array being assigned to a non-array type.
- The regression test `unpacked_array2` is promoted from KNOWNBUG to CORE with the expected error message.