### PR TITLE
Verilog preprocessor: track bracket nesting when splitting macro arguments

### DIFF
--- a/regression/verilog/preprocessor/macro_arg_commas1.desc
+++ b/regression/verilog/preprocessor/macro_arg_commas1.desc
@@ -1,0 +1,7 @@
+CORE
+macro_arg_commas1.sv
+--bound 0
+^no properties$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/verilog/preprocessor/macro_arg_commas1.sv
+++ b/regression/verilog/preprocessor/macro_arg_commas1.sv
@@ -1,0 +1,12 @@
+// Commas nested inside (), [] or {} within a single macro argument
+// must not be counted as argument separators (IEEE 1800-2017 22.5.1).
+// Reduced from LogikBench blocks/picorv32.
+`define debug(debug_command) debug_command
+
+module main(input clk);
+  integer a, b;
+  always @(posedge clk) begin
+    `debug($display("LD_RS2: %2d 0x%08x", a, b);)
+    a <= b + 1;
+  end
+endmodule

--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -353,6 +353,11 @@ auto verilog_preprocessort::parse_define_arguments(const definet &define)
   // which contains one empty vector of argument tokens.
   std::vector<std::vector<tokent>> arguments = {{}};
 
+  // 1800-2017 22.5.1: an actual argument that contains a comma must be
+  // enclosed within parentheses, brackets or braces. Commas and the
+  // closing ')' are therefore only significant at nesting depth zero.
+  std::size_t nesting = 0;
+
   while(true)
   {
     if(tokenizer().eof())
@@ -360,15 +365,21 @@ auto verilog_preprocessort::parse_define_arguments(const definet &define)
         << "eof inside a define argument list";
 
     auto token = tokenizer().next_token();
-    if(token == ',')
+    if(token == ',' && nesting == 0)
     {
       arguments.push_back({}); // next argument
       tokenizer().skip_ws();
     }
-    else if(token == ')')
+    else if(token == ')' && nesting == 0)
       break; // done
     else
+    {
+      if(token == '(' || token == '[' || token == '{')
+        nesting++;
+      else if(token == ')' || token == ']' || token == '}')
+        nesting--;
       arguments.back().push_back(std::move(token));
+    }
   }
 
   // does the number of arguments match the number of parameters?


### PR DESCRIPTION
When splitting the actual arguments of a function-like macro on commas,
the preprocessor treated every comma and the first ')' as significant,
regardless of nesting. A single argument containing commas inside
parentheses, brackets or braces -- e.g.
`debug($display("%d %d", a, b);)` -- was therefore miscounted, and the
first inner ')' terminated the list prematurely.

Commas and the closing ')' are now only significant at nesting depth
zero (IEEE 1800-2017 22.5.1).

Fixes LogikBench blocks/picorv32.

New regression test: `regression/verilog/preprocessor/macro_arg_commas1`.