### PR TITLE
Verilog: fix stale parser stack slot for the interface keyword

### DIFF
--- a/regression/verilog/interface/interface2.desc
+++ b/regression/verilog/interface/interface2.desc
@@ -1,7 +1,7 @@
 CORE
 interface2.sv
 
-^error: duplicate definition of interface foobar$
+^file .* line 6: error: duplicate definition of interface foobar$
 ^EXIT=2$
 ^SIGNAL=0$
 --

--- a/regression/verilog/interface/two_files1.desc
+++ b/regression/verilog/interface/two_files1.desc
@@ -1,0 +1,10 @@
+CORE
+two_filesB1.sv
+two_filesA1.sv --show-parse
+^Interface: bus_if$
+^Interface: some_if$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+An interface declaration in each of two separately parsed files.

--- a/regression/verilog/interface/two_files2.desc
+++ b/regression/verilog/interface/two_files2.desc
@@ -1,0 +1,10 @@
+CORE
+two_filesB2.sv
+two_filesA2.sv
+^\[main\.sub_inst\.assert\.1\] always main\.sub_inst\.bus\.i == 123: PROVED
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+An interface declared in one file is used by a module in another file,
+where that other file also declares an interface of its own.

--- a/regression/verilog/interface/two_filesA1.sv
+++ b/regression/verilog/interface/two_filesA1.sv
@@ -1,0 +1,3 @@
+interface bus_if;
+  logic req;
+endinterface

--- a/regression/verilog/interface/two_filesA2.sv
+++ b/regression/verilog/interface/two_filesA2.sv
@@ -1,0 +1,4 @@
+interface bus_if;
+  int i;
+  initial i = 123;
+endinterface

--- a/regression/verilog/interface/two_filesB1.sv
+++ b/regression/verilog/interface/two_filesB1.sv
@@ -1,0 +1,3 @@
+interface some_if;
+  logic ack;
+endinterface

--- a/regression/verilog/interface/two_filesB2.sv
+++ b/regression/verilog/interface/two_filesB2.sv
@@ -1,0 +1,13 @@
+interface some_if;
+  logic ack;
+endinterface
+
+module sub(bus_if bus);
+  always @(bus.i)
+    assert(bus.i == 123);
+endmodule
+
+module main;
+  bus_if interface_instance();
+  sub sub_inst(interface_instance);
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -755,6 +755,14 @@ interface_declaration:
                 }
         ;
 
+// This deviates from the IEEE 1800-2017 grammar, which uses the
+// "interface" keyword directly. We need a nonterminal to attach a
+// semantic value to the keyword, mirroring module_keyword. Note that
+// the scanner does not allocate a stack slot for keyword tokens.
+interface_keyword:
+          TOK_INTERFACE { init($$, ID_interface); }
+        ;
+
 interface_identifier_with_scope:
           interface_identifier
                 {
@@ -768,7 +776,7 @@ interface_identifier_with_scope:
 
 interface_nonansi_header:
           attribute_instance_brace
-          TOK_INTERFACE
+          interface_keyword
           lifetime_opt
           interface_identifier_with_scope
           package_import_declaration_brace
@@ -787,7 +795,7 @@ interface_nonansi_header:
 
 interface_ansi_header:
           attribute_instance_brace
-          TOK_INTERFACE
+          interface_keyword
           lifetime_opt
           interface_identifier_with_scope
           package_import_declaration_brace


### PR DESCRIPTION
## What was broken

EBMC segfaulted whenever two or more separately-parsed input files each contained an interface declaration:

```systemverilog
// a.sv
interface ia;
  logic x;
endinterface
```

```systemverilog
// b.sv
interface ib;
  logic y;
endinterface
```

```
$ ebmc --systemverilog a.sv b.sv --show-modules
Segmentation fault
```

The same code concatenated into a single file was accepted, which is what made this confusing to track down.

```
#0 irept::find(dstringt const&) const
#1 verilog_parse_treet::create_module(...)
#2 yyverilogparse()
#3 verilog_ebmc_languaget::parse(std::filesystem::path const&, verilog_scopest&)
```

## Root cause

`interface_nonansi_header` and `interface_ansi_header` in `src/verilog/parser.y` read the semantic value of the `interface` keyword (`$2`) and hand it to `verilog_parse_treet::create_module`, which uses it as the source location of the interface.

The scanner only allocates a parser stack slot (via `newstack`) for identifier and literal tokens. Plain keyword tokens such as `TOK_INTERFACE` leave `yyveriloglval` holding whatever index was last assigned, so these two rules indexed an arbitrary — and often out-of-range — element of `verilog_parsert::stack`.

Within a single file this silently attached a wrong source location to the interface. Across files it crashed: `verilog_ebmc_languaget::parse()` creates a fresh `verilog_parsert`, and hence a fresh and initially empty `stack`, for each input file, so a stale index left over from the previous file is out of bounds and `create_module` dereferenced past the end of the vector. Whether it segfaulted or merely misbehaved depended on how large the previous file's stack had grown, which is why an intervening module in the second file could mask it.

Confirmed with valgrind: `Invalid read of size 8 ... 16 bytes after a block of size 64 alloc'd by _newstack`. The build is clean under valgrind after the fix.

## The fix

Introduce an `interface_keyword` nonterminal that does `init($$, ID_interface)`, exactly mirroring the existing `module_keyword` rule, so the keyword gets a properly allocated stack slot. Bison reports no new conflicts.

Per IEEE 1800-2017 A.1.2, `interface_declaration` is a `description`, and several descriptions may be spread over separate source files of a single compilation unit.

## Tests

- `regression/verilog/interface/two_files1.desc` — an interface declaration in each of two separately parsed files; segfaults before this change.
- `regression/verilog/interface/two_files2.desc` — additionally checks that an interface declared in one file remains visible to a module in another file, so the cross-file visibility that made `iface.sv mod.sv` work is not regressed.
- `regression/verilog/interface/interface2.desc` now expects the error message to carry a source location (`^file .* line 6: error: ...`), matching the neighbouring `duplicate1.desc`. It previously lacked one precisely because of this bug, so this is the same latent defect showing up as a user-visible diagnostic improvement.

Full `regression/verilog` suite passes. `regression/ebmc` has one pre-existing failure, `neural-liveness/counter1.desc`, which fails identically on `main` (it needs an external ranking-function tool).
