### PR TITLE
KNOWNBUG test for a null element in a named port connection list

### DIFF
--- a/regression/verilog/modules/named_port_connection2.desc
+++ b/regression/verilog/modules/named_port_connection2.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+named_port_connection2.sv
+
+^\[main\.assert\.1\] main\.m1\.a == 1: PROVED .*$
+^\[main\.assert\.2\] main\.m1\.c == 1: PROVED .*$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+A null element in a named port connection list is rejected by the parser:
+syntax error, unexpected ','.

--- a/regression/verilog/modules/named_port_connection2.sv
+++ b/regression/verilog/modules/named_port_connection2.sv
@@ -1,0 +1,17 @@
+module my_module(input a, b, c);
+
+endmodule
+
+module main();
+
+  // A null element in a port connection list denotes an unconnected port.
+  // Per 1800-2017 A.4.1.1, list_of_port_connections permits null elements
+  // in ordered_port_connection only; named_port_connection has no such
+  // alternative.  The construct below nevertheless occurs in practice, with
+  // the null element carrying no information beyond leaving b unconnected.
+  my_module m1(.a(1), , .c(1));
+
+  initial assert (m1.a == 1);
+  initial assert (m1.c == 1);
+
+endmodule


### PR DESCRIPTION
The parser rejects a null element in a *named* port connection list:

```systemverilog
module my_module(input a, b, c);
endmodule

module main();
  my_module m1(.a(1), , .c(1));
endmodule
```

```
syntax error, unexpected ',', expecting .* or '.' before ','
```

A null element in an *ordered* port connection list is accepted already
(see `modules/unconnected_ports1.sv`).

Note that per 1800-2017 A.4.1.1, `list_of_port_connections` permits a null
element in `ordered_port_connection` only, and `named_port_connection` has no
such alternative -- so strictly speaking the current behaviour is
conformant. The construct nevertheless occurs in practice, where the null
element merely leaves the corresponding port unconnected. Marked KNOWNBUG on
that basis; happy to turn it into a syntax-error test in
`regression/verilog/syntax-errors/` instead if we would rather stay strict.