### PR TITLE
Verilog: parse packages before the files that import them

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,9 @@
 * Verilog: procedural assignments to hierarchical identifiers
 * SystemVerilog: ports for sequence and property declarations
 * SystemVerilog: $typename for logic types
+* SystemVerilog: packages may now be given in any order on the command
+  line, and importing a package that is not declared now yields a
+  diagnostic that names the package
 * Verilog: +define+ command-line option
 * Verilog: +incdir+ command-line option
 * Verilog: -l and +libfile+ command-line options

--- a/regression/verilog/packages/import10.desc
+++ b/regression/verilog/packages/import10.desc
@@ -1,0 +1,10 @@
+CORE
+import10.sv
+
+^file import10\.sv line 1: unknown package `no_such_package'$
+^EXIT=1$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+An import of a package that is not declared anywhere.

--- a/regression/verilog/packages/import10.sv
+++ b/regression/verilog/packages/import10.sv
@@ -1,0 +1,4 @@
+import no_such_package::*;
+
+module main;
+endmodule

--- a/regression/verilog/packages/import11.desc
+++ b/regression/verilog/packages/import11.desc
@@ -1,0 +1,10 @@
+CORE
+import11.sv
+
+^file import11\.sv line 2: unknown package `no_such_package'$
+^EXIT=1$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+An import of a single identifier from a package that is not declared anywhere.

--- a/regression/verilog/packages/import11.sv
+++ b/regression/verilog/packages/import11.sv
@@ -1,0 +1,3 @@
+module main;
+  import no_such_package::some_name;
+endmodule

--- a/regression/verilog/packages/three_files1.desc
+++ b/regression/verilog/packages/three_files1.desc
@@ -1,0 +1,9 @@
+CORE
+three_filesA1.sv
+three_filesC1.sv three_filesB1.sv --top top
+^\[top\.assert\.1\] \$bits\(top\.some_var\) == 8: PROVED .*$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+A chain of packages, with the files given in reverse dependency order.

--- a/regression/verilog/packages/three_filesA1.sv
+++ b/regression/verilog/packages/three_filesA1.sv
@@ -1,0 +1,5 @@
+package some_pkg;
+
+  typedef logic [7:0] some_type;
+
+endpackage

--- a/regression/verilog/packages/three_filesB1.sv
+++ b/regression/verilog/packages/three_filesB1.sv
@@ -1,0 +1,7 @@
+package other_pkg;
+
+  import some_pkg::*;
+
+  typedef some_type other_type;
+
+endpackage

--- a/regression/verilog/packages/three_filesC1.sv
+++ b/regression/verilog/packages/three_filesC1.sv
@@ -1,0 +1,9 @@
+module top;
+
+  import other_pkg::*;
+
+  other_type some_var;
+
+  initial assert($bits(some_var) == 8);
+
+endmodule

--- a/regression/verilog/packages/two_files2.desc
+++ b/regression/verilog/packages/two_files2.desc
@@ -1,0 +1,9 @@
+CORE
+two_filesA2.sv
+two_filesB2.sv --top top
+^\[top\.assert\.1\] \$bits\(top\.some_var\) == 32: PROVED .*$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+The package is given after the file that imports it.

--- a/regression/verilog/packages/two_files3.desc
+++ b/regression/verilog/packages/two_files3.desc
@@ -1,0 +1,9 @@
+CORE
+two_filesA3.sv
+two_filesB3.sv --top top
+^\[top\.assert\.1\] my_package::my_parameter == 1: PROVED .*$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+The package is given after the file that imports a single identifier from it.

--- a/regression/verilog/packages/two_filesA2.sv
+++ b/regression/verilog/packages/two_filesA2.sv
@@ -1,0 +1,3 @@
+package my_package;
+  typedef int some_type;
+endpackage

--- a/regression/verilog/packages/two_filesA3.sv
+++ b/regression/verilog/packages/two_filesA3.sv
@@ -1,0 +1,3 @@
+package my_package;
+  parameter my_parameter = 1;
+endpackage

--- a/regression/verilog/packages/two_filesB2.sv
+++ b/regression/verilog/packages/two_filesB2.sv
@@ -1,0 +1,6 @@
+import my_package::*;
+
+module top;
+  some_type some_var;
+  initial assert($bits(some_var) == 32);
+endmodule

--- a/regression/verilog/packages/two_filesB3.sv
+++ b/regression/verilog/packages/two_filesB3.sv
@@ -1,0 +1,4 @@
+module top;
+  import my_package::my_parameter;
+  initial assert(my_parameter == 1);
+endmodule

