### PR TITLE
Verilog: allow interface, package and class names as named formals

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,8 @@
 * SystemVerilog: $typename for logic types
 * Verilog: +incdir+ command-line option
 * Verilog: -l and +libfile+ command-line options
+* SystemVerilog: named port connections and named parameter assignments
+  may name formals that clash with interface, package or class names
 * Refreshed IC3 engine --new-ic3
 
 # EBMC 6.0

--- a/regression/verilog/interface/port4.desc
+++ b/regression/verilog/interface/port4.desc
@@ -1,0 +1,8 @@
+CORE
+port4.sv
+--module main --bound 0
+^\[main\.s\.p0\] main\.s\.data_if == 1: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+--

--- a/regression/verilog/interface/port4.sv
+++ b/regression/verilog/interface/port4.sv
@@ -1,0 +1,17 @@
+// The formal name in a named port connection lives in the port name
+// space of the instantiated module, and hence may coincide with the
+// name of an interface.
+module sub(input logic data_if);
+  initial p0: assert(data_if == 1);
+endmodule
+
+interface data_if;
+  logic value;
+  initial value = 1;
+endinterface
+
+module main;
+  data_if shared();
+
+  sub s(.data_if(shared.value));
+endmodule

--- a/regression/verilog/modules/named_parameter_assignment1.desc
+++ b/regression/verilog/modules/named_parameter_assignment1.desc
@@ -1,0 +1,8 @@
+CORE
+named_parameter_assignment1.sv
+--module main --bound 0
+^\[main\.u\.assert\.1\] .*: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+--

--- a/regression/verilog/modules/named_parameter_assignment1.sv
+++ b/regression/verilog/modules/named_parameter_assignment1.sv
@@ -1,0 +1,32 @@
+// The parameter name in a named parameter assignment is looked up in the
+// parameter name space of the instantiated module, and hence may coincide
+// with a typedef, interface, package or class name that happens to be
+// visible at the point of instantiation.
+module sub #(
+  parameter int some_type = 1,
+  parameter int some_if = 2,
+  parameter int some_pkg = 3,
+  parameter int some_class = 4) ();
+
+  initial assert (some_type == 10 && some_if == 20 &&
+                  some_pkg == 30 && some_class == 40);
+
+endmodule
+
+typedef int some_type;
+
+interface some_if;
+  logic x;
+endinterface
+
+package some_pkg;
+endpackage
+
+class some_class;
+endclass
+
+module main;
+
+  sub #(.some_type(10), .some_if(20), .some_pkg(30), .some_class(40)) u();
+
+endmodule

--- a/regression/verilog/modules/named_port_connection2.desc
+++ b/regression/verilog/modules/named_port_connection2.desc
@@ -1,0 +1,8 @@
+CORE
+named_port_connection2.sv
+--module main --bound 0
+^\[main\.u\.assert\.1\] .*: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+--

--- a/regression/verilog/modules/named_port_connection2.sv
+++ b/regression/verilog/modules/named_port_connection2.sv
@@ -1,0 +1,31 @@
+// The formal name in a named port connection is looked up in the
+// port name space of the instantiated module, and hence may coincide
+// with a typedef, interface, package or class name that happens to be
+// visible at the point of instantiation.
+module sub(
+  input some_type,
+  input some_if,
+  input some_pkg,
+  input some_class);
+
+  initial assert (some_type && some_if && some_pkg && some_class);
+
+endmodule
+
+typedef int some_type;
+
+interface some_if;
+  logic x;
+endinterface
+
+package some_pkg;
+endpackage
+
+class some_class;
+endclass
+
+module main;
+
+  sub u(.some_type(1), .some_if(1), .some_pkg(1), .some_class(1));
+
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3874,8 +3874,10 @@ named_port_connection_brace:
         ;
 
 named_port_connection:
