### PR TITLE
Verilog: interface ports no longer depend on declaration order

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,8 @@
 * Verilog: procedural assignments to hierarchical identifiers
 * SystemVerilog: ports for sequence and property declarations
 * SystemVerilog: $typename for logic types
+* SystemVerilog: interface ports no longer require the interface to be
+  declared before the module that uses it
 * Verilog: +define+ command-line option
 * Verilog: +incdir+ command-line option
 * Verilog: -l and +libfile+ command-line options

--- a/regression/verilog/interface/port4.desc
+++ b/regression/verilog/interface/port4.desc
@@ -1,0 +1,10 @@
+CORE
+port4B.sv
+port4A.sv --bound 5
+^\[main\.s\.p0\] always main\.s\.bus\.v == 1: PROVED up to bound 5$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+An interface port with a modport, where the interface is declared in a file
+that is given later on the command line.

--- a/regression/verilog/interface/port4A.sv
+++ b/regression/verilog/interface/port4A.sv
@@ -1,0 +1,5 @@
+// The interface used by this module is declared in port4B.sv, which is
+// given later on the command line.
+module sub(my_if.slave bus);
+  p0: assert property (bus.v == 1);
+endmodule

--- a/regression/verilog/interface/port4B.sv
+++ b/regression/verilog/interface/port4B.sv
@@ -1,0 +1,10 @@
+module main;
+  my_if i();
+  sub s(i);
+endmodule
+
+interface my_if;
+  logic v;
+  initial v = 1;
+  modport slave (input v);
+endinterface

--- a/regression/verilog/interface/port5.desc
+++ b/regression/verilog/interface/port5.desc
@@ -1,0 +1,10 @@
+CORE
+port5B.sv
+port5A.sv --bound 5
+^\[main\.s\.p0\] always main\.s\.bus\.v == 1: PROVED up to bound 5$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+An interface port without a modport, where the interface is declared in a file
+that is given later on the command line.

--- a/regression/verilog/interface/port5A.sv
+++ b/regression/verilog/interface/port5A.sv
@@ -1,0 +1,5 @@
+// The interface used by this module is declared in port5B.sv, which is
+// given later on the command line.
+module sub(my_if bus);
+  p0: assert property (bus.v == 1);
+endmodule

--- a/regression/verilog/interface/port5B.sv
+++ b/regression/verilog/interface/port5B.sv
@@ -1,0 +1,9 @@
+module main;
+  my_if i();
+  sub s(i);
+endmodule
+
+interface my_if;
+  logic v;
+  initial v = 1;
+endinterface

--- a/regression/verilog/interface/port6.desc
+++ b/regression/verilog/interface/port6.desc
@@ -1,0 +1,10 @@
+CORE
+port6.sv
+--bound 5
+^\[main\.s\.p0\] always main\.s\.bus\.v == 1: PROVED up to bound 5$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+An interface port with a modport, where the interface is declared after the
+module that uses it.

--- a/regression/verilog/interface/port6.sv
+++ b/regression/verilog/interface/port6.sv
@@ -1,0 +1,15 @@
+// The interface is declared after the module that uses it as a port.
+module sub(my_if.slave bus);
+  p0: assert property (bus.v == 1);
+endmodule
+
+interface my_if;
+  logic v;
+  initial v = 1;
+  modport slave (input v);
+endinterface
+
+module main;
+  my_if i();
+  sub s(i);
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1108,8 +1108,16 @@ list_of_port_declarations: '(' ansi_port_declaration_brace ')' { $$=$2; }
 ansi_port_declaration_brace:
           attribute_instance_brace ansi_port_declaration
                 { init($$); mts($$, $2); }
+          // Interface ports are a separate alternative here, rather than an
+          // alternative of ansi_port_declaration, to keep the grammar LALR(1):
+          // the leading identifier of an interface port has to be shifted
+          // before the (possibly empty) attribute_instance_brace is reduced.
+        | interface_port_declaration
+                { init($$); mts($$, $1); }
         | ansi_port_declaration_brace ',' attribute_instance_brace ansi_port_declaration
                 { $$=$1; mts($$, $4); }
