### PR TITLE
Verilog: interpret `if` statements in the constant-expression interpreter

### DIFF
--- a/regression/verilog/const_function_if1/main.v
+++ b/regression/verilog/const_function_if1/main.v
@@ -1,0 +1,26 @@
+// Constant function whose body uses an if statement, evaluated by the
+// Verilog constant-expression interpreter to compute a parameter.
+// Minimal reproduction of large/axicrossbar (rtl/axi_crossbar_addr.v:140),
+// where the interpreter did not know how to interpret an `if' statement.
+module main;
+
+  function [31:0] f(input [31:0] x);
+    reg [31:0] r;
+    begin
+      r = 0;
+      if(x > 10)
+        r = x + 1; // taken for x==20
+      else
+        r = x - 1;
+      // if without else
+      if(r > 100)
+        r = 0;
+    end
+    f = r;
+  endfunction
+
+  parameter P = f(20);
+
+  always assert p1: P == 21;
+
+endmodule

--- a/regression/verilog/const_function_if1/test.desc
+++ b/regression/verilog/const_function_if1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.v
+--bound 0
+^\[main\.property\.p1\] always main\.P == 21: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+Don't know how to interpret statement

--- a/src/verilog/verilog_interpreter.cpp
+++ b/src/verilog/verilog_interpreter.cpp
@@ -86,6 +86,36 @@ void verilog_typecheckt::verilog_interpreter(
       verilog_interpreter(verilog_for.inc_statement());
     }
   }
+  else if(statement.id() == ID_if)
+  {
+    const verilog_ift &verilog_if = to_verilog_if(statement);
+
+    exprt cond = elaborate_constant_expression(verilog_if.cond());
+
+    bool taken;
+
+    if(cond.is_true())
+      taken = true;
+    else if(cond.is_false())
+      taken = false;
+    else
+    {
+      mp_integer cond_i;
+
+      if(to_integer_non_constant(cond, cond_i))
+      {
+        throw errort().with_location(verilog_if.source_location())
+          << "if condition is not constant: " << cond.pretty();
+      }
+
+      taken = (cond_i != 0);
+    }
+
+    if(taken)
+      verilog_interpreter(verilog_if.then_case());
+    else if(verilog_if.has_else_case())
+      verilog_interpreter(verilog_if.else_case());
+  }
   else
   {
     throw errort().with_location(statement.source_location())


### PR DESCRIPTION
The small interpreter used to evaluate Verilog functions in constant
contexts (e.g. computing a parameter value) handled blocking assignments,
blocks and for loops, but threw "Don't know how to interpret statement
if" on `if` statements. Adds support: evaluate the condition as a constant
expression and interpret the taken branch (handling both if and if/else).

New regression test: `regression/verilog/const_function_if1`.