-          // This needs to be 'any_identifier' to allow identifiers that
-          // are typedefs in the local scope.
+          // This needs to be 'any_identifier': the formal name is looked
+          // up in the instantiated module's port name space, and hence may
+          // coincide with a typedef, interface, package or class name that
+          // is visible in the local scope.
           '.' any_identifier '(' expression_opt ')'
                 { init($$, ID_verilog_named_port_connection);
                   mto($$, $2);
@@ -5490,8 +5492,14 @@ attr_name: identifier
 // An extension of the System Verilog grammar to allow defining new identifiers
 // even if they are already used for a different kind of identifier
 // in a higher scope.
+// Note that the scanner gives all identifier tokens the same shape,
+// namely ID_verilog_identifier with ID_base_name set. Hence, no action
+// is required to normalize the alternatives below.
 any_identifier:
           TOK_TYPE_IDENTIFIER
+        | TOK_CLASS_IDENTIFIER
+        | TOK_PACKAGE_IDENTIFIER
+        | TOK_INTERFACE_IDENTIFIER
         | non_type_identifier
         ;
 
@@ -5603,7 +5611,10 @@ type_identifier: TOK_TYPE_IDENTIFIER
 
 ps_type_identifier: type_identifier;
 
-parameter_identifier: non_type_identifier;
+// This needs to be 'any_identifier': the parameter name in a named
+// parameter assignment is looked up in the instantiated module's
+// parameter name space, not in the local scope.
+parameter_identifier: any_identifier;
 
 udp_identifier: non_type_identifier;
 


### PR DESCRIPTION
Once a name has been declared as an interface, a package or a class, it could no longer be used as the formal name in a named port connection `.name(expr)` or in a named parameter assignment `.NAME(value)`.

## Minimal example

```systemverilog
module sub(input logic data_if);
  initial p0: assert(data_if == 1);
endmodule

interface data_if;
  logic value;
  initial value = 1;
endinterface

module main;
  data_if shared();

  sub s(.data_if(shared.value));
endmodule
```

Before this change, the parser rejected the instantiation with

```
syntax error, unexpected TOK_INTERFACE_IDENTIFIER, expecting TOK_NON_TYPE_IDENTIFIER or TOK_TYPE_IDENTIFIER before 'data_if'
```

The same happened for named parameter assignments, e.g. `sub #(.data_if(1)) u();`.

## Why this is legal

The formal name in a named port connection resp. a named parameter assignment is resolved in the port resp. parameter name space of the *instantiated* module (IEEE 1800-2017, 3.13 and 23.3.2.2), not in the scope in which the instantiation appears. Hence any name may be used there, irrespective of what it denotes locally.

This is aggravated by the fact that interface, package and class names go into the global scope and persist across all input files, so a single interface declaration anywhere in the input would poison the formal-name space of every module instantiation in the design.

## The fix

The scanner classifies identifiers into distinct token classes (`TOK_NON_TYPE_IDENTIFIER`, `TOK_TYPE_IDENTIFIER`, `TOK_INTERFACE_IDENTIFIER`, `TOK_PACKAGE_IDENTIFIER`, `TOK_CLASS_IDENTIFIER`) from the scope table, but the grammar's `any_identifier` covered only the first two. The same problem had previously been patched for typedefs only; this change is the general version of that fix:

* `any_identifier` now covers all identifier token classes.
* `parameter_identifier`, which is used by named parameter assignments, now uses `any_identifier`.

No action code is needed for the new alternatives, since the scanner gives every identifier token the same irep shape, namely `ID_verilog_identifier` with `ID_base_name` set, which is what the consumers read. The grammar remains conflict-free.

`port_identifier` (the name of a port in a declaration) is deliberately left unchanged. It is a different case, as the name being declared does live in the local scope, and it cannot be widened without introducing grammar conflicts: widening `port_identifier` gives 2 shift/reduce conflicts for `TOK_INTERFACE_IDENTIFIER` (states where `attribute_instance_brace` can be reduced empty ahead of an ANSI port declaration, which itself may start with `TOK_INTERFACE_IDENTIFIER`), and 6 shift/reduce conflicts each for the other token classes (against the empty reductions of `net_type_opt` and `signing_opt`, i.e. an implicitly typed port name is indistinguishable from a data type). Widening individual uses of `port_identifier` instead produces reduce/reduce conflicts between the port declaration and port reference rules.

## Tests

* `regression/verilog/modules/named_port_connection2` -- formals named after a typedef, interface, package and class
* `regression/verilog/modules/named_parameter_assignment1` -- the same for named parameter assignments
* `regression/verilog/interface/port4` -- the interface case above
