### PR TITLE
Verilog: end labels after `endfunction`/`endtask`

### DIFF
--- a/regression/verilog/functions/end_label1.desc
+++ b/regression/verilog/functions/end_label1.desc
@@ -1,0 +1,8 @@
+CORE
+end_label1.sv
+--bound 0
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/verilog/functions/end_label1.sv
+++ b/regression/verilog/functions/end_label1.sv
@@ -1,0 +1,21 @@
+// End labels after endfunction/endtask, IEEE 1800-2017 A.9.3.
+// Reduced from LogikBench blocks/hmac, blocks/i2c, blocks/uart, large/aes.
+module main;
+
+  function automatic bit is_width_valid(int width);
+    unique case (width)
+      16: return 1'b1;
+      32: return 1'b1;
+      default: return 1'b0;
+    endcase
+  endfunction : is_width_valid
+
+  task set_zero(output int o);
+    o = 0;
+  endtask : set_zero
+
+  initial begin
+    assert(is_width_valid(16));
+  end
+
+endmodule

--- a/regression/verilog/tasks/task_name_collision.desc
+++ b/regression/verilog/tasks/task_name_collision.desc
@@ -1,7 +1,7 @@
 CORE
 task_name_collision.v
 
-^file .* line 11: definition of symbol `some_task' conflicts with earlier definition at line 7$
+^file .* line 9: definition of symbol `some_task' conflicts with earlier definition at line 5$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2703,7 +2703,7 @@ function_body_declaration:
           ';'
           tf_item_declaration_brace
           function_statement_or_null_brace
-          TOK_ENDFUNCTION
+          TOK_ENDFUNCTION end_identifier_opt
                 { init($$, ID_decl);
                   stack_expr($$).set(ID_class, ID_function);
                   addswap($$, ID_type, $1);
@@ -2720,7 +2720,7 @@ function_body_declaration:
           '(' tf_port_list_opt ')' ';'
           block_item_declaration_brace
           function_statement_or_null_brace
-          TOK_ENDFUNCTION
+          TOK_ENDFUNCTION end_identifier_opt
                 { init($$, ID_decl);
                   stack_expr($$).set(ID_class, ID_function);
                   addswap($$, ID_type, $1);
@@ -2768,7 +2768,7 @@ task_declaration:
           ';'
           tf_item_declaration_brace
           task_statement_or_null_brace
-          TOK_ENDTASK
+          TOK_ENDTASK end_identifier_opt
                 { init($$, ID_decl);
                   stack_expr($$).set(ID_class, ID_task);
                   mto($$, $2); // declarator
@@ -2782,7 +2782,7 @@ task_declaration:
           '(' tf_port_list_opt ')' ';'
           tf_item_declaration_brace
           task_statement_or_null_brace
-          TOK_ENDTASK
+          TOK_ENDTASK end_identifier_opt
                 { init($$, ID_decl);
                   stack_expr($$).set(ID_class, ID_task);
                   mto($$, $2); // declarator
@@ -5513,6 +5513,13 @@ topmodule_identifier: non_type_identifier;
 endmodule_identifier_opt:
           /* Optional */
         | TOK_COLON module_identifier
+        ;
+
+// Optional block name repeated after endfunction/endtask etc.,
+// e.g. "endfunction : is_width_valid". IEEE 1800-2017 A.9.3.
+end_identifier_opt:
+          /* Optional */
+        | TOK_COLON any_identifier
         ;
 
 clocking_identifier: non_type_identifier;

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -2709,6 +2709,11 @@ function_body_declaration:
                   addswap($$, ID_type, $1);
                   add_as_subtype(stack_type($1), stack_type($1));
                   mto($$, $2); // declarator
+                  // Anchor the declaration's location to the declarator
+                  // so it does not follow the lookahead token consumed for
+                  // the optional end label.
+                  stack_expr($$).add_source_location() =
+                    stack_expr($$).operands().back().source_location();
                   addswap($$, ID_verilog_declarations, $5);
                   addswap($$, ID_body, $6);
                   pop_scope();
@@ -2726,6 +2731,11 @@ function_body_declaration:
                   addswap($$, ID_type, $1);
                   add_as_subtype(stack_type($1), stack_type($1));
                   mto($$, $2); // declarator
+                  // Anchor the declaration's location to the declarator
+                  // so it does not follow the lookahead token consumed for
+                  // the optional end label.
+                  stack_expr($$).add_source_location() =
+                    stack_expr($$).operands().back().source_location();
                   addswap($$, ID_ports, $5);
                   addswap($$, ID_verilog_declarations, $8);
                   addswap($$, ID_body, $9);
@@ -2772,6 +2782,11 @@ task_declaration:
                 { init($$, ID_decl);
                   stack_expr($$).set(ID_class, ID_task);
                   mto($$, $2); // declarator
+                  // Anchor the declaration's location to the declarator
+                  // so it does not follow the lookahead token consumed for
+                  // the optional end label.
+                  stack_expr($$).add_source_location() =
+                    stack_expr($$).operands().back().source_location();
                   addswap($$, ID_verilog_declarations, $5);
                   addswap($$, ID_body, $6);
                   pop_scope();
@@ -2786,6 +2801,11 @@ task_declaration:
                 { init($$, ID_decl);
                   stack_expr($$).set(ID_class, ID_task);
                   mto($$, $2); // declarator
+                  // Anchor the declaration's location to the declarator
+                  // so it does not follow the lookahead token consumed for
+                  // the optional end label.
+                  stack_expr($$).add_source_location() =
+                    stack_expr($$).operands().back().source_location();
                   addswap($$, ID_ports, $5);
                   addswap($$, ID_verilog_declarations, $8);
                   addswap($$, ID_body, $9);


### PR DESCRIPTION
SystemVerilog allows an optional block name after `endfunction` and `endtask`.