### PR TITLE
New IC3: extract blocking phase

### DIFF
--- a/src/new-ic3/ic3_solver.cpp
+++ b/src/new-ic3/ic3_solver.cpp
@@ -27,69 +27,91 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <unordered_set>
 
 /// A cnf_clause_listt that can be instantiated (provides missing virtuals).
-class recording_cnft : public cnf_clause_listt {
+class recording_cnft : public cnf_clause_listt
+{
 public:
-  explicit recording_cnft(message_handlert &mh) : cnf_clause_listt(mh) {}
-  bool is_in_conflict(literalt) const override { return false; }
-  void set_assignment(literalt, bool) override {}
+  explicit recording_cnft(message_handlert &mh) : cnf_clause_listt(mh)
+  {
+  }
+  bool is_in_conflict(literalt) const override
+  {
+    return false;
+  }
+  void set_assignment(literalt, bool) override
+  {
+  }
 };
 
 /// A frame clause: literals sorted by literal code, plus a Bloom-style
 /// signature for constant-time subsumption rejection.
-struct ic3_solvert::frame_clauset {
+struct ic3_solvert::frame_clauset
+{
   clauset clause; // sorted by literalt::get()
   // Bloom signature: each literal sets bit (lit_code & 63). 64 bits
   // matches the register width on x86-64, giving a single-instruction
   // shift and a cheap early-reject in subsumes().
   uint64_t sig;
 
-  explicit frame_clauset(clauset c) : clause(std::move(c)) {
-    std::sort(clause.begin(), clause.end(),
-              [](literalt a, literalt b) { return a.get() < b.get(); });
+  explicit frame_clauset(clauset c) : clause(std::move(c))
+  {
+    std::sort(
+      clause.begin(),
+      clause.end(),
+      [](literalt a, literalt b) { return a.get() < b.get(); });
     sig = 0;
-    for (auto l : clause)
+    for(auto l : clause)
       sig |= uint64_t(1) << (l.get() & 63);
   }
 
-  bool operator==(const frame_clauset &other) const {
+  bool operator==(const frame_clauset &other) const
+  {
     return clause == other.clause;
   }
 };
 
-clauset negate_cube(const cubet &cube) {
+clauset negate_cube(const cubet &cube)
+{
   clauset clause;
   clause.reserve(cube.size());
-  for (auto l : cube)
+  for(auto l : cube)
     clause.push_back(!l);
   return clause;
 }
 
 /// Check if clause a subsumes clause b (a ⊆ b as literal sets).
 /// Both literal vectors must be sorted by literal code.
-bool ic3_solvert::subsumes(const ic3_solvert::frame_clauset &a,
-                           const ic3_solvert::frame_clauset &b) {
-  if (a.clause.size() > b.clause.size())
+bool ic3_solvert::subsumes(
+  const ic3_solvert::frame_clauset &a,
+  const ic3_solvert::frame_clauset &b)
+{
+  if(a.clause.size() > b.clause.size())
     return false;
-  if ((a.sig & ~b.sig) != 0)
+  if((a.sig & ~b.sig) != 0)
     return false;
   return std::includes(
-      b.clause.begin(), b.clause.end(), a.clause.begin(), a.clause.end(),
-      [](literalt x, literalt y) { return x.get() < y.get(); });
+    b.clause.begin(),
+    b.clause.end(),
+    a.clause.begin(),
+    a.clause.end(),
+    [](literalt x, literalt y) { return x.get() < y.get(); });
 }
 
 /// Translate a (non-constant) CBMC literal to an IC3-MiniSAT literal.
-static inline IctMinisat::Lit to_minisat(literalt l) {
+static inline IctMinisat::Lit to_minisat(literalt l)
+{
   return IctMinisat::mkLit(l.var_no(), l.sign());
 }
 
 /// Add a clause of CBMC literals to an IC3-MiniSAT solver.
 /// Tautologies are skipped; false literals are dropped.
-static void add_minisat_clause(IctMinisat::Solver &S, const bvt &clause) {
+static void add_minisat_clause(IctMinisat::Solver &S, const bvt &clause)
+{
   IctMinisat::vec<IctMinisat::Lit> mc;
-  for (auto l : clause) {
-    if (l.is_true())
+  for(auto l : clause)
+  {
+    if(l.is_true())
       return;
-    if (!l.is_false())
+    if(!l.is_false())
       mc.push(to_minisat(l));
   }
   S.addClause(mc);
@@ -99,9 +121,12 @@ static void add_minisat_clause(IctMinisat::Solver &S, const bvt &clause) {
 // ic3_solvert implementation
 // ============================================================
 
-ic3_solvert::ic3_solvert(const netlistt &netlist, literalt prop_netlist_lit,
-                         message_handlert &message_handler)
-    : message_handler(message_handler) {
+ic3_solvert::ic3_solvert(
+  const netlistt &netlist,
+  literalt prop_netlist_lit,
+  message_handlert &message_handler)
+  : message_handler(message_handler)
+{
   // Encode the netlist into CNF: one timeframe only — the next-state
   // functions are nodes in the same variable space.
   base_cnf = std::make_unique<recording_cnft>(message_handler);
@@ -114,28 +139,35 @@ ic3_solvert::ic3_solvert(const netlistt &netlist, literalt prop_netlist_lit,
   prop_current = bmc_map.translate(0, prop_netlist_lit);
 
   // The initial state constraint, as unit clauses.
-  for (auto n : netlist.initial) {
+  for(auto n : netlist.initial)
+  {
     literalt l = bmc_map.translate(0, n);
-    if (!l.is_true())
+    if(!l.is_true())
       init_units.push_back(l);
   }
 
   // Collect latch and input literals.
-  for (auto v_it : netlist.var_map.sorted()) {
+  for(auto v_it : netlist.var_map.sorted())
+  {
     const var_mapt::vart &var = v_it->second;
-    if (var.is_latch()) {
-      for (const auto &bit : var.bits) {
+    if(var.is_latch())
+    {
+      for(const auto &bit : var.bits)
+      {
         literalt current = bmc_map.translate(0, bit.current);
-        if (current.is_constant())
+        if(current.is_constant())
           continue;
         literalt next = bmc_map.translate(0, bit.next);
         current_to_latch[current.var_no()] = latches.size();
         latches.push_back({current, next});
       }
-    } else if (var.is_input() || var.is_nondet()) {
-      for (const auto &bit : var.bits) {
+    }
+    else if(var.is_input() || var.is_nondet())
+    {
+      for(const auto &bit : var.bits)
+      {
         literalt current = bmc_map.translate(0, bit.current);
-        if (!current.is_constant())
+        if(!current.is_constant())
           input_lits.push_back(current);
       }
     }
@@ -145,7 +177,7 @@ ic3_solvert::ic3_solvert(const netlistt &netlist, literalt prop_netlist_lit,
 
   // Create the initial state solver.
   init_solver =
-      std::make_unique<satcheck_no_simplifiert>(solver_message_handler);
+    std::make_unique<satcheck_no_simplifiert>(solver_message_handler);
   replay_base_cnf(*init_solver, true);
 
   // Create lifting solver using IC3's MiniSAT (has releaseVar).
@@ -155,18 +187,21 @@ ic3_solvert::ic3_solvert(const netlistt &netlist, literalt prop_netlist_lit,
   // forced, the initial state is unique and intersection checks
   // become purely syntactic.
   init_values.resize(latches.size(), tvt::unknown());
-  if (init_solver->prop_solve(bvt{}) == propt::resultt::P_SATISFIABLE) {
+  if(init_solver->prop_solve(bvt{}) == propt::resultt::P_SATISFIABLE)
+  {
     std::vector<bool> model(latches.size());
-    for (std::size_t i = 0; i < latches.size(); i++)
+    for(std::size_t i = 0; i < latches.size(); i++)
       model[i] = init_solver->l_get(latches[i].current).is_true();
 
     init_is_unique_state = true;
-    for (std::size_t i = 0; i < latches.size(); i++) {
+    for(std::size_t i = 0; i < latches.size(); i++)
+    {
       bvt assumption = {model[i] ? !latches[i].current : latches[i].current};
-      if (init_solver->prop_solve(assumption) ==
-          propt::resultt::P_UNSATISFIABLE) {
+      if(init_solver->prop_solve(assumption) == propt::resultt::P_UNSATISFIABLE)
+      {
         init_values[i] = tvt(model[i]);
-      } else
+      }
+      else
         init_is_unique_state = false;
     }
   }
@@ -182,37 +217,43 @@ ic3_solvert::ic3_solvert(const netlistt &netlist, literalt prop_netlist_lit,
 
 ic3_solvert::~ic3_solvert() = default;
 
-std::size_t ic3_solvert::number_of_frames() const {
+std::size_t ic3_solvert::number_of_frames() const
+{
   return frame_clauses.size();
 }
 
-std::size_t ic3_solvert::total_clauses() const {
+std::size_t ic3_solvert::total_clauses() const
+{
   std::size_t n = 0;
-  for (const auto &f : frame_clauses)
+  for(const auto &f : frame_clauses)
     n += f.size();
   return n;
 }
 
-double ic3_solvert::average_clause_size() const {
+double ic3_solvert::average_clause_size() const
+{
   std::size_t n = 0, lits = 0;
-  for (const auto &f : frame_clauses)
-    for (const auto &c : f) {
+  for(const auto &f : frame_clauses)
+    for(const auto &c : f)
+    {
       n++;
       lits += c.clause.size();
     }
   return n == 0 ? 0.0 : double(lits) / double(n);
 }
 
-void ic3_solvert::replay_base_cnf(cnft &dest, bool with_init) {
+void ic3_solvert::replay_base_cnf(cnft &dest, bool with_init)
+{
   dest.set_no_variables(base_cnf->no_variables());
-  for (const auto &clause : base_cnf->get_clauses())
+  for(const auto &clause : base_cnf->get_clauses())
     dest.lcnf(clause);
-  if (with_init)
-    for (auto l : init_units)
+  if(with_init)
+    for(auto l : init_units)
       dest.lcnf({l});
 }
 
-literalt ic3_solvert::to_next(literalt l) const {
+literalt ic3_solvert::to_next(literalt l) const
+{
   auto it = current_to_latch.find(l.var_no());
   PRECONDITION(it != current_to_latch.end());
   const auto &latch = latches[it->second];
@@ -220,137 +261,156 @@ literalt ic3_solvert::to_next(literalt l) const {
   return latch.next ^ (l.sign() != latch.current.sign());
 }
 
-cubet ic3_solvert::extract_state(const IctMinisat::Solver &S) {
+cubet ic3_solvert::extract_state(const IctMinisat::Solver &S)
+{
   cubet cube;
   cube.reserve(latches.size());
-  for (const auto &latch : latches) {
+  for(const auto &latch : latches)
+  {
     auto val = S.modelValue(to_minisat(latch.current));
-    if (val == IctMinisat::l_True)
+    if(val == IctMinisat::l_True)
       cube.push_back(latch.current);
-    else if (val == IctMinisat::l_False)
+    else if(val == IctMinisat::l_False)
       cube.push_back(!latch.current);
     // skip don't-care (unknown) bits — smaller cubes
   }
   return cube;
 }
 
-void ic3_solvert::new_frame() { frame_clauses.emplace_back(); }
+void ic3_solvert::new_frame()
+{
+  frame_clauses.emplace_back();
+}
 
-std::unique_ptr<IctMinisat::Solver> ic3_solvert::new_minisat_solver() {
+std::unique_ptr<IctMinisat::Solver> ic3_solvert::new_minisat_solver()
+{
   auto S = std::make_unique<IctMinisat::Solver>();
   auto nv = base_cnf->no_variables();
-  while (S->nVars() < (int)nv)
+  while(S->nVars() < (int)nv)
     S->newVar();
-  for (const auto &clause : base_cnf->get_clauses())
+  for(const auto &clause : base_cnf->get_clauses())
     add_minisat_clause(*S, clause);
   return S;
 }
 
-IctMinisat::Solver &ic3_solvert::get_solver(std::size_t level) {
-  while (frame_solvers.size() <= level)
+IctMinisat::Solver &ic3_solvert::get_solver(std::size_t level)
+{
+  while(frame_solvers.size() <= level)
     frame_solvers.emplace_back();
   auto &fs = frame_solvers[level];
-  if (!fs) {
+  if(!fs)
+  {
     fs = new_minisat_solver();
-    if (level == 0)
-      for (auto l : init_units)
+    if(level == 0)
+      for(auto l : init_units)
         add_minisat_clause(*fs, {l});
-    for (std::size_t j = level; j < frame_clauses.size(); j++)
-      for (const auto &cl : frame_clauses[j])
+    for(std::size_t j = level; j < frame_clauses.size(); j++)
+      for(const auto &cl : frame_clauses[j])
         add_minisat_clause(*fs, cl.clause);
   }
   return *fs;
 }
 
-void ic3_solvert::add_clause(std::size_t level, const clauset &clause) {
+void ic3_solvert::add_clause(std::size_t level, const clauset &clause)
+{
   PRECONDITION(level < frame_clauses.size());
 
   frame_clauset new_clause(clause);
 
   // Redundant if subsumed by a clause at the same or a higher level.
-  for (std::size_t j = level; j < frame_clauses.size(); j++)
-    for (const auto &existing : frame_clauses[j])
-      if (subsumes(existing, new_clause))
+  for(std::size_t j = level; j < frame_clauses.size(); j++)
+    for(const auto &existing : frame_clauses[j])
+      if(subsumes(existing, new_clause))
         return;
 
   // Remove clauses the new one subsumes; they are at levels <= level,
   // where the new clause is active as well. The subsumed clauses stay
   // in already-built solvers, which is harmless.
-  for (std::size_t j = 0; j <= level; j++) {
+  for(std::size_t j = 0; j <= level; j++)
+  {
     auto &cls = frame_clauses[j];
-    cls.erase(std::remove_if(cls.begin(), cls.end(),
-                             [&](const frame_clauset &c) {
-                               return subsumes(new_clause, c);
-                             }),
-              cls.end());
+    cls.erase(
+      std::remove_if(
+        cls.begin(),
+        cls.end(),
+        [&](const frame_clauset &c) { return subsumes(new_clause, c); }),
+      cls.end());
   }
 
-  for (std::size_t i = 0; i <= level && i < frame_solvers.size(); i++)
-    if (frame_solvers[i])
+  for(std::size_t i = 0; i <= level && i < frame_solvers.size(); i++)
+    if(frame_solvers[i])
       add_minisat_clause(*frame_solvers[i], new_clause.clause);
 
   frame_clauses[level].push_back(std::move(new_clause));
   num_clauses_added++;
 }
 
-bool ic3_solvert::is_blocked(const cubet &cube, std::size_t level) {
+bool ic3_solvert::is_blocked(const cubet &cube, std::size_t level)
+{
   // The cube is blocked iff some frame clause subsumes its negation.
   frame_clauset negated(negate_cube(cube));
 
-  for (std::size_t j = level; j < frame_clauses.size(); j++)
-    for (const auto &clause : frame_clauses[j])
-      if (subsumes(clause, negated))
+  for(std::size_t j = level; j < frame_clauses.size(); j++)
+    for(const auto &clause : frame_clauses[j])
+      if(subsumes(clause, negated))
         return true;
 
   return false;
 }
 
-bool ic3_solvert::initial_state_is_bad() {
+bool ic3_solvert::initial_state_is_bad()
+{
   bvt assumptions = {!prop_current};
   return init_solver->prop_solve(assumptions) == propt::resultt::P_SATISFIABLE;
 }
 
-bool ic3_solvert::init_intersects(const cubet &cube) {
+bool ic3_solvert::init_intersects(const cubet &cube)
+{
   // Syntactic check against forced initial values first.
   bool all_bits_known = init_is_unique_state;
 
-  for (auto l : cube) {
+  for(auto l : cube)
+  {
     auto it = current_to_latch.find(l.var_no());
-    if (it == current_to_latch.end()) {
+    if(it == current_to_latch.end())
+    {
       all_bits_known = false;
       continue;
     }
     tvt v = init_values[it->second];
-    if (v.is_unknown()) {
+    if(v.is_unknown())
+    {
       all_bits_known = false;
       continue;
     }
     const auto &latch = latches[it->second];
     bool asserts_true = l.sign() == latch.current.sign();
-    if (v.is_true() != asserts_true)
+    if(v.is_true() != asserts_true)
       return false; // contradicts the forced initial value
   }
 
-  if (all_bits_known)
+  if(all_bits_known)
     return true; // consistent with the unique initial state
 
   // Fall back to the initial-state solver.
   return init_solver->prop_solve(cube) == propt::resultt::P_SATISFIABLE;
 }
 
-void ic3_solvert::repair_init(const cubet &cube, cubet &reduced) {
-  if (!init_intersects(reduced))
+void ic3_solvert::repair_init(const cubet &cube, cubet &reduced)
+{
+  if(!init_intersects(reduced))
     return;
 
   std::unordered_set<unsigned> in_reduced;
-  for (auto l : reduced)
+  for(auto l : reduced)
     in_reduced.insert(l.get());
 
-  for (auto l : cube) {
-    if (in_reduced.find(l.get()) != in_reduced.end())
+  for(auto l : cube)
+  {
+    if(in_reduced.find(l.get()) != in_reduced.end())
       continue;
     reduced.push_back(l);
-    if (!init_intersects(reduced))
+    if(!init_intersects(reduced))
       return;
   }
 
@@ -358,14 +418,17 @@ void ic3_solvert::repair_init(const cubet &cube, cubet &reduced) {
   UNREACHABLE;
 }
 
-cubet ic3_solvert::lift(const IctMinisat::Solver &query_solver,
-                        const cubet &full_state, const bvt &target_clause) {
+cubet ic3_solvert::lift(
+  const IctMinisat::Solver &query_solver,
+  const cubet &full_state,
+  const bvt &target_clause)
+{
   auto &S = *lift_minisat;
   using namespace IctMinisat;
 
   // A tautological target cannot be lifted against.
-  for (auto l : target_clause)
-    if (l.is_true())
+  for(auto l : target_clause)
+    if(l.is_true())
       return full_state;
 
   // Activation literal for the target clause: act -> target_clause
@@ -374,8 +437,8 @@ cubet ic3_solvert::lift(const IctMinisat::Solver &query_solver,
   {
     vec<Lit> clause;
     clause.push(~act);
-    for (auto l : target_clause)
-      if (!l.is_false())
+    for(auto l : target_clause)
+      if(!l.is_false())
         clause.push(to_minisat(l));
     S.addClause(clause);
   }
@@ -383,22 +446,25 @@ cubet ic3_solvert::lift(const IctMinisat::Solver &query_solver,
   // Solve with act + inputs + state as assumptions
   vec<Lit> assumptions;
   assumptions.push(act);
-  for (auto l : input_lits) {
+  for(auto l : input_lits)
+  {
     auto val = query_solver.modelValue(to_minisat(l));
-    if (val == l_True)
+    if(val == l_True)
       assumptions.push(to_minisat(l));
-    else if (val == l_False)
+    else if(val == l_False)
       assumptions.push(to_minisat(!l));
   }
-  for (auto l : full_state)
+  for(auto l : full_state)
     assumptions.push(to_minisat(l));
 
   num_lifts++;
   cubet result;
-  if (!S.solve(assumptions)) {
+  if(!S.solve(assumptions))
+  {
     // UNSAT — extract minimal state from conflict
-    for (auto l : full_state) {
-      if (S.conflict.has(~to_minisat(l)))
+    for(auto l : full_state)
+    {
+      if(S.conflict.has(~to_minisat(l)))
         result.push_back(l);
     }
   }
@@ -409,13 +475,17 @@ cubet ic3_solvert::lift(const IctMinisat::Solver &query_solver,
   return result.empty() ? full_state : result;
 }
 
-bool ic3_solvert::relative_induction(std::size_t level, const cubet &cube,
-                                     cubet *predecessor,
-                                     bool lift_predecessor) {
+bool ic3_solvert::relative_induction(
+  std::size_t level,
+  const cubet &cube,
+  cubet *predecessor,
+  bool lift_predecessor)
+{
   // A literal with constant-false next-state function makes the cube
   // trivially unreachable; the solver's conflict would be stale.
-  for (auto l : cube)
-    if (to_next(l).is_false()) {
+  for(auto l : cube)
+    if(to_next(l).is_false())
+    {
       core = {l};
       repair_init(cube, core);
       return true;
@@ -427,51 +497,60 @@ bool ic3_solvert::relative_induction(std::size_t level, const cubet &cube,
   vec<Lit> assumptions;
   Lit act = lit_Undef;
 
-  if (WITH_NEGATED_CUBE) {
+  if(WITH_NEGATED_CUBE)
+  {
     // Activation literal for ¬cube at timeframe 0
     act = mkLit(S.newVar());
     vec<Lit> act_clause;
     act_clause.push(~act);
-    for (auto l : cube)
+    for(auto l : cube)
       act_clause.push(to_minisat(!l));
     S.addClause(act_clause);
     assumptions.push(act);
   }
 
-  for (auto l : cube) {
+  for(auto l : cube)
+  {
     literalt nl = to_next(l);
-    if (!nl.is_true())
+    if(!nl.is_true())
       assumptions.push(to_minisat(nl));
   }
 
   num_queries++;
   bool unsat = !S.solve(assumptions);
 
-  if (unsat) {
+  if(unsat)
+  {
     core.clear();
-    for (auto l : cube) {
+    for(auto l : cube)
+    {
       literalt nl = to_next(l);
-      if (!nl.is_true() && S.conflict.has(~to_minisat(nl)))
+      if(!nl.is_true() && S.conflict.has(~to_minisat(nl)))
         core.push_back(l);
     }
-    if (core.empty())
+    if(core.empty())
       core = cube;
     else
       repair_init(cube, core);
-  } else if (predecessor != nullptr) {
+  }
+  else if(predecessor != nullptr)
+  {
     cubet full_state = extract_state(S);
-    if (lift_predecessor) {
+    if(lift_predecessor)
+    {
       // act -> ¬cube'
       bvt target_clause;
       target_clause.reserve(cube.size());
-      for (auto l : cube)
+      for(auto l : cube)
         target_clause.push_back(!to_next(l));
       *predecessor = lift(S, full_state, target_clause);
-    } else
+    }
+    else
       *predecessor = std::move(full_state);
   }
 
-  if (WITH_NEGATED_CUBE) {
+  if(WITH_NEGATED_CUBE)
+  {
     // Release the activation literal
     S.releaseVar(~act);
   }
@@ -479,26 +558,29 @@ bool ic3_solvert::relative_induction(std::size_t level, const cubet &cube,
   return unsat;
 }
 
-std::optional<cubet> ic3_solvert::solve_relative(std::size_t level,
-                                                 const cubet &cube) {
+std::optional<cubet>
+ic3_solvert::solve_relative(std::size_t level, const cubet &cube)
+{
   cubet predecessor;
-  if (relative_induction(level, cube, &predecessor, true))
+  if(relative_induction(level, cube, &predecessor, true))
     return std::nullopt;
   return predecessor;
 }
 
-std::optional<cubet> ic3_solvert::solve_bad(std::size_t level) {
-  if (prop_current.is_true())
+std::optional<cubet> ic3_solvert::solve_bad(std::size_t level)
+{
+  if(prop_current.is_true())
     return std::nullopt;
 
   auto &S = get_solver(level);
 
   IctMinisat::vec<IctMinisat::Lit> assumptions;
-  if (!prop_current.is_false())
+  if(!prop_current.is_false())
     assumptions.push(to_minisat(!prop_current));
 
   num_queries++;
-  if (S.solve(assumptions)) {
+  if(S.solve(assumptions))
+  {
     // Lift against the property: act -> prop
     return lift(S, extract_state(S), {prop_current});
   }
@@ -506,16 +588,21 @@ std::optional<cubet> ic3_solvert::solve_bad(std::size_t level) {
   return std::nullopt;
 }
 
-bool ic3_solvert::ctg_down(std::size_t level, cubet &cand,
-                           std::size_t &ctg_budget) {
+bool ic3_solvert::ctg_down(
+  std::size_t level,
+  cubet &cand,
+  std::size_t &ctg_budget)
+{
   std::size_t joins = 0;
 
-  while (true) {
-    if (init_intersects(cand))
+  while(true)
+  {
+    if(init_intersects(cand))
       return false;
 
     cubet predecessor;
-    if (relative_induction(level, cand, &predecessor, false)) {
+    if(relative_induction(level, cand, &predecessor, false))
+    {
       cand = core;
       return true;
     }
@@ -523,45 +610,54 @@ bool ic3_solvert::ctg_down(std::size_t level, cubet &cand,
     // Counterexample-to-generalization: try to block the predecessor.
     // The budget is shared across the enclosing generalize call —
     // unbounded CTG blocking floods the frames with weak clauses.
-    if (ctg_budget > 0 && level > 0 && !init_intersects(predecessor) &&
-        relative_induction(level, predecessor, nullptr, false)) {
-      add_clause(std::min(level + 1, frame_clauses.size() - 1),
-                 negate_cube(core));
+    if(
+      ctg_budget > 0 && level > 0 && !init_intersects(predecessor) &&
+      relative_induction(level, predecessor, nullptr, false))
+    {
+      add_clause(
+        std::min(level + 1, frame_clauses.size() - 1), negate_cube(core));
       ctg_budget--;
       continue;
     }
 
     // Join cand with the predecessor.
-    if (++joins > JOIN_MAX)
+    if(++joins > JOIN_MAX)
       return false;
     std::unordered_set<unsigned> pred_lits;
-    for (auto l : predecessor)
+    for(auto l : predecessor)
       pred_lits.insert(l.get());
 
     cubet joined;
     joined.reserve(cand.size());
-    for (auto l : cand)
-      if (pred_lits.find(l.get()) != pred_lits.end())
+    for(auto l : cand)
+      if(pred_lits.find(l.get()) != pred_lits.end())
         joined.push_back(l);
 
-    if (joined.empty() || joined.size() >= cand.size())
+    if(joined.empty() || joined.size() >= cand.size())
       return false; // no progress
 
     cand = std::move(joined);
   }
 }
 
-cubet ic3_solvert::generalize(std::size_t level, cubet cube) {
+cubet ic3_solvert::generalize(std::size_t level, cubet cube)
+{
   std::size_t ctg_budget = CTG_MAX;
 
   // Sort by activity: drop least-active literals first
-  std::sort(cube.begin(), cube.end(), [&](literalt a, literalt b) {
-    auto ia = current_to_latch.find(a.var_no());
-    auto ib = current_to_latch.find(b.var_no());
-    float aa = (ia != current_to_latch.end()) ? lit_activity[ia->second] : 0.0f;
-    float ab = (ib != current_to_latch.end()) ? lit_activity[ib->second] : 0.0f;
-    return aa < ab;
-  });
+  std::sort(
+    cube.begin(),
+    cube.end(),
+    [&](literalt a, literalt b)
+    {
+      auto ia = current_to_latch.find(a.var_no());
+      auto ib = current_to_latch.find(b.var_no());
+      float aa =
+        (ia != current_to_latch.end()) ? lit_activity[ia->second] : 0.0f;
+      float ab =
+        (ib != current_to_latch.end()) ? lit_activity[ib->second] : 0.0f;
+      return aa < ab;
+    });
 
   // MIC: try dropping each literal, with ctg_down deciding whether the
   // remainder is still relatively inductive. On success, ctg_down has
@@ -569,39 +665,46 @@ cubet ic3_solvert::generalize(std::size_t level, cubet cube) {
   // are ordered by activity, so after several consecutive failures the
   // remaining literals are unlikely to be droppable — give up early.
   std::size_t i = 0, consecutive_fails = 0;
-  while (cube.size() > 1 && i < cube.size() &&
-         consecutive_fails < MIC_FAIL_MAX) {
+  while(cube.size() > 1 && i < cube.size() && consecutive_fails < MIC_FAIL_MAX)
+  {
     cubet cand;
     cand.reserve(cube.size() - 1);
-    for (std::size_t j = 0; j < cube.size(); j++)
-      if (j != i)
+    for(std::size_t j = 0; j < cube.size(); j++)
+      if(j != i)
         cand.push_back(cube[j]);
 
-    if (ctg_down(level, cand, ctg_budget)) {
+    if(ctg_down(level, cand, ctg_budget))
+    {
       cube = std::move(cand); // retry at the same index
       consecutive_fails = 0;
-    } else {
+    }
+    else
+    {
       i++;
       consecutive_fails++;
     }
   }
 
   // Bump activity for literals that survived generalization
-  for (auto l : cube) {
+  for(auto l : cube)
+  {
     auto it = current_to_latch.find(l.var_no());
-    if (it != current_to_latch.end())
+    if(it != current_to_latch.end())
       lit_activity[it->second] += 1.0f;
   }
 
   return cube;
 }
 
-bool ic3_solvert::propagate() {
-  for (std::size_t i = 1; i + 1 < frame_clauses.size(); i++) {
+bool ic3_solvert::propagate()
+{
+  for(std::size_t i = 1; i + 1 < frame_clauses.size(); i++)
+  {
     // The clauses of F_i's delta; a copy, since pushing mutates the frame.
     auto clauses = frame_clauses[i];
 
-    for (const auto &fc : clauses) {
+    for(const auto &fc : clauses)
+    {
       // The clause itself is in the level-i solver already, so the
       // query F_i ∧ T ∧ cube' needs no activation literal.
       auto &S = get_solver(i);
@@ -609,32 +712,35 @@ bool ic3_solvert::propagate() {
 
       bool trivially_unsat = false;
       IctMinisat::vec<IctMinisat::Lit> assumptions;
-      for (auto l : cube) {
+      for(auto l : cube)
+      {
         literalt nl = to_next(l);
-        if (nl.is_false()) {
+        if(nl.is_false())
+        {
           trivially_unsat = true;
           break;
         }
-        if (!nl.is_true())
+        if(!nl.is_true())
           assumptions.push(to_minisat(nl));
       }
 
       num_queries++;
-      if (trivially_unsat || !S.solve(assumptions)) {
+      if(trivially_unsat || !S.solve(assumptions))
+      {
         // Holds at F_{i+1}: move the delta entry up. The solvers at
         // levels <= i contain the clause already; only level i+1 needs it.
         auto &cls = frame_clauses[i];
         auto it = std::find(cls.begin(), cls.end(), fc);
-        if (it != cls.end())
+        if(it != cls.end())
           cls.erase(it);
 
-        if (i + 1 < frame_solvers.size() && frame_solvers[i + 1])
+        if(i + 1 < frame_solvers.size() && frame_solvers[i + 1])
           add_minisat_clause(*frame_solvers[i + 1], fc.clause);
         frame_clauses[i + 1].push_back(fc);
       }
     }
 
-    if (frame_clauses[i].empty())
+    if(frame_clauses[i].empty())
       return true; // F_i = F_{i+1}: inductive invariant found
   }
 
@@ -646,40 +752,48 @@ bool ic3_solvert::propagate() {
 // ============================================================
 
 /// A proof obligation: a cube that must be blocked at a given frame level.
-struct proof_obligationt {
+struct proof_obligationt
+{
   cubet cube;
   std::size_t level;
   // Number of transitions from this cube to the property-violating
   // state; used for the counterexample length when refuting.
   std::size_t depth;
 
-  bool operator>(const proof_obligationt &other) const {
+  bool operator>(const proof_obligationt &other) const
+  {
     return level > other.level;
   }
 };
 
-std::optional<ic3_resultt> ic3_solvert::block_frame(std::size_t k) {
+std::optional<ic3_resultt> ic3_solvert::block_frame(std::size_t k)
+{
   messaget message{message_handler};
 
-  std::priority_queue<proof_obligationt, std::vector<proof_obligationt>,
-                      std::greater<proof_obligationt>>
-      obligations;
+  std::priority_queue<
+    proof_obligationt,
+    std::vector<proof_obligationt>,
+    std::greater<proof_obligationt>>
+    obligations;
 
-  while (true) {
+  while(true)
+  {
     auto bad_cube = solve_bad(k);
-    if (!bad_cube.has_value())
+    if(!bad_cube.has_value())
       return std::nullopt;
 
     obligations.push({bad_cube.value(), k, 0});
 
-    while (!obligations.empty()) {
+    while(!obligations.empty())
+    {
       auto [cube, level, depth] = obligations.top();
       obligations.pop();
 
-      if (is_blocked(cube, level))
+      if(is_blocked(cube, level))
         continue;
 
-      if (init_intersects(cube)) {
+      if(init_intersects(cube))
+      {
         // The cube contains an initial state, and the bad state is
         // depth transitions away: depth + 1 states in total.
         message.status() << "Property refuted with counterexample of length "
@@ -687,39 +801,46 @@ std::optional<ic3_resultt> ic3_solvert::block_frame(std::size_t k) {
         return ic3_resultt::refuted(depth + 1);
       }
 
-      if (level == 0) {
+      if(level == 0)
+      {
         add_clause(0, negate_cube(cube));
         continue;
       }
 
       auto pred = solve_relative(level - 1, cube);
-      if (pred.has_value()) {
+      if(pred.has_value())
+      {
         obligations.push({pred.value(), level - 1, depth + 1});
         obligations.push({std::move(cube), level, depth});
-      } else {
+      }
+      else
+      {
         cubet generalized = generalize(level - 1, core);
         add_clause(level, negate_cube(generalized));
 
         // Re-queue at level+1 to push the blocking clause higher
-        if (level + 1 <= k)
+        if(level + 1 <= k)
           obligations.push({std::move(cube), level + 1, depth});
       }
     }
   }
 }
 
-ic3_resultt ic3_solvert::solve() {
+ic3_resultt ic3_solvert::solve()
+{
   messaget message{message_handler};
 
   auto start_time = std::chrono::steady_clock::now();
 
   // Check: can initial states violate the property?
-  if (initial_state_is_bad()) {
+  if(initial_state_is_bad())
+  {
     message.status() << "Property violated in initial state" << messaget::eom;
     return ic3_resultt::refuted(1);
   }
 
-  while (true) {
+  while(true)
+  {
     new_frame();
     std::size_t k = number_of_frames() - 1;
 
@@ -728,17 +849,18 @@ ic3_resultt ic3_solvert::solve() {
                        << total_clauses() << " clauses, avg size "
                        << average_clause_size() << ")" << messaget::eom;
 
-    if (auto result = block_frame(k); result.has_value())
+    if(auto result = block_frame(k); result.has_value())
       return *result;
 
     // Propagation: push clauses from F_i to F_{i+1}
-    if (propagate()) {
+    if(propagate())
+    {
       auto end_time = std::chrono::steady_clock::now();
       message.status()
-          << "IC3: converged at frame " << k << " in " << std::fixed
-          << std::setprecision(3)
-          << std::chrono::duration<double>(end_time - start_time).count()
-          << " seconds (" << num_queries << " queries)" << messaget::eom;
+        << "IC3: converged at frame " << k << " in " << std::fixed
+        << std::setprecision(3)
+        << std::chrono::duration<double>(end_time - start_time).count()
+        << " seconds (" << num_queries << " queries)" << messaget::eom;
       return ic3_resultt::proved();
     }
   }

--- a/src/new-ic3/ic3_solver.cpp
+++ b/src/new-ic3/ic3_solver.cpp
@@ -27,91 +27,69 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <unordered_set>
 
 /// A cnf_clause_listt that can be instantiated (provides missing virtuals).
-class recording_cnft : public cnf_clause_listt
-{
+class recording_cnft : public cnf_clause_listt {
 public:
-  explicit recording_cnft(message_handlert &mh) : cnf_clause_listt(mh)
-  {
-  }
-  bool is_in_conflict(literalt) const override
-  {
-    return false;
-  }
-  void set_assignment(literalt, bool) override
-  {
-  }
+  explicit recording_cnft(message_handlert &mh) : cnf_clause_listt(mh) {}
+  bool is_in_conflict(literalt) const override { return false; }
+  void set_assignment(literalt, bool) override {}
 };
 
 /// A frame clause: literals sorted by literal code, plus a Bloom-style
 /// signature for constant-time subsumption rejection.
-struct ic3_solvert::frame_clauset
-{
+struct ic3_solvert::frame_clauset {
   clauset clause; // sorted by literalt::get()
   // Bloom signature: each literal sets bit (lit_code & 63). 64 bits
   // matches the register width on x86-64, giving a single-instruction
   // shift and a cheap early-reject in subsumes().
   uint64_t sig;
 
-  explicit frame_clauset(clauset c) : clause(std::move(c))
-  {
-    std::sort(
-      clause.begin(),
-      clause.end(),
-      [](literalt a, literalt b) { return a.get() < b.get(); });
+  explicit frame_clauset(clauset c) : clause(std::move(c)) {
+    std::sort(clause.begin(), clause.end(),
+              [](literalt a, literalt b) { return a.get() < b.get(); });
     sig = 0;
-    for(auto l : clause)
+    for (auto l : clause)
       sig |= uint64_t(1) << (l.get() & 63);
   }
 
-  bool operator==(const frame_clauset &other) const
-  {
+  bool operator==(const frame_clauset &other) const {
     return clause == other.clause;
   }
 };
 
-clauset negate_cube(const cubet &cube)
-{
+clauset negate_cube(const cubet &cube) {
   clauset clause;
   clause.reserve(cube.size());
-  for(auto l : cube)
+  for (auto l : cube)
     clause.push_back(!l);
   return clause;
 }
 
 /// Check if clause a subsumes clause b (a ⊆ b as literal sets).
 /// Both literal vectors must be sorted by literal code.
-bool ic3_solvert::subsumes(
-  const ic3_solvert::frame_clauset &a,
-  const ic3_solvert::frame_clauset &b)
-{
-  if(a.clause.size() > b.clause.size())
+bool ic3_solvert::subsumes(const ic3_solvert::frame_clauset &a,
+                           const ic3_solvert::frame_clauset &b) {
+  if (a.clause.size() > b.clause.size())
     return false;
-  if((a.sig & ~b.sig) != 0)
+  if ((a.sig & ~b.sig) != 0)
     return false;
   return std::includes(
-    b.clause.begin(),
-    b.clause.end(),
-    a.clause.begin(),
-    a.clause.end(),
-    [](literalt x, literalt y) { return x.get() < y.get(); });
+      b.clause.begin(), b.clause.end(), a.clause.begin(), a.clause.end(),
+      [](literalt x, literalt y) { return x.get() < y.get(); });
 }
 
 /// Translate a (non-constant) CBMC literal to an IC3-MiniSAT literal.
-static inline IctMinisat::Lit to_minisat(literalt l)
-{
+static inline IctMinisat::Lit to_minisat(literalt l) {
   return IctMinisat::mkLit(l.var_no(), l.sign());
 }
 
 /// Add a clause of CBMC literals to an IC3-MiniSAT solver.
 /// Tautologies are skipped; false literals are dropped.
-static void add_minisat_clause(IctMinisat::Solver &S, const bvt &clause)
-{
+static void add_minisat_clause(IctMinisat::Solver &S, const bvt &clause) {
   IctMinisat::vec<IctMinisat::Lit> mc;
-  for(auto l : clause)
-  {
-    if(l.is_true())
+  for (auto l : clause) {
+    if (l.is_true())
       return;
-    if(!l.is_false())
+    if (!l.is_false())
       mc.push(to_minisat(l));
   }
   S.addClause(mc);
@@ -121,12 +99,9 @@ static void add_minisat_clause(IctMinisat::Solver &S, const bvt &clause)
 // ic3_solvert implementation
 // ============================================================
 
-ic3_solvert::ic3_solvert(
-  const netlistt &netlist,
-  literalt prop_netlist_lit,
-  message_handlert &message_handler)
-  : message_handler(message_handler)
-{
+ic3_solvert::ic3_solvert(const netlistt &netlist, literalt prop_netlist_lit,
+                         message_handlert &message_handler)
+    : message_handler(message_handler) {
   // Encode the netlist into CNF: one timeframe only — the next-state
   // functions are nodes in the same variable space.
   base_cnf = std::make_unique<recording_cnft>(message_handler);
@@ -139,35 +114,28 @@ ic3_solvert::ic3_solvert(
   prop_current = bmc_map.translate(0, prop_netlist_lit);
 
   // The initial state constraint, as unit clauses.
-  for(auto n : netlist.initial)
-  {
+  for (auto n : netlist.initial) {
     literalt l = bmc_map.translate(0, n);
-    if(!l.is_true())
+    if (!l.is_true())
       init_units.push_back(l);
   }
 
   // Collect latch and input literals.
-  for(auto v_it : netlist.var_map.sorted())
-  {
+  for (auto v_it : netlist.var_map.sorted()) {
     const var_mapt::vart &var = v_it->second;
-    if(var.is_latch())
-    {
-      for(const auto &bit : var.bits)
-      {
+    if (var.is_latch()) {
+      for (const auto &bit : var.bits) {
         literalt current = bmc_map.translate(0, bit.current);
-        if(current.is_constant())
+        if (current.is_constant())
           continue;
         literalt next = bmc_map.translate(0, bit.next);
         current_to_latch[current.var_no()] = latches.size();
         latches.push_back({current, next});
       }
-    }
-    else if(var.is_input() || var.is_nondet())
-    {
-      for(const auto &bit : var.bits)
-      {
+    } else if (var.is_input() || var.is_nondet()) {
+      for (const auto &bit : var.bits) {
         literalt current = bmc_map.translate(0, bit.current);
-        if(!current.is_constant())
+        if (!current.is_constant())
           input_lits.push_back(current);
       }
     }
@@ -177,7 +145,7 @@ ic3_solvert::ic3_solvert(
 
   // Create the initial state solver.
   init_solver =
-    std::make_unique<satcheck_no_simplifiert>(solver_message_handler);
+      std::make_unique<satcheck_no_simplifiert>(solver_message_handler);
   replay_base_cnf(*init_solver, true);
 
   // Create lifting solver using IC3's MiniSAT (has releaseVar).
@@ -187,21 +155,18 @@ ic3_solvert::ic3_solvert(
   // forced, the initial state is unique and intersection checks
   // become purely syntactic.
   init_values.resize(latches.size(), tvt::unknown());
-  if(init_solver->prop_solve(bvt{}) == propt::resultt::P_SATISFIABLE)
-  {
+  if (init_solver->prop_solve(bvt{}) == propt::resultt::P_SATISFIABLE) {
     std::vector<bool> model(latches.size());
-    for(std::size_t i = 0; i < latches.size(); i++)
+    for (std::size_t i = 0; i < latches.size(); i++)
       model[i] = init_solver->l_get(latches[i].current).is_true();
 
     init_is_unique_state = true;
-    for(std::size_t i = 0; i < latches.size(); i++)
-    {
+    for (std::size_t i = 0; i < latches.size(); i++) {
       bvt assumption = {model[i] ? !latches[i].current : latches[i].current};
-      if(init_solver->prop_solve(assumption) == propt::resultt::P_UNSATISFIABLE)
-      {
+      if (init_solver->prop_solve(assumption) ==
+          propt::resultt::P_UNSATISFIABLE) {
         init_values[i] = tvt(model[i]);
-      }
-      else
+      } else
         init_is_unique_state = false;
     }
   }
@@ -217,43 +182,37 @@ ic3_solvert::ic3_solvert(
 
 ic3_solvert::~ic3_solvert() = default;
 
-std::size_t ic3_solvert::number_of_frames() const
-{
+std::size_t ic3_solvert::number_of_frames() const {
   return frame_clauses.size();
 }
 
-std::size_t ic3_solvert::total_clauses() const
-{
+std::size_t ic3_solvert::total_clauses() const {
   std::size_t n = 0;
-  for(const auto &f : frame_clauses)
+  for (const auto &f : frame_clauses)
     n += f.size();
   return n;
 }
 
-double ic3_solvert::average_clause_size() const
-{
+double ic3_solvert::average_clause_size() const {
   std::size_t n = 0, lits = 0;
-  for(const auto &f : frame_clauses)
-    for(const auto &c : f)
-    {
+  for (const auto &f : frame_clauses)
+    for (const auto &c : f) {
       n++;
       lits += c.clause.size();
     }
   return n == 0 ? 0.0 : double(lits) / double(n);
 }
 
-void ic3_solvert::replay_base_cnf(cnft &dest, bool with_init)
-{
+void ic3_solvert::replay_base_cnf(cnft &dest, bool with_init) {
   dest.set_no_variables(base_cnf->no_variables());
-  for(const auto &clause : base_cnf->get_clauses())
+  for (const auto &clause : base_cnf->get_clauses())
     dest.lcnf(clause);
-  if(with_init)
-    for(auto l : init_units)
+  if (with_init)
+    for (auto l : init_units)
       dest.lcnf({l});
 }
 
-literalt ic3_solvert::to_next(literalt l) const
-{
+literalt ic3_solvert::to_next(literalt l) const {
   auto it = current_to_latch.find(l.var_no());
   PRECONDITION(it != current_to_latch.end());
   const auto &latch = latches[it->second];
@@ -261,156 +220,137 @@ literalt ic3_solvert::to_next(literalt l) const
   return latch.next ^ (l.sign() != latch.current.sign());
 }
 
-cubet ic3_solvert::extract_state(const IctMinisat::Solver &S)
-{
+cubet ic3_solvert::extract_state(const IctMinisat::Solver &S) {
   cubet cube;
   cube.reserve(latches.size());
-  for(const auto &latch : latches)
-  {
+  for (const auto &latch : latches) {
     auto val = S.modelValue(to_minisat(latch.current));
-    if(val == IctMinisat::l_True)
+    if (val == IctMinisat::l_True)
       cube.push_back(latch.current);
-    else if(val == IctMinisat::l_False)
+    else if (val == IctMinisat::l_False)
       cube.push_back(!latch.current);
     // skip don't-care (unknown) bits — smaller cubes
   }
   return cube;
 }
 
-void ic3_solvert::new_frame()
-{
-  frame_clauses.emplace_back();
-}
+void ic3_solvert::new_frame() { frame_clauses.emplace_back(); }
 
-std::unique_ptr<IctMinisat::Solver> ic3_solvert::new_minisat_solver()
-{
+std::unique_ptr<IctMinisat::Solver> ic3_solvert::new_minisat_solver() {
   auto S = std::make_unique<IctMinisat::Solver>();
   auto nv = base_cnf->no_variables();
-  while(S->nVars() < (int)nv)
+  while (S->nVars() < (int)nv)
     S->newVar();
-  for(const auto &clause : base_cnf->get_clauses())
+  for (const auto &clause : base_cnf->get_clauses())
     add_minisat_clause(*S, clause);
   return S;
 }
 
-IctMinisat::Solver &ic3_solvert::get_solver(std::size_t level)
-{
-  while(frame_solvers.size() <= level)
+IctMinisat::Solver &ic3_solvert::get_solver(std::size_t level) {
+  while (frame_solvers.size() <= level)
     frame_solvers.emplace_back();
   auto &fs = frame_solvers[level];
-  if(!fs)
-  {
+  if (!fs) {
     fs = new_minisat_solver();
-    if(level == 0)
-      for(auto l : init_units)
+    if (level == 0)
+      for (auto l : init_units)
         add_minisat_clause(*fs, {l});
-    for(std::size_t j = level; j < frame_clauses.size(); j++)
-      for(const auto &cl : frame_clauses[j])
+    for (std::size_t j = level; j < frame_clauses.size(); j++)
+      for (const auto &cl : frame_clauses[j])
         add_minisat_clause(*fs, cl.clause);
   }
   return *fs;
 }
 
-void ic3_solvert::add_clause(std::size_t level, const clauset &clause)
-{
+void ic3_solvert::add_clause(std::size_t level, const clauset &clause) {
   PRECONDITION(level < frame_clauses.size());
 
   frame_clauset new_clause(clause);
 
   // Redundant if subsumed by a clause at the same or a higher level.
-  for(std::size_t j = level; j < frame_clauses.size(); j++)
-    for(const auto &existing : frame_clauses[j])
-      if(subsumes(existing, new_clause))
+  for (std::size_t j = level; j < frame_clauses.size(); j++)
+    for (const auto &existing : frame_clauses[j])
+      if (subsumes(existing, new_clause))
         return;
 
   // Remove clauses the new one subsumes; they are at levels <= level,
   // where the new clause is active as well. The subsumed clauses stay
   // in already-built solvers, which is harmless.
-  for(std::size_t j = 0; j <= level; j++)
-  {
+  for (std::size_t j = 0; j <= level; j++) {
     auto &cls = frame_clauses[j];
-    cls.erase(
-      std::remove_if(
-        cls.begin(),
-        cls.end(),
-        [&](const frame_clauset &c) { return subsumes(new_clause, c); }),
-      cls.end());
+    cls.erase(std::remove_if(cls.begin(), cls.end(),
+                             [&](const frame_clauset &c) {
+                               return subsumes(new_clause, c);
+                             }),
+              cls.end());
   }
 
-  for(std::size_t i = 0; i <= level && i < frame_solvers.size(); i++)
-    if(frame_solvers[i])
+  for (std::size_t i = 0; i <= level && i < frame_solvers.size(); i++)
+    if (frame_solvers[i])
       add_minisat_clause(*frame_solvers[i], new_clause.clause);
 
   frame_clauses[level].push_back(std::move(new_clause));
   num_clauses_added++;
 }
 
-bool ic3_solvert::is_blocked(const cubet &cube, std::size_t level)
-{
+bool ic3_solvert::is_blocked(const cubet &cube, std::size_t level) {
   // The cube is blocked iff some frame clause subsumes its negation.
   frame_clauset negated(negate_cube(cube));
 
-  for(std::size_t j = level; j < frame_clauses.size(); j++)
-    for(const auto &clause : frame_clauses[j])
-      if(subsumes(clause, negated))
+  for (std::size_t j = level; j < frame_clauses.size(); j++)
+    for (const auto &clause : frame_clauses[j])
+      if (subsumes(clause, negated))
         return true;
 
   return false;
 }
 
-bool ic3_solvert::initial_state_is_bad()
-{
+bool ic3_solvert::initial_state_is_bad() {
   bvt assumptions = {!prop_current};
   return init_solver->prop_solve(assumptions) == propt::resultt::P_SATISFIABLE;
 }
 
-bool ic3_solvert::init_intersects(const cubet &cube)
-{
+bool ic3_solvert::init_intersects(const cubet &cube) {
   // Syntactic check against forced initial values first.
   bool all_bits_known = init_is_unique_state;
 
-  for(auto l : cube)
-  {
+  for (auto l : cube) {
     auto it = current_to_latch.find(l.var_no());
-    if(it == current_to_latch.end())
-    {
+    if (it == current_to_latch.end()) {
       all_bits_known = false;
       continue;
     }
     tvt v = init_values[it->second];
-    if(v.is_unknown())
-    {
+    if (v.is_unknown()) {
       all_bits_known = false;
       continue;
     }
     const auto &latch = latches[it->second];
     bool asserts_true = l.sign() == latch.current.sign();
-    if(v.is_true() != asserts_true)
+    if (v.is_true() != asserts_true)
       return false; // contradicts the forced initial value
   }
 
-  if(all_bits_known)
+  if (all_bits_known)
     return true; // consistent with the unique initial state
 
   // Fall back to the initial-state solver.
   return init_solver->prop_solve(cube) == propt::resultt::P_SATISFIABLE;
 }
 
-void ic3_solvert::repair_init(const cubet &cube, cubet &reduced)
-{
-  if(!init_intersects(reduced))
+void ic3_solvert::repair_init(const cubet &cube, cubet &reduced) {
+  if (!init_intersects(reduced))
     return;
 
   std::unordered_set<unsigned> in_reduced;
-  for(auto l : reduced)
+  for (auto l : reduced)
     in_reduced.insert(l.get());
 
-  for(auto l : cube)
-  {
-    if(in_reduced.find(l.get()) != in_reduced.end())
+  for (auto l : cube) {
+    if (in_reduced.find(l.get()) != in_reduced.end())
       continue;
     reduced.push_back(l);
-    if(!init_intersects(reduced))
+    if (!init_intersects(reduced))
       return;
   }
 
@@ -418,17 +358,14 @@ void ic3_solvert::repair_init(const cubet &cube, cubet &reduced)
   UNREACHABLE;
 }
 
-cubet ic3_solvert::lift(
-  const IctMinisat::Solver &query_solver,
-  const cubet &full_state,
-  const bvt &target_clause)
-{
+cubet ic3_solvert::lift(const IctMinisat::Solver &query_solver,
+                        const cubet &full_state, const bvt &target_clause) {
   auto &S = *lift_minisat;
   using namespace IctMinisat;
 
   // A tautological target cannot be lifted against.
-  for(auto l : target_clause)
-    if(l.is_true())
+  for (auto l : target_clause)
+    if (l.is_true())
       return full_state;
 
   // Activation literal for the target clause: act -> target_clause
@@ -437,8 +374,8 @@ cubet ic3_solvert::lift(
   {
     vec<Lit> clause;
     clause.push(~act);
-    for(auto l : target_clause)
-      if(!l.is_false())
+    for (auto l : target_clause)
+      if (!l.is_false())
         clause.push(to_minisat(l));
     S.addClause(clause);
   }
@@ -446,25 +383,22 @@ cubet ic3_solvert::lift(
   // Solve with act + inputs + state as assumptions
   vec<Lit> assumptions;
   assumptions.push(act);
-  for(auto l : input_lits)
-  {
+  for (auto l : input_lits) {
     auto val = query_solver.modelValue(to_minisat(l));
-    if(val == l_True)
+    if (val == l_True)
       assumptions.push(to_minisat(l));
-    else if(val == l_False)
+    else if (val == l_False)
       assumptions.push(to_minisat(!l));
   }
-  for(auto l : full_state)
+  for (auto l : full_state)
     assumptions.push(to_minisat(l));
 
   num_lifts++;
   cubet result;
-  if(!S.solve(assumptions))
-  {
+  if (!S.solve(assumptions)) {
     // UNSAT — extract minimal state from conflict
-    for(auto l : full_state)
-    {
-      if(S.conflict.has(~to_minisat(l)))
+    for (auto l : full_state) {
+      if (S.conflict.has(~to_minisat(l)))
         result.push_back(l);
     }
   }
@@ -475,17 +409,13 @@ cubet ic3_solvert::lift(
   return result.empty() ? full_state : result;
 }
 
-bool ic3_solvert::relative_induction(
-  std::size_t level,
-  const cubet &cube,
-  cubet *predecessor,
-  bool lift_predecessor)
-{
+bool ic3_solvert::relative_induction(std::size_t level, const cubet &cube,
+                                     cubet *predecessor,
+                                     bool lift_predecessor) {
   // A literal with constant-false next-state function makes the cube
   // trivially unreachable; the solver's conflict would be stale.
-  for(auto l : cube)
-    if(to_next(l).is_false())
-    {
+  for (auto l : cube)
+    if (to_next(l).is_false()) {
       core = {l};
       repair_init(cube, core);
       return true;
@@ -497,60 +427,51 @@ bool ic3_solvert::relative_induction(
   vec<Lit> assumptions;
   Lit act = lit_Undef;
 
-  if(WITH_NEGATED_CUBE)
-  {
+  if (WITH_NEGATED_CUBE) {
     // Activation literal for ¬cube at timeframe 0
     act = mkLit(S.newVar());
     vec<Lit> act_clause;
     act_clause.push(~act);
-    for(auto l : cube)
+    for (auto l : cube)
       act_clause.push(to_minisat(!l));
     S.addClause(act_clause);
     assumptions.push(act);
   }
 
-  for(auto l : cube)
-  {
+  for (auto l : cube) {
     literalt nl = to_next(l);
-    if(!nl.is_true())
+    if (!nl.is_true())
       assumptions.push(to_minisat(nl));
   }
 
   num_queries++;
   bool unsat = !S.solve(assumptions);
 
-  if(unsat)
-  {
+  if (unsat) {
     core.clear();
-    for(auto l : cube)
-    {
+    for (auto l : cube) {
       literalt nl = to_next(l);
-      if(!nl.is_true() && S.conflict.has(~to_minisat(nl)))
+      if (!nl.is_true() && S.conflict.has(~to_minisat(nl)))
         core.push_back(l);
     }
-    if(core.empty())
+    if (core.empty())
       core = cube;
     else
       repair_init(cube, core);
-  }
-  else if(predecessor != nullptr)
-  {
+  } else if (predecessor != nullptr) {
     cubet full_state = extract_state(S);
-    if(lift_predecessor)
-    {
+    if (lift_predecessor) {
       // act -> ¬cube'
       bvt target_clause;
       target_clause.reserve(cube.size());
-      for(auto l : cube)
+      for (auto l : cube)
         target_clause.push_back(!to_next(l));
       *predecessor = lift(S, full_state, target_clause);
-    }
-    else
+    } else
       *predecessor = std::move(full_state);
   }
 
-  if(WITH_NEGATED_CUBE)
-  {
+  if (WITH_NEGATED_CUBE) {
     // Release the activation literal
     S.releaseVar(~act);
   }
@@ -558,29 +479,26 @@ bool ic3_solvert::relative_induction(
   return unsat;
 }
 
-std::optional<cubet>
-ic3_solvert::solve_relative(std::size_t level, const cubet &cube)
-{
+std::optional<cubet> ic3_solvert::solve_relative(std::size_t level,
+                                                 const cubet &cube) {
   cubet predecessor;
-  if(relative_induction(level, cube, &predecessor, true))
+  if (relative_induction(level, cube, &predecessor, true))
     return std::nullopt;
   return predecessor;
 }
 
-std::optional<cubet> ic3_solvert::solve_bad(std::size_t level)
-{
-  if(prop_current.is_true())
+std::optional<cubet> ic3_solvert::solve_bad(std::size_t level) {
+  if (prop_current.is_true())
     return std::nullopt;
 
   auto &S = get_solver(level);
 
   IctMinisat::vec<IctMinisat::Lit> assumptions;
-  if(!prop_current.is_false())
+  if (!prop_current.is_false())
     assumptions.push(to_minisat(!prop_current));
 
   num_queries++;
-  if(S.solve(assumptions))
-  {
+  if (S.solve(assumptions)) {
     // Lift against the property: act -> prop
     return lift(S, extract_state(S), {prop_current});
   }
@@ -588,21 +506,16 @@ std::optional<cubet> ic3_solvert::solve_bad(std::size_t level)
   return std::nullopt;
 }
 
-bool ic3_solvert::ctg_down(
-  std::size_t level,
-  cubet &cand,
-  std::size_t &ctg_budget)
-{
+bool ic3_solvert::ctg_down(std::size_t level, cubet &cand,
+                           std::size_t &ctg_budget) {
   std::size_t joins = 0;
 
-  while(true)
-  {
-    if(init_intersects(cand))
+  while (true) {
+    if (init_intersects(cand))
       return false;
 
     cubet predecessor;
-    if(relative_induction(level, cand, &predecessor, false))
-    {
+    if (relative_induction(level, cand, &predecessor, false)) {
       cand = core;
       return true;
     }
@@ -610,54 +523,45 @@ bool ic3_solvert::ctg_down(
     // Counterexample-to-generalization: try to block the predecessor.
     // The budget is shared across the enclosing generalize call —
     // unbounded CTG blocking floods the frames with weak clauses.
-    if(
-      ctg_budget > 0 && level > 0 && !init_intersects(predecessor) &&
-      relative_induction(level, predecessor, nullptr, false))
-    {
-      add_clause(
-        std::min(level + 1, frame_clauses.size() - 1), negate_cube(core));
+    if (ctg_budget > 0 && level > 0 && !init_intersects(predecessor) &&
+        relative_induction(level, predecessor, nullptr, false)) {
+      add_clause(std::min(level + 1, frame_clauses.size() - 1),
+                 negate_cube(core));
       ctg_budget--;
       continue;
     }
 
     // Join cand with the predecessor.
-    if(++joins > JOIN_MAX)
+    if (++joins > JOIN_MAX)
       return false;
     std::unordered_set<unsigned> pred_lits;
-    for(auto l : predecessor)
+    for (auto l : predecessor)
       pred_lits.insert(l.get());
 
     cubet joined;
     joined.reserve(cand.size());
-    for(auto l : cand)
-      if(pred_lits.find(l.get()) != pred_lits.end())
+    for (auto l : cand)
+      if (pred_lits.find(l.get()) != pred_lits.end())
         joined.push_back(l);
 
-    if(joined.empty() || joined.size() >= cand.size())
+    if (joined.empty() || joined.size() >= cand.size())
       return false; // no progress
 
     cand = std::move(joined);
   }
 }
 
-cubet ic3_solvert::generalize(std::size_t level, cubet cube)
-{
+cubet ic3_solvert::generalize(std::size_t level, cubet cube) {
   std::size_t ctg_budget = CTG_MAX;
 
   // Sort by activity: drop least-active literals first
-  std::sort(
-    cube.begin(),
-    cube.end(),
-    [&](literalt a, literalt b)
-    {
-      auto ia = current_to_latch.find(a.var_no());
-      auto ib = current_to_latch.find(b.var_no());
-      float aa =
-        (ia != current_to_latch.end()) ? lit_activity[ia->second] : 0.0f;
-      float ab =
-        (ib != current_to_latch.end()) ? lit_activity[ib->second] : 0.0f;
-      return aa < ab;
-    });
+  std::sort(cube.begin(), cube.end(), [&](literalt a, literalt b) {
+    auto ia = current_to_latch.find(a.var_no());
+    auto ib = current_to_latch.find(b.var_no());
+    float aa = (ia != current_to_latch.end()) ? lit_activity[ia->second] : 0.0f;
+    float ab = (ib != current_to_latch.end()) ? lit_activity[ib->second] : 0.0f;
+    return aa < ab;
+  });
 
   // MIC: try dropping each literal, with ctg_down deciding whether the
   // remainder is still relatively inductive. On success, ctg_down has
@@ -665,46 +569,39 @@ cubet ic3_solvert::generalize(std::size_t level, cubet cube)
   // are ordered by activity, so after several consecutive failures the
   // remaining literals are unlikely to be droppable — give up early.
   std::size_t i = 0, consecutive_fails = 0;
-  while(cube.size() > 1 && i < cube.size() && consecutive_fails < MIC_FAIL_MAX)
-  {
+  while (cube.size() > 1 && i < cube.size() &&
+         consecutive_fails < MIC_FAIL_MAX) {
     cubet cand;
     cand.reserve(cube.size() - 1);
-    for(std::size_t j = 0; j < cube.size(); j++)
-      if(j != i)
+    for (std::size_t j = 0; j < cube.size(); j++)
+      if (j != i)
         cand.push_back(cube[j]);
 
-    if(ctg_down(level, cand, ctg_budget))
-    {
+    if (ctg_down(level, cand, ctg_budget)) {
       cube = std::move(cand); // retry at the same index
       consecutive_fails = 0;
-    }
-    else
-    {
+    } else {
       i++;
       consecutive_fails++;
     }
   }
 
   // Bump activity for literals that survived generalization
-  for(auto l : cube)
-  {
+  for (auto l : cube) {
     auto it = current_to_latch.find(l.var_no());
-    if(it != current_to_latch.end())
+    if (it != current_to_latch.end())
       lit_activity[it->second] += 1.0f;
   }
 
   return cube;
 }
 
-bool ic3_solvert::propagate()
-{
-  for(std::size_t i = 1; i + 1 < frame_clauses.size(); i++)
-  {
+bool ic3_solvert::propagate() {
+  for (std::size_t i = 1; i + 1 < frame_clauses.size(); i++) {
     // The clauses of F_i's delta; a copy, since pushing mutates the frame.
     auto clauses = frame_clauses[i];
 
-    for(const auto &fc : clauses)
-    {
+    for (const auto &fc : clauses) {
       // The clause itself is in the level-i solver already, so the
       // query F_i ∧ T ∧ cube' needs no activation literal.
       auto &S = get_solver(i);
@@ -712,35 +609,32 @@ bool ic3_solvert::propagate()
 
       bool trivially_unsat = false;
       IctMinisat::vec<IctMinisat::Lit> assumptions;
-      for(auto l : cube)
-      {
+      for (auto l : cube) {
         literalt nl = to_next(l);
-        if(nl.is_false())
-        {
+        if (nl.is_false()) {
           trivially_unsat = true;
           break;
         }
-        if(!nl.is_true())
+        if (!nl.is_true())
           assumptions.push(to_minisat(nl));
       }
 
       num_queries++;
-      if(trivially_unsat || !S.solve(assumptions))
-      {
+      if (trivially_unsat || !S.solve(assumptions)) {
         // Holds at F_{i+1}: move the delta entry up. The solvers at
         // levels <= i contain the clause already; only level i+1 needs it.
         auto &cls = frame_clauses[i];
         auto it = std::find(cls.begin(), cls.end(), fc);
-        if(it != cls.end())
+        if (it != cls.end())
           cls.erase(it);
 
-        if(i + 1 < frame_solvers.size() && frame_solvers[i + 1])
+        if (i + 1 < frame_solvers.size() && frame_solvers[i + 1])
           add_minisat_clause(*frame_solvers[i + 1], fc.clause);
         frame_clauses[i + 1].push_back(fc);
       }
     }
 
-    if(frame_clauses[i].empty())
+    if (frame_clauses[i].empty())
       return true; // F_i = F_{i+1}: inductive invariant found
   }
 
@@ -752,48 +646,40 @@ bool ic3_solvert::propagate()
 // ============================================================
 
 /// A proof obligation: a cube that must be blocked at a given frame level.
-struct proof_obligationt
-{
+struct proof_obligationt {
   cubet cube;
   std::size_t level;
   // Number of transitions from this cube to the property-violating
   // state; used for the counterexample length when refuting.
   std::size_t depth;
 
-  bool operator>(const proof_obligationt &other) const
-  {
+  bool operator>(const proof_obligationt &other) const {
     return level > other.level;
   }
 };
 
-std::optional<ic3_resultt> ic3_solvert::block_frame(std::size_t k)
-{
+std::optional<ic3_resultt> ic3_solvert::block_frame(std::size_t k) {
   messaget message{message_handler};
 
-  std::priority_queue<
-    proof_obligationt,
-    std::vector<proof_obligationt>,
-    std::greater<proof_obligationt>>
-    obligations;
+  std::priority_queue<proof_obligationt, std::vector<proof_obligationt>,
+                      std::greater<proof_obligationt>>
+      obligations;
 
-  while(true)
-  {
+  while (true) {
     auto bad_cube = solve_bad(k);
-    if(!bad_cube.has_value())
+    if (!bad_cube.has_value())
       return std::nullopt;
 
     obligations.push({bad_cube.value(), k, 0});
 
-    while(!obligations.empty())
-    {
+    while (!obligations.empty()) {
       auto [cube, level, depth] = obligations.top();
       obligations.pop();
 
-      if(is_blocked(cube, level))
+      if (is_blocked(cube, level))
         continue;
 
-      if(init_intersects(cube))
-      {
+      if (init_intersects(cube)) {
         // The cube contains an initial state, and the bad state is
         // depth transitions away: depth + 1 states in total.
         message.status() << "Property refuted with counterexample of length "
@@ -801,46 +687,39 @@ std::optional<ic3_resultt> ic3_solvert::block_frame(std::size_t k)
         return ic3_resultt::refuted(depth + 1);
       }
 
-      if(level == 0)
-      {
+      if (level == 0) {
         add_clause(0, negate_cube(cube));
         continue;
       }
 
       auto pred = solve_relative(level - 1, cube);
-      if(pred.has_value())
-      {
+      if (pred.has_value()) {
         obligations.push({pred.value(), level - 1, depth + 1});
         obligations.push({std::move(cube), level, depth});
-      }
-      else
-      {
+      } else {
         cubet generalized = generalize(level - 1, core);
         add_clause(level, negate_cube(generalized));
 
         // Re-queue at level+1 to push the blocking clause higher
-        if(level + 1 <= k)
+        if (level + 1 <= k)
           obligations.push({std::move(cube), level + 1, depth});
       }
     }
   }
 }
 
-ic3_resultt ic3_solvert::solve()
-{
+ic3_resultt ic3_solvert::solve() {
   messaget message{message_handler};
 
   auto start_time = std::chrono::steady_clock::now();
 
   // Check: can initial states violate the property?
-  if(initial_state_is_bad())
-  {
+  if (initial_state_is_bad()) {
     message.status() << "Property violated in initial state" << messaget::eom;
     return ic3_resultt::refuted(1);
   }
 
-  while(true)
-  {
+  while (true) {
     new_frame();
     std::size_t k = number_of_frames() - 1;
 
@@ -849,18 +728,17 @@ ic3_resultt ic3_solvert::solve()
                        << total_clauses() << " clauses, avg size "
                        << average_clause_size() << ")" << messaget::eom;
 
-    if(auto result = block_frame(k); result.has_value())
+    if (auto result = block_frame(k); result.has_value())
       return *result;
 
     // Propagation: push clauses from F_i to F_{i+1}
-    if(propagate())
-    {
+    if (propagate()) {
       auto end_time = std::chrono::steady_clock::now();
       message.status()
-        << "IC3: converged at frame " << k << " in " << std::fixed
-        << std::setprecision(3)
-        << std::chrono::duration<double>(end_time - start_time).count()
-        << " seconds (" << num_queries << " queries)" << messaget::eom;
+          << "IC3: converged at frame " << k << " in " << std::fixed
+          << std::setprecision(3)
+          << std::chrono::duration<double>(end_time - start_time).count()
+          << " seconds (" << num_queries << " queries)" << messaget::eom;
       return ic3_resultt::proved();
     }
   }

--- a/src/new-ic3/ic3_solver.cpp
+++ b/src/new-ic3/ic3_solver.cpp
@@ -766,6 +766,66 @@ struct proof_obligationt
   }
 };
 
+std::optional<ic3_resultt> ic3_solvert::block_frame(std::size_t k)
+{
+  messaget message{message_handler};
+
+  std::priority_queue<
+    proof_obligationt,
+    std::vector<proof_obligationt>,
+    std::greater<proof_obligationt>>
+    obligations;
+
+  while(true)
+  {
+    auto bad_cube = solve_bad(k);
+    if(!bad_cube.has_value())
+      return std::nullopt;
+
+    obligations.push({bad_cube.value(), k, 0});
+
+    while(!obligations.empty())
+    {
+      auto [cube, level, depth] = obligations.top();
+      obligations.pop();
+
+      if(is_blocked(cube, level))
+        continue;
+
+      if(init_intersects(cube))
+      {
+        // The cube contains an initial state, and the bad state is
+        // depth transitions away: depth + 1 states in total.
+        message.status() << "Property refuted with counterexample of length "
+                         << depth + 1 << messaget::eom;
+        return ic3_resultt::refuted(depth + 1);
+      }
+
+      if(level == 0)
+      {
+        add_clause(0, negate_cube(cube));
+        continue;
+      }
+
+      auto pred = solve_relative(level - 1, cube);
+      if(pred.has_value())
+      {
+        obligations.push({pred.value(), level - 1, depth + 1});
+        obligations.push({std::move(cube), level, depth});
+      }
+      else
+      {
+        cubet generalized = generalize(level - 1, core);
+        add_clause(level, negate_cube(generalized));
+
+        // Re-queue at level+1 to push the blocking clause higher
+        if(level + 1 <= k)
+          obligations.push({std::move(cube), level + 1, depth});
+      }
+    }
+  }
+}
+
 ic3_resultt ic3_solvert::solve()
 {
   messaget message{message_handler};
@@ -789,61 +849,8 @@ ic3_resultt ic3_solvert::solve()
                        << total_clauses() << " clauses, avg size "
                        << average_clause_size() << ")" << messaget::eom;
 
-    std::priority_queue<
-      proof_obligationt,
-      std::vector<proof_obligationt>,
-      std::greater<proof_obligationt>>
-      obligations;
-
-    // Blocking phase
-    while(true)
-    {
-      auto bad_cube = solve_bad(k);
-      if(!bad_cube.has_value())
-        break;
-
-      obligations.push({bad_cube.value(), k, 0});
-
-      while(!obligations.empty())
-      {
-        auto [cube, level, depth] = obligations.top();
-        obligations.pop();
-
-        if(is_blocked(cube, level))
-          continue;
-
-        if(init_intersects(cube))
-        {
-          // The cube contains an initial state, and the bad state is
-          // depth transitions away: depth + 1 states in total.
-          message.status() << "Property refuted with counterexample of length "
-                           << depth + 1 << messaget::eom;
-          return ic3_resultt::refuted(depth + 1);
-        }
-
-        if(level == 0)
-        {
-          add_clause(0, negate_cube(cube));
-          continue;
-        }
-
-        auto pred = solve_relative(level - 1, cube);
-        if(pred.has_value())
-        {
-          obligations.push({pred.value(), level - 1, depth + 1});
-          obligations.push({std::move(cube), level, depth});
-        }
-        else
-        {
-          cubet generalized = generalize(level - 1, core);
-          add_clause(level, negate_cube(generalized));
-
-          // Re-queue at level+1 to push the blocking clause higher
-          if(level + 1 <= k)
-            obligations.push({std::move(cube), level + 1, depth});
-        }
-      }
-    } // end blocking phase
+    if(auto result = block_frame(k); result.has_value())
+      return *result;
 
     // Propagation: push clauses from F_i to F_{i+1}
     if(propagate())

--- a/src/new-ic3/ic3_solver.h
+++ b/src/new-ic3/ic3_solver.h
@@ -34,18 +34,12 @@ clauset negate_cube(const cubet &cube);
 class cnft;
 class recording_cnft;
 
-namespace IctMinisat
-{
+namespace IctMinisat {
 class Solver;
 }
 
-struct ic3_resultt
-{
-  enum class outcomet
-  {
-    PROVED,
-    REFUTED
-  } outcome;
+struct ic3_resultt {
+  enum class outcomet { PROVED, REFUTED } outcome;
 
   /// When REFUTED, the number of states in the counterexample trace:
   /// the trace has states at timeframes 0, ..., length - 1, and the
@@ -56,13 +50,9 @@ struct ic3_resultt
   /// state before a minimal-length one is explored.
   std::size_t counterexample_length = 0;
 
-  static ic3_resultt proved()
-  {
-    return {outcomet::PROVED, 0};
-  }
+  static ic3_resultt proved() { return {outcomet::PROVED, 0}; }
 
-  static ic3_resultt refuted(std::size_t counterexample_length)
-  {
+  static ic3_resultt refuted(std::size_t counterexample_length) {
     return {outcomet::REFUTED, counterexample_length};
   }
 };
@@ -78,13 +68,10 @@ struct ic3_resultt
 /// F_i for all i <= j, and the solver for level i contains the
 /// clauses of all levels >= i. F_0 additionally contains the initial
 /// state constraint.
-class ic3_solvert
-{
+class ic3_solvert {
 public:
-  ic3_solvert(
-    const netlistt &,
-    literalt property_literal,
-    message_handlert &message_handler);
+  ic3_solvert(const netlistt &, literalt property_literal,
+              message_handlert &message_handler);
 
   ~ic3_solvert();
 
@@ -117,8 +104,7 @@ private:
   std::size_t total_clauses() const;
   double average_clause_size() const;
 
-  struct latch_infot
-  {
+  struct latch_infot {
     literalt current, next;
   };
 
@@ -166,16 +152,11 @@ private:
 
   cubet extract_state(const IctMinisat::Solver &);
 
-  cubet lift(
-    const IctMinisat::Solver &query_solver,
-    const cubet &full_state,
-    const bvt &target_clause);
+  cubet lift(const IctMinisat::Solver &query_solver, const cubet &full_state,
+             const bvt &target_clause);
 
-  bool relative_induction(
-    std::size_t level,
-    const cubet &cube,
-    cubet *predecessor,
-    bool lift_predecessor);
+  bool relative_induction(std::size_t level, const cubet &cube,
+                          cubet *predecessor, bool lift_predecessor);
 
   void repair_init(const cubet &cube, cubet &reduced);
 

--- a/src/new-ic3/ic3_solver.h
+++ b/src/new-ic3/ic3_solver.h
@@ -34,12 +34,18 @@ clauset negate_cube(const cubet &cube);
 class cnft;
 class recording_cnft;
 
-namespace IctMinisat {
+namespace IctMinisat
+{
 class Solver;
 }
 
-struct ic3_resultt {
-  enum class outcomet { PROVED, REFUTED } outcome;
+struct ic3_resultt
+{
+  enum class outcomet
+  {
+    PROVED,
+    REFUTED
+  } outcome;
 
   /// When REFUTED, the number of states in the counterexample trace:
   /// the trace has states at timeframes 0, ..., length - 1, and the
@@ -50,9 +56,13 @@ struct ic3_resultt {
   /// state before a minimal-length one is explored.
   std::size_t counterexample_length = 0;
 
-  static ic3_resultt proved() { return {outcomet::PROVED, 0}; }
+  static ic3_resultt proved()
+  {
+    return {outcomet::PROVED, 0};
+  }
 
-  static ic3_resultt refuted(std::size_t counterexample_length) {
+  static ic3_resultt refuted(std::size_t counterexample_length)
+  {
     return {outcomet::REFUTED, counterexample_length};
   }
 };
@@ -68,10 +78,13 @@ struct ic3_resultt {
 /// F_i for all i <= j, and the solver for level i contains the
 /// clauses of all levels >= i. F_0 additionally contains the initial
 /// state constraint.
-class ic3_solvert {
+class ic3_solvert
+{
 public:
-  ic3_solvert(const netlistt &, literalt property_literal,
-              message_handlert &message_handler);
+  ic3_solvert(
+    const netlistt &,
+    literalt property_literal,
+    message_handlert &message_handler);
 
   ~ic3_solvert();
 
@@ -104,7 +117,8 @@ private:
   std::size_t total_clauses() const;
   double average_clause_size() const;
 
-  struct latch_infot {
+  struct latch_infot
+  {
     literalt current, next;
   };
 
@@ -152,11 +166,16 @@ private:
 
   cubet extract_state(const IctMinisat::Solver &);
 
-  cubet lift(const IctMinisat::Solver &query_solver, const cubet &full_state,
-             const bvt &target_clause);
+  cubet lift(
+    const IctMinisat::Solver &query_solver,
+    const cubet &full_state,
+    const bvt &target_clause);
 
-  bool relative_induction(std::size_t level, const cubet &cube,
-                          cubet *predecessor, bool lift_predecessor);
+  bool relative_induction(
+    std::size_t level,
+    const cubet &cube,
+    cubet *predecessor,
+    bool lift_predecessor);
 
   void repair_init(const cubet &cube, cubet &reduced);
 

--- a/src/new-ic3/ic3_solver.h
+++ b/src/new-ic3/ic3_solver.h
@@ -100,6 +100,7 @@ private:
   static bool subsumes(const frame_clauset &a, const frame_clauset &b);
 
   bool initial_state_is_bad();
+  std::optional<ic3_resultt> block_frame(std::size_t level);
   std::optional<cubet> solve_relative(std::size_t level, const cubet &);
   std::optional<cubet> solve_bad(std::size_t level);
   cubet generalize(std::size_t level, cubet cube);


### PR DESCRIPTION
Summary:
- extract the frame-blocking loop into a dedicated helper
- keep the top-level solve loop focused on frame creation, progress reporting, and propagation
- preserve the existing obligation-processing behavior while clarifying the phase split

Verification:
- make -C src/new-ic3 CXX='ccache clang++' CCACHE_DIR=/tmp/ccache-hw
- make -C src/ebmc CXX='ccache clang++' CCACHE_DIR=/tmp/ccache-hw
- ./src/ebmc/ebmc regression/ebmc/new-ic3/proved1.sv --new-ic3 --property main.p0
- ./src/ebmc/ebmc regression/ebmc/new-ic3/refuted1.sv --new-ic3 --top main
- ./src/ebmc/ebmc regression/ebmc/new-ic3/cover1.sv --new-ic3 --top main