+        | ansi_port_declaration_brace ',' interface_port_declaration
+                { $$=$1; mts($$, $3); }
 
           // append to last one -- required to make
           // the grammar LR1
@@ -1173,7 +1181,19 @@ ansi_port_declaration:
                   addswap($2, ID_type, $3);
                   stack_expr($2).set(ID_value, stack_expr($4));
                   mto($$, $2); /* declarator */ }
-        | TOK_INTERFACE_IDENTIFIER port_identifier
+        ;
+
+// IEEE 1800-2017 A.1.3 interface_port_header, applied to
+// ansi_port_declaration.
+//
+// The interface name is accepted as a plain identifier, and not just as
+// TOK_INTERFACE_IDENTIFIER: an interface may be declared in a file that is
+// parsed after the file that uses it, in which case the scanner has not yet
+// seen the interface and returns TOK_NON_TYPE_IDENTIFIER. Inside a port list,
+// an identifier that is followed by another identifier, with or without an
+// intervening ".modport", can only be an interface port.
+interface_port_declaration:
+          interface_identifier port_identifier
                 {
                   // Interface port: myInterface bus
                   PARSER.scopes.add_identifier(stack_expr($2).get(ID_base_name), verilog_scopet::VAR);
@@ -1183,7 +1203,7 @@ ansi_port_declaration:
                   stack_expr($$).type() = typet(ID_verilog_interface);
                   stack_expr($$).type().set(ID_base_name, interface_base_name);
                   mto($$, $2); /* declarator */ }
-        | TOK_INTERFACE_IDENTIFIER '.' non_type_identifier port_identifier
+        | interface_identifier '.' non_type_identifier port_identifier
                 {
                   // Interface port with modport: myInterface.some_port bus
                   PARSER.scopes.add_identifier(stack_expr($4).get(ID_base_name), verilog_scopet::VAR);


### PR DESCRIPTION
An ANSI port list could only use an interface port if the interface declaration had already been parsed. This made the order of the input files on the command line significant, so valid RTL was accepted or rejected depending purely on the file order.

## Example

```systemverilog
// mod.sv
module m(my_if.slave a, my_if.master b);
  assign b.valid = a.valid;
endmodule
```

```systemverilog
// iface.sv
interface my_if;
  logic valid;
  modport slave  (input valid);
  modport master (output valid);
endinterface
```

```
$ ebmc --systemverilog iface.sv mod.sv --show-modules   # accepted
$ ebmc --systemverilog mod.sv iface.sv --show-modules
file mod.sv line 1: syntax error, unexpected '.', expecting ')' or ',' before '.'
```

The same syntax error occurred for a single file in which the interface is declared after the module that uses it.

## Cause

The two grammar rules for interface ports in `ansi_port_declaration` were keyed on `TOK_INTERFACE_IDENTIFIER`. That token class is decided in the scanner (`make_identifier` in `src/verilog/scanner.l`, via `verilog_scopet::identifier_token`) and is only produced for identifiers that are already in the scope table as an interface. For an interface that has not been seen yet the scanner returns `TOK_NON_TYPE_IDENTIFIER`, and no port-list production matched.

## Fix

Interface ports are now recognised by their shape rather than by the token class: within a port list, an identifier followed by another identifier, optionally with an intervening `.modport`, can only be an interface port (IEEE 1800-2017 A.1.3, `interface_port_header`).

The two rules are moved into a new `interface_port_declaration` nonterminal, which is an alternative of `ansi_port_declaration_brace` rather than of `ansi_port_declaration`. That placement is what keeps the grammar LALR(1): the leading identifier is shifted before the nullable `attribute_instance_brace` has to be reduced. Adding the rules directly to `ansi_port_declaration` instead produces two shift/reduce conflicts. With this structure Bison reports no shift/reduce or reduce/reduce conflicts.

Both the `my_if.modport name` and the plain `my_if name` forms are fixed.

## Tests

New tests under `regression/verilog/interface/`:

- `port4` — modport form, with the interface file listed *after* the module file on the command line
- `port5` — no-modport form, same file ordering
- `port6` — modport form, interface declared after the module within a single file
