### PR TITLE
KNOWNBUG test for a cycle delay given by a constant expression

### DIFF
--- a/regression/verilog/SVA/cycle_delay5.desc
+++ b/regression/verilog/SVA/cycle_delay5.desc
@@ -1,0 +1,19 @@
+KNOWNBUG
+cycle_delay5.sv
+--bound 10
+^\[main\.p0\] always \(main\.x == 0 \|-> \(##main\.CYCLES main\.x == main\.CYCLES\)\): PROVED up to bound 10$
+^\[main\.p1\] always \(main\.x == 0 \|-> \(##main\.CYCLES main\.x == main\.CYCLES\)\): PROVED up to bound 10$
+^\[main\.p2\] always \(main\.x == 0 \|-> \(##main\.DELAY main\.x == main\.DELAY\)\): PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The delay of the SVA cycle delay operator ## is parsed as a literal number
+only, whereas 1800-2017 A.2.10 gives cycle_delay_range as
+"## constant_primary".  A parameter or localparam identifier hence yields
+"syntax error, unexpected TOK_NON_TYPE_IDENTIFIER, expecting [* or [+ or
+TOK_NUMBER or '['", and a parenthesized constant expression ##(CYCLES) fails
+in the same way.  See cycle_delay_range in src/verilog/parser.y.  The range
+form ##[CYCLES:CYCLES] does accept a constant expression and can be used as
+a workaround.

--- a/regression/verilog/SVA/cycle_delay5.sv
+++ b/regression/verilog/SVA/cycle_delay5.sv
@@ -1,0 +1,20 @@
+module main(input clk);
+
+  parameter CYCLES = 2;
+  localparam DELAY = CYCLES + 1;
+
+  reg [3:0] x = 0;
+
+  always_ff @(posedge clk)
+    x++;
+
+  // Per 1800-2017 A.2.10, cycle_delay_range is
+  //   ## constant_primary | ## [ cycle_delay_const_range_expression ] | ...
+  // and a constant_primary (A.8.4) covers a parameter identifier as well as
+  // a parenthesized constant expression.  The delay in ##n therefore need
+  // not be a literal number.
+  p0: assert property (@(posedge clk) x == 0 |-> ##CYCLES x == CYCLES);
+  p1: assert property (@(posedge clk) x == 0 |-> ##(CYCLES) x == CYCLES);
+  p2: assert property (@(posedge clk) x == 0 |-> ##DELAY x == DELAY);
+
+endmodule


### PR DESCRIPTION
The delay of the SVA cycle delay operator `##` is parsed as a literal number
only, and hence a `parameter`/`localparam` identifier or a parenthesized
constant expression is rejected.

Reproducer:

```systemverilog
module main(input clk);

  parameter CYCLES = 2;
  localparam DELAY = CYCLES + 1;

  reg [3:0] x = 0;

  always_ff @(posedge clk)
    x++;

  p0: assert property (@(posedge clk) x == 0 |-> ##CYCLES x == CYCLES);
  p1: assert property (@(posedge clk) x == 0 |-> ##(CYCLES) x == CYCLES);
  p2: assert property (@(posedge clk) x == 0 |-> ##DELAY x == DELAY);

endmodule
```

Verbatim output (`ebmc cycle_delay5.sv --bound 10`, `EXIT=1`):

```
file cycle_delay5.sv line 16: syntax error, unexpected TOK_NON_TYPE_IDENTIFIER, expecting [* or [+ or TOK_NUMBER or '[' before 'CYCLES'
```

`##(CYCLES)` fails in the same way:

```
file t_paren.sv line 3: syntax error, unexpected '(', expecting [* or [+ or TOK_NUMBER or '[' before '('
```

A `localparam` behaves exactly like a `parameter`.

Per 1800-2017 A.2.10 (assertion declarations),

```
cycle_delay_range ::=
    ## constant_primary
  | ## [ cycle_delay_const_range_expression ]
  | ## [*]
  | ## [+]
```

and `constant_primary` (A.8.4, primaries) covers a parameter identifier as
well as `( constant_mintypmax_expression )`.  The delay therefore need not be
a literal number.

The offending grammar rule is `cycle_delay_range` in
`src/verilog/parser.y`, which spells the first alternative as `"##" number`
instead of `"##" constant_primary`.

Workaround: the range form does accept constant expressions, so
`##[CYCLES:CYCLES]` can be used in place of `##CYCLES`.

The expected output in the `.desc` file describes the desired behaviour.  It
was derived from the workaround analogue `##[CYCLES:CYCLES]`, which prints
`[main.p1] always (main.x == 0 |-> (##[main.CYCLES:main.CYCLES] main.x == main.CYCLES)): PROVED up to bound 10`,
i.e. the parameter is rendered by name rather than folded.