### PR TITLE
CI: fix the summary counters in the HWMCC08 report

### DIFF
--- a/benchmarking/hwmcc08-report.sh
+++ b/benchmarking/hwmcc08-report.sh
@@ -37,7 +37,10 @@ skip=0
 ROWS=`mktemp`
 trap 'rm -f "$ROWS" ebmc.out' EXIT
 
-(# Ignore the three-line CSV header.
+# Note the use of a brace group, not a subshell: the counters below must
+# survive the loop.
+{
+# Ignore the three-line CSV header.
 read -r line
 read -r line
 read -r line
@@ -71,7 +74,7 @@ while read -r line; do
     if [ "$status" = 10 ] ; then
       echo $BENCHMARK: got unexpected counterexample
       css=fail
-      label=unexpected counterexample
+      label="unexpected counterexample"
       observed="counterexample at bound $bound"
     else
       echo $BENCHMARK: ok "(UNSAT smoke test)"
@@ -87,7 +90,7 @@ while read -r line; do
     if [ "$LENGTH" = "*" ] ; then
       echo $BENCHMARK: no counterexample length
       css=skip
-      label=no reference bound
+      label="no reference bound"
       observed="expected SAT, but no published counterexample length"
     else
       bound=$LENGTH
@@ -104,14 +107,14 @@ while read -r line; do
       else
         echo $BENCHMARK: failed to find counterexample at bound $LENGTH
         css=fail
-        label=missed counterexample
+        label="missed counterexample"
         observed="no counterexample at bound $LENGTH (exit $status)"
       fi
     fi
   else
     echo $BENCHMARK: unknown expected result \"$RESULT\"
     css=skip
-    label=unknown expectation
+    label="unknown expectation"
     observed="unsupported expected result \"$RESULT\""
   fi
 
@@ -125,7 +128,8 @@ while read -r line; do
 
   printf '<tr class="%s"><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td class="result" data-log="log-%s">%s</td></tr>\n<tr class="log-row" id="log-%s"><td colspan="5"><pre>%s</pre></td></tr>\n' \
     "$css" "$BENCHMARK" "$expected" "$bound" "$observed" "$total" "$label" "$total" "${log_html:-no log captured}" >> "$ROWS"
-done ) < hwmcc08results.csv
+done
+} < hwmcc08results.csv
 
 echo
 echo "HWMCC08 summary: $pass/$total checks passed ($fail failed, $skip skipped)"


### PR DESCRIPTION
Fixup for #2073

The four summary cards on https://diffblue.github.io/hw-cbmc/hwmcc/ all read
zero, and the CI summary line reported `0/0 checks passed`, despite a fully
populated result table.

The benchmark loop in `benchmarking/hwmcc08-report.sh` ran inside a subshell
(`( ... ) < hwmcc08results.csv`), so the increments of `total`, `pass`, `fail`
and `skip` were discarded when the subshell exited. The table rows were
unaffected because they are collected in a temporary file. Replaced with a
brace group, which does not fork.

While testing this, a second problem showed up: the multi-word assignments to
`label` were unquoted, so `label=no reference bound` assigned just `no` and
then tried to run `reference bound`. That truncated the Result column on the
published page (`no`, `unknown`, `missed`, `unexpected`) and added
`command not found` noise to the CI log. Now quoted.

Verified with a synthetic harness (a fake `ebmc` on `PATH` and a six-row CSV
covering the uns, sat, no-published-bound, unknown-expectation,
missed-counterexample and missing-file cases): the report now reads
`6 benchmarks, 2 passed, 2 failed, 2 skipped`, all six result labels are
intact, and the HTML escaping of the captured logs still works.