### PR TITLE
Verilog: don't treat 'integer' loop counters as synthesis driver conflicts

### DIFF
--- a/regression/verilog/shared-integer-loop-variable/combinational_and_clocked.desc
+++ b/regression/verilog/shared-integer-loop-variable/combinational_and_clocked.desc
@@ -1,0 +1,9 @@
+CORE
+combinational_and_clocked.sv
+--bound 0
+^\[main\.p0\] always main\.a == main\.din: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+conflicting assignment types

--- a/regression/verilog/shared-integer-loop-variable/combinational_and_clocked.sv
+++ b/regression/verilog/shared-integer-loop-variable/combinational_and_clocked.sv
@@ -1,0 +1,15 @@
+// A module-level 'integer' loop counter shared by a combinational and a
+// clocked always block must not be reported as "conflicting assignment
+// types" (new: clocked, old: combinational): integers are elaboration-only
+// scratch, not state, so the reuse is benign.
+// Regression for LogikBench blocks/viterbi (signal j) and large/qr (k).
+module main(input clk, input [3:0] din, output reg [3:0] a, output reg [3:0] b);
+  integer i;
+  always @(*)
+    for (i = 0; i < 4; i = i + 1)
+      a[i] = din[i];
+  always @(posedge clk)
+    for (i = 0; i < 4; i = i + 1)
+      b[i] <= din[i];
+  p0: assert final (a == din);
+endmodule

--- a/regression/verilog/shared-integer-loop-variable/two_combinational_blocks.desc
+++ b/regression/verilog/shared-integer-loop-variable/two_combinational_blocks.desc
@@ -1,0 +1,9 @@
+CORE
+two_combinational_blocks.sv
+--bound 0
+^\[main\.p0\] always main\.a == main\.b: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+conflict with previous assignment

--- a/regression/verilog/shared-integer-loop-variable/two_combinational_blocks.sv
+++ b/regression/verilog/shared-integer-loop-variable/two_combinational_blocks.sv
@@ -1,0 +1,15 @@
+// A module-level 'integer' loop counter shared by two combinational
+// always blocks must not be reported as a driver conflict: integers are
+// elaboration-only scratch and are turned into wires, not state.
+// Regression for LogikBench basic/crossbar (and the koios circuits),
+// which previously failed with "conflict with previous assignment".
+module main(input [3:0] din, output reg [3:0] a, output reg [3:0] b);
+  integer i;
+  always @(*)
+    for (i = 0; i < 4; i = i + 1)
+      a[i] = din[i];
+  always @(*)
+    for (i = 0; i < 4; i = i + 1)
+      b[i] = din[i];
+  p0: assert final (a == b);
+endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -710,7 +710,15 @@ void verilog_synthesist::assignment_rec(
 
     assignmentt &assignment=assignments[symbol.name];
 
-    if(assignment.is_cycle_local)
+    // Variables declared with the Verilog 'integer' type are idiomatically
+    // used as loop counters and combinational scratch. They are effectively
+    // a fresh temporary in each always/initial block and may therefore
+    // legitimately be (blocking-)assigned by more than one block. Exempt
+    // them from assignment-type and driver-conflict tracking, which would
+    // otherwise flag the reuse as a spurious multiple-driver conflict.
+    bool is_integer = symbol.type.get(ID_C_verilog_type) == ID_integer;
+
+    if(assignment.is_cycle_local || is_integer)
     {
     }
     else


### PR DESCRIPTION
## Summary

Part of the LogikBench elaboration triage (`benchmarking/logikbench.sh`,
report at https://diffblue.github.io/hw-cbmc/). This addresses the
**synthesis driver-conflict** bucket: circuits that failed `ebmc --bound 0`
during synthesis with either

- "conflict with previous assignment", or
- "conflicting assignment types for `X` (new: clocked, old: combinational)".

Both are thrown from `src/verilog/verilog_synthesis.cpp` while tracking, per
signal, which bit-ranges/members have already been assigned so that a signal
driven twice in an unmergeable way is rejected.

## Root cause (differs from the original branch-merge / generate-instance hypotheses)

The tracking in `assignment()` runs for **every** assigned symbol, but
`synth_assignments()` never turns Verilog `integer`-typed variables into state
or wires — they are elaboration-only scratch. Module-level `integer`
variables are idiomatically used as **`for`-loop counters** and shared across
several `always`/`initial` blocks. Because the member tracking persists across
blocks (`move_assignments()` runs at each block's end), a loop counter such as
`integer i` assigned in two blocks was flagged as a spurious multiple-driver
conflict:

- assigned in two *combinational* blocks → "conflict with previous assignment"
  (the reported location is the `for (i = 0; …)` header, i.e. the counter, not
  the data signal);
- assigned in a combinational and a *clocked* block → "conflicting assignment
  types (new: clocked, old: combinational)".

Only the last block's value of such a counter is ever observable, so the reuse
is benign.

## Fix

Exempt symbols carrying the Verilog `integer` type
(`type.get(ID_C_verilog_type) == ID_integer`) from assignment-type and
member/driver-conflict tracking — consistent with `synth_assignments()`, which
already excludes them from synthesis. One-line guard plus a comment; no change
to how genuine state/wire signals are checked.

## Circuits fixed (3)

| Circuit | Was failing on |
|---|---|
| `basic/crossbar` | conflict on shared `integer i` across two `always @(*)` |
| `blocks/viterbi` | `integer j` combinational vs clocked (rtl/viterbi.v:121) |
| `large/qr` | `integer k` combinational vs clocked (rtl/qr.v:90) |

All three now elaborate (`ebmc --bound 0` → exit 0/10).

## Circuits deliberately left failing (12) — genuine conflicts / real EBMC limitation, not false positives

- **`blocks/reedsolomon`** — genuinely invalid RTL. Register `s_nz` is driven
  by **two separate `always @(posedge clk)` blocks** (rs_syndrome.v:58 and
  :72/:75). This is a real multiple-driver situation that hardware synthesis
  tools also reject; EBMC is correct to error.

- **11 koios circuits** (`attention_layer`, `clstm_like_small`,
  `clstm_like_medium`, `conv_layer`, `conv_layer_hls`, `dla_like_small`,
  `dla_like_medium`, `eltwise_layer`, `spmv`, `tpu_like_small_os`,
  `tpu_like_small_ws`) — all conflict on a `.ram` array inside a **true
  dual-port RAM** (two write ports, `ram[address_a] <= data_a` and
  `ram[address_b] <= data_b`, in two separate clocked blocks, non-constant
  indices). EBMC models array writes as a single per-signal "next value"
  (last-writer-wins), so it cannot represent two independent write ports; the
  conflict check is honestly reporting that limitation. Suppressing it would
  silently drop one write port and produce a semantically wrong model, so these
  are left failing. Real multi-write-port memory support is a separate, larger
  enhancement.

## Regression tests

`regression/verilog/shared-integer-loop-variable/`:
- `two_combinational_blocks` — shared `integer` counter in two `always @(*)`
  (models crossbar / the koios loop-counter idiom);
- `combinational_and_clocked` — shared `integer` counter in a combinational and
  a clocked block (models viterbi/qr).

Both `PROVED` after the fix and would previously have hit the conflict errors.
`make -C regression/verilog test` passes (no other tests regress; no existing
test relied on the removed conflict behaviour).

## Known follow-up (out of scope here)

After the fix, `blocks/viterbi` gets past the conflict error but its synthesis
is very slow/heavy (min-path-metric logic explodes into a large `WITH`/wire
network), so it may still not pass CI within resource limits. That is a
separate synthesis-performance issue, not a driver-conflict one, and is not
addressed in this PR.
