### PR TITLE
Verilog preprocessor: replace, not append, on macro redefinition

### DIFF
--- a/regression/verilog/preprocessor/macro_redefine1.desc
+++ b/regression/verilog/preprocessor/macro_redefine1.desc
@@ -1,0 +1,7 @@
+CORE
+macro_redefine1.sv
+--bound 0
+^no properties$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/verilog/preprocessor/macro_redefine1.sv
+++ b/regression/verilog/preprocessor/macro_redefine1.sv
@@ -1,0 +1,11 @@
+// A repeated `define must replace the previous definition, not append to
+// it (IEEE 1800-2017 22.5.1). Reduced from LogikBench large/nvdlafull and
+// large/nvdlasmall, where FORCE_CONTENTION_ASSERTION_RESET_ACTIVE is
+// defined as 1'b1 several times in the same file; appending turned the
+// expansion into "1'b11'b1".
+`define FORCE 1'b1
+`define FORCE 1'b1
+module sub #(parameter P = 0) (input a); endmodule
+module main(input a);
+  sub #(`FORCE) u (.a(a));
+endmodule

--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -440,6 +440,11 @@ void verilog_preprocessort::directive()
     auto &identifier = identifier_token.text;
     auto &define = defines[identifier];
 
+    // A repeated `define replaces any previous definition (1800-2017
+    // 22.5.1: "the most recent definition ... is used"). Reset the entry
+    // so parameters and tokens are not appended to a stale definition.
+    define = definet{};
+
     // Is there a parameter list?
     // These have been introduced in Verilog 2001.
     // 1800-2017: "The left parenthesis shall follow the text macro name


### PR DESCRIPTION
`defines[identifier]` returns a reference to any existing macro entry.
When a macro was redefined, the new parameters and body tokens were
appended to the previous definition instead of replacing it. For a macro
such as `FORCE_CONTENTION_ASSERTION_RESET_ACTIVE`, defined as `1'b1`
several times in one file, the expansion became `1'b11'b1`, which the
parser then rejected.

The entry is now reset before it is populated, so the most recent
definition wins (IEEE 1800-2017 22.5.1).

Resolves the parse error in LogikBench large/nvdlafull and
large/nvdlasmall (both still need library modules that are not part of
the benchmark).

New regression test: `regression/verilog/preprocessor/macro_redefine1`.

(Split out of #2051, which originally bundled this together with an
unrelated macro-argument-splitting fix and two grammar fixes — all
independent of each other. The macro-argument-splitting fix now has its
own PR too: #2055.)