### PR TITLE
Verilog: fix three type-checker gaps from LogikBench triage

### DIFF
--- a/regression/verilog/continuous_assign_implicit_net1/main.v
+++ b/regression/verilog/continuous_assign_implicit_net1/main.v
@@ -1,0 +1,15 @@
+// An undeclared identifier used as a member of a concatenation on the LHS
+// of a continuous assignment is implicitly declared as a scalar net of the
+// default net type (IEEE 1800-2017 6.10). Here `cout` is never declared;
+// it is the discarded carry-out of the subtraction.
+// Regression for LogikBench arithmetic/sub.
+module main #(parameter DW = 16)
+  (
+   input [DW-1:0]  a,
+   input [DW-1:0]  b,
+   output [DW-1:0] out
+   );
+
+  assign {cout, out[DW-1:0]} = a[DW-1:0] - b[DW-1:0];
+
+endmodule

--- a/regression/verilog/continuous_assign_implicit_net1/test.desc
+++ b/regression/verilog/continuous_assign_implicit_net1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.v
+--module main --bound 0
+^Synthesis Verilog::main$
+^EXIT=10$
+^SIGNAL=0$
+--
+^.*unknown identifier cout.*$

--- a/regression/verilog/generate_instance_genvar1/main.v
+++ b/regression/verilog/generate_instance_genvar1/main.v
@@ -1,0 +1,21 @@
+// A module output port connected to a genvar-indexed bit of a vector
+// inside a generate for-loop. The genvar must be evaluated with its
+// per-iteration value when the port connection is elaborated; a regression
+// (LogikBench blocks/lpddr5, blocks/chiplink, koios/bwave_like_*) used the
+// stale post-loop genvar value, which mis-evaluated arr[g] (in particular
+// the top index arr[WIDTH-1] was flagged out of bounds and folded to 0).
+module child(output reg o);
+endmodule
+
+module main;
+
+  wire [3:0] locked;
+
+  genvar g;
+  generate
+    for(g = 0; g < 4; g = g + 1) begin: trn
+      child u(.o(locked[g]));
+    end
+  endgenerate
+
+endmodule

--- a/regression/verilog/generate_instance_genvar1/test.desc
+++ b/regression/verilog/generate_instance_genvar1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.v
+--module main --bound 0
+^Synthesis Verilog::main$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+^.*failed to get identifier on LHS.*$

--- a/regression/verilog/localparam_clog2_width1/main.v
+++ b/regression/verilog/localparam_clog2_width1/main.v
@@ -1,0 +1,16 @@
+// Assigning the result of $clog2 (a mathematical/unbounded integer) to a
+// sized localparam requires a concrete width for the integer type in the
+// assignment context; the integer type is treated as 32-bit wide
+// (IEEE 1800-2017 6.11, 11.8.1).
+// Regression for LogikBench blocks/dma (rtl/dma_read.v) and koios/dnnweaver.
+module main #(parameter DW = 32)
+  (
+   input  [DW-1:0] a,
+   output [2:0]    out
+   );
+
+  localparam [2:0] ARSIZE = $clog2(DW/8);
+
+  assign out = ARSIZE;
+
+endmodule

--- a/regression/verilog/localparam_clog2_width1/test.desc
+++ b/regression/verilog/localparam_clog2_width1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.v
+--module main --bound 0
+^Synthesis Verilog::main$
+^EXIT=10$
+^SIGNAL=0$
+--
+^.*has unknown number of bits.*$

--- a/src/verilog/verilog_bits.cpp
+++ b/src/verilog/verilog_bits.cpp
@@ -61,6 +61,15 @@ std::optional<mp_integer> verilog_bits_opt(const typet &type)
     return max;
   }
 
+  if(type.id() == ID_integer)
+  {
+    // A mathematical (unbounded) integer, e.g. the result of $clog2 or an
+    // unsized integer constant expression. In a context that requires a
+    // concrete width it is treated as the 32-bit integer type
+    // (IEEE 1800-2017 Sec. 6.11, 11.8.1).
+    return 32;
+  }
+
   if(type.id() == ID_verilog_shortint)
     return 16;
   else if(type.id() == ID_verilog_int)

