### PR TITLE
Verilog: add `-l` and `+libfile+` command-line options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * Verilog: procedural assignments to hierarchical identifiers
 * SystemVerilog: ports for sequence and property declarations
 * SystemVerilog: $typename for logic types
+* Verilog: -l and +libfile+ command-line options
 * Refreshed IC3 engine --new-ic3
 
 # EBMC 6.0

--- a/regression/ebmc/library-files/lib.sv
+++ b/regression/ebmc/library-files/lib.sv
@@ -1,0 +1,9 @@
+module lib_counter(input clk);
+
+  reg [3:0] cnt;
+
+  initial cnt = 0;
+
+  always @(posedge clk) cnt = cnt + 1;
+
+endmodule

--- a/regression/ebmc/library-files/library1.desc
+++ b/regression/ebmc/library-files/library1.desc
@@ -1,0 +1,7 @@
+CORE
+main.sv
+-l lib.sv --bound 3
+^\[main\.p1\] always main\.cnt != 3: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/ebmc/library-files/library2.desc
+++ b/regression/ebmc/library-files/library2.desc
@@ -1,0 +1,7 @@
+CORE
+main_simple.sv
+-l standalone_lib.sv --bound 3
+^\[main\.p1\] always main\.cnt != 3: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/ebmc/library-files/library3.desc
+++ b/regression/ebmc/library-files/library3.desc
@@ -1,0 +1,8 @@
+CORE
+main_simple.sv
+-l standalone_lib.sv --show-modules
+^  Name:       main$
+^  Name:       standalone_lib$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ebmc/library-files/library4.desc
+++ b/regression/ebmc/library-files/library4.desc
@@ -1,0 +1,7 @@
+CORE
+main_simple.sv
++libfile+standalone_lib.sv --bound 3
+^\[main\.p1\] always main\.cnt != 3: REFUTED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/ebmc/library-files/main.sv
+++ b/regression/ebmc/library-files/main.sv
@@ -1,0 +1,13 @@
+module main(input clk, input x);
+
+  reg [1:0] cnt;
+
+  initial cnt = 0;
+
+  always @(posedge clk) cnt = cnt + 1;
+
+  lib_counter my_lib(clk);
+
+  p1: assert property (@(posedge clk) cnt != 3);
+
+endmodule

--- a/regression/ebmc/library-files/main_simple.sv
+++ b/regression/ebmc/library-files/main_simple.sv
@@ -1,0 +1,11 @@
+module main(input clk);
+
+  reg [1:0] cnt;
+
+  initial cnt = 0;
+
+  always @(posedge clk) cnt = cnt + 1;
+
+  p1: assert property (@(posedge clk) cnt != 3);
+
+endmodule

--- a/regression/ebmc/library-files/standalone_lib.sv
+++ b/regression/ebmc/library-files/standalone_lib.sv
@@ -1,0 +1,14 @@
+// This module is not instantiated by any non-library module.
+// Without -l, it would be considered a top-level module.
+// With -l, it should NOT be considered top-level.
+module standalone_lib(input clk);
+
+  reg [3:0] cnt;
+
+  initial cnt = 0;
+
+  always @(posedge clk) cnt = cnt + 1;
+
+  p_lib: assert property (@(posedge clk) cnt < 15);
+
+endmodule

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/exit_codes.h>
 #include <util/help_formatter.h>
 #include <util/output_file.h>
+#include <util/prefix.h>
 #include <util/string2int.h>
 
 #include <trans-netlist/compute_ct.h>
