### PR TITLE
Verilog: fold Verilog-specific constructs when propagating constants in synthesis

### DIFF
--- a/regression/verilog/synth_loop_guard_bitvector1/main.v
+++ b/regression/verilog/synth_loop_guard_bitvector1/main.v
@@ -1,0 +1,29 @@
+// Synthesis of a for loop whose loop variable is a bit-vector reg (not an
+// integer), initialised with a replication expression. Synthesis has to
+// constant-fold the guard and increment across iterations to unroll the loop;
+// this requires the Verilog-aware simplifier to reduce the replication
+// {DW-1{1'b0}} in the initialiser to a constant.
+// Minimal reproduction of blocks/lfsr (rtl/lfsr.v:235) and blocks/ethmac
+// (rtl/eth_lfsr.v:235):
+//   for(data_mask = {1'b1, {DW-1{1'b0}}}; data_mask != 0;
+//       data_mask = data_mask >> 1)
+module main;
+
+  parameter DW = 8;
+
+  // Counts how many bit positions the walking-one mask visits: exactly DW.
+  function [DW-1:0] popcount(input [31:0] dummy);
+    reg [DW-1:0] data_mask;
+    begin
+      popcount = 0;
+      for(data_mask = {1'b1, {DW-1{1'b0}}}; data_mask != 0;
+          data_mask = data_mask >> 1)
+        popcount = popcount + 1;
+    end
+  endfunction
+
+  wire [DW-1:0] r = popcount(0);
+
+  always assert p1: r == DW;
+
+endmodule

--- a/regression/verilog/synth_loop_guard_bitvector1/test.desc
+++ b/regression/verilog/synth_loop_guard_bitvector1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.v
+--bound 0
+^\[main\.property\.p1\] always main\.r == main\.DW: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+synthesis failed to evaluate loop guard

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -27,6 +27,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "verilog_expr.h"
 #include "verilog_initializer.h"
 #include "verilog_lowering.h"
+#include "verilog_simplifier.h"
 #include "verilog_typecheck_expr.h"
 
 #include <cassert>
@@ -2306,7 +2307,12 @@ void verilog_synthesist::synth_assign(const verilog_assignt &statement)
   }
 
   // Can the rhs be simplified to a constant, for propagation?
-  auto rhs_simplified = simplify_expr(rhs, ns);
+  // We use the Verilog-aware simplifier so that Verilog-specific constructs
+  // such as replication (e.g. the loop-variable initializer
+  // {1'b1, {DW-1{1'b0}}}) are folded; the plain simplifier does not know how
+  // to reduce these to a constant, which would otherwise leave an unrolled
+  // loop guard unevaluable.
+  auto rhs_simplified = verilog_simplifier(rhs, ns);
 
   if(rhs_simplified.is_constant())
     rhs = rhs_simplified;


### PR DESCRIPTION
When synthesising a blocking assignment, `synth_assign` tries to simplify
the right-hand side to a constant so the value can be propagated (needed,
among other things, to unroll for/while loops by evaluating their guard
each iteration). It used the plain simplifier, which does not know how to
reduce Verilog-specific constructs such as replication (`{n{x}}`) to a
constant.

As a result a loop whose bit-vector loop variable is initialised with a
replication, e.g.

```verilog
for(data_mask = {1'b1, {DW-1{1'b0}}}; data_mask != 0;
    data_mask = data_mask >> 1)
```

left `data_mask` non-constant, so synthesis reported "synthesis failed to
evaluate loop guard". Uses the Verilog-aware simplifier instead, which
lowers replication to a concatenation before folding. The result is only
used when it is constant, so non-constant right-hand sides are unaffected.

This is the root cause of the loop-guard failures for the LogikBench
`blocks/ethmac` (rtl/eth_lfsr.v:235) and `blocks/lfsr` (rtl/lfsr.v:235)
benchmarks.

New regression test: `regression/verilog/synth_loop_guard_bitvector1`.