### PR TITLE
Print version and architecture banner

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # EBMC 6.1
 
+* version and architecture banner
 * Netlist: module outputs are now classified as outputs rather than
   wires (visible in --show-varmap); they remain shown in
   counterexample traces

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -85,6 +85,8 @@ int ebmc_parse_optionst::doit()
     return 0;
   }
 
+  log_version_and_architecture("EBMC");
+
   try
   {
     if(cmdline.isset("diatest"))

--- a/src/vlindex/vlindex_parse_options.cpp
+++ b/src/vlindex/vlindex_parse_options.cpp
@@ -44,6 +44,8 @@ int vlindex_parse_optionst::doit()
     return 0;
   }
 
+  log_version_and_architecture("VLINDEX");
+
   try
   {
     return verilog_index(cmdline);


### PR DESCRIPTION
This adds a call to `log_version_and_architecture(...)` to both ebmc and vlindex, to match the behavior of cbmc and hw-cbmc.