### PR TITLE
Verilog: KNOWNBUG test for hierarchical references into generate loop blocks

### DIFF
--- a/regression/verilog/hierarchical_identifiers/generate_loop_block1.desc
+++ b/regression/verilog/hierarchical_identifiers/generate_loop_block1.desc
@@ -1,0 +1,15 @@
+KNOWNBUG
+generate_loop_block1.sv
+--module main --bound 0
+^\[main\.p0\] main\.blk\[0\]\.x == 10: PROVED up to bound 0$
+^\[main\.p1\] main\.blk\[1\]\.x == 11: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The names of the generate blocks created by a generate loop, blk[0] and
+blk[1] here, are not visible to hierarchical references.  ebmc rejects the
+references with "unknown identifier blk", although it does use these very
+names when reporting the properties and signals inside the blocks.  The
+same gap for the block of a generate-if is hierarchical_identifiers2.

--- a/regression/verilog/hierarchical_identifiers/generate_loop_block1.sv
+++ b/regression/verilog/hierarchical_identifiers/generate_loop_block1.sv
@@ -1,0 +1,18 @@
+module main;
+
+  genvar i;
+
+  // 1800-2017 27.6: a generate loop with a block name yields an array of
+  // generate blocks, and the individual blocks are named blk[0], blk[1],
+  // and so on.  These names are part of the hierarchy, and hence can be
+  // used in hierarchical references.
+  generate
+    for(i = 0; i < 2; i = i + 1) begin : blk
+      wire [7:0] x = 8'd10 + i;
+    end
+  endgenerate
+
+  initial p0: assert (blk[0].x == 8'd10);
+  initial p1: assert (blk[1].x == 8'd11);
+
+endmodule


### PR DESCRIPTION
Per 1800-2017 section 27.6, a generate loop with a block name creates an array
of generate blocks whose members are named `blk[0]`, `blk[1]`, and so on. These
names are part of the design hierarchy, and hence usable in hierarchical
references.

```systemverilog
module main;
  genvar i;
  generate
    for(i = 0; i < 2; i = i + 1) begin : blk
      wire [7:0] x = 8'd10 + i;
    end
  endgenerate

  initial p0: assert (blk[0].x == 8'd10);
  initial p1: assert (blk[1].x == 8'd11);
endmodule
```

ebmc rejects this with

```
file generate_loop_block1.sv line 15: unknown identifier blk
```

although it uses the very same names when reporting properties and signals
declared *inside* the blocks:

```
[main.blk[0].p] main.blk[0].x == 10: PROVED up to bound 0
```

The corresponding gap for the block of a generate-if is already covered by the
existing KNOWNBUG test `hierarchical_identifiers2`.