### PR TITLE
Verilog: end labels after endinterface, endchecker, and named block/generate end

### DIFF
--- a/regression/verilog/checker/end_label1.desc
+++ b/regression/verilog/checker/end_label1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 end_label1.sv
 --show-parse
 ^Checker: c$
@@ -8,6 +8,5 @@ end_label1.sv
 ^warning: ignoring
 --
 Per 1800-2017 A.7.1, checker_declaration ends with
-"endchecker [ : checker_identifier ]".  The end label is rejected with
-"syntax error, unexpected :, expecting class", as checker_declaration has no
-equivalent of the endmodule_identifier_opt rule used for endmodule.
+"endchecker [ : checker_identifier ]".  The end label is accepted and
+discarded.

--- a/regression/verilog/generate/end_label1.desc
+++ b/regression/verilog/generate/end_label1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 end_label1.sv
 --bound 0
 ^\[main\.g1\.p0\] main\.g1\.w == 42: PROVED up to bound 0$
@@ -9,6 +9,5 @@ end_label1.sv
 --
 Per 1800-2017 27.6, the name of a named generate block may be repeated after
 the "end" keyword, and per A.4.2 generate_block ends with
-"end [ : generate_block_identifier ]".  The end label is rejected with
-"syntax error, unexpected :, expecting class", as the generate_block rule
-stops at the "end" keyword.
+"end [ : generate_block_identifier ]".  The end label is accepted and
+discarded.

--- a/regression/verilog/interface/end_label1.desc
+++ b/regression/verilog/interface/end_label1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 end_label1.sv
 --bound 0
 ^\[main\.p0\] main\.i\.W == 8: PROVED up to bound 0$
@@ -8,6 +8,5 @@ end_label1.sv
 ^warning: ignoring
 --
 Per 1800-2017 A.1.3, interface_declaration ends with
-"endinterface [ : interface_identifier ]".  The end label is rejected with
-"syntax error, unexpected :, expecting class", as interface_declaration has
-no equivalent of the endmodule_identifier_opt rule used for endmodule.
+"endinterface [ : interface_identifier ]".  The end label is accepted and
+discarded.

--- a/regression/verilog/named_block/end_label1.desc
+++ b/regression/verilog/named_block/end_label1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 end_label1.sv
 --bound 0
 ^\[main\.blk\.p0\] main\.blk\.x == 3: PROVED up to bound 0$
@@ -9,5 +9,4 @@ end_label1.sv
 --
 Per 1800-2017 9.3.4, a block name may be repeated after the "end" of a named
 block, and per A.6.3 seq_block ends with "end [ : block_identifier ]".  The
-end label is rejected with "syntax error, unexpected :, expecting class", as
-the seq_block rule stops at the "end" keyword.
+end label is accepted and discarded.

--- a/regression/verilog/named_block/end_label2.desc
+++ b/regression/verilog/named_block/end_label2.desc
@@ -1,0 +1,11 @@
+CORE
+end_label2.sv
+--bound 0
+^\[main\.fb\.p0\] main\.W == 7: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Per 1800-2017 9.3.4, the name of a named parallel block may be repeated
+after the "join" keyword.  The end label is accepted and discarded.

--- a/regression/verilog/named_block/end_label2.sv
+++ b/regression/verilog/named_block/end_label2.sv
@@ -1,0 +1,11 @@
+module main;
+
+  parameter int W = 7;
+
+  // End label after the "join" of a named parallel block,
+  // IEEE 1800-2017 9.3.4.
+  initial fork : fb
+    p0: assert (W == 7);
+  join : fb
+
+endmodule

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3995,11 +3995,11 @@ case_generate_item:
 
 generate_block:
           generate_item
-        | TOK_BEGIN generate_item_brace TOK_END
+        | TOK_BEGIN generate_item_brace TOK_END end_identifier_opt
                 { init($$, ID_generate_block); swapop($$, $2); }
         | TOK_BEGIN TOK_COLON any_identifier
                 { push_scope(stack_expr($3).get(ID_base_name), ".", verilog_scopet::BLOCK); }
