### PR TITLE
KNOWNBUG tests for missing end labels

### DIFF
--- a/regression/verilog/checker/end_label1.desc
+++ b/regression/verilog/checker/end_label1.desc
@@ -1,0 +1,13 @@
+KNOWNBUG
+end_label1.sv
+--show-parse
+^Checker: c$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Per 1800-2017 A.7.1, checker_declaration ends with
+"endchecker [ : checker_identifier ]".  The end label is rejected with
+"syntax error, unexpected :, expecting class", as checker_declaration has no
+equivalent of the endmodule_identifier_opt rule used for endmodule.

--- a/regression/verilog/checker/end_label1.sv
+++ b/regression/verilog/checker/end_label1.sv
@@ -1,0 +1,6 @@
+// End label after endchecker, IEEE 1800-2017 A.7.1.
+checker c;
+endchecker : c
+
+module main;
+endmodule

--- a/regression/verilog/generate/end_label1.desc
+++ b/regression/verilog/generate/end_label1.desc
@@ -1,0 +1,14 @@
+KNOWNBUG
+end_label1.sv
+--bound 0
+^\[main\.g1\.p0\] main\.g1\.w == 42: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Per 1800-2017 27.6, the name of a named generate block may be repeated after
+the "end" keyword, and per A.4.2 generate_block ends with
+"end [ : generate_block_identifier ]".  The end label is rejected with
+"syntax error, unexpected :, expecting class", as the generate_block rule
+stops at the "end" keyword.

--- a/regression/verilog/generate/end_label1.sv
+++ b/regression/verilog/generate/end_label1.sv
@@ -1,0 +1,11 @@
+module main;
+
+  // End label after the "end" of a named generate block,
+  // IEEE 1800-2017 27.6.
+  if (1)
+  begin : g1
+    wire [7:0] w = 8'd42;
+    initial p0: assert (w == 42);
+  end : g1
+
+endmodule

--- a/regression/verilog/interface/end_label1.desc
+++ b/regression/verilog/interface/end_label1.desc
@@ -1,0 +1,13 @@
+KNOWNBUG
+end_label1.sv
+--bound 0
+^\[main\.p0\] main\.i\.W == 8: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Per 1800-2017 A.1.3, interface_declaration ends with
+"endinterface [ : interface_identifier ]".  The end label is rejected with
+"syntax error, unexpected :, expecting class", as interface_declaration has
+no equivalent of the endmodule_identifier_opt rule used for endmodule.

--- a/regression/verilog/interface/end_label1.sv
+++ b/regression/verilog/interface/end_label1.sv
@@ -1,0 +1,13 @@
+// End label after endinterface, IEEE 1800-2017 A.1.3.
+interface ifc;
+  parameter int W = 8;
+  logic [W-1:0] data;
+endinterface : ifc
+
+module main;
+
+  ifc i();
+
+  initial p0: assert (i.W == 8);
+
+endmodule

--- a/regression/verilog/named_block/end_label1.desc
+++ b/regression/verilog/named_block/end_label1.desc
@@ -1,0 +1,13 @@
+KNOWNBUG
+end_label1.sv
+--bound 0
+^\[main\.blk\.p0\] main\.blk\.x == 3: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Per 1800-2017 9.3.4, a block name may be repeated after the "end" of a named
+block, and per A.6.3 seq_block ends with "end [ : block_identifier ]".  The
+end label is rejected with "syntax error, unexpected :, expecting class", as
+the seq_block rule stops at the "end" keyword.

--- a/regression/verilog/named_block/end_label1.sv
+++ b/regression/verilog/named_block/end_label1.sv
@@ -1,0 +1,10 @@
+module main;
+
+  // End label after the "end" of a named block, IEEE 1800-2017 9.3.4.
+  initial begin : blk
+    int x;
+    x = 3;
+    p0: assert (x == 3);
+  end : blk
+
+endmodule


### PR DESCRIPTION
End labels are accepted after `endmodule`, `endpackage`, `endprogram`,
`endclass`, `endfunction`, `endtask`, `endproperty` and `endsequence`, but
are rejected after `endinterface`, after the `end` of a named begin/end
block, after the `end` of a named generate block, and after `endchecker`.

All four fail with the same message, `syntax error, unexpected :, expecting
class before ':'`.

## Reproducers and verbatim errors

