### PR TITLE
Verilog: KNOWNBUG test for an unpacked array of struct at a port

### DIFF
--- a/regression/verilog/structs/array_of_structs2.desc
+++ b/regression/verilog/structs/array_of_structs2.desc
@@ -1,0 +1,16 @@
+KNOWNBUG
+array_of_structs2.sv
+--module main --bound 0
+^\[main\.s\.p0\] main\.s\.data\[0\] == 171: PROVED up to bound 0$
+^\[main\.s\.p1\] main\.s\.data\[1\] == 205: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+An unpacked array of a packed struct is not recognised as being of a type
+equivalent to an unpacked array of a vector of the same width, and hence
+the port connection is rejected with "failed to convert `unpacked array
+[2] of struct packed' to `unpacked array [2] of [7:0]'".  The same
+diagnostic is given for a plain assignment between the two, i.e., the gap
+is in the type equivalence rules and not specific to ports.

--- a/regression/verilog/structs/array_of_structs2.sv
+++ b/regression/verilog/structs/array_of_structs2.sv
@@ -1,0 +1,25 @@
+module sub(input [7:0] data [2]);
+
+  initial p0: assert (data[0] == 8'hab);
+  initial p1: assert (data[1] == 8'hcd);
+
+endmodule
+
+module main;
+
+  typedef struct packed { logic [7:0] f; } byte_t;
+
+  byte_t arr [2];
+
+  // 1800-2017 6.22.1: byte_t is a packed struct that is 4-state, unsigned
+  // and 8 bits wide, and hence is an equivalent type to [7:0].  Unpacked
+  // arrays with the same size and equivalent element types are equivalent
+  // in turn, and hence arr can be connected to the port.
+  sub s(.data(arr));
+
+  initial begin
+    arr[0].f = 8'hab;
+    arr[1].f = 8'hcd;
+  end
+
+endmodule


### PR DESCRIPTION
Per 1800-2017 section 6.22.1, a packed struct that is 4-state, unsigned and
eight bits wide is an equivalent type to `[7:0]`, and unpacked arrays with the
same size and equivalent element types are equivalent in turn. An unpacked array
of such a struct can therefore be connected to a port whose type is an unpacked
array of `[7:0]`.

```systemverilog
module sub(input [7:0] data [2]);
  initial p0: assert (data[0] == 8'hab);
  initial p1: assert (data[1] == 8'hcd);
endmodule

module main;
  typedef struct packed { logic [7:0] f; } byte_t;
  byte_t arr [2];

  sub s(.data(arr));

  initial begin
    arr[0].f = 8'hab;
    arr[1].f = 8'hcd;
  end
endmodule
```

ebmc rejects this with

```
file array_of_structs2.sv line 18: failed to convert `unpacked array [2] of struct packed' to `unpacked array [2] of [7:0]'
```

The same diagnostic is given for a plain assignment between the two, so the gap
is in the type equivalence rules rather than specific to port connections; the
prose in the `.desc` records this.