### PR TITLE
Verilog: add `-y` and `+libdir+` library directory command-line option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * SystemVerilog: $typename for logic types
 * Verilog: +incdir+ command-line option
 * Verilog: -l and +libfile+ command-line options
+* Verilog: -y and +libdir+ command-line options
 * Refreshed IC3 engine --new-ic3
 
 # EBMC 6.0

--- a/regression/verilog/library-dir/library_dir1.desc
+++ b/regression/verilog/library-dir/library_dir1.desc
@@ -1,0 +1,6 @@
+CORE
+library_dir1.sv
+-y library_dir1_lib --bound 10
+^\[.*p1\] .* REFUTED$
+^EXIT=10$
+^SIGNAL=0$

--- a/regression/verilog/library-dir/library_dir1.sv
+++ b/regression/verilog/library-dir/library_dir1.sv
@@ -1,0 +1,11 @@
+module main(input clk);
+
+  reg [7:0] count;
+
+  initial count = 0;
+
+  always @(posedge clk) count = count + 1;
+
+  sub my_sub(.clk(clk), .data(count));
+
+endmodule

--- a/regression/verilog/library-dir/library_dir1_lib/sub.sv
+++ b/regression/verilog/library-dir/library_dir1_lib/sub.sv
@@ -1,0 +1,5 @@
+module sub(input clk, input [7:0] data);
+
+  p1: assert property (@(posedge clk) data < 5);
+
+endmodule

--- a/regression/verilog/library-dir/library_dir2.desc
+++ b/regression/verilog/library-dir/library_dir2.desc
@@ -1,0 +1,6 @@
+CORE
+library_dir1.sv
++libdir+library_dir1_lib --bound 10
+^\[.*p1\] .* REFUTED$
+^EXIT=10$
+^SIGNAL=0$

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -130,6 +130,7 @@ int ebmc_parse_optionst::doit()
   // Process Verilog-style +plusarg+ arguments.
   plus_arg("incdir");
   plus_arg("libfile");