`regression/verilog/interface/end_label1.sv`:
```systemverilog
interface ifc;
  parameter int W = 8;
  logic [W-1:0] data;
endinterface : ifc

module main;
  ifc i();
  initial p0: assert (i.W == 8);
endmodule
```
```
file end_label1.sv line 5: syntax error, unexpected :, expecting class before ':'
```

`regression/verilog/named_block/end_label1.sv`:
```systemverilog
module main;
  initial begin : blk
    int x;
    x = 3;
    p0: assert (x == 3);
  end : blk
endmodule
```
```
file end_label1.sv line 8: syntax error, unexpected :, expecting class before ':'
```

`regression/verilog/generate/end_label1.sv`:
```systemverilog
module main;
  if (1)
  begin : g1
    wire [7:0] w = 8'd42;
    initial p0: assert (w == 42);
  end : g1
endmodule
```
```
file end_label1.sv line 9: syntax error, unexpected :, expecting class before ':'
```

`regression/verilog/checker/end_label1.sv`:
```systemverilog
checker c;
endchecker : c

module main;
endmodule
```
```
file end_label1.sv line 3: syntax error, unexpected :, expecting class before ':'
```

## Contrast: `endmodule :` and `endpackage :` do work

```systemverilog
module main;
  initial p0: assert (1);
endmodule : main
```
```
[main.p0] 1: PROVED up to bound 0
```

```systemverilog
package p;
  parameter int K = 1;
endpackage : p
module main;
  initial p0: assert (p::K == 1);
endmodule
```
```
[main.p0] p::K == 1: PROVED up to bound 0
```

Both are handled by dedicated optional-label rules: `endmodule_identifier_opt`
(`src/verilog/parser.y:684`, `:698`) and `endpackage_identifier_opt`
(`src/verilog/parser.y:1050`). The same pattern exists for
`endprogram_identifier_opt` (`:863`), `class_identifier_opt` (`:1033`),
`end_identifier_opt` (`:2716`, `:2791`), `property_identifier_opt` (`:3064`)
and `sequence_identifier_opt` (`:3296`).

## Grammar locations that lack the equivalent

* `interface_declaration` — `src/verilog/parser.y:724` (both alternatives end
  at bare `TOK_ENDINTERFACE`, lines 728 and 743)
* `seq_block` — `src/verilog/parser.y:4312` (both alternatives end at bare
  `TOK_END`, lines 4318 and 4325)
* `generate_block` — `src/verilog/parser.y:3986` (both `begin`/`end`
  alternatives end at bare `TOK_END`, lines 3988 and 3992)
* `checker_declaration` — `src/verilog/parser.y:868` (ends at bare
  `TOK_ENDCHECKER`, line 878)

## LRM citations

* **`endinterface`** — 1800-2017 A.1.3:
  `interface_declaration ::= { attribute_instance } interface_nonansi_header
  [ timeunits_declaration ] { interface_item } endinterface
  [ : interface_identifier ]`. Also the syntax box in 25.3.
* **`end` of a named block** — 1800-2017 9.3.4 (block names) allows a
  matching block name after the block `end`; A.6.3:
  `seq_block ::= begin [ : block_identifier ] { block_item_declaration }
  { statement_or_null } end [ : block_identifier ]`.
* **`end` of a named generate block** — 1800-2017 27.6 (generate block
  naming); A.4.2: `generate_block ::= ... | [ generate_block_identifier : ]
  begin [ : generate_block_identifier ] { generate_item } end
  [ : generate_block_identifier ]`.
* **`endchecker`** — 1800-2017 A.7.1:
  `checker_declaration ::= checker checker_identifier
  [ ( [ checker_port_list ] ) ] ; { { attribute_instance }
  checker_or_generate_item } endchecker [ : checker_identifier ]`.

## Neighbouring constructs that were probed and are fine

`endfunction :` and `endtask :` already have CORE coverage in
`regression/verilog/functions/end_label1.desc` (added by #2065).
`endclass :`, `endprogram :`, `endproperty :` and `endsequence :` were
confirmed working. `endgenerate` and `endcase` take no end label in the LRM
(A.4.2 `generate_region`, A.6.7 `case_statement`), so their rejection is
correct and no test was added.

## Notes on the tests

The expected output in each `.desc` describes the desired post-fix behaviour.
It was derived empirically by running the same design with the end label
removed and mirroring the observed output verbatim, rather than by guessing
regexes.

Verilog regression suite stays green; the skipped count goes from 223 to 227,
i.e. exactly the four new KNOWNBUG tests. All four also pass the
`KNOWNBUG checks` job locally (`test.pl -K`), confirming they really do fail
today.