### PR TITLE
Verilog: assignments between unpacked arrays of equivalent types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * Verilog: +incdir+ command-line option
 * Verilog: -l and +libfile+ command-line options
 * Verilog: -y and +libdir+ command-line options
+* SystemVerilog: assignments between unpacked arrays of equivalent types
 * Refreshed IC3 engine --new-ic3
 
 # EBMC 6.0

--- a/regression/verilog/structs/array_of_structs2.desc
+++ b/regression/verilog/structs/array_of_structs2.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 array_of_structs2.sv
 --module main --bound 0
 ^\[main\.s\.p0\] main\.s\.data\[0\] == 171: PROVED up to bound 0$
@@ -8,9 +8,6 @@ array_of_structs2.sv
 --
 ^warning: ignoring
 --
-An unpacked array of a packed struct is not recognised as being of a type
-equivalent to an unpacked array of a vector of the same width, and hence
-the port connection is rejected with "failed to convert `unpacked array
-[2] of struct packed' to `unpacked array [2] of [7:0]'".  The same
-diagnostic is given for a plain assignment between the two, i.e., the gap
-is in the type equivalence rules and not specific to ports.
+An unpacked array of a packed struct is of a type equivalent to an
+unpacked array of a vector of the same width, and hence can be connected
+to the port.

--- a/regression/verilog/structs/array_of_structs3.desc
+++ b/regression/verilog/structs/array_of_structs3.desc
@@ -1,0 +1,16 @@
+CORE
+array_of_structs3.sv
+--module main --bound 0
+^\[main\.0\.p0\] main\.b\[0\] == 16'h102: PROVED up to bound 0$
+^\[main\.0\.p1\] main\.b\[1\] == 16'h304: PROVED up to bound 0$
+^\[main\.0\.p2\] main\.b\[2\] == 16'h506: PROVED up to bound 0$
+^\[main\.1\.p3\] main\.c\[0\]\.hi == 17 && main\.c\[0\]\.lo == 34: PROVED up to bound 0$
+^\[main\.1\.p4\] main\.c\[1\]\.hi == 51 && main\.c\[1\]\.lo == 68: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Assignment between unpacked arrays of equivalent types, in both
+directions, with a check on the order of the array elements and on the
+order of the struct members.

