### PR TITLE
Verilog: null element in a named port connection list

### DIFF
--- a/regression/verilog/modules/named_port_connection2.desc
+++ b/regression/verilog/modules/named_port_connection2.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 named_port_connection2.sv
 
 ^\[main\.assert\.1\] main\.m1\.a == 1: PROVED .*$
@@ -7,5 +7,3 @@ named_port_connection2.sv
 ^SIGNAL=0$
 --
 --
-A null element in a named port connection list is rejected by the parser:
-syntax error, unexpected ','.

--- a/regression/verilog/modules/named_port_connection3.desc
+++ b/regression/verilog/modules/named_port_connection3.desc
@@ -1,0 +1,10 @@
+CORE
+named_port_connection3.sv
+
+^\[main\.assert\.1\] main\.m1\.a == 1 && main\.m1\.c == 1: PROVED .*$
+^\[main\.assert\.2\] main\.m2\.a == 1 && main\.m2\.c == 1: PROVED .*$
+^\[main\.assert\.3\] main\.m3\.a == 1: PROVED .*$
+^EXIT=0$
+^SIGNAL=0$
+--
+--

--- a/regression/verilog/modules/named_port_connection3.sv
+++ b/regression/verilog/modules/named_port_connection3.sv
@@ -1,0 +1,25 @@
+module my_module(input a, b, c);
+
+endmodule
+
+module main();
+
+  // Null elements in a list of named port connections leave the
+  // corresponding ports unconnected.  Per 1800-2017 A.4.1.1, null elements
+  // are permitted in ordered_port_connection only; the constructs below are
+  // an extension.
+
+  // a trailing null element
+  my_module m1(.a(1), .c(1), );
+
+  // several consecutive null elements
+  my_module m2(.a(1), , , .c(1));
+
+  // nothing but null elements after the first connection
+  my_module m3(.a(1), , );
+
+  initial assert (m1.a == 1 && m1.c == 1);
+  initial assert (m2.a == 1 && m2.c == 1);
+  initial assert (m3.a == 1);
+
+endmodule

--- a/regression/verilog/modules/named_port_connection4.desc
+++ b/regression/verilog/modules/named_port_connection4.desc
@@ -1,0 +1,10 @@
+CORE
+named_port_connection4.sv
+
+^file .* line 12: syntax error, unexpected '\.', expecting '\)' before '\.'$
+^EXIT=1$
+^SIGNAL=0$
+--
+--
+A null element as the first element of a list of named port connections
+remains a syntax error.

--- a/regression/verilog/modules/named_port_connection4.sv
+++ b/regression/verilog/modules/named_port_connection4.sv
@@ -1,0 +1,14 @@
+module my_module(input a, b, c);
+
+endmodule
+
+module main();
+
+  // A leading null element gives no clue whether an ordered or a named list
+  // of port connections follows, and hence remains rejected.  Note that
+  // 1800-2017 A.4.1.1 permits null elements in ordered_port_connection only,
+  // and that the ordered list below has fewer elements than my_module has
+  // ports.
+  my_module m1(, .b(1), .c(1));
+
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3879,6 +3879,15 @@ named_port_connection_brace:
                 { init($$); mto($$, $1); }
         | named_port_connection_brace ',' named_port_connection
                 { $$=$1;    mto($$, $3); }
+        // The next rule is not in 1800-2017: A.4.1.1 permits a null element
+        // in ordered_port_connection only.  A null element in a list of
+        // named port connections nevertheless occurs in practice, e.g., as
+        // the result of macro expansion.  Unlike in an ordered list, where
+        // the position of a null element identifies the port that is left
+        // unconnected, a null element in a named list carries no
+        // information at all, and hence is discarded here.
+        | named_port_connection_brace ','
+                { $$=$1; }
         ;
 
 named_port_connection:


### PR DESCRIPTION
Fixes the KNOWNBUG added in #2084.

## Root cause