+  plus_arg("libdir");
 
   if(config.set(cmdline))
   {
@@ -536,6 +537,8 @@ void ebmc_parse_optionst::help()
     " {y-I} {upath}                  \t set include path\n"
     " {y+incdir+}{upath}[{y+}{upath}...] \t set include path\n"
     " {y-D} {uvar}[={uvalue}]        \t set preprocessor define\n"
+    " {y-y} {upath}                  \t set library directory\n"
+    " {y+libdir+}{upath}[{y+}{upath}...] \t set library directory\n"
     " {y-l} {ufile}                  \t library file (modules are not top-level)\n"
     " {y+libfile+}{ufile}            \t library file (modules are not top-level)\n"
     " {y--systemverilog}             \t force SystemVerilog instead of Verilog\n"

--- a/src/ebmc/ebmc_parse_options.h
+++ b/src/ebmc/ebmc_parse_options.h
@@ -53,6 +53,7 @@ public:
         "(liveness-to-safety)(buechi)"
         "I:(incdir):D:"
         "l:(libfile):"
+        "y:(libdir):"
         "(preprocess)(systemverilog)(vl2smv-extensions)"
         "(warn-implicit-nets)",
         argc,

--- a/src/verilog/verilog_ebmc_language.cpp
+++ b/src/verilog/verilog_ebmc_language.cpp
@@ -379,6 +379,135 @@ symbol_tablet verilog_ebmc_languaget::elaborate_compilation_units(
   return symbol_table;
 }
 
+/// Collect all module base names that are instantiated by the given
+/// parse trees, recursively descending into generate blocks.
+static void collect_module_dependencies_rec(
+  const verilog_module_itemt &module_item,
+  std::set<irep_idt> &deps)
+{
+  if(module_item.id() == ID_inst)
+  {
+    deps.insert(to_verilog_inst(module_item).module_base_name());
+  }
+  else if(module_item.id() == ID_generate_block)
+  {
+    for(auto &sub_item : to_verilog_generate_block(module_item).module_items())
+      collect_module_dependencies_rec(sub_item, deps);
+  }
+  else if(module_item.id() == ID_generate_if)
+  {
+    auto &generate_if = to_verilog_generate_if(module_item);
+    collect_module_dependencies_rec(generate_if.then_case(), deps);
+    if(generate_if.has_else_case())
+      collect_module_dependencies_rec(generate_if.else_case(), deps);
+  }
+  else if(module_item.id() == ID_generate_for)
+  {
+    collect_module_dependencies_rec(
+      to_verilog_generate_for(module_item).body(), deps);
+  }
+}
+
+static std::set<irep_idt> collect_all_dependencies(
+  const verilog_ebmc_languaget::parse_treest &parse_trees)
+{
+  std::set<irep_idt> deps;
+
+  for(auto &parse_tree : parse_trees)
+    for(auto &item : parse_tree.items)
+      if(
+        item.id() == ID_verilog_module || item.id() == ID_verilog_program ||
+        item.id() == ID_verilog_checker)
+      {
+        for(auto &module_item : to_verilog_module_source(item).items())
+          collect_module_dependencies_rec(module_item, deps);
+      }
+
+  return deps;
+}
+
+static std::set<irep_idt>
+collect_all_provided(const verilog_ebmc_languaget::parse_treest &parse_trees)
+{
+  std::set<irep_idt> provided;
+
+  for(auto &parse_tree : parse_trees)
+    for(auto &item : parse_tree.items)
+      if(
+        item.id() == ID_verilog_module || item.id() == ID_verilog_checker ||
+        item.id() == ID_verilog_interface)
+      {
+        provided.insert(to_verilog_module_source(item).base_name());
+      }
+
+  return provided;
+}
+
+void verilog_ebmc_languaget::resolve_library_modules(parse_treest &parse_trees)
+{
+  std::list<std::string> library_dirs;
+
+  for(auto &dir : cmdline.get_values('y'))
+    library_dirs.push_back(dir);
+
+  for(auto &dir : cmdline.get_values("libdir"))
+    library_dirs.push_back(dir);
+
+  messaget log{message_handler};
+
+  // Iteratively resolve library dependencies until no new
+  // unresolved modules are found.
+  while(true)
+  {
+    auto provided = collect_all_provided(parse_trees);
+    auto dependencies = collect_all_dependencies(parse_trees);
+
+    // Determine which dependencies are unresolved
+    std::set<irep_idt> unresolved;
+    for(auto &dep : dependencies)
+      if(provided.find(dep) == provided.end())
+        unresolved.insert(dep);
+
+    if(unresolved.empty())
+      break;
+
+    bool found_any = false;
+
+    for(auto &module_name : unresolved)
+    {
+      bool found = false;
+
+      for(auto &dir : library_dirs)
+      {
+        // Try <dir>/<module>.v and <dir>/<module>.sv
+        for(auto ext : {".v", ".sv"})
+        {
+          auto path =
+            std::filesystem::path{dir} / (id2string(module_name) + ext);
+
+          if(std::filesystem::exists(path))
+          {
+            log.status() << "Library: parsing " << path << messaget::eom;
+
+            verilog_scopest scopes;
+            parse_trees.push_back(parse(path, scopes));
+            found = true;
+            found_any = true;
+            break;
+          }
+        }
+
+        if(found)
+          break;
+      }
+    }
+
+    // If no new files were found in this iteration, stop.
+    if(!found_any)
+      break;
+  }
+}
+
 void verilog_ebmc_languaget::create_reset_logic(
   const std::string &reset_constraint_string,
   transition_systemt &transition_system)
@@ -438,6 +567,10 @@ std::optional<transition_systemt> verilog_ebmc_languaget::transition_system()
   }
 
   auto parse_trees = parse();
+
+  // resolve library directories (-y)
+  if(cmdline.isset('y') || cmdline.isset("libdir"))
+    resolve_library_modules(parse_trees);
 
   if(cmdline.isset("show-modules"))
   {

--- a/src/verilog/verilog_ebmc_language.h
+++ b/src/verilog/verilog_ebmc_language.h
@@ -49,6 +49,8 @@ protected:
 
   parse_treest parse();
 
+  void resolve_library_modules(parse_treest &);
+
   void copy_parse_tree(const parse_treet &, symbol_tablet &);
 
   class modulet


### PR DESCRIPTION
Add support for the `-y` and `+libdir+` command-line options to specify Verilog library directories for automatic module resolution.

## Summary

When a module instantiation references a module not defined in the source files, EBMC now searches each `-y` directory for `<module_name>.v` or `<module_name>.sv`, following the convention used by other Verilog tools (VCS, Icarus Verilog, etc.).

## Details

- Multiple `-y` flags can be given; directories are searched in order
- Resolution is iterative — library modules that themselves instantiate other library modules are handled correctly
- `.v` is tried first, then `.sv`
- Per IEEE 1800-2017 section 33.3 (source libraries)

## Usage

```bash
ebmc top.sv -y /path/to/lib1 -y /path/to/lib2 --bound 10
```

## Testing

- Added regression test `modules/library_dir1`
- All existing regression tests pass

Fixes #1338