--- a/regression/verilog/structs/array_of_structs3.sv
+++ b/regression/verilog/structs/array_of_structs3.sv
@@ -1,0 +1,38 @@
+module main;
+
+  typedef struct packed { logic [7:0] hi; logic [7:0] lo; } pair_t;
+
+  pair_t a [3];
+  logic [15:0] b [3];
+
+  pair_t c [2];
+  logic [15:0] d [2];
+
+  // 1800-2017 6.22.1: the two element types have the same number of bits
+  // and the same signing, and hence the unpacked arrays are of equivalent
+  // types.  The first member of a packed struct is the most significant,
+  // and the array element with index zero is the first element.
+  initial begin
+    a[0].hi = 8'h01; a[0].lo = 8'h02;
+    a[1].hi = 8'h03; a[1].lo = 8'h04;
+    a[2].hi = 8'h05; a[2].lo = 8'h06;
+
+    b = a;
+
+    p0: assert (b[0] == 16'h0102);
+    p1: assert (b[1] == 16'h0304);
+    p2: assert (b[2] == 16'h0506);
+  end
+
+  // the same in the other direction
+  initial begin
+    d[0] = 16'h1122;
+    d[1] = 16'h3344;
+
+    c = d;
+
+    p3: assert (c[0].hi == 8'h11 && c[0].lo == 8'h22);
+    p4: assert (c[1].hi == 8'h33 && c[1].lo == 8'h44);
+  end
+
+endmodule

--- a/regression/verilog/structs/array_of_structs4.desc
+++ b/regression/verilog/structs/array_of_structs4.desc
@@ -1,0 +1,10 @@
+CORE
+array_of_structs4.sv
+--module main --bound 0
+^file .* line 11: failed to convert `unpacked array \[2\] of struct packed' to `unpacked array \[2\] of \[7:0\]'$
+^EXIT=2$
+^SIGNAL=0$
+--
+--
+Unpacked arrays whose element types differ in the number of bits are not
+of equivalent types, and hence the assignment is rejected.

--- a/regression/verilog/structs/array_of_structs4.sv
+++ b/regression/verilog/structs/array_of_structs4.sv
@@ -1,0 +1,13 @@
+module main;
+
+  typedef struct packed { logic [7:0] hi; logic [7:0] lo; } pair_t;
+
+  pair_t a [2];
+  logic [7:0] b [2];
+
+  // 1800-2017 6.22.1: the element types do not have the same number of
+  // bits, and hence the two unpacked arrays are not of equivalent types.
+  // 1800-2017 7.6 does not allow the assignment.
+  initial b = a;
+
+endmodule

--- a/src/verilog/verilog_lowering.cpp
+++ b/src/verilog/verilog_lowering.cpp
@@ -411,7 +411,10 @@ exprt verilog_lowering_cast(typecast_exprt expr)
       dest_type.id() == ID_struct || dest_type.id() == ID_union ||
       dest_type.id() == ID_array)
     {
-      return from_bitvector(expr.op(), 0, dest_type);
+      // to_bitvector yields the operand unchanged unless it is a struct,
+      // union or array, and hence also covers the casts from one composite
+      // type to another.
+      return from_bitvector(to_bitvector(expr.op()), 0, dest_type);
     }
     else
     {

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -425,6 +425,14 @@ void verilog_typecheck_exprt::assignment_conversion(
     lhs_type.id() == ID_array &&
     lhs_type.get(ID_C_verilog_type) == ID_verilog_unpacked_array)
   {
+    // 1800-2017 7.6: an unpacked array can be assigned an unpacked array
+    // of an equivalent type.
+    if(equivalent_type(lhs_type, rhs.type()))
+    {
+      rhs = typecast_exprt{rhs, lhs_type};
+      return;
+    }
+
     // assignment of a non-matching type to unpacked array
     throw errort().with_location(rhs.source_location())
       << "failed to convert `" << to_string(original_rhs_type) << "' to `"
@@ -2741,6 +2749,108 @@ void verilog_typecheck_exprt::decay_to_vector(exprt &expr) const
   enum_decay(expr);
   struct_decay(expr);
   union_decay(expr);
+}
+
+/*******************************************************************\
+
+Function: verilog_typecheck_exprt::is_signed_type
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+bool verilog_typecheck_exprt::is_signed_type(const typet &type)
+{
+  // 1800-2017 7.2.1 and 7.4.1: packed structs, packed unions and packed
+  // arrays are unsigned unless declared signed, and hence the signed types
+  // are the vector types with a signed range.
+  return type.id() == ID_signedbv || type.id() == ID_verilog_signedbv;
+}
+
+/*******************************************************************\
+
+Function: verilog_typecheck_exprt::is_integral_type
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+bool verilog_typecheck_exprt::is_integral_type(const typet &type)
+{
+  // 1800-2017 6.11.1: the integral types are the packed arrays, the packed
+  // structs and unions, and the built-in integral types.
+  if(type.id() == ID_array)
+    return type.get(ID_C_verilog_type) == ID_verilog_packed_array;
+  else if(type.id() == ID_struct || type.id() == ID_union)
+    return type.get_bool(ID_packed);
+  else
+  {
+    return type.id() == ID_bool || type.id() == ID_unsignedbv ||
+           type.id() == ID_signedbv || type.id() == ID_verilog_unsignedbv ||
+           type.id() == ID_verilog_signedbv;
+  }
+}
+
+/*******************************************************************\
+
+Function: verilog_typecheck_exprt::equivalent_type
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+bool verilog_typecheck_exprt::equivalent_type(
+  const typet &type1,
+  const typet &type2) const
+{
+  // 1800-2017 6.22.1 (a): identical types are equivalent.
+  if(type1 == type2)
+    return true;
+
+  // 1800-2017 6.22.1 (c): fixed-size unpacked arrays are equivalent when
+  // they have equal size and equivalent element types.
+  if(type1.id() == ID_array && type2.id() == ID_array)
+  {
+    auto &array_type1 = to_array_type(type1);
+    auto &array_type2 = to_array_type(type2);
+
+    if(
+      type1.get(ID_C_verilog_type) == ID_verilog_unpacked_array &&
+      type2.get(ID_C_verilog_type) == ID_verilog_unpacked_array)
+    {
+      return array_type1.size() == array_type2.size() &&
+             equivalent_type(
+               array_type1.element_type(), array_type2.element_type());
+    }
+  }
+
+  // 1800-2017 6.22.1 (d): packed arrays, packed structs, packed unions and
+  // the built-in integral types are equivalent when they have the same
+  // number of bits, are either all 2-state or all 4-state, and are either
+  // all signed or all unsigned.  Note that the elaborated types do not
+  // record whether a vector was declared as 2-state or 4-state, and hence
+  // the 2-state/4-state condition only rules out the types that carry x
+  // and z.
+  if(is_integral_type(type1) && is_integral_type(type2))
+  {
+    return get_width(type1) == get_width(type2) &&
+           is_four_valued(type1) == is_four_valued(type2) &&
+           is_signed_type(type1) == is_signed_type(type2);
+  }
+
+  return false;
 }
 
 /*******************************************************************\

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -169,6 +169,11 @@ protected:
     return type.id() == ID_verilog_signedbv ||
            type.id() == ID_verilog_unsignedbv;
   }
+  static bool is_signed_type(const typet &);
+  static bool is_integral_type(const typet &);
+
+  // 1800-2017 6.22.1
+  bool equivalent_type(const typet &, const typet &) const;
 
   // named blocks
   typedef std::vector<std::string> named_blockst;


### PR DESCRIPTION
Fixes the KNOWNBUG from #2099. **Based on #2099**, please merge that one first.

Per 1800-2017 section 7.6, an unpacked array can be assigned an unpacked array of
an *equivalent type*, and section 6.22.1 gives the equivalence rules:

* (c) fixed-size unpacked arrays are equivalent when they have the same size and
  equivalent element types;
* (d) packed arrays, packed structs, packed unions and the built-in integral
  types are equivalent when they have the same number of bits, are all 2-state or
  all 4-state, and are all signed or all unsigned.

An unpacked array of an eight-bit packed struct is therefore assignable to, and
connectable to a port of, an unpacked array of `[7:0]`.

## Changes

* **`src/verilog/verilog_typecheck_expr.cpp`** — new `equivalent_type`
  implementing 6.22.1, with `is_integral_type` (6.11.1) and `is_signed_type`
  (7.2.1, 7.4.1) helpers. `assignment_conversion` now inserts a typecast where
  the two unpacked array types are equivalent but not identical, instead of
  rejecting the assignment.
* **`src/verilog/verilog_lowering.cpp`** — the lowering of a typecast to a
  struct, union or array passed the operand to `from_bitvector` without
  converting it to a bit vector first, which tripped the `src.type().id() !=
  ID_array` precondition in `extract` once the operand was itself of a composite
  type. It now goes through `to_bitvector`, which returns non-composite operands
  unchanged, so the existing paths are unaffected.

Note that the elaborated types do not record whether a vector was declared as
2-state or 4-state (`logic [7:0]` and `bit [7:0]` both elaborate to the same
type), so the 2-state/4-state condition only rules out the types that carry x
and z. This is noted in a comment.

## Tests

* `structs/array_of_structs2` — flipped KNOWNBUG to CORE (the reported port
  connection).
* `structs/array_of_structs3` — new CORE test asserting the conversion in **both**
  directions, checking the order of the array elements *and* the order of the
  struct members, using a two-field struct against `[15:0]` so a swap would be
  caught.
* `structs/array_of_structs4` — new CORE test that non-equivalent element widths
  are still rejected.

Also checked by hand, and still rejected: array size mismatch, signedness
mismatch, and an *unpacked* struct as the element type. Nested
`array of array of struct` works via the recursive case.

Full `regression/{verilog,ebmc,smv,vlindex}` in `-C` and `-K` modes plus the unit
tests pass.