### PR TITLE
Verilog: accept struct/array/union as constant expressions

### DIFF
--- a/regression/verilog/parameters/array_parameter1.desc
+++ b/regression/verilog/parameters/array_parameter1.desc
@@ -1,0 +1,8 @@
+CORE
+array_parameter1.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/parameters/array_parameter1.sv
+++ b/regression/verilog/parameters/array_parameter1.sv
@@ -1,0 +1,10 @@
+module main;
+
+  typedef int int_array [3];
+  parameter int_array A = '{ 10, 20, 30 };
+
+  parameter Q = A[1];
+
+  initial assert(Q == 20);
+
+endmodule

--- a/regression/verilog/parameters/array_parameter2.desc
+++ b/regression/verilog/parameters/array_parameter2.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+array_parameter2.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Array dimension after the parameter name is not yet supported.

--- a/regression/verilog/parameters/array_parameter2.sv
+++ b/regression/verilog/parameters/array_parameter2.sv
@@ -1,0 +1,9 @@
+module main;
+
+  parameter int A [3] = '{ 10, 20, 30 };
+
+  parameter Q = A[1];
+
+  initial assert(Q == 20);
+
+endmodule

--- a/regression/verilog/parameters/struct_parameter1.desc
+++ b/regression/verilog/parameters/struct_parameter1.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+struct_parameter1.sv
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The struct literal is not recognised as a constant.

--- a/regression/verilog/parameters/struct_parameter1.desc
+++ b/regression/verilog/parameters/struct_parameter1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 struct_parameter1.sv
 
 ^EXIT=0$
@@ -6,4 +6,4 @@ struct_parameter1.sv
 --
 ^warning: ignoring
 --
-The struct literal is not recognised as a constant.
+

--- a/regression/verilog/parameters/struct_parameter1.sv
+++ b/regression/verilog/parameters/struct_parameter1.sv
@@ -1,0 +1,8 @@
+module main;
+
+  typedef struct { int x; } my_struct_type;
+  parameter my_struct_type P = '{ x: 123 };
+
+  parameter Q = P.x;
+
+endmodule

--- a/regression/verilog/parameters/struct_parameter1.sv
+++ b/regression/verilog/parameters/struct_parameter1.sv
@@ -5,4 +5,6 @@ module main;
 
   parameter Q = P.x;
 
+  initial assert(Q == 123);
+
 endmodule

--- a/src/verilog/verilog_simplifier.cpp
+++ b/src/verilog/verilog_simplifier.cpp
@@ -53,6 +53,22 @@ static constant_exprt onehot0(const constant_exprt &expr, const namespacet &ns)
     return false_exprt();
 }
 
+static bool is_constant_rec(const exprt &expr)
+{
+  if(expr.is_constant())
+    return true;
+
+  if(expr.id() == ID_struct || expr.id() == ID_array || expr.id() == ID_union)
+  {
+    for(auto &op : expr.operands())
+      if(!is_constant_rec(op))
+        return false;
+    return true;
+  }
+
+  return false;
+}
+
 static exprt verilog_simplifier_rec(exprt expr, const namespacet &ns)
 {
   // Remember the Verilog type.
@@ -69,7 +85,7 @@ static exprt verilog_simplifier_rec(exprt expr, const namespacet &ns)
   {
     // recursive call
     op = verilog_simplifier_rec(op, ns);
-    if(!op.is_constant())
+    if(!is_constant_rec(op))
       operands_are_constant = false;
   }
 

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -2210,6 +2210,36 @@ exprt verilog_typecheck_exprt::elaborate_constant_expression_rec(exprt expr)
 
 /*******************************************************************\
 
+Function: is_constant_rec
+
+  Inputs:
+
+ Outputs:
+
+ Purpose: returns true iff the given expression is a constant,
+          including struct, union and array expressions with
+          all-constant members
+
+\*******************************************************************/
+
+static bool is_constant_rec(const exprt &expr)
+{
+  if(expr.is_constant() || expr.id() == ID_infinity)
+    return true;
+
+  if(expr.id() == ID_struct || expr.id() == ID_array || expr.id() == ID_union)
+  {
+    for(auto &op : expr.operands())
+      if(!is_constant_rec(op))
+        return false;
+    return true;
+  }
+
+  return false;
+}
+
+/*******************************************************************\
+
 Function: verilog_typecheck_exprt::elaborate_constant_expression_check
 
   Inputs:
@@ -2226,8 +2256,7 @@ exprt verilog_typecheck_exprt::elaborate_constant_expression_check(exprt expr)
 
   exprt tmp = elaborate_constant_expression(std::move(expr));
 
-  // $ counts as a constant
-  if(!tmp.is_constant() && tmp.id() != ID_infinity)
+  if(!is_constant_rec(tmp))
   {
     throw errort().with_location(source_location)
       << "expected constant expression, but got `" << to_string(tmp) << '\'';


### PR DESCRIPTION
Fixes the KNOWNBUG from #2057 by extending the constant expression check to accept struct, array, and union expressions with all-constant operands.

## Changes

- **`src/verilog/verilog_typecheck_expr.cpp`**: Added recursive `is_constant_rec()` helper and updated `elaborate_constant_expression_check()` to use it instead of the simple `is_constant()` check.
- **`src/verilog/verilog_simplifier.cpp`**: Added the same recursive check so the simplifier doesn't bail early on member access of struct-valued expressions (allowing `P.x` to be reduced to a constant).
- **Test**: Updated `struct_parameter1` from KNOWNBUG to CORE and added an assertion verifying the value.

## Testing

- `[main.assert.1] main.Q == 123: PROVED (tautology)`
- Full `regression/verilog` suite passes with no regressions.