### PR TITLE
KNOWNBUG test for a multi-operand streaming concatenation

### DIFF
--- a/regression/verilog/expressions/streaming_concatenation3.desc
+++ b/regression/verilog/expressions/streaming_concatenation3.desc
@@ -1,0 +1,16 @@
+KNOWNBUG
+streaming_concatenation3.sv
+
+^\[main\.p1\] main\.s1 == 171: PROVED .*$
+^\[main\.p2\] main\.s2 == 186: PROVED .*$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+A streaming concatenation with more than one stream_expression is not
+implemented.  The streaming operator is type checked as a unary expression
+whose operand is required to be a concatenation with exactly one operand,
+and hence any such streaming concatenation trips the precondition
+`expr.op().operands().size() == 1' in convert_unary_expr.  This is an
+invariant violation rather than a diagnostic, i.e., ebmc aborts.

--- a/regression/verilog/expressions/streaming_concatenation3.sv
+++ b/regression/verilog/expressions/streaming_concatenation3.sv
@@ -1,0 +1,16 @@
+module main;
+
+  // Per 1800-2017 11.4.14, the stream_concatenation of a streaming
+  // concatenation is a braced list of stream_expression, i.e., it may
+  // contain more than one expression.
+
+  // right-to-left, which preserves the order of the operands
+  wire [7:0] s1 = {>>{4'ha, 4'hb}};
+
+  // left-to-right with a slice size of 4, which swaps the two nibbles
+  wire [7:0] s2 = {<<4{4'ha, 4'hb}};
+
+  initial p1: assert (s1 == 8'hab);
+  initial p2: assert (s2 == 8'hba);
+
+endmodule


### PR DESCRIPTION
Per 1800-2017 11.4.14, the `stream_concatenation` of a streaming concatenation
is a braced list of `stream_expression`, and hence may hold more than one
expression:

```systemverilog
wire [7:0] s1 = {>>{4'ha, 4'hb}};
wire [7:0] s2 = {<<4{4'ha, 4'hb}};
```

Any such streaming concatenation aborts `ebmc`:

```
Invariant check failed
File: verilog_typecheck_expr.cpp:3202 function: convert_unary_expr
Condition: expr.op().operands().size() == 1
Reason: Precondition
```

The streaming operator is type checked as a unary expression whose operand is
required to be a concatenation with exactly one operand. This is an invariant
violation rather than a diagnostic, i.e., the tool aborts with `EXIT=134`
instead of reporting an error.

A streaming concatenation with a single operand works, which is why the
existing `streaming_concatenation1` test passes. The number of operands is
what matters, not their nature -- `{>>{a, b}}` fails just as
`{>>{a, {0{1'b1}}}}` does, so this is unrelated to zero-width replication.

The test asserts the values required by 11.4.14: `{>>{...}}` preserves the
order of the operands, and `{<<4{4'ha, 4'hb}}` reverses the two nibbles of
`8'hab` to give `8'hba`.