### PR TITLE
Verilog: preserve genvars while elaborating module instances

### DIFF
--- a/regression/verilog/generate/generate-inst3.desc
+++ b/regression/verilog/generate/generate-inst3.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 generate-inst3.sv
 --bound 0
 ^\[main\.property1\] always main\.out == main\.in: PROVED up to bound 0$
@@ -6,4 +6,3 @@ generate-inst3.sv
 ^SIGNAL=0$
 --
 --
-The parameter is not passed correctly.

--- a/regression/verilog/port-connections/output_port_genvar1.desc
+++ b/regression/verilog/port-connections/output_port_genvar1.desc
@@ -1,0 +1,6 @@
+CORE
+output_port_genvar1.sv
+--module main --bound 1
+^EXIT=10$
+^SIGNAL=0$
+^no properties$

--- a/regression/verilog/port-connections/output_port_genvar1.sv
+++ b/regression/verilog/port-connections/output_port_genvar1.sv
@@ -1,0 +1,14 @@
+module child(output reg o);
+endmodule
+
+module main;
+  wire [3:0] locked;
+  genvar g;
+
+  generate
+    for(g = 0; g < 4; g = g + 1)
+    begin : genblk
+      child c(.o(locked[g]));
+    end
+  endgenerate
+endmodule

--- a/src/verilog/verilog_elaborate_module_instances.cpp
+++ b/src/verilog/verilog_elaborate_module_instances.cpp
@@ -162,8 +162,11 @@ void verilog_typecheckt::elaborate_module_instances(
   }
   else if(module_item.id() == ID_set_genvars)
   {
-    elaborate_module_instances(
-      to_verilog_set_genvars(module_item).module_item());
+    auto old_genvars = genvars;
+    auto &set_genvars = to_verilog_set_genvars(module_item);
+    genvars = set_genvars.build_map();
+    elaborate_module_instances(set_genvars.module_item());
+    genvars = std::move(old_genvars);
   }
 }
 
@@ -295,8 +298,11 @@ void verilog_typecheckt::parameterize_instantiated_modules(
   }
   else if(module_item.id() == ID_set_genvars)
   {
-    parameterize_instantiated_modules(
-      to_verilog_set_genvars(module_item).module_item());
+    auto old_genvars = genvars;
+    auto &set_genvars = to_verilog_set_genvars(module_item);
+    genvars = set_genvars.build_map();
+    parameterize_instantiated_modules(set_genvars.module_item());
+    genvars = std::move(old_genvars);
   }
 }
 

--- a/src/verilog/verilog_expr.cpp
+++ b/src/verilog/verilog_expr.cpp
@@ -526,3 +526,12 @@ verilog_module_instancet::verilog_module_instancet(
 {
   module_identifier(_module_identifier);
 }
+
+verilog_set_genvarst::genvarst verilog_set_genvarst::build_map() const
+{
+  const auto &variables = this->variables();
+  genvarst genvars;
+  for(auto &var : variables)
+    genvars[id2string(var.first)] = string2integer(var.second.id_string());
+  return genvars;
+}

--- a/src/verilog/verilog_expr.h
+++ b/src/verilog/verilog_expr.h
@@ -9,8 +9,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_VERILOG_EXPR_H
 #define CPROVER_VERILOG_EXPR_H
 
+#include <util/mp_arith.h>
 #include <util/std_expr.h>
 
+#include <map>
 #include <set>
 
 /// A simple Verilog identifier, unqualified
@@ -941,24 +943,29 @@ public:
 
   const verilog_module_itemt &module_item() const
   {
-    return static_cast<const verilog_module_itemt &>(get_sub()[0]);
+    return static_cast<const verilog_module_itemt &>(op0());
   }
 
   verilog_module_itemt &module_item()
   {
-    return static_cast<verilog_module_itemt &>(get_sub()[0]);
+    return static_cast<verilog_module_itemt &>(op0());
   }
+
+  typedef std::map<irep_idt, mp_integer> genvarst;
+  genvarst build_map() const;
 };
 
 inline const verilog_set_genvarst &to_verilog_set_genvars(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_set_genvars);
+  PRECONDITION(expr.operands().size() == 1);
   return static_cast<const verilog_set_genvarst &>(expr);
 }
 
 inline verilog_set_genvarst &to_verilog_set_genvars(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_set_genvars);
+  PRECONDITION(expr.operands().size() == 1);
   return static_cast<verilog_set_genvarst &>(expr);
 }
 

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1707,15 +1707,8 @@ void verilog_typecheckt::convert_module_item(
   }
   else if(module_item.id() == ID_set_genvars)
   {
-    genvars.clear();
-    const auto &variables = to_verilog_set_genvars(module_item).variables();
-    for(auto &var : variables)
-      genvars[id2string(var.first)] = string2integer(var.second.id_string());
-
-    if(module_item.operands().size()!=1)
-    {
-      throw errort() << "set_genvars expects one operand";
-    }
+    auto &set_genvars = to_verilog_set_genvars(module_item);
+    genvars = set_genvars.build_map();
 
     exprt tmp;
     tmp.swap(to_unary_expr(module_item).op());


### PR DESCRIPTION
This fixes LogikBench failures caused by genvars being dropped while elaborating parameterized module instances.