### PR TITLE
Verilog: support package export declarations

### DIFF
--- a/regression/verilog/packages/package_export1.desc
+++ b/regression/verilog/packages/package_export1.desc
@@ -1,0 +1,6 @@
+CORE
+package_export1.sv
+--module main --bound 1
+^EXIT=10$
+^SIGNAL=0$
+^no properties$

--- a/regression/verilog/packages/package_export1.sv
+++ b/regression/verilog/packages/package_export1.sv
@@ -1,0 +1,11 @@
+package inner;
+  parameter int P = 1;
+endpackage
+
+package outer;
+  import inner::P;
+  export inner::P;
+endpackage
+
+module main;
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1664,7 +1664,7 @@ package_item_brace:
 package_item:
           package_or_generate_item_declaration
 //      | anonymous_program
-//      | package_export_declaration
+        | package_export_declaration
         | timeunits_declaration
         ;
 
@@ -1834,6 +1834,11 @@ package_import_item:
                   stack_expr($$).set(ID_verilog_package, package_base_name);
                   stack_expr($$).set(ID_base_name, "*");
                   PARSER.scopes.wildcard_import(package_base_name); }
+        ;
+
+package_export_declaration:
+          TOK_EXPORT package_import_item_brace ';'
+                { init($$, ID_verilog_empty_item); }
         ;
 
 genvar_declaration:


### PR DESCRIPTION
This accepts package export declarations such as `export pkg::id;` as package items.