--- a/src/verilog/Makefile
+++ b/src/verilog/Makefile
@@ -19,6 +19,7 @@ SRC = aval_bval_encoding.cpp \
       verilog_language.cpp \
       verilog_lex.yy.cpp \
       verilog_lowering.cpp \
+      verilog_parse_order.cpp \
       verilog_parse_tree.cpp \
       verilog_parser.cpp \
       verilog_preprocessor.cpp \
@@ -68,3 +69,4 @@ verilog_preprocessor_lex.yy.cpp: verilog_preprocessor_tokenizer.l
 verilog_y.tab$(OBJEXT): verilog_y.tab.cpp verilog_y.tab.h
 verilog_lex.yy$(OBJEXT): verilog_y.tab.cpp verilog_lex.yy.cpp verilog_y.tab.h
 verilog_scope$(OBJEXT): verilog_y.tab.h
+verilog_parse_order$(OBJEXT): verilog_y.tab.h

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -1821,19 +1821,36 @@ package_import_item_brace:
         ;
 
 package_import_item:
-          package_identifier "::" identifier
+          import_package_identifier "::" identifier
                 { init($$, ID_verilog_import_item);
                   auto package_base_name = stack_expr($1).get(ID_base_name);
                   auto identifier_base_name = stack_expr($3).get(ID_base_name);
                   stack_expr($$).set(ID_verilog_package, package_base_name);
                   stack_expr($$).set(ID_base_name, identifier_base_name);
                   PARSER.scopes.import(package_base_name, identifier_base_name); }
-        | package_identifier "::" "*"
+        | import_package_identifier "::" "*"
                 { init($$, ID_verilog_import_item);
                   auto package_base_name = stack_expr($1).get(ID_base_name);
                   stack_expr($$).set(ID_verilog_package, package_base_name);
                   stack_expr($$).set(ID_base_name, "*");
                   PARSER.scopes.wildcard_import(package_base_name); }
+        ;
+
+// The operand of an import can only ever be a package name, and hence we
+// also accept an identifier that the scanner did not classify as a package
+// name. That yields a diagnostic that names the offending package, instead
+// of a syntax error about the token class.
+import_package_identifier:
+          package_identifier
+        | non_type_identifier
+                { $$ = $1;
+                  auto base_name = stack_expr($$).get(ID_base_name);
+                  PARSER.error(
+                    stack_expr($$).source_location(),
+                    PARSER.scopes.lookup(base_name) == nullptr
+                      ? "unknown package `" + id2string(base_name) + '\''
+                      : '`' + id2string(base_name) + "' is not a package");
+                  YYERROR; }
         ;
 
 genvar_declaration:

--- a/src/verilog/verilog_ebmc_language.cpp
+++ b/src/verilog/verilog_ebmc_language.cpp
@@ -26,6 +26,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #include "verilog_elaborate_compilation_unit.h"
 #include "verilog_language.h"
 #include "verilog_lowering.h"
+#include "verilog_parse_order.h"
 #include "verilog_parser.h"
 #include "verilog_preprocessor.h"
 #include "verilog_synthesis.h"
@@ -96,23 +97,23 @@ void verilog_ebmc_languaget::preprocess()
   preprocess(file_name, std::cout);
 }
 
