### PR TITLE
Verilog: add `+define+` command-line option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Verilog: procedural assignments to hierarchical identifiers
 * SystemVerilog: ports for sequence and property declarations
 * SystemVerilog: $typename for logic types
+* Verilog: +define+ command-line option
 * Verilog: +incdir+ command-line option
 * Verilog: -l and +libfile+ command-line options
 * Verilog: -y and +libdir+ command-line options

--- a/regression/verilog/preprocessor/plus_define1.desc
+++ b/regression/verilog/preprocessor/plus_define1.desc
@@ -1,0 +1,10 @@
+CORE
+cmdline_define1.v
+--preprocess +define+SOMETHING+ELSE=foo
+^A$
+^foo$
+^EXIT=0$
+^SIGNAL=0$
+--
+^B$
+^PREPROCESSING FAILED$

--- a/regression/verilog/preprocessor/plus_define2.desc
+++ b/regression/verilog/preprocessor/plus_define2.desc
@@ -1,0 +1,8 @@
+CORE
+cmdline_define2.v
+--show-modules +define+SOME_NAME=foo
+^  Name:       foo$
+^EXIT=0$
+^SIGNAL=0$
+--
+^PREPROCESSING FAILED$

--- a/regression/verilog/preprocessor/plus_define3.desc
+++ b/regression/verilog/preprocessor/plus_define3.desc
@@ -1,0 +1,8 @@
+CORE
+plus_define3.v
+--show-modules +define+A+B=my_module
+^  Name:       my_module$
+^EXIT=0$
+^SIGNAL=0$
+--
+^PREPROCESSING FAILED$

--- a/regression/verilog/preprocessor/plus_define3.v
+++ b/regression/verilog/preprocessor/plus_define3.v
@@ -1,0 +1,4 @@
+`ifdef A
+module `B();
+endmodule
+`endif

--- a/regression/verilog/preprocessor/plus_define4.desc
+++ b/regression/verilog/preprocessor/plus_define4.desc
@@ -1,0 +1,10 @@
+CORE
+cmdline_define1.v
+--preprocess -D SOMETHING +define+ELSE=foo
+^A$
+^foo$
+^EXIT=0$
+^SIGNAL=0$
+--
+^B$
+^PREPROCESSING FAILED$

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -128,6 +128,7 @@ int ebmc_parse_optionst::doit()
     ui_message_handler.set_verbosity(messaget::M_STATUS); // default
 
   // Process Verilog-style +plusarg+ arguments.
+  plus_arg("define");
   plus_arg("incdir");
   plus_arg("libfile");
   plus_arg("libdir");
@@ -537,6 +538,7 @@ void ebmc_parse_optionst::help()
     " {y-I} {upath}                  \t set include path\n"
     " {y+incdir+}{upath}[{y+}{upath}...] \t set include path\n"
     " {y-D} {uvar}[={uvalue}]        \t set preprocessor define\n"
+    " {y+define+}{uvar}[={uvalue}]   \t set preprocessor define(s)\n"
     " {y-y} {upath}                  \t set library directory\n"
     " {y+libdir+}{upath}[{y+}{upath}...] \t set library directory\n"
     " {y-l} {ufile}                  \t library file (modules are not top-level)\n"

--- a/src/ebmc/ebmc_parse_options.h
+++ b/src/ebmc/ebmc_parse_options.h
@@ -51,7 +51,7 @@ public:
         "(random-trace)(random-waveform)"
         "(bmc-with-assumptions)"
         "(liveness-to-safety)(buechi)"
-        "I:(incdir):D:"
+        "I:(incdir):D:(define):"
         "l:(libfile):"
         "y:(libdir):"
         "(preprocess)(systemverilog)(vl2smv-extensions)"

--- a/src/verilog/verilog_ebmc_language.cpp
+++ b/src/verilog/verilog_ebmc_language.cpp
@@ -46,12 +46,21 @@ void verilog_ebmc_languaget::preprocess(
     throw ebmc_errort{}.with_exit_code(1)
       << "failed to open input file " << path;
 
-  // do -D
-  auto &initial_defines = cmdline.get_values('D');
+  // -D
+  auto &d_list = cmdline.get_values('D');
+  auto &define_list = cmdline.get_values("define");
 
-  // Collect +incdir+ paths and merge with -I paths
+  // Merge -D defines with +define+ defines
+  std::list<std::string> initial_defines;
+  initial_defines.insert(initial_defines.end(), d_list.begin(), d_list.end());
+  initial_defines.insert(
+    initial_defines.end(), define_list.begin(), define_list.end());
+
+  // -I
   auto &I_paths = cmdline.get_values('I');
   auto &incdir_paths = cmdline.get_values("incdir");
+
+  // Collect +incdir+ paths and merge with -I paths
   std::list<std::string> all_include_paths;
   all_include_paths.insert(
     all_include_paths.end(), I_paths.begin(), I_paths.end());


### PR DESCRIPTION
Add support for the Verilog simulator convention of specifying
preprocessor defines using `+define+NAME=VALUE` syntax. Multiple
defines can be specified in a single argument separated by `+`,
e.g., `+define+A+B=2+C=hello`.

The `+define+` arguments are extracted from the command line early
in processing (before file extension detection) and merged with
any `-D` flags before being passed to the Verilog preprocessor.

## Testing

- 4 new regression tests covering: single define, value substitution,
  multiple defines, and mixing `-D` with `+define+`
- All 28 preprocessor regression tests pass