@@ -52,6 +53,62 @@ Author: Daniel Kroening, kroening@kroening.com
 
 /*******************************************************************\
 
+Function: ebmc_parse_optionst::plus_arg
+
+  Inputs:
+
+ Outputs:
+
+ Purpose: turn a +plusarg into a cmdlinet option
+
+\*******************************************************************/
+
+void ebmc_parse_optionst::plus_arg(const std::string &plus_arg)
+{
+  // The format is +plus_arg+opt1+opt2+...
+  // We extract these from cmdline.args (where cmdlinet puts them
+  // since they don't start with '-') and store them as option values
+  // so that they can be obtained via cmdline.get_values("plus_arg").
+
+  const std::string prefix = '+' + plus_arg + '+';
+  cmdlinet::argst remaining_args;
+  for(const auto &arg : cmdline.args)
+  {
+    if(has_prefix(arg, prefix))
+    {
+      // Split on '+' to get individual option values
+      std::string arg_str = arg.substr(prefix.size());
+      std::string::size_type pos = 0;
+      while(pos < arg_str.size())
+      {
+        auto next = arg_str.find('+', pos);
+        std::string arg_value;
+        if(next == std::string::npos)
+        {
+          arg_value = arg_str.substr(pos);
+          pos = arg_str.size();
+        }
+        else
+        {
+          arg_value = arg_str.substr(pos, next - pos);
+          pos = next + 1;
+        }
+
+        if(!arg_value.empty())
+          cmdline.set(plus_arg, arg_value);
+      }
+    }
+    else
+    {
+      remaining_args.push_back(arg);
+    }
+  }
+
+  cmdline.args = std::move(remaining_args);
+}
+
+/*******************************************************************\
+
 Function: ebmc_parse_optionst::doit
 
   Inputs:
@@ -69,6 +126,9 @@ int ebmc_parse_optionst::doit()
       unsafe_string2unsigned(cmdline.get_value("verbosity")));
   else
     ui_message_handler.set_verbosity(messaget::M_STATUS); // default
+
+  // Process Verilog-style +plusarg+ arguments.
+  plus_arg("libfile");
 
   if(config.set(cmdline))
   {
@@ -472,6 +532,8 @@ void ebmc_parse_optionst::help()
     "Verilog options:\n"
     " {y-I} {upath}                  \t set include path\n"
     " {y-D} {uvar}[={uvalue}]        \t set preprocessor define\n"
+    " {y-l} {ufile}                  \t library file (modules are not top-level)\n"
+    " {y+libfile+}{ufile}            \t library file (modules are not top-level)\n"
     " {y--systemverilog}             \t force SystemVerilog instead of Verilog\n"
     " {y--reset} {uexpr}             \t set up module reset\n"
     " {y--ignore-initial}            \t disregard initial blocks\n"

--- a/src/ebmc/ebmc_parse_options.h
+++ b/src/ebmc/ebmc_parse_options.h
@@ -52,7 +52,8 @@ public:
         "(bmc-with-assumptions)"
         "(liveness-to-safety)(buechi)"
         "I:D:(preprocess)(systemverilog)(vl2smv-extensions)"
-        "(warn-implicit-nets)",
+        "(warn-implicit-nets)"
+        "l:(libfile):",
         argc,
         argv,
         std::string("EBMC ") + EBMC_VERSION),
@@ -64,7 +65,8 @@ public:
   
 protected:
   void register_languages();
-  
+  void plus_arg(const std::string &);
+
   ui_message_handlert ui_message_handler;
 };
 

--- a/src/verilog/top_level_modules.cpp
+++ b/src/verilog/top_level_modules.cpp
@@ -61,22 +61,40 @@ static void module_dependencies(
 
 /// Determine the set of top-level modules following 1800 2017 23.3.1,
 /// given via their base names. Sorted alphabetically.
+/// The library_count parameter specifies how many parse trees at the end
+/// of the list are library files. Modules in library parse trees are
+/// not candidates for being top-level, but are still used for dependency
+/// erasure.
 std::vector<irep_idt> top_level_modules(
   const std::list<verilog_parse_treet> &parse_trees,
-  const cmdlinet &cmdline)
+  const cmdlinet &cmdline,
+  std::size_t library_count)
 {
-  // start with a set of all modules, from all the files
+  // Determine which parse trees are non-library (regular)
+  const std::size_t total = parse_trees.size();
+  const std::size_t regular_count =
+    total >= library_count ? total - library_count : total;
+
+  // start with a set of all modules from non-library files only
   std::set<irep_idt> all_modules;
 
-  for(auto &parse_tree : parse_trees)
-    for(auto &item : parse_tree.items)
+  {
+    std::size_t index = 0;
+    for(auto &parse_tree : parse_trees)
     {
-      if(item.id() == ID_verilog_module)
+      if(index >= regular_count)
+        break;
+      for(auto &item : parse_tree.items)
       {
-        auto base_name = to_verilog_module_source(item).base_name();
-        all_modules.insert(base_name);
+        if(item.id() == ID_verilog_module)
+        {
+          auto base_name = to_verilog_module_source(item).base_name();
+          all_modules.insert(base_name);
+        }
       }
+      ++index;
     }
+  }
 
   // Did the user specify a set of top level modules?
   std::vector<irep_idt> given_modules;
@@ -113,6 +131,8 @@ std::vector<irep_idt> top_level_modules(
   // No modules given. Find all modules that are not used
   // as a submodule. Start with all modules, and then erase
   // the ones that are used as a submodule.
+  // We consider dependencies from all parse trees (including library)
+  // for erasure purposes.
   std::set<irep_idt> top_level_modules = all_modules;
 
   for(auto &parse_tree : parse_trees)

--- a/src/verilog/top_level_modules.h
+++ b/src/verilog/top_level_modules.h
@@ -19,7 +19,13 @@ class cmdlinet;
 // Returns the base_names of the top-level modules in alphabetical order.
 // Throws ebmc_errort when a given top-level module is not found,
 // or when there is no top-level module.
-std::vector<irep_idt>
-top_level_modules(const std::list<verilog_parse_treet> &, const cmdlinet &);
+// The library_count parameter specifies how many parse trees at the end
+// of the list are library files. Modules in library parse trees are
+// excluded from top-level consideration but still used for dependency
+// erasure.
+std::vector<irep_idt> top_level_modules(
+  const std::list<verilog_parse_treet> &,
+  const cmdlinet &,
+  std::size_t library_count = 0);
 
 #endif // EBMC_VERILOG_TOP_LEVEL_MODULES_H

--- a/src/verilog/verilog_ebmc_language.cpp
+++ b/src/verilog/verilog_ebmc_language.cpp
@@ -137,6 +137,13 @@ verilog_ebmc_languaget::parse_treest verilog_ebmc_languaget::parse()
   for(auto &arg : cmdline.args)
     parse_trees.push_back(parse(arg, scopes));
 
+  // Parse library files specified with -l and +libfile+
+  for(auto &lib_file : cmdline.get_values('l'))
+    parse_trees.push_back(parse(lib_file, scopes));
+
+  for(auto &lib_file : cmdline.get_values("libfile"))
+    parse_trees.push_back(parse(lib_file, scopes));
+
   return parse_trees;
 }
 
@@ -453,7 +460,10 @@ std::optional<transition_systemt> verilog_ebmc_languaget::transition_system()
   //
   // determine the top-level modules
   //
-  auto top_level_modules = ::top_level_modules(parse_trees, cmdline);
+  auto library_count =
+    cmdline.get_values('l').size() + cmdline.get_values("libfile").size();
+  auto top_level_modules =
+    ::top_level_modules(parse_trees, cmdline, library_count);
 
   //
   // type checking


### PR DESCRIPTION
Add support for library files via `-l` and the Verilog simulator
convention `+libfile+`. Modules in library files are parsed and
available for instantiation but are not considered as top-level
modules.

This follows the Icarus Verilog convention where library modules
are only elaborated when explicitly instantiated by a non-library
module.

The `+libfile+` handling uses the same `plus_arg()` mechanism
introduced in #2076.

## Testing
* 4 new regression tests covering: instantiated library module,
  standalone library module excluded from top-level, show-modules
  visibility, and `+libfile+` plusarg syntax
* All existing regression tests pass