### PR TITLE
KNOWNBUG test for loop-local `genvar` scoping

### DIFF
--- a/regression/verilog/generate/genvar_scope1.desc
+++ b/regression/verilog/generate/genvar_scope1.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+genvar_scope1.sv
+
+^no properties$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+A genvar declared in a loop generate construct header is not local to that
+loop, and hence the second loop yields "definition of symbol `gi' conflicts
+with earlier definition".

--- a/regression/verilog/generate/genvar_scope1.sv
+++ b/regression/verilog/generate/genvar_scope1.sv
@@ -1,0 +1,17 @@
+module main;
+
+  // Per 1800-2017 27.4, a genvar declared in the loop_generate_construct
+  // header is local to that loop.  Two loops in the same scope may hence
+  // both use the name gi.
+
+  for (genvar gi = 0; gi < 2; gi++)
+  begin : b1
+    wire [7:0] w = gi;
+  end
+
+  for (genvar gi = 0; gi < 2; gi++)
+  begin : b2
+    wire [7:0] w = gi + 10;
+  end
+
+endmodule


### PR DESCRIPTION
Per 1800-2017 27.4, a genvar declared in the header of a loop generate
construct is local to that loop. Two such loops in the same scope may
therefore both declare a genvar of the same name:

```systemverilog
module main;
  for (genvar gi = 0; gi < 2; gi++)
  begin : b1
    wire [7:0] w = gi;
  end

  for (genvar gi = 0; gi < 2; gi++)
  begin : b2
    wire [7:0] w = gi + 10;
  end
endmodule
```

Currently the second loop yields

```
definition of symbol `gi' conflicts with earlier definition at line 3
```

The genvar is evidently placed in the enclosing scope rather than in a scope
local to the loop.