### PR TITLE
KNOWNBUG test for `$realtime`

### DIFF
--- a/regression/verilog/system-functions/realtime1.desc
+++ b/regression/verilog/system-functions/realtime1.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+realtime1.sv
+
+^no properties$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+$realtime is not implemented, and yields "unknown system function
+`$realtime'".  The same applies to $time and $stime.

--- a/regression/verilog/system-functions/realtime1.sv
+++ b/regression/verilog/system-functions/realtime1.sv
@@ -1,0 +1,9 @@
+module main;
+
+  real t;
+
+  // 1800-2017 20.3.1: $realtime returns the current simulation time,
+  // scaled to the time unit of the module that invokes it, as a real.
+  initial t = $realtime;
+
+endmodule


### PR DESCRIPTION
The simulation time system functions of 1800-2017 20.3 are not implemented:

```systemverilog
module main;
  real t;
  initial t = $realtime;
endmodule
```

```
unknown system function `$realtime'
```

The same applies to `$time` and `$stime`. The test covers `$realtime` only.