`named_port_connection_brace` in `src/verilog/parser.y` had no alternative
for a null (empty) element, so

```systemverilog
module my_module(input a, b, c);
endmodule

module main();
  my_module m1(.a(1), , .c(1));
endmodule
```

was rejected with `syntax error, unexpected ',', expecting .* or '.' before ','`.
The equivalent construct in an *ordered* list was already accepted, because
`ordered_port_connection` derives `expression_opt`, which can be empty (see
`regression/verilog/modules/unconnected_ports1.sv`).

## The grammar change

One rule is added:

```
named_port_connection_brace:
          named_port_connection
        | named_port_connection_brace ',' named_port_connection
        // The next rule is not in 1800-2017: A.4.1.1 permits a null element
        // in ordered_port_connection only. ...
        | named_port_connection_brace ','
                { $$=$1; }
        ;
```

The null element is *discarded* rather than represented in the AST. That is
sound because, unlike in an ordered list — where the position of an element
identifies the port — the position of an element in a named list carries no
information; a null element therefore means nothing beyond leaving the
corresponding port unconnected, which is exactly what omitting it means.
Consequently no change to the type checker, elaboration or synthesis was
needed, and the existing "we don't require that all ports are connected"
behaviour for named lists applies unchanged.

This is the same treatment other tolerated non-LRM constructs get in this
grammar (compare the vendor extension for `system_tf_call` as a module item,
and the `any_identifier` extension in A.9.3): silent acceptance with an
explanatory comment. There is no `--strict`-style option or parser-level
warning facility in the front end to hook into.

## Conformance trade-off

Per 1800-2017 A.4.1.1, `list_of_port_connections` is

```
{ attribute_instance } [ ordered_port_connection ] { , { attribute_instance } [ ordered_port_connection ] }
| { attribute_instance } named_port_connection { , { attribute_instance } named_port_connection }
```

so the null element is permitted for `ordered_port_connection` only, and
rejecting it in a named list — the behaviour before this PR — was strictly
conformant. This PR deliberately extends beyond the LRM grammar to accept
the construct, on the grounds that it occurs in practice (typically from
macro expansion or generated code) and that the intent is unambiguous. Other
simulators accept it too.

## Grammar conflicts

Bison reports **0 shift/reduce and 0 reduce/reduce conflicts both before and
after** the change (`parser.y` has no `%expect`, and none was added). The new
rule is LALR(1)-clean because `named_port_connection` can only begin with
`.` or `.*`, whereas the null element is only reduced on a `,` or `)`
lookahead.

## Known limitation

A null element as the *first* element of the list remains a syntax error:

```systemverilog
my_module m1(, .b(1), .c(1));  // still rejected
```

A leading null gives the LALR(1) parser no clue whether an ordered or a
named list follows, since the choice between the two alternatives of
`list_of_module_connections` has to be made at the first element. This is
covered by a new test (`named_port_connection4`) so the boundary is
documented rather than accidental.

## Tests

- `regression/verilog/modules/named_port_connection2.desc`: `KNOWNBUG` -> `CORE`
  (expected output was already correct; the stale bug note was removed).
- `regression/verilog/modules/named_port_connection3.{sv,desc}` (new):
  trailing null element, several consecutive null elements, and nothing but
  null elements after the first connection.
- `regression/verilog/modules/named_port_connection4.{sv,desc}` (new):
  leading null element remains a syntax error.

Detection of a port assigned twice still works across a null element
(`.a(1), , .a(1)` -> `port name a assigned twice`).

All suites pass locally:

```
make -C regression/verilog test     -> All tests were successful, 222 tests skipped (947 run)
make -C regression/verilog test-z3  -> All tests were successful, 229 tests skipped (947 run)
make -C regression/ebmc test        -> All tests were successful, 9 tests skipped (273 run)
make -C regression/smv test         -> All tests were successful, 32 tests skipped
make -C regression/vlindex test     -> All tests were successful
make -C unit                        -> All tests passed (190 assertions in 45 test cases)
```