### PR TITLE
Verilog: narrowing a wide output port to a one-bit net

### DIFF
--- a/regression/verilog/modules/implicit_net_port_width1.desc
+++ b/regression/verilog/modules/implicit_net_port_width1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 implicit_net_port_width1.sv
 --bound 1
 ^\[main\.p0\] always main\.cam == main\.din\[0\]: PROVED up to bound 1$
@@ -8,5 +8,4 @@ implicit_net_port_width1.sv
 --
 An output port that is wider than the (one-bit) net it drives must be
 truncated to the least-significant bit, as a narrowing continuous
-assignment would be. EBMC instead casts to bool, i.e. computes (port != 0),
-so the property is wrongly REFUTED.
+assignment would be.

--- a/regression/verilog/modules/implicit_net_port_width1.desc
+++ b/regression/verilog/modules/implicit_net_port_width1.desc
@@ -1,0 +1,12 @@
+KNOWNBUG
+implicit_net_port_width1.sv
+--bound 1
+^\[main\.p0\] always main\.cam == main\.din\[0\]: PROVED up to bound 1$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+An output port that is wider than the (one-bit) net it drives must be
+truncated to the least-significant bit, as a narrowing continuous
+assignment would be. EBMC instead casts to bool, i.e. computes (port != 0),
+so the property is wrongly REFUTED.

--- a/regression/verilog/modules/implicit_net_port_width1.sv
+++ b/regression/verilog/modules/implicit_net_port_width1.sv
@@ -1,0 +1,15 @@
+// The width of an implicitly declared net used in a port connection
+// is one bit (IEEE 1800-2017 6.10). When a wider output port drives
+// such a net, the value must be truncated to the least-significant
+// bit, exactly as a narrowing continuous assignment would.
+module sub(input [7:0] din, output [7:0] dout);
+  assign dout = din;
+endmodule
+
+module main(input [7:0] din);
+  // cam is implicitly declared, hence a one-bit scalar net
+  sub s(.din(din), .dout(cam));
+
+  // narrowing the 8-bit port to the 1-bit net yields the LSB
+  p0: assert property (cam == din[0]);
+endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -1364,21 +1364,32 @@ void verilog_synthesist::instantiate_port(
 
   symbol_exprt port_symbol{port.identifier(), port.type()};
 
+  // Convert the rhs to the type of the lhs, as an assignment would.
+  // Note that the types need not match. Narrowing to a one-bit net must
+  // take the least-significant bit, as in assignment_conversion; a plain
+  // typecast to bool would instead compute a (!= 0) reduction.
+  auto narrowing_cast = [](exprt src, const typet &dest_type) -> exprt
+  {
+    if(dest_type.id() == ID_bool && src.type().id() != ID_bool)
+      return extractbit_exprt{std::move(src), from_integer(0, integer_typet{})};
+    else
+      return typecast_exprt::conditional_cast(src, dest_type);
+  };
+
   // Much like
   //   always @(*) port = value for an input, and
   //   always @(*) value = port for an output.
-  // Note that the types need not match.
   exprt lhs, rhs;
 
   if(port.output())
   {
     lhs = value;
-    rhs = typecast_exprt::conditional_cast(port_symbol, value.type());
+    rhs = narrowing_cast(port_symbol, value.type());
   }
   else
   {
     lhs = port_symbol;
-    rhs = typecast_exprt::conditional_cast(value, port_symbol.type());
+    rhs = narrowing_cast(value, port_symbol.type());
   }
 
   verilog_forcet assignment{lhs, rhs};


### PR DESCRIPTION
## Summary

Fixes incorrect narrowing when a port connection ties a signal wider
than one bit to a one-bit net.

An implicitly declared net used in a port connection is a one-bit scalar
net (IEEE 1800-2017 6.10). When a wider signal drives such a net (or a
one-bit port drives a wider net), the value must be **truncated to the
least-significant bit**, exactly as a narrowing continuous assignment
(`assign cam = din;`) already is in `assignment_conversion`.

`instantiate_port` (`src/verilog/verilog_synthesis.cpp`) instead used
`typecast_exprt::conditional_cast` to `bool`, which lowers to a
`(!= 0)` reduction. The net therefore received the wrong bit for any
source value whose LSB differed from its zero/non-zero status.

## Fix

Narrow to a one-bit destination with `extractbit_exprt{src, 0}` (the
LSB), mirroring `assignment_conversion`; other widths keep the existing
conditional cast. Applied to both the output-port and input-port
directions.

## Reproduction

```verilog
module sub(input [7:0] din, output [7:0] dout);
  assign dout = din;
endmodule

module main(input [7:0] din);
  sub s(.din(din), .dout(cam));        // cam: implicit one-bit net
  p0: assert property (cam == din[0]); // truncation => LSB
endmodule
```

Before: `p0` REFUTED (`cam == (din != 0)`). After: `p0` PROVED.

## Testing

- New regression test `regression/verilog/modules/implicit_net_port_width1`
  (CORE).
- `make -C regression/verilog test`, `regression/ebmc test`,
  `regression/smv test` all pass.