-          generate_item_brace TOK_END
+          generate_item_brace TOK_END end_identifier_opt
                 { pop_scope();
                   init($$, ID_generate_block);
                   swapop($$, $5);
@@ -5564,7 +5564,8 @@ endmodule_identifier_opt:
 
 // Optional block name repeated after the keyword that ends a named
 // construct, e.g. "endfunction : is_width_valid" (IEEE 1800-2017 A.9.3),
-// "end : blk" for a named sequential block (9.3.4, A.6.3), and
+// "end : blk" for a named sequential or generate block (9.3.4, A.4.2,
+// A.6.3), and
 // "join : blk" for a named parallel block (9.3.4).
 // The identifier is accepted and discarded, mirroring the treatment of
 // endmodule_identifier_opt and friends.

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -725,7 +725,7 @@ module_keyword:
 interface_declaration:
           interface_nonansi_header
           interface_item_brace
-          TOK_ENDINTERFACE
+          TOK_ENDINTERFACE endinterface_identifier_opt
                 {
                   pop_scope();
                   init($$);
@@ -740,7 +740,7 @@ interface_declaration:
                 }
         | interface_ansi_header
           interface_item_brace
-          TOK_ENDINTERFACE
+          TOK_ENDINTERFACE endinterface_identifier_opt
                 {
                   pop_scope();
                   init($$);
@@ -753,6 +753,16 @@ interface_declaration:
                     stack_expr($2));              // module_items
                   stack_expr($$).id(ID_verilog_interface);
                 }
+        ;
+
+// Optional interface name repeated after "endinterface",
+// IEEE 1800-2017 A.1.2. The name is accepted and discarded, mirroring
+// endmodule_identifier_opt. Note that the scanner classifies the name of
+// an interface that is in scope as TOK_INTERFACE_IDENTIFIER, which is
+// why interface_identifier is used here.
+endinterface_identifier_opt:
+          /* Optional */
+        | TOK_COLON interface_identifier
         ;
 
 // This deviates from the IEEE 1800-2017 grammar, which uses the

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -4325,14 +4325,14 @@ seq_block:
                   push_scope(id, ".", verilog_scopet::BLOCK);
                   init($$); stack_expr($$).set(ID_block_id, id); }
           block_item_declaration_or_statement_or_null_brace
-          TOK_END
+          TOK_END end_identifier_opt
                 { init($$, ID_block); swapop($$, $3);
                   stack_expr($$).set(ID_block_id, stack_expr($2).get(ID_block_id));
                   pop_scope(); }
         | TOK_BEGIN TOK_COLON any_identifier
                 { push_scope(stack_expr($3).get(ID_base_name), ".", verilog_scopet::BLOCK); }
           block_item_declaration_or_statement_or_null_brace
