### PR TITLE
KNOWNBUG tests for the constant-expression interpreter

### DIFF
--- a/regression/verilog/expressions/conditional_operator_short_circuit1.desc
+++ b/regression/verilog/expressions/conditional_operator_short_circuit1.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+conditional_operator_short_circuit1.sv
+
+^\[main\.assert\.1\] \$bits\(main\.x\) == 3: PROVED .*$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+The constant-expression interpreter evaluates both operands of the
+conditional operator, and hence gives "expected constant expression, but got
+`(0 ? 1 / 0 : 3) - 1'".

--- a/regression/verilog/expressions/conditional_operator_short_circuit1.sv
+++ b/regression/verilog/expressions/conditional_operator_short_circuit1.sv
@@ -1,0 +1,12 @@
+module main;
+
+  // Per 1800-2017 11.4.11, the conditional operator evaluates the first
+  // expression when the condition is true, and the second expression when
+  // it is false.  Only when the condition is ambiguous are both operands
+  // evaluated.  The condition here is 0, hence 1/0 is not evaluated and the
+  // range is [2:0].
+  wire [(0 ? 1/0 : 3)-1:0] x;
+
+  initial assert ($bits(x) == 3);
+
+endmodule

--- a/regression/verilog/expressions/conditional_operator_short_circuit2.desc
+++ b/regression/verilog/expressions/conditional_operator_short_circuit2.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+conditional_operator_short_circuit2.sv
+
+^\[main\.assert\.1\] \$bits\(main\.x\) == 3: PROVED .*$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+The constant-expression interpreter evaluates both operands of the
+conditional operator, and hence gives "expected constant expression, but got
+`(1 ? 3 : 1 / 0) - 1'".

--- a/regression/verilog/expressions/conditional_operator_short_circuit2.sv
+++ b/regression/verilog/expressions/conditional_operator_short_circuit2.sv
@@ -1,0 +1,10 @@
+module main;
+
+  // As conditional_operator_short_circuit1.sv, but with the unevaluated
+  // operand in the 'false' branch.  Per 1800-2017 11.4.11, 1/0 is not
+  // evaluated, and hence the range is [2:0].
+  wire [(1 ? 3 : 1/0)-1:0] x;
+
+  initial assert ($bits(x) == 3);
+
+endmodule

--- a/regression/verilog/expressions/replication4.desc
+++ b/regression/verilog/expressions/replication4.desc
@@ -1,0 +1,12 @@
+KNOWNBUG
+replication4.sv
+
+^\[main\.assert\.1\] main\.p == 4'b1001: PROVED .*$
+^\[main\.assert\.2\] main\.x == 4'b1001: PROVED .*$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+The zero-width replication is fine in the net declaration, but the
+constant-expression interpreter does not evaluate it, and hence gives
+"expected constant expression" for the localparam.

--- a/regression/verilog/expressions/replication4.sv
+++ b/regression/verilog/expressions/replication4.sv
@@ -1,0 +1,16 @@
+module main;
+
+  // Per 1800-2017 11.4.12.1, a replication with a zero replication constant
+  // is legal inside a concatenation that has at least one operand of nonzero
+  // size.  Its size is zero, and it contributes nothing to the result.
+
+  // In a constant expression.
+  localparam [3:0] p = {2'b10, {0{1'b1}}, 2'b01};
+
+  // The very same expression in a non-constant context.
+  wire [3:0] x = {2'b10, {0{1'b1}}, 2'b01};
+
+  initial assert (p == 4'b1001);
+  initial assert (x == 4'b1001);
+
+endmodule


### PR DESCRIPTION
Two related gaps in the constant-expression interpreter.

### The conditional operator is not short-circuited

Per 1800-2017 11.4.11, the conditional operator evaluates the first
expression when the condition is true and the second expression when it is
false; both operands are evaluated and merged only when the condition is
ambiguous. The constant-expression interpreter evaluates both operands
unconditionally:

```systemverilog
wire [(0 ? 1/0 : 3)-1:0] x;   // conditional_operator_short_circuit1.sv
wire [(1 ? 3 : 1/0)-1:0] x;   // conditional_operator_short_circuit2.sv
```

```
expected constant expression, but got `(0 ? 1 / 0 : 3) - 1'
```

This is the usual idiom for guarding a width computation against a degenerate
parameter value. Note that a fix could equally come from propagating `x` out
of a division by zero (1800-2017 11.4.4) rather than from short-circuiting.

### Zero-width replication is not a constant expression

Per 1800-2017 11.4.12.1, a replication with a zero replication constant is
legal inside a concatenation that has at least one operand of nonzero size;
its size is zero and it contributes nothing:

```systemverilog
localparam [3:0] p = {2'b10, {0{1'b1}}, 2'b01};  // rejected
wire      [3:0] x = {2'b10, {0{1'b1}}, 2'b01};  // accepted
```

The net declaration works, but the `localparam` gives "expected constant
expression". `replication4.sv` contains both, to make the contrast explicit.