### PR TITLE
Verilog: fix synthesis crash on full-width part-select of signed vector

### DIFF
--- a/regression/verilog/synthesis/signed_part_select_lhs1.desc
+++ b/regression/verilog/synthesis/signed_part_select_lhs1.desc
@@ -1,0 +1,12 @@
+CORE
+signed_part_select_lhs1.sv
+
+^\[main\.p0\] always main\.via_part_select == main\.via_whole: PROVED \(1-induction\)$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Minimal reproducer for the synthesis crash on LogikBench arithmetic/mulreg.
+A full-width part-select on the LHS of a signed register used to abort
+synthesis with a "synth_assignments type consistency" invariant violation.

--- a/regression/verilog/synthesis/signed_part_select_lhs1.sv
+++ b/regression/verilog/synthesis/signed_part_select_lhs1.sv
@@ -1,0 +1,29 @@
+// Minimal reproducer for a synthesis crash triggered by the LogikBench
+// arithmetic/mulreg benchmark.
+//
+// A full-width part-select on the left-hand side of a *signed* register
+// used to abort synthesis with a type-consistency invariant violation.
+// A part-select expression is unsigned even when it selects the entire
+// vector (IEEE 1800-2017 11.5.1), and the shortcut for full-width
+// part-selects assigned the (unsigned) right-hand side straight into the
+// signed register, so the left- and right-hand sides differed in
+// signedness.  A non-constant right-hand side is required, as constants
+// are folded to the matching type before the check.
+module main(input clk, input signed [15:0] a);
+
+  // assigned via a full-width part-select (the construct under test)
+  reg signed [15:0] via_part_select = 0;
+
+  // assigned directly, for reference
+  reg signed [15:0] via_whole = 0;
+
+  always @(posedge clk)
+    begin
+      via_part_select[15:0] <= a;
+      via_whole <= a;
+    end
+
+  // the full-width part-select assignment preserves the (signed) value
+  p0: assert property (via_part_select == via_whole);
+
+endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -829,7 +829,16 @@ exprt verilog_synthesist::assignment_rec(
     // redundant?
     if(from == 0 && to == get_width(lhs_src.type()) - 1)
     {
-      return assignment_rec(lhs_src, rhs); // recursive call
+      // The part-select spans the entire source, hence the assignment
+      // is equivalent to assigning to the source directly. Note that a
+      // part-select expression is always unsigned (1800-2017 11.5.1),
+      // even when it selects a signed vector in its entirety, so the rhs
+      // may differ in signedness from the source. As the bits are the
+      // same, we reinterpret the rhs to the type of the source.
+      return assignment_rec(
+        lhs_src,
+        typecast_exprt::conditional_cast(
+          rhs, lhs_src.type())); // recursive call
     }
 
     // turn


### PR DESCRIPTION
## Problem

`ebmc -I rtl --bound 0 rtl/mulreg.v` on the LogikBench `arithmetic/mulreg`
benchmark aborted with exit 134 (SIGABRT):

```
--- begin invariant violation report ---
Invariant check failed
File: verilog_synthesis.cpp function: synth_assignments
Condition: lhs.type() == new_value.type()
Reason: synth_assignments type consistency
```

`mulreg.v` registers its inputs with full-width part-selects on the LHS:

```verilog
reg signed [DW-1:0] areg;
always @(posedge clk)
  areg[DW-1:0] <= a;   // full-width part-select of a *signed* reg
```

## Root cause

Per IEEE 1800-2017 11.5.1, a **part-select expression is unsigned**, even
when it selects a signed vector *in its entirety*. The type-checker
faithfully implements this (`verilog_typecheck_exprt::convert_trinary_expr`
gives `areg[DW-1:0]` type `unsignedbv[16]`, even though `areg` is
`signedbv[16]`), and the RHS of the assignment is converted to that
unsigned type.

In synthesis, `assignment_rec` has a shortcut for a part-select that spans
the whole source: it drops the part-select and assigns the RHS directly to
the source symbol.

```cpp
// redundant?
if(from == 0 && to == get_width(lhs_src.type()) - 1)
  return assignment_rec(lhs_src, rhs);
```

For a *signed* source this assigns an `unsignedbv[16]` value straight into
a `signedbv[16]` symbol. The two have the same width but differ in
signedness, so later in `synth_assignments` the
`lhs.type() == new_value.type()` `DATA_INVARIANT` fails and EBMC aborts.

The crash only manifests for **registers** driven by a **non-constant**
RHS: continuous assignments to nets flow through a different path, and a
constant RHS is folded to the matching type before the check — which is why
most differently-sized/signed assignments don't hit this and only `mulreg`
(signed registered multiplier) does.

## Fix

When the full-width part-select is elided, reinterpret the RHS to the type
of the source. The selected bits are identical to the whole source, so this
is a bit-preserving, sign-reinterpreting cast — exactly the Verilog
semantics for assigning the entire vector — and it makes the invariant hold
rather than suppressing it. For the already-lowered bitvector types seen
here, a `typecast_exprt` between equal-width signed/unsigned is a plain
reinterpret (the same thing `verilog_lowering_cast` would emit).

## Testing

- `mulreg.v` now elaborates cleanly (exit 10 "no properties", was 134).
- New regression `regression/verilog/synthesis/signed_part_select_lhs1`
  (a signed register assigned via a full-width part-select, hand-reduced
  from `mulreg`): aborts with the exact invariant on `main`, is
  `PROVED (1-induction)` with this fix.
- `make -C regression/verilog test`: all pass, no regressions.