-          TOK_END
+          TOK_END end_identifier_opt
                 { init($$, ID_block);
                   swapop($$, $5);
                   stack_expr($$).set(ID_base_name, stack_expr($3).get(ID_base_name));
@@ -4341,10 +4341,10 @@ seq_block:
         ;
 
 par_block:
-          TOK_FORK statement_or_null_brace TOK_JOIN
+          TOK_FORK statement_or_null_brace TOK_JOIN end_identifier_opt
                 { init($$, ID_fork); swapop($$, $2); }
         | TOK_FORK TOK_COLON any_identifier
-          statement_or_null_brace TOK_JOIN
+          statement_or_null_brace TOK_JOIN end_identifier_opt
                 { init($$, ID_block);
                   swapop($$, $4);
                   stack_expr($$).set(ID_base_name, stack_expr($3).get(ID_base_name));
@@ -5562,8 +5562,12 @@ endmodule_identifier_opt:
         | TOK_COLON module_identifier
         ;
 
-// Optional block name repeated after endfunction/endtask etc.,
-// e.g. "endfunction : is_width_valid". IEEE 1800-2017 A.9.3.
+// Optional block name repeated after the keyword that ends a named
+// construct, e.g. "endfunction : is_width_valid" (IEEE 1800-2017 A.9.3),
+// "end : blk" for a named sequential block (9.3.4, A.6.3), and
+// "join : blk" for a named parallel block (9.3.4).
+// The identifier is accepted and discarded, mirroring the treatment of
+// endmodule_identifier_opt and friends.
 end_identifier_opt:
           /* Optional */
         | TOK_COLON any_identifier

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -885,7 +885,7 @@ checker_declaration:
           }
           checker_port_list_paren_opt ';'
           checker_or_generate_item_brace
-          TOK_ENDCHECKER
+          TOK_ENDCHECKER end_identifier_opt
                 {
                   pop_scope();
                   init($$);
@@ -5564,9 +5564,9 @@ endmodule_identifier_opt:
 
 // Optional block name repeated after the keyword that ends a named
 // construct, e.g. "endfunction : is_width_valid" (IEEE 1800-2017 A.9.3),
+// "endchecker : chk" (A.7.1),
 // "end : blk" for a named sequential or generate block (9.3.4, A.4.2,
-// A.6.3), and
-// "join : blk" for a named parallel block (9.3.4).
+// A.6.3), and "join : blk" for a named parallel block (9.3.4).
 // The identifier is accepted and discarded, mirroring the treatment of
 // endmodule_identifier_opt and friends.
 end_identifier_opt:


### PR DESCRIPTION
Fixes the four gaps documented by the KNOWNBUG tests added in #2095.

#2095 has already been merged into `main`, so this PR is effectively a
follow-up rather than a stack: it flips those tests from `KNOWNBUG` to `CORE`
and adds the grammar support they were documenting. Nothing else needs to be
merged first.

## What was broken

End labels were accepted after `endmodule`, `endpackage`, `endprogram`,
`endclass`, `endfunction`, `endtask`, `endproperty` and `endsequence`, but
rejected after `endinterface`, after the `end` of a named begin/end block,
after the `end` of a named generate block, and after `endchecker`. All four
failed with `syntax error, unexpected :, expecting class before ':'`.

## Constructs fixed

| Construct | IEEE 1800-2017 | Grammar change |
|---|---|---|
| `endinterface : ifc` | A.1.2, 25.3 | new `endinterface_identifier_opt` after both `TOK_ENDINTERFACE` alternatives of `interface_declaration` |
| `end : blk` (named sequential block) | 9.3.4, A.6.3 | `end_identifier_opt` after `TOK_END` in both `seq_block` alternatives |
| `join : blk` (named parallel block) | 9.3.4, A.6.3 | `end_identifier_opt` after `TOK_JOIN` in both `par_block` alternatives |
| `end : g1` (named generate block) | 27.6, A.4.2 | `end_identifier_opt` after `TOK_END` in both `begin`/`end` alternatives of `generate_block` |
| `endchecker : chk` | A.7.1 | `end_identifier_opt` after `TOK_ENDCHECKER` in `checker_declaration` |

`join : blk` fell out naturally from the `par_block` work and is covered by a
new CORE test, `regression/verilog/named_block/end_label2`. Note that
`join_any` and `join_none` are recognised by the scanner but have no
production in the grammar at all, so they are out of scope here; adding them
is a separate change.

## Accept-and-discard, not name matching

Per 9.3.4 and 27.6 the trailing name *shall* match the block name, but this
change only accepts and discards it. This is deliberate, for consistency with
every end label the parser already supports: `endmodule_identifier_opt`,
`endpackage_identifier_opt`, `endprogram_identifier_opt`,
`class_identifier_opt`, `property_identifier_opt` and `end_identifier_opt`
all discard the name without checking it. Adding matching for these four
constructs alone would leave the front end inconsistent; if we want the
conformance check, it should be done for all end labels at once, ideally in
the type checker where the enclosing name is readily available. There is
therefore no mismatch-diagnostic test in this PR, since there is no
diagnostic to test.

## Notes on the implementation

* `endinterface` needs its own rule rather than the shared
  `end_identifier_opt`: the scanner classifies the name of an interface that
  is in scope as `TOK_INTERFACE_IDENTIFIER`, which `any_identifier` does not
  cover. `interface_identifier` accepts both that and
  `TOK_NON_TYPE_IDENTIFIER`.
* `end :` and `join :` are unambiguous with a following labelled statement
  with one token of lookahead, since a statement label precedes its
  statement (`blk : stmt`) and no statement can begin with `:`. Bison reports
  **zero conflicts** before and after this change.

## Testing

`make -C unit` passes. All of `regression/verilog`, `regression/ebmc`,
`regression/smv` (SAT and Z3) and `regression/vlindex` pass in both `-C` and
`-K` mode, i.e. no previously failing `KNOWNBUG` test started passing as a
result of the grammar widening.