--- a/src/verilog/verilog_elaborate_module_instances.cpp
+++ b/src/verilog/verilog_elaborate_module_instances.cpp
@@ -295,8 +295,22 @@ void verilog_typecheckt::parameterize_instantiated_modules(
   }
   else if(module_item.id() == ID_set_genvars)
   {
+    // Restore the genvar values that were in effect when this generate
+    // item was elaborated. Parameter assignments and port connections of
+    // the enclosed instance may refer to genvars (e.g. an output connected
+    // to arr[g]); without this the live genvars map still holds the
+    // post-loop value and such references are mis-evaluated. This mirrors
+    // the restore done in convert_module_item.
+    auto saved_genvars = genvars;
+    genvars.clear();
+    const auto &variables = to_verilog_set_genvars(module_item).variables();
+    for(auto &var : variables)
+      genvars[id2string(var.first)] = string2integer(var.second.id_string());
+
     parameterize_instantiated_modules(
       to_verilog_set_genvars(module_item).module_item());
+
+    genvars = std::move(saved_genvars);
   }
 }
 

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -156,7 +156,7 @@ void verilog_typecheckt::typecheck_port_connections(
       const irep_idt &base_name =
         to_verilog_identifier_expr(named_port_connection.port()).base_name();
 
-      bool found=false;
+      bool found = false;
 
       irep_idt full_identifier =
         id2string(inst.identifier()) + '.' + id2string(base_name);
@@ -175,7 +175,7 @@ void verilog_typecheckt::typecheck_port_connections(
       {
         if(port.identifier() == full_identifier)
         {
-          found=true;
+          found = true;
           typecheck_port_connection(value, port);
           named_port_connection.port().type() = port.type();
           break;
@@ -240,8 +240,8 @@ void verilog_typecheckt::typecheck_builtin_port_connections(
 
   inst.remove(ID_range);
 
-  typet &type=inst.type();
-  if(width==1)
+  typet &type = inst.type();
+  if(width == 1)
     type.id(ID_bool);
   else
   {
@@ -287,16 +287,16 @@ void verilog_typecheckt::convert_function_or_task(
 {
   const auto identifier = hierarchical_identifier(decl.base_name());
 
-  auto result=symbol_table.get_writeable(identifier);
+  auto result = symbol_table.get_writeable(identifier);
 
-  if(result==nullptr)
+  if(result == nullptr)
   {
     throw errort().with_location(decl.source_location())
       << "expected to find " << decl.id() << " symbol `" << identifier
       << "' in symbol_table";
   }
 
-  symbolt &symbol=*result;
+  symbolt &symbol = *result;
 
   decl.set_identifier(symbol.name);
 
@@ -308,9 +308,9 @@ void verilog_typecheckt::convert_function_or_task(
   for(auto &statement : decl.body().statements())
     convert_statement(statement);
 
-  function_or_task_name="";
+  function_or_task_name = "";
 
-  symbol.value=decl.body();
+  symbol.value = decl.body();
 }
 
 /*******************************************************************\
@@ -381,18 +381,17 @@ Function: verilog_typecheckt::elaborate_constant_function_call
 exprt verilog_typecheckt::elaborate_constant_function_call(
   const function_call_exprt &function_call)
 {
-  const function_call_exprt::argumentst &arguments=
-    function_call.arguments();
+  const function_call_exprt::argumentst &arguments = function_call.arguments();
 
   // find the function
-  if(function_call.function().id()!=ID_symbol)
+  if(function_call.function().id() != ID_symbol)
   {
     throw errort().with_location(function_call.source_location())
       << "expected function symbol, but got `"
       << to_string(function_call.function()) << '\'';
   }
 
-  const symbolt &function_symbol=
+  const symbolt &function_symbol =
     ns.lookup(to_symbol_expr(function_call.function()));
 
   verilog_function_or_task_declt::bodyt function_body;
@@ -419,13 +418,11 @@ exprt verilog_typecheckt::elaborate_constant_function_call(
       function_symbol.value);
   }
 
-  const code_typet &code_type=
-    to_code_type(function_symbol.type);
+  const code_typet &code_type = to_code_type(function_symbol.type);
 
-  const code_typet::parameterst &parameters=
-    code_type.parameters();
+  const code_typet::parameterst &parameters = code_type.parameters();
 
-  if(parameters.size()!=arguments.size())
+  if(parameters.size() != arguments.size())
   {
     throw errort().with_location(function_call.source_location())
       << "function call has wrong number of arguments";
@@ -435,7 +432,7 @@ exprt verilog_typecheckt::elaborate_constant_function_call(
 
   varst old_vars;
 
-  for(std::size_t i=0; i<arguments.size(); i++)
+  for(std::size_t i = 0; i < arguments.size(); i++)
   {
     exprt value = elaborate_constant_expression(arguments[i]);
 
@@ -445,10 +442,10 @@ exprt verilog_typecheckt::elaborate_constant_function_call(
         << "constant function argument is not constant";
     }
 
-    irep_idt p_identifier=parameters[i].get_identifier();
+    irep_idt p_identifier = parameters[i].get_identifier();
 
-    old_vars[p_identifier]=var_value(p_identifier);
-    vars[p_identifier]=value;
+    old_vars[p_identifier] = var_value(p_identifier);
+    vars[p_identifier] = value;
 
 #if 0
     status() << "ASSIGN " << p_identifier << " <- " << to_string(value) << eom;
@@ -459,12 +456,12 @@ exprt verilog_typecheckt::elaborate_constant_function_call(
   for(auto &statement : function_body.statements())
     verilog_interpreter(statement);
 
-  function_or_task_name="";
+  function_or_task_name = "";
 
   // get return value
 
-  exprt return_value=var_value(
-    id2string(function_symbol.name)+"."+
+  exprt return_value = var_value(
+    id2string(function_symbol.name) + "." +
     id2string(function_symbol.base_name));
 
   return return_value;
@@ -536,10 +533,9 @@ Function: verilog_typecheckt::convert_initial
 
 \*******************************************************************/
 
-void verilog_typecheckt::convert_initial(
-  verilog_initialt &module_item)
+void verilog_typecheckt::convert_initial(verilog_initialt &module_item)
 {
-  if(module_item.operands().size()!=1)
+  if(module_item.operands().size() != 1)
   {
     throw errort().with_location(module_item.source_location())
       << "initial statement expected to have one operand";
@@ -582,17 +578,15 @@ Function: verilog_typecheckt::check_lhs
 
 \*******************************************************************/
 
-void verilog_typecheckt::check_lhs(
-  const exprt &lhs,
-  vassignt vassign)
+void verilog_typecheckt::check_lhs(const exprt &lhs, vassignt vassign)
 {
-  if(lhs.id()==ID_index)
+  if(lhs.id() == ID_index)
   {
     check_lhs(to_index_expr(lhs).array(), vassign);
   }
-  else if(lhs.id()==ID_extractbit)
+  else if(lhs.id() == ID_extractbit)
   {
-    if(lhs.operands().size()!=2)
+    if(lhs.operands().size() != 2)
     {
       throw errort() << "extractbit takes two operands";
     }
@@ -615,16 +609,16 @@ void verilog_typecheckt::check_lhs(
     auto &part_select = to_verilog_indexed_part_select_plus_or_minus_expr(lhs);
     check_lhs(part_select.src(), vassign);
   }
-  else if(lhs.id()==ID_concatenation)
+  else if(lhs.id() == ID_concatenation)
   {
     forall_operands(it, lhs)
       check_lhs(*it, vassign);
 
     return;
   }
-  else if(lhs.id()==ID_symbol)
+  else if(lhs.id() == ID_symbol)
   {
-    const symbolt &symbol=ns.lookup(to_symbol_expr(lhs));
+    const symbolt &symbol = ns.lookup(to_symbol_expr(lhs));
 
     // check for 'const'
     if(symbol.type.get_bool(ID_C_const))
@@ -799,13 +793,13 @@ void verilog_typecheckt::convert_continuous_assign(
 {
   Forall_operands(it, module_item)
   {
-    if(it->id()!=ID_equal || it->operands().size()!=2)
+    if(it->id() != ID_equal || it->operands().size() != 2)
     {
       throw errort().with_location(it->source_location())
         << "malformed continuous assignment";
     }
 
-    it->type()=bool_typet();
+    it->type() = bool_typet();
 
     exprt &lhs = to_binary_expr(*it).lhs();
     exprt &rhs = to_binary_expr(*it).rhs();
@@ -817,6 +811,22 @@ void verilog_typecheckt::convert_continuous_assign(
     {
       lhs = convert_verilog_identifier(
         to_verilog_identifier_expr(lhs), unsignedbv_typet{1});
+    }
+    else if(lhs.id() == ID_concatenation)
+    {
+      // The implicit net rule also applies to undeclared identifiers that
+      // appear as members of a concatenation on the LHS, e.g.
+      //   assign {carry, sum} = a + b;   // carry is undeclared
+      // Declare each such member as a scalar net of the default net type,
+      // then convert the concatenation as usual.
+      for(auto &op : lhs.operands())
+      {
+        if(op.id() == ID_verilog_identifier)
+          op = convert_verilog_identifier(
+            to_verilog_identifier_expr(op), unsignedbv_typet{1});
+      }
+
+      convert_expr(lhs);
     }
     else
       convert_expr(lhs);
@@ -902,16 +912,16 @@ void verilog_typecheckt::convert_function_call_or_task_enable(
     const code_typet &code_type = to_code_type(symbol->type);
 
     // check arguments
-    const code_typet::parameterst &parameter_types=code_type.parameters();
-    exprt::operandst &arguments=statement.arguments();
+    const code_typet::parameterst &parameter_types = code_type.parameters();
+    exprt::operandst &arguments = statement.arguments();
 
-    if(parameter_types.size()!=arguments.size())
+    if(parameter_types.size() != arguments.size())
     {
       throw errort().with_location(statement.source_location())
         << "wrong number of arguments";
     }
 
-    for(unsigned i=0; i<arguments.size(); i++)
+    for(unsigned i = 0; i < arguments.size(); i++)
     {
       convert_expr(arguments[i]);
       assignment_conversion(arguments[i], parameter_types[i].type());
@@ -936,8 +946,8 @@ Function: verilog_typecheckt::convert_assign
 
 void verilog_typecheckt::convert_force(verilog_forcet &statement)
 {
-  exprt &lhs=statement.lhs();
-  exprt &rhs=statement.rhs();
+  exprt &lhs = statement.lhs();
+  exprt &rhs = statement.rhs();
 
   convert_expr(lhs);
   convert_expr(rhs);
@@ -962,7 +972,7 @@ void verilog_typecheckt::convert_assign(
   verilog_assignt &statement,
   bool blocking)
 {
-  if(statement.operands().size()!=2)
+  if(statement.operands().size() != 2)
   {
     throw errort().with_location(statement.source_location())
       << "assign statement expected to have two operands";
@@ -973,7 +983,7 @@ void verilog_typecheckt::convert_assign(
 
   convert_expr(lhs);
   convert_expr(rhs);
-  check_lhs(lhs, blocking?A_BLOCKING:A_NON_BLOCKING);
+  check_lhs(lhs, blocking ? A_BLOCKING : A_NON_BLOCKING);
   assignment_conversion(rhs, lhs.type());
 }
 
@@ -1243,16 +1253,15 @@ Function: verilog_typecheckt::convert_event_guard
 
 \*******************************************************************/
 
-void verilog_typecheckt::convert_event_guard(
-  verilog_event_guardt &statement)
+void verilog_typecheckt::convert_event_guard(verilog_event_guardt &statement)
 {
-  if(statement.operands().size()!=2)
+  if(statement.operands().size() != 2)
   {
     throw errort().with_location(statement.source_location())
       << "event_guard expected to have two operands";
   }
 
-  exprt &guard=statement.guard();
+  exprt &guard = statement.guard();
 
   convert_expr(guard);
   make_boolean(guard);
@@ -1274,7 +1283,7 @@ Function: verilog_typecheckt::convert_delay
 
 void verilog_typecheckt::convert_delay(verilog_delayt &statement)
 {
-  if(statement.operands().size()!=2)
+  if(statement.operands().size() != 2)
   {
     throw errort().with_location(statement.source_location())
       << "delay expected to have two operands";
@@ -1297,7 +1306,7 @@ Function: verilog_typecheckt::convert_for
 
 void verilog_typecheckt::convert_for(verilog_fort &statement)
 {
-  if(statement.operands().size()!=4)
+  if(statement.operands().size() != 4)
   {
     throw errort().with_location(statement.source_location())
       << "for expected to have four operands";
@@ -1309,7 +1318,7 @@ void verilog_typecheckt::convert_for(verilog_fort &statement)
   for(auto &init : statement.initialization())
     convert_statement(init);
 
-  exprt &condition=statement.condition();
+  exprt &condition = statement.condition();
   convert_expr(condition);
   make_boolean(condition);
 
@@ -1382,7 +1391,7 @@ Function: verilog_typecheckt::convert_prepostincdec
 
 void verilog_typecheckt::convert_prepostincdec(verilog_statementt &statement)
 {
-  if(statement.operands().size()!=1)
+  if(statement.operands().size() != 1)
   {
     throw errort().with_location(statement.source_location())
       << statement.id() << " expected to have one operand";
@@ -1403,16 +1412,15 @@ Function: verilog_typecheckt::convert_while
 
 \*******************************************************************/
 
-void verilog_typecheckt::convert_while(
-  verilog_whilet &statement)
+void verilog_typecheckt::convert_while(verilog_whilet &statement)
 {
-  if(statement.operands().size()!=2)
+  if(statement.operands().size() != 2)
   {
     throw errort().with_location(statement.source_location())
       << "while expected to have two operands";
   }
 
-  exprt &condition=statement.condition();
+  exprt &condition = statement.condition();
   convert_expr(condition);
   make_boolean(condition);
 
@@ -1431,16 +1439,15 @@ Function: verilog_typecheckt::convert_repeat
 
 \*******************************************************************/
 
-void verilog_typecheckt::convert_repeat(
-  verilog_repeatt &statement)
+void verilog_typecheckt::convert_repeat(verilog_repeatt &statement)
 {
-  if(statement.operands().size()!=2)
+  if(statement.operands().size() != 2)
   {
     throw errort().with_location(statement.source_location())
       << "repeat expected to have two operands";
   }
 
-  exprt &condition=statement.condition();
+  exprt &condition = statement.condition();
   convert_expr(condition);
   make_boolean(condition);
 
@@ -1459,10 +1466,9 @@ Function: verilog_typecheckt::convert_forever
 
 \*******************************************************************/
 
-void verilog_typecheckt::convert_forever(
-  verilog_forevert &statement)
+void verilog_typecheckt::convert_forever(verilog_forevert &statement)
 {
-  if(statement.operands().size()!=1)
+  if(statement.operands().size() != 1)
   {
     throw errort().with_location(statement.source_location())
       << "forever expected to have one operand";
@@ -1483,10 +1489,9 @@ Function: verilog_typecheckt::convert_statement
 
 \*******************************************************************/
 
-void verilog_typecheckt::convert_statement(
-  verilog_statementt &statement)
+void verilog_typecheckt::convert_statement(verilog_statementt &statement)
 {
-  if(statement.id()==ID_block)
+  if(statement.id() == ID_block)
     convert_block(to_verilog_block(statement));
   else if(
     statement.id() == ID_verilog_case || statement.id() == ID_verilog_casex ||
@@ -1538,32 +1543,31 @@ void verilog_typecheckt::convert_statement(
   }
   else if(statement.id() == ID_verilog_non_blocking_assign)
     convert_assign(to_verilog_assign(statement), false);
-  else if(statement.id()==ID_if)
+  else if(statement.id() == ID_if)
     convert_if(to_verilog_if(statement));
-  else if(statement.id()==ID_event_guard)
+  else if(statement.id() == ID_event_guard)
     convert_event_guard(to_verilog_event_guard(statement));
-  else if(statement.id()==ID_delay)
+  else if(statement.id() == ID_delay)
     convert_delay(to_verilog_delay(statement));
-  else if(statement.id()==ID_for)
+  else if(statement.id() == ID_for)
     convert_for(to_verilog_for(statement));
-  else if(statement.id()==ID_while)
+  else if(statement.id() == ID_while)
     convert_while(to_verilog_while(statement));
-  else if(statement.id()==ID_repeat)
+  else if(statement.id() == ID_repeat)
     convert_repeat(to_verilog_repeat(statement));
-  else if(statement.id()==ID_forever)
+  else if(statement.id() == ID_forever)
     convert_forever(to_verilog_forever(statement));
-  else if(statement.id()==ID_skip)
+  else if(statement.id() == ID_skip)
   {
     // do nothing
   }
-  else if(statement.id()==ID_preincrement ||
-          statement.id()==ID_predecrement ||
-          statement.id()==ID_postincrement ||
-          statement.id()==ID_postdecrement)
+  else if(
+    statement.id() == ID_preincrement || statement.id() == ID_predecrement ||
+    statement.id() == ID_postincrement || statement.id() == ID_postdecrement)
     convert_prepostincdec(statement);
-  else if(statement.id()==ID_function_call)
+  else if(statement.id() == ID_function_call)
     convert_function_call_or_task_enable(to_verilog_function_call(statement));
-  else if(statement.id()==ID_decl)
+  else if(statement.id() == ID_decl)
   {
     auto decl_class = to_verilog_decl(statement).get_class();
     if(decl_class == ID_function || decl_class == ID_task)
@@ -1572,7 +1576,7 @@ void verilog_typecheckt::convert_statement(
     else
       convert_decl(to_verilog_decl(statement));
   }
-  else if(statement.id()==ID_force)
+  else if(statement.id() == ID_force)
     convert_force(to_verilog_force(statement));
   else if(statement.id() == ID_verilog_label_statement)
   {
@@ -1628,13 +1632,12 @@ Function: verilog_typecheckt::convert_module_item
 
 \*******************************************************************/
 
-void verilog_typecheckt::convert_module_item(
-  verilog_module_itemt &module_item)
+void verilog_typecheckt::convert_module_item(verilog_module_itemt &module_item)
 {
-  if(module_item.id()==ID_specify)
+  if(module_item.id() == ID_specify)
   {
   }
-  else if(module_item.id()==ID_decl)
+  else if(module_item.id() == ID_decl)
   {
     auto decl_class = to_verilog_decl(module_item).get_class();
 
@@ -1648,8 +1651,9 @@ void verilog_typecheckt::convert_module_item(
   else if(module_item.id() == ID_verilog_generate_decl)
   {
   }
-  else if(module_item.id()==ID_parameter_decl ||
-          module_item.id()==ID_local_parameter_decl)
+  else if(
+    module_item.id() == ID_parameter_decl ||
+    module_item.id() == ID_local_parameter_decl)
   {
   }
   else if(module_item.id() == ID_parameter_override)
@@ -1680,17 +1684,17 @@ void verilog_typecheckt::convert_module_item(
     convert_assert_assume_cover(
       to_verilog_assertion_item(module_item).statement());
   }
-  else if(module_item.id()==ID_initial)
+  else if(module_item.id() == ID_initial)
     convert_initial(to_verilog_initial(module_item));
-  else if(module_item.id()==ID_continuous_assign)
+  else if(module_item.id() == ID_continuous_assign)
     convert_continuous_assign(to_verilog_continuous_assign(module_item));
-  else if(module_item.id()==ID_inst)
+  else if(module_item.id() == ID_inst)
   {
   }
-  else if(module_item.id()==ID_inst_builtin)
+  else if(module_item.id() == ID_inst_builtin)
   {
   }
-  else if(module_item.id()==ID_generate_block)
+  else if(module_item.id() == ID_generate_block)
   {
     // these introduce a scope, much like a named block
     auto &generate_block = to_verilog_generate_block(module_item);
@@ -1712,7 +1716,7 @@ void verilog_typecheckt::convert_module_item(
     for(auto &var : variables)
       genvars[id2string(var.first)] = string2integer(var.second.id_string());
 
-    if(module_item.operands().size()!=1)
+    if(module_item.operands().size() != 1)
     {
       throw errort() << "set_genvars expects one operand";
     }
@@ -1941,17 +1945,17 @@ bool verilog_typecheckt::implicit_wire(
 
   symbolt symbol;
 
-  symbol.mode=mode;
+  symbol.mode = mode;
   symbol.module = verilog_root_module_identifier();
   symbol.value.make_nil();
-  symbol.base_name=identifier;
-  symbol.name=full_identifier;
+  symbol.base_name = identifier;
+  symbol.name = full_identifier;
   symbol.type = net_type;
   symbol.pretty_name = strip_verilog_root_prefix(full_identifier);
 
   symbolt *new_symbol;
   symbol_table.move(symbol, new_symbol);
-  symbol_ptr=new_symbol;
+  symbol_ptr = new_symbol;
 
   return false;
 }
@@ -2116,7 +2120,7 @@ symbolt &copy_module_source(
 
   symbol.base_name = base_name;
   symbol.pretty_name = base_name;
-  symbol.module=symbol.name;
+  symbol.module = symbol.name;
   symbol.location = verilog_module_source.source_location();
 
   symbol.type.add(ID_module_source) = verilog_module_source;


### PR DESCRIPTION
This addresses the **type-checker gaps** bucket of the LogikBench RTL
triage (parse+elaborate only, `ebmc --bound 0`). Three independent
root causes, one commit each, each with a hand-authored regression test.

## Root cause 1 — "failed to get identifier on LHS constant" (genvar)
`parameterize_instantiated_modules()` did not restore the per-iteration
genvar values when descending into a `set_genvars` wrapper, so port
connections / parameter assignments of a generate-loop instance were
evaluated against the **post-loop** genvar value. A module output
connected to a genvar-indexed vector bit (`child u(.o(arr[g]))`) then
used the wrong index; for the top index `arr[WIDTH-1]` this looked
out-of-bounds, was folded to constant 0, and `check_lhs` rejected it.
Fix: restore (and afterwards re-restore) the captured genvar values,
mirroring `convert_module_item`.

- **blocks/lpddr5** — now fully passes.
- **blocks/chiplink**, **koios/bwave_like_fixed_small**,
  **koios/bwave_like_float_small** — clear this error; they now fail
  later on a *different, unrelated* synthesis issue ("conflicting
  assignment types" / "conflict with previous assignment"), which is a
  separate root-cause bucket, not fixed here.

## Root cause 2 — implicit nets in a concatenation LHS
IEEE 1800-2017 6.10 implicitly declares an undeclared identifier used on
the LHS of a continuous assignment as a net. This was handled for a bare
identifier but not for a concatenation member, e.g.
`assign {cout, out} = a - b;` (discard-carry idiom). Fix: declare each
undeclared bare-identifier member as a scalar net before converting.

- **arithmetic/sub** — now fully passes.

## Root cause 3 — `integer` has unknown number of bits
`verilog_bits_opt()` had no case for the mathematical integer type
`ID_integer` (produced by `$clog2` and unsized integer constants), so a
width query threw. Assigning such a value to a sized parameter reaches
`assignment_conversion`, which needs the width, e.g.
`localparam [2:0] ARSIZE = $clog2(DW/8);`. Fix: treat `integer` as 32
bits in width contexts, consistent with the existing
integer→`signedbv{32}` casts (IEEE 1800-2017 6.11, 11.8.1).

- **blocks/dma** — now fully passes.
- **koios/dnnweaver** — clears this error; then fails on an unrelated
  hierarchical reference into a generate-block array
  (`LOOP_N[n-1].buf_read_req_fwd`), a separate feature not in scope.

## Not fixed (left failing, with rationale)
- **large/vortex** — uses deep hierarchical references rooted at the
  module's own name into nested SystemVerilog interface instances
  (`vortex_core_wrap.core.warp_ctl_if.split_valid`). This is valid SV but
  needs substantial cross-module hierarchical-interface-reference support
  that EBMC does not have; out of scope for a targeted type-checker fix.
- **koios/dnnweaver** — beyond the `integer` fix it needs generate-block-
  array hierarchical references (see above).

## Summary of the 8 circuits
| Circuit | Status |
|---|---|
| arithmetic/sub | **fixed** |
| blocks/dma | **fixed** |
| blocks/lpddr5 | **fixed** |
| blocks/chiplink | past this error; blocked by unrelated synthesis issue |
| koios/bwave_like_fixed_small | past this error; blocked by unrelated synthesis issue |
| koios/bwave_like_float_small | past this error; blocked by unrelated synthesis issue |
| koios/dnnweaver | past this error; blocked by generate-block hierarchical ref |
| large/vortex | not fixed — needs hierarchical interface references |

`make -C regression/verilog test` passes with the three new tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)