### PR TITLE
extract `verilog_set_genvarst::build_map()`

### DIFF
--- a/src/verilog/verilog_expr.cpp
+++ b/src/verilog/verilog_expr.cpp
@@ -526,3 +526,12 @@ verilog_module_instancet::verilog_module_instancet(
 {
   module_identifier(_module_identifier);
 }
+
+verilog_set_genvarst::genvarst verilog_set_genvarst::build_map() const
+{
+  const auto &variables = this->variables();
+  genvarst genvars;
+  for(auto &var : variables)
+    genvars[id2string(var.first)] = string2integer(var.second.id_string());
+  return genvars;
+}

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -9,8 +9,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_VERILOG_EXPR_H
 #define CPROVER_VERILOG_EXPR_H
 
+#include <util/mp_arith.h>
 #include <util/std_expr.h>
 
+#include <map>
 #include <set>
 
 /// A simple Verilog identifier, unqualified
@@ -941,24 +943,29 @@ public:
 
   const verilog_module_itemt &module_item() const
   {
-    return static_cast<const verilog_module_itemt &>(get_sub()[0]);
+    return static_cast<const verilog_module_itemt &>(op0());
   }
 
   verilog_module_itemt &module_item()
   {
-    return static_cast<verilog_module_itemt &>(get_sub()[0]);
+    return static_cast<verilog_module_itemt &>(op0());
   }
+
+  typedef std::map<irep_idt, mp_integer> genvarst;
+  genvarst build_map() const;
 };
 
 inline const verilog_set_genvarst &to_verilog_set_genvars(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_set_genvars);
+  PRECONDITION(expr.operands().size() == 1);
   return static_cast<const verilog_set_genvarst &>(expr);
 }
 
 inline verilog_set_genvarst &to_verilog_set_genvars(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_set_genvars);
+  PRECONDITION(expr.operands().size() == 1);
   return static_cast<verilog_set_genvarst &>(expr);
 }
 

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1707,15 +1707,8 @@ void verilog_typecheckt::convert_module_item(
   }
   else if(module_item.id() == ID_set_genvars)
   {
-    genvars.clear();
-    const auto &variables = to_verilog_set_genvars(module_item).variables();
-    for(auto &var : variables)
-      genvars[id2string(var.first)] = string2integer(var.second.id_string());
-
-    if(module_item.operands().size()!=1)
-    {
-      throw errort() << "set_genvars expects one operand";
-    }
+    auto &set_genvars = to_verilog_set_genvars(module_item);
+    genvars = set_genvars.build_map();
 
     exprt tmp;
     tmp.swap(to_unary_expr(module_item).op());


### PR DESCRIPTION
This extracts the code that turns the data in `verilog_set_genvarst` into a `map` into a method.