+verilog_standardt
+verilog_ebmc_languaget::standard(const std::filesystem::path &path) const
+{
+  if(path.extension() == ".sv" || cmdline.isset("systemverilog"))
+    return verilog_standardt::SV2023;
+  else if(cmdline.isset("vl2smv-extensions"))
+    return verilog_standardt::V2005_SMV;
+  else
+    return verilog_standardt::V2005_SMV;
+}
+
 verilog_parse_treet verilog_ebmc_languaget::parse(
   const std::filesystem::path &path,
+  std::istream &preprocessed,
   verilog_scopest &scopes)
 {
-  verilog_standardt standard;
-
-  if(path.extension() == ".sv" || cmdline.isset("systemverilog"))
-    standard = verilog_standardt::SV2023;
-  else if(cmdline.isset("vl2smv-extensions"))
-    standard = verilog_standardt::V2005_SMV;
-  else
-    standard = verilog_standardt::V2005_SMV;
-
-  std::stringstream preprocessed;
-  preprocess(path, preprocessed);
-
-  verilog_parsert verilog_parser{standard, scopes, message_handler};
+  verilog_parsert verilog_parser{standard(path), scopes, message_handler};
 
   verilog_parser.set_file(path.u8string());
   verilog_parser.in = &preprocessed;
@@ -126,6 +127,16 @@ verilog_parse_treet verilog_ebmc_languaget::parse(
   verilog_parser.parse_tree.build_item_map();
 
   return std::move(verilog_parser.parse_tree);
+}
+
+verilog_parse_treet verilog_ebmc_languaget::parse(
+  const std::filesystem::path &path,
+  verilog_scopest &scopes)
+{
+  std::stringstream preprocessed;
+  preprocess(path, preprocessed);
+
+  return parse(path, preprocessed, scopes);
 }
 
 void verilog_ebmc_languaget::show_parse(const std::filesystem::path &path)
@@ -148,18 +159,61 @@ void verilog_ebmc_languaget::show_parse()
 
 verilog_ebmc_languaget::parse_treest verilog_ebmc_languaget::parse()
 {
-  parse_treest parse_trees;
-  verilog_scopest scopes;
+  // The input files, in the order in which they were given.
+  std::vector<std::filesystem::path> paths;
 
   for(auto &arg : cmdline.args)
-    parse_trees.push_back(parse(arg, scopes));
+    paths.push_back(widen_if_needed(arg));
 
-  // Parse library files specified with -l and +libfile+
+  // Library files specified with -l and +libfile+
   for(auto &lib_file : cmdline.get_values('l'))
-    parse_trees.push_back(parse(lib_file, scopes));
+    paths.push_back(widen_if_needed(lib_file));
 
   for(auto &lib_file : cmdline.get_values("libfile"))
-    parse_trees.push_back(parse(lib_file, scopes));
+    paths.push_back(widen_if_needed(lib_file));
+
+  // Preprocess the input files, in the order in which they were given.
+  // We keep the results, as each of them is read twice below.
+  std::vector<std::stringstream> preprocessed(paths.size());
+
+  for(std::size_t i = 0; i < paths.size(); i++)
+    preprocess(paths[i], preprocessed[i]);
+
+  // IEEE 1800-2017 26.3 requires that a package is compiled before the
+  // scopes that import it, but the order of the input files is not
+  // prescribed. We hence determine the order in which to parse the files
+  // from the packages that they declare and reference.
+  std::vector<verilog_package_usaget> usage;
+  usage.reserve(paths.size());
+
+  for(std::size_t i = 0; i < paths.size(); i++)
+  {
+    usage.push_back(
+      verilog_scan_package_usage(preprocessed[i], standard(paths[i])));
+
+    // rewind, for the parser
+    preprocessed[i].clear();
+    preprocessed[i].seekg(0);
+  }
+
+  // Now parse, in dependency order, using one scope table for all files.
+  std::vector<std::optional<parse_treet>> results(paths.size());
+  verilog_scopest scopes;
+
+  elaboration_order = verilog_parse_order(usage);
+
+  for(auto i : elaboration_order)
+    results[i] = parse(paths[i], preprocessed[i], scopes);
+
+  // The parse trees are returned in the order in which the files were
+  // given, which is what determines the top-level modules.
+  parse_treest parse_trees;
+
+  for(auto &result : results)
+  {
+    CHECK_RETURN(result.has_value());
+    parse_trees.push_back(std::move(*result));
+  }
 
   return parse_trees;
 }
@@ -381,9 +435,21 @@ symbol_tablet verilog_ebmc_languaget::elaborate_compilation_units(
 
   const bool warn_implicit_nets = cmdline.isset("warn-implicit-nets");
 
+  // Random access into the parse tree list, which is a std::list.
+  std::vector<const parse_treet *> vector;
+  vector.reserve(parse_trees.size());
+
   for(auto &parse_tree : parse_trees)
+    vector.push_back(&parse_tree);
+
+  // A package is elaborated before the compilation units that import it,
+  // which is the order in which the files were parsed.
+  for(auto i : elaboration_order)
+  {
+    DATA_INVARIANT(i < vector.size(), "elaboration order must be in range");
     verilog_elaborate_compilation_unit(
-      parse_tree, warn_implicit_nets, symbol_table, message_handler);
+      *vector[i], warn_implicit_nets, symbol_table, message_handler);
+  }
 
   return symbol_table;
 }

