### PR TITLE
Verilog: add `+libext+` command-line option

### DIFF
--- a/regression/verilog/library-dir/libext1.desc
+++ b/regression/verilog/library-dir/libext1.desc
@@ -1,0 +1,6 @@
+CORE
+library_dir1.sv
+-y library_dir1_lib +libext+.vlib --systemverilog --bound 10
+^\[.*p1\] .* REFUTED$
+^EXIT=10$
+^SIGNAL=0$

--- a/regression/verilog/library-dir/libext2.desc
+++ b/regression/verilog/library-dir/libext2.desc
@@ -1,0 +1,6 @@
+CORE
+library_dir1.sv
++libdir+library_dir1_lib +libext+.vlib+.sv --systemverilog --bound 10
+^\[.*p1\] .* REFUTED$
+^EXIT=10$
+^SIGNAL=0$

--- a/regression/verilog/library-dir/libext3.desc
+++ b/regression/verilog/library-dir/libext3.desc
@@ -1,0 +1,6 @@
+CORE
+library_dir1.sv
+-y library_dir1_lib +libext+.xyz --bound 10
+module `sub' not found
+^EXIT=2$
+^SIGNAL=0$

--- a/regression/verilog/library-dir/library_dir1_lib/sub.vlib
+++ b/regression/verilog/library-dir/library_dir1_lib/sub.vlib
@@ -1,0 +1,5 @@
+module sub(input clk, input [7:0] data);
+
+  p1: assert property (@(posedge clk) data < 5);
+
+endmodule

--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -132,6 +132,7 @@ int ebmc_parse_optionst::doit()
   plus_arg("incdir");
   plus_arg("libfile");
   plus_arg("libdir");
+  plus_arg("libext");
 
   if(config.set(cmdline))
   {
@@ -541,6 +542,7 @@ void ebmc_parse_optionst::help()
     " {y+define+}{uvar}[={uvalue}]   \t set preprocessor define(s)\n"
     " {y-y} {upath}                  \t set library directory\n"
     " {y+libdir+}{upath}[{y+}{upath}...] \t set library directory\n"
+    " {y+libext+}{u.ext}[{y+}{u.ext}...] \t set library file extension(s)\n"
     " {y-l} {ufile}                  \t library file (modules are not top-level)\n"
     " {y+libfile+}{ufile}            \t library file (modules are not top-level)\n"
     " {y--systemverilog}             \t force SystemVerilog instead of Verilog\n"

--- a/src/ebmc/ebmc_parse_options.h
+++ b/src/ebmc/ebmc_parse_options.h
@@ -53,7 +53,7 @@ public:
         "(liveness-to-safety)(buechi)"
         "I:(incdir):D:(define):"
         "l:(libfile):"
-        "y:(libdir):"
+        "y:(libdir):(libext):"
         "(preprocess)(systemverilog)(vl2smv-extensions)"
         "(warn-implicit-nets)",
         argc,

--- a/src/verilog/verilog_ebmc_language.cpp
+++ b/src/verilog/verilog_ebmc_language.cpp
@@ -462,6 +462,21 @@ void verilog_ebmc_languaget::resolve_library_modules(parse_treest &parse_trees)
   for(auto &dir : cmdline.get_values("libdir"))
     library_dirs.push_back(dir);
 
+  // Get file extensions from +libext+, or default to .v and .sv
+  auto &libext_values = cmdline.get_values("libext");
+  std::vector<std::string> extensions;
+
+  if(!libext_values.empty())
+  {
+    for(auto &ext : libext_values)
+      extensions.push_back(ext);
+  }
+  else
+  {
+    extensions.push_back(".v");
+    extensions.push_back(".sv");
+  }
+
   messaget log{message_handler};
 
   // Iteratively resolve library dependencies until no new
@@ -488,8 +503,7 @@ void verilog_ebmc_languaget::resolve_library_modules(parse_treest &parse_trees)
 
       for(auto &dir : library_dirs)
       {
-        // Try <dir>/<module>.v and <dir>/<module>.sv
-        for(auto ext : {".v", ".sv"})
+        for(auto &ext : extensions)
         {
           auto path =
             std::filesystem::path{dir} / (id2string(module_name) + ext);


### PR DESCRIPTION
Add support for the standard Verilog `+libext+` option, which specifies
file extensions to use when searching library directories for unresolved
module definitions.

## Syntax

```
+libext+.ext1+.ext2+...
```

When `+libext+` is given, only the specified extensions are tried when
resolving library modules. Without it, the default `.v` and `.sv`
extensions are used. This works in conjunction with `-y`/`+libdir+`.

## Example

```bash
ebmc top.sv -y ./libs +libext+.v+.sv+.vlib --bound 10
```

## Changes

- `src/ebmc/ebmc_parse_options.h`: Register `(libext):` option
- `src/ebmc/ebmc_parse_options.cpp`: Add `plus_arg("libext")` processing and help text
- `src/verilog/verilog_ebmc_language.cpp`: Use libext extensions in `resolve_library_modules()`
- 3 new regression tests in `regression/verilog/library-dir/`

## Testing

- All verilog regression tests pass
- All ebmc regression tests pass
- New tests cover: custom extension with `-y`, multiple extensions with `+libdir+`, and wrong extension (error case)