### PR TITLE
Verilog: cycle delay given by a constant expression

### DIFF
--- a/regression/verilog/SVA/cycle_delay5.desc
+++ b/regression/verilog/SVA/cycle_delay5.desc
@@ -1,19 +1,16 @@
-KNOWNBUG
+CORE
 cycle_delay5.sv
 --bound 10
-^\[main\.p0\] always \(main\.x == 0 \|-> \(##main\.CYCLES main\.x == main\.CYCLES\)\): PROVED up to bound 10$
-^\[main\.p1\] always \(main\.x == 0 \|-> \(##main\.CYCLES main\.x == main\.CYCLES\)\): PROVED up to bound 10$
-^\[main\.p2\] always \(main\.x == 0 \|-> \(##main\.DELAY main\.x == main\.DELAY\)\): PROVED up to bound 10$
+^\[main\.p0\] always \(main\.x == 0 \|-> \(##2 main\.x == main\.CYCLES\)\): PROVED up to bound 10$
+^\[main\.p1\] always \(main\.x == 0 \|-> \(##2 main\.x == main\.CYCLES\)\): PROVED up to bound 10$
+^\[main\.p2\] always \(main\.x == 0 \|-> \(##3 main\.x == main\.DELAY\)\): PROVED up to bound 10$
 ^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-The delay of the SVA cycle delay operator ## is parsed as a literal number
-only, whereas 1800-2017 A.2.10 gives cycle_delay_range as
-"## constant_primary".  A parameter or localparam identifier hence yields
-"syntax error, unexpected TOK_NON_TYPE_IDENTIFIER, expecting [* or [+ or
-TOK_NUMBER or '['", and a parenthesized constant expression ##(CYCLES) fails
-in the same way.  See cycle_delay_range in src/verilog/parser.y.  The range
-form ##[CYCLES:CYCLES] does accept a constant expression and can be used as
-a workaround.
+Per 1800-2017 A.2.10, cycle_delay_range is "## constant_primary", and a
+constant_primary (A.8.4) covers a parameter identifier as well as a
+parenthesized constant expression.  The delay of ## hence need not be a
+literal number.  The delay is elaborated during type checking, and is
+therefore shown as its value in the property.

--- a/regression/verilog/SVA/cycle_delay6.desc
+++ b/regression/verilog/SVA/cycle_delay6.desc
@@ -1,0 +1,14 @@
+CORE
+cycle_delay6.sv
+--bound 10 --top main
+^\[main\.p0\] always \(main\.x == 0 \|-> \(##2 main\.x == 2\)\): PROVED up to bound 10$
+^\[main\.p1\] always \(main\.x == 0 \|-> \(##2 main\.x == 2\)\): PROVED up to bound 10$
+^\[main\.p2\] always \(main\.x == 0 \|-> \(##1 main\.x == 1\)\): PROVED up to bound 10$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Per 1800-2017 A.2.10, the delay of ## is a constant_primary (A.8.4), which
+covers parenthesized constant expressions and package-scoped parameter
+identifiers.  The delay is elaborated during type checking.

--- a/regression/verilog/SVA/cycle_delay6.sv
+++ b/regression/verilog/SVA/cycle_delay6.sv
@@ -1,0 +1,23 @@
+package delays;
+
+  parameter N = 1;
+
+endpackage
+
+module main(input clk);
+
+  parameter N = 1;
+
+  reg [3:0] x = 0;
+
+  always_ff @(posedge clk)
+    x++;
+
+  // Per 1800-2017 A.2.10, the delay of ## is a constant_primary (A.8.4),
+  // which includes a parenthesized constant expression and a
+  // package-scoped parameter identifier.
+  p0: assert property (@(posedge clk) x == 0 |-> ##(N + 1) x == 2);
+  p1: assert property (@(posedge clk) x == 0 |-> ##(2 * N) x == 2);
+  p2: assert property (@(posedge clk) x == 0 |-> ##delays::N x == 1);
+
+endmodule

--- a/regression/verilog/SVA/cycle_delay7.desc
+++ b/regression/verilog/SVA/cycle_delay7.desc
@@ -1,0 +1,9 @@
+CORE
+cycle_delay7.sv
+
+^file cycle_delay7\.sv line \d+: delay must not be negative$
+^EXIT=2$
+^SIGNAL=0$
+--
+^warning: ignoring
+--

--- a/regression/verilog/SVA/cycle_delay7.sv
+++ b/regression/verilog/SVA/cycle_delay7.sv
@@ -1,0 +1,11 @@
+module main(input clk);
+
+  reg [31:0] x;
+
+  always_ff @(posedge clk)
+    x++;
+
+  // The cycle delay must not be negative.
+  initial assert property (##(-1) x != 10);
+
+endmodule

--- a/regression/verilog/SVA/unbounded1.buechi.desc
+++ b/regression/verilog/SVA/unbounded1.buechi.desc
@@ -1,7 +1,7 @@
 CORE buechi
 unbounded1.sv
 --buechi --module main --bound 1
-^\[.*\] always \(main\.a ##\[0:main\.upper\] main\.b\): UNSUPPORTED: sva_cycle_delay not convertible to Buechi$
+^\[.*\] always \(main\.a ##\[0:\$\] main\.b\): UNSUPPORTED: sva_cycle_delay not convertible to Buechi$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/verilog/SVA/unbounded1.desc
+++ b/regression/verilog/SVA/unbounded1.desc
@@ -1,7 +1,7 @@
 CORE
 unbounded1.sv
 --module main --bound 1
-^\[main\.assert\.1\] always \(main\.a ##\[0:main\.upper\] main.b\): REFUTED$
+^\[main\.assert\.1\] always \(main\.a ##\[0:\$\] main.b\): REFUTED$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/src/verilog/parser.y
+++ b/src/verilog/parser.y
@@ -3456,7 +3456,7 @@ goto_repetition:
         ;
 
 cycle_delay_range:
-          "##" number
+          "##" cycle_delay_constant_primary
                 { init($$, ID_sva_cycle_delay); mto($$, $2); stack_expr($$).operands().push_back(nil_exprt()); }
         | "##" '[' cycle_delay_const_range_expression ']'
                 { $$ = $3; }
@@ -3464,6 +3464,26 @@ cycle_delay_range:
                 { init($$, ID_sva_cycle_delay_star); }
         | "##" "[+" ']'
                 { init($$, ID_sva_cycle_delay_plus); }
+        ;
+
+// 1800-2017 gives the delay of ## as a constant_primary (A.8.4).  The
+// full constant_primary yields grammar conflicts here, as ## may be
+// followed by a sequence_expr, which may start with '(' or with a system
+// function call.  We hence allow the subset of constant_primary that is
+// unambiguous in this context, which covers numbers, (hierarchical and
+// package-scoped) parameter identifiers, and parenthesized constant
+// expressions.
+cycle_delay_constant_primary:
+          number
+        | hierarchical_identifier_select
+        | package_scope hierarchical_identifier_select
+                { $$ = $1;
+                  mto($$, $2);
+                  // exit the package scope
+                  pop_scope();
+                }
+        | '(' constant_expression ')'
+                { $$ = $2; }
         ;
 
 const_or_range_expression:

--- a/src/verilog/verilog_typecheck_sva.cpp
+++ b/src/verilog/verilog_typecheck_sva.cpp
@@ -460,15 +460,47 @@ exprt verilog_typecheck_exprt::convert_other_sva(exprt expr)
       require_sva_sequence(expr.operands()[0]);
     }
 
-    // from
-    convert_expr(expr.operands()[1]);
-    elaborate_constant_expression_check(expr.operands()[1]);
+    // from -- the delay is a constant expression, and is replaced by its
+    // value, as sva_cycle_delay_exprt::from() is a constant.
+    auto &from_op = expr.operands()[1];
+    auto from_location = from_op.source_location();
 
-    // to
+    convert_expr(from_op);
+    implicit_typecast(from_op, integer_typet{});
+    from_op = elaborate_constant_expression_check(from_op);
+    from_op.add_source_location() = from_location;
+
+    auto from = numeric_cast_v<mp_integer>(to_constant_expr(from_op));
+
+    if(from < 0)
+    {
+      throw errort().with_location(from_location)
+        << "delay must not be negative";
+    }
+
+    // to -- this is a constant expression, or $ for an unbounded range.
+    // Note that $ has type natural and is not an integer, and hence the
+    // conversion to an integer is done once $ has been ruled out.
     if(expr.operands()[2].is_not_nil())
     {
-      convert_expr(expr.operands()[2]);
-      elaborate_constant_expression_check(expr.operands()[2]);
+      auto &to_op = expr.operands()[2];
+      auto to_location = to_op.source_location();
+
+      convert_expr(to_op);
+      to_op = elaborate_constant_expression_check(to_op);
+
+      if(to_op.id() != ID_infinity)
+      {
+        implicit_typecast(to_op, integer_typet{});
+
+        if(numeric_cast_v<mp_integer>(to_constant_expr(to_op)) < from)
+        {
+          throw errort().with_location(expr.source_location())
+            << "range must be lower <= upper";
+        }
+      }
+
+      to_op.add_source_location() = to_location;
     }
 
     // rhs


### PR DESCRIPTION
Per 1800-2017 A.2.10,

```
cycle_delay_range ::= ## constant_primary | ## [ cycle_delay_const_range_expression ] | ##[*] | ##[+]
```

i.e. the delay of `##` is a `constant_primary` (A.8.4), which covers an
identifier such as a parameter, a parenthesized constant expression, and a
literal number.  The grammar accepted a literal number only, so `##CYCLES`
and `##(CYCLES)` were syntax errors, and `##[CYCLES:CYCLES]` was the only
workaround.

This PR flips the `KNOWNBUG` test added by #2094 (now merged) to `CORE`; it
is stacked on that commit.

### Grammar

`cycle_delay_range` now uses a new nonterminal `cycle_delay_constant_primary`,
which is the subset of `constant_primary` that is unambiguous in this
position:

* a number,
* a hierarchical identifier, optionally package-scoped (`pkg::N`),
* a parenthesized constant expression, `##(N + 1)`.

The full `constant_primary` is not attainable here: `##` is followed by a
`sequence_expr`, which may itself start with `(` or with a system function
call, so `function_subroutine_call`, `cast` and
`assignment_pattern_expression` introduce shift/reduce and reduce/reduce
conflicts.  The grammar remains free of conflicts (`bison` reports none, as
before).

### Elaboration

`sva_cycle_delay_exprt::from()` and `::to()` are `constant_exprt`, but the
type checker merely _checked_ that the delay is a constant expression
without replacing it by its value.  This worked by accident for a plain
parameter identifier, since synthesis substitutes the value of a parameter
symbol, but an expression such as `##(N+1)` or `##[N+1:N+1]` was silently
taken to be a delay of zero -- a wrong verification result rather than an
error.

The delay is now elaborated during type checking, in the same way as the
bounds of the ranged SVA operators (`sva_ranged_always` etc.), and `$` is
turned into `infinity` right away.  A negative delay now yields an error
instead of a failing invariant downstream.  Consequently, properties are
reported with the value of the delay, e.g. `##2` instead of `##main.CYCLES`,
and `##[0:$]` instead of `##[0:main.upper]`; the expected output of
`SVA/cycle_delay5.desc` and `SVA/unbounded1.desc` is updated accordingly.

### Tests

* `SVA/cycle_delay5.desc`: `KNOWNBUG` -> `CORE`
* `SVA/cycle_delay6`: new, covers `##(N + 1)`, `##(2 * N)` and `##pkg::N`
* `SVA/cycle_delay7`: new, negative delay `##(-1)` yields an error
* `SVA/unbounded1.desc`: expected output updated

`regression/{verilog,ebmc,smv,vlindex}` pass in both `-C` and `-K` mode, with
SAT and with Z3, and `make -C unit` passes.