--- a/src/verilog/verilog_ebmc_language.cpp
+++ b/src/verilog/verilog_ebmc_language.cpp
@@ -442,6 +442,12 @@ symbol_tablet verilog_ebmc_languaget::elaborate_compilation_units(
   for(auto &parse_tree : parse_trees)
     vector.push_back(&parse_tree);
 
+  // Every parse tree is elaborated exactly once. Any parse tree that is added
+  // after parsing, e.g. a library file, must extend the elaboration order.
+  DATA_INVARIANT(
+    elaboration_order.size() == vector.size(),
+    "elaboration order must cover all parse trees");
+
   // A package is elaborated before the compilation units that import it,
   // which is the order in which the files were parsed.
   for(auto i : elaboration_order)
@@ -566,6 +572,9 @@ void verilog_ebmc_languaget::resolve_library_modules(parse_treest &parse_trees)
 
             verilog_scopest scopes;
             parse_trees.push_back(parse(path, scopes));
+            // The library file is parsed after the given files, and hence is
+            // also elaborated last.
+            elaboration_order.push_back(parse_trees.size() - 1);
             found = true;
             found_any = true;
             break;

--- a/src/verilog/verilog_ebmc_language.h
+++ b/src/verilog/verilog_ebmc_language.h
@@ -15,10 +15,12 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <ebmc/ebmc_language.h>
 
 #include "verilog_parse_tree.h"
+#include "verilog_standard.h"
 
 #include <filesystem>
 #include <iosfwd>
 #include <map>
+#include <vector>
 
 class symbol_tablet;
 class verilog_scopest;
@@ -43,6 +45,9 @@ public:
 protected:
   void preprocess(const std::filesystem::path &, std::ostream &);
   void preprocess();
+  verilog_standardt standard(const std::filesystem::path &) const;
+  verilog_parse_treet
+  parse(const std::filesystem::path &, std::istream &, verilog_scopest &);
   verilog_parse_treet parse(const std::filesystem::path &, verilog_scopest &);
   void show_parse(const std::filesystem::path &);
   void show_parse();
@@ -50,6 +55,11 @@ protected:
   parse_treest parse();
 
   void resolve_library_modules(parse_treest &);
+
+  /// The order in which the compilation units are to be elaborated, given as
+  /// indices into the parse tree list that parse() has returned. A package is
+  /// elaborated before the compilation units that import it.
+  std::vector<std::size_t> elaboration_order;
 
   void copy_parse_tree(const parse_treet &, symbol_tablet &);
 

--- a/src/verilog/verilog_parse_order.cpp
+++ b/src/verilog/verilog_parse_order.cpp
@@ -1,0 +1,207 @@
+/*******************************************************************\
+
+Module: Verilog Parse Order
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+/// \file
+/// Verilog Parse Order
+
+#include "verilog_parse_order.h"
+
+#include <util/message.h>
+
+// This must match the definition that the scanner and the parser use.
+#define YYSTYPE unsigned
+
+#include "verilog_parser.h"
+#include "verilog_y.tab.h"
+
+#include <map>
+#include <queue>
+
+// scanner interface
+int yyveriloglex();
+extern char *yyverilogtext;
+extern int yyverilogleng;
+
+// The semantic value of the token that the scanner has produced. Note that
+// this is an index into the expression stack of the parser that is current
+// while scanning, and hence must not be allowed to outlive that parser.
+extern YYSTYPE yyveriloglval;
+
+/// Is the given token an identifier?
+static bool is_identifier(int token)
+{
+  return token == TOK_NON_TYPE_IDENTIFIER || token == TOK_TYPE_IDENTIFIER ||
+         token == TOK_PACKAGE_IDENTIFIER || token == TOK_CLASS_IDENTIFIER ||
+         token == TOK_INTERFACE_IDENTIFIER;
+}
+
+/// The base name of the identifier token that the scanner has just returned.
+static irep_idt identifier_base_name()
+{
+  std::string text{yyverilogtext, std::size_t(yyverilogleng)};
+
+  // The backslash of an escaped identifier is not part of the name.
+  if(!text.empty() && text[0] == '\\')
+    return text.substr(1);
+
+  return text;
+}
+
+verilog_package_usaget
+verilog_scan_package_usage(std::istream &in, verilog_standardt standard)
+{
+  verilog_package_usaget result;
+
+  // A throw-away scope table -- we do not record any identifiers -- and a
+  // message handler that discards the scanner's diagnostics, which are
+  // given when the file is parsed.
+  verilog_scopest scopes;
+  null_message_handlert message_handler;
+  verilog_parsert verilog_parser{standard, scopes, message_handler};
+
+  verilog_parser.in = &in;
+  verilog_parser.grammar = verilog_parsert::LANGUAGE;
+
+  // yyveriloglval indexes into the expression stack of the parser that is
+  // current while scanning, and hence is meaningless once we are done. We
+  // restore it, as the scanner writes it but the parser reads it, and the
+  // parser that runs next starts out with an empty stack.
+  auto saved_lval = yyveriloglval;
+
+  verilog_scanner_init();
+
+  // The token before the current one, and its base name when it is an
+  // identifier.
+  int previous_token = 0;
+  irep_idt previous_base_name;
+
+  while(true)
+  {
+    auto token = yyveriloglex();
+
+    if(token == 0 || token == TOK_SCANNER_ERROR)
+      break; // end of file, or a scanner error
+
+    if(token == TOK_COLONCOLON && is_identifier(previous_token))
+    {
+      // 'some_name::' -- a reference to a package. This also matches a
+      // reference to a class, which merely adds a spurious dependency
+      // when a package of that name exists.
+      result.references.insert(previous_base_name);
+    }
+    else if(is_identifier(token) && previous_token == TOK_PACKAGE)
+    {
+      // 'package some_name' -- a package declaration.
+      result.declares.insert(identifier_base_name());
+    }
+
+    if(token == TOK_AUTOMATIC || token == TOK_STATIC)
+    {
+      // This is the optional lifetime in 'package automatic some_name;'.
+      // Retain the 'package' keyword as the previous token.
+    }
+    else
+    {
+      previous_token = token;
+      previous_base_name =
+        is_identifier(token) ? identifier_base_name() : irep_idt{};
+    }
+  }
+
+  yyveriloglval = saved_lval;
+
+  return result;
+}
+
+std::vector<std::size_t>
+verilog_parse_order(const std::vector<verilog_package_usaget> &usage)
+{
+  const auto number_of_files = usage.size();
+
+  // Which files declare a given package? Note that a package may,
+  // erroneously, be declared by more than one file.
+  std::map<irep_idt, std::vector<std::size_t>> declared_by;
+
+  for(std::size_t i = 0; i < number_of_files; i++)
+    for(const auto &package : usage[i].declares)
+      declared_by[package].push_back(i);
+
+  // The files that must be parsed after file i, and the number of files
+  // that must be parsed before file i and have not been emitted yet.
+  std::vector<std::vector<std::size_t>> successors(number_of_files);
+  std::vector<std::size_t> pending(number_of_files, 0);
+
+  for(std::size_t i = 0; i < number_of_files; i++)
+    for(const auto &package : usage[i].references)
+    {
+      auto d_it = declared_by.find(package);
+      if(d_it == declared_by.end())
+        continue; // no input file declares this package
+
+      for(auto j : d_it->second)
+      {
+        if(j == i)
+          continue; // a file may reference a package it declares itself
+
+        successors[j].push_back(i);
+        pending[i]++;
+      }
+    }
+
+  // Topological sort, always taking the file that comes first on the
+  // command line among those that are ready. Files without a dependency
+  // hence retain their relative order.
+  std::priority_queue<
+    std::size_t,
+    std::vector<std::size_t>,
+    std::greater<std::size_t>>
+    ready;
+
+  for(std::size_t i = 0; i < number_of_files; i++)
+    if(pending[i] == 0)
+      ready.push(i);
+
+  std::vector<std::size_t> result;
+  result.reserve(number_of_files);
+  std::vector<bool> emitted(number_of_files, false);
+
+  while(result.size() != number_of_files)
+  {
+    std::size_t i;
+
+    if(ready.empty())
+    {
+      // There is a cycle, which is illegal. Break it at the first file
+      // that has not been emitted yet; the parser then reports the
+      // offending reference to a package that is not declared yet.
+      i = 0;
+      while(emitted[i])
+        i++;
+    }
+    else
+    {
+      i = ready.top();
+      ready.pop();
+    }
+
+    emitted[i] = true;
+    result.push_back(i);
+
+    for(auto j : successors[i])
+    {
+      if(emitted[j])
+        continue;
+
+      DATA_INVARIANT(pending[j] != 0, "pending count must be consistent");
+      if(--pending[j] == 0)
+        ready.push(j);
+    }
+  }
+
+  return result;
+}

--- a/src/verilog/verilog_parse_order.h
+++ b/src/verilog/verilog_parse_order.h
@@ -1,0 +1,53 @@
+/*******************************************************************\
+
+Module: Verilog Parse Order
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+/// \file
+/// Verilog Parse Order
+
+#ifndef CPROVER_VERILOG_VERILOG_PARSE_ORDER_H
+#define CPROVER_VERILOG_VERILOG_PARSE_ORDER_H
+
+#include <util/irep.h>
+
+#include "verilog_standard.h"
+
+#include <cstddef>
+#include <iosfwd>
+#include <set>
+#include <vector>
+
+/// The package declarations and the references to packages found in one
+/// (preprocessed) Verilog input file.
+struct verilog_package_usaget
+{
+  /// the packages declared by the file
+  std::set<irep_idt> declares;
+
+  /// the packages referenced by the file, e.g., in an import
+  std::set<irep_idt> references;
+};
+
+/// Scan the given preprocessed Verilog text for package declarations and for
+/// references to packages. This uses the scanner only, i.e., no parse tree is
+/// built and no scopes are created. Any scanner error is ignored; it is
+/// reported when the file is parsed.
+verilog_package_usaget
+verilog_scan_package_usage(std::istream &, verilog_standardt);
+
+/// Given the package usage of the input files, in the order in which they
+/// were given, return the order in which the files are to be parsed, such
+/// that the file declaring a package is parsed before the files that
+/// reference that package. IEEE 1800-2017 26.3 requires that a package is
+/// compiled before it is referenced, but says nothing about the order of the
+/// input files. Files without such a dependency retain their relative order.
+/// Dependency cycles, which are illegal, are broken arbitrarily; the parser
+/// then reports the offending reference.
+std::vector<std::size_t>
+verilog_parse_order(const std::vector<verilog_package_usaget> &);
+
+#endif // CPROVER_VERILOG_VERILOG_PARSE_ORDER_H

--- a/src/verilog/verilog_parser.h
+++ b/src/verilog/verilog_parser.h
@@ -63,6 +63,15 @@ public:
 
   verilog_scopest &scopes;
 
+  // Report an error at the given source location. This is for errors that
+  // are not expressible in the grammar, and hence would otherwise be
+  // reported as a syntax error about a token class.
+  void error(const source_locationt &location, const std::string &message)
+  {
+    log.error().source_location = location;
+    log.error() << message << messaget::eom;
+  }
+
   // These are used for anonymous gate instances
   // and to create a unique identifier for enum types.
   std::size_t next_id_counter = 0;


### PR DESCRIPTION
`import some_pkg::*;` was a syntax error unless the file declaring `some_pkg`
happened to be given earlier on the command line, and the diagnostic named a
token class rather than the package.

IEEE 1800-2017 26.3 requires that the compilation of a package precedes the
compilation of the scopes in which the package is imported, but the standard
does not prescribe an order for the input files, and command files produced by
other tools do not generally list a package ahead of its importers.

Example, which previously failed in one of the two orders:

```systemverilog
// A.sv
package some_pkg;
  typedef logic [3:0] some_type;
endpackage
```

```systemverilog
// B.sv
import some_pkg::*;
module top;
  some_type x;
  initial assert($bits(x) == 4);
endmodule
```

## Ordering

Identifiers are classified by the scanner, which consults the scope table, and
hence the members of an imported package must be in scope while the importing
file is scanned. Accepting the import and resolving it later is therefore not
sufficient: `some_type` above would still not be classified as a type name.

Instead, a scanner-only pre-pass over the preprocessed input records the
packages that each file declares and the packages that it references. A
topological sort then gives the order in which the files are parsed and
elaborated. Files without such a dependency retain their relative order, and
the parse trees are returned in the order in which the files were given, so
the choice of top-level modules is unaffected. Transitive chains, i.e., a
package that itself imports another package, are handled. A dependency cycle,
which is illegal, is broken arbitrarily, and the parser then reports the
offending reference.

## Diagnostic

The operand of an import can only ever be a package name. The grammar now also
accepts an identifier that the scanner did not classify as a package name, and
reports

```
file B.sv line 1: unknown package `no_such_package'
```

or, when the name denotes something other than a package,

```
file B.sv line 3: `m' is not a package
```

There are no new grammar conflicts.

## Tests

New tests in `regression/verilog/packages`: `two_files2`, `two_files3` (a
wildcard import and an explicit import, with the package given after the
importing file), `three_files1` (a chain of two packages, files given in
reverse dependency order), and `import10`, `import11` for the diagnostic on a
package that is not declared.