### PR TITLE
Verilog: hierarchical references into named generate blocks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * Verilog: +incdir+ command-line option
 * Verilog: -l and +libfile+ command-line options
 * Verilog: -y and +libdir+ command-line options
+* Verilog: hierarchical references into named generate blocks
 * Refreshed IC3 engine --new-ic3
 
 # EBMC 6.0

--- a/regression/verilog/hierarchical_identifiers/generate_loop_block1.desc
+++ b/regression/verilog/hierarchical_identifiers/generate_loop_block1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 generate_loop_block1.sv
 --module main --bound 0
 ^\[main\.p0\] main\.blk\[0\]\.x == 10: PROVED up to bound 0$
@@ -9,7 +9,5 @@ generate_loop_block1.sv
 ^warning: ignoring
 --
 The names of the generate blocks created by a generate loop, blk[0] and
-blk[1] here, are not visible to hierarchical references.  ebmc rejects the
-references with "unknown identifier blk", although it does use these very
-names when reporting the properties and signals inside the blocks.  The
-same gap for the block of a generate-if is hierarchical_identifiers2.
+blk[1] here, are part of the hierarchy, and hence can be used in
+hierarchical references.

--- a/regression/verilog/hierarchical_identifiers/generate_loop_block2.desc
+++ b/regression/verilog/hierarchical_identifiers/generate_loop_block2.desc
@@ -1,0 +1,15 @@
+CORE
+generate_loop_block2.sv
+--module main --bound 0
+^\[main\.p0\] main\.outer\[0\]\.inner\[0\]\.x == 10: PROVED up to bound 0$
+^\[main\.p1\] main\.outer\[0\]\.inner\[1\]\.x == 11: PROVED up to bound 0$
+^\[main\.p2\] main\.outer\[1\]\.inner\[0\]\.x == 12: PROVED up to bound 0$
+^\[main\.chk\[0\]\.p\] main\.outer\[0\]\.inner\[0\]\.x == 10 \+ 1'b0 \* 2: PROVED up to bound 0$
+^\[main\.chk\[1\]\.p\] main\.outer\[1\]\.inner\[0\]\.x == 10 \+ 1'b1 \* 2: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Hierarchical references into the blocks of nested generate loops, using a
+genvar as the index in one of the cases.

--- a/regression/verilog/hierarchical_identifiers/generate_loop_block2.sv
+++ b/regression/verilog/hierarchical_identifiers/generate_loop_block2.sv
@@ -1,0 +1,26 @@
+module main;
+
+  genvar i, j, k;
+
+  // 1800-2017 27.6: nested generate loops yield nested arrays of generate
+  // blocks, named outer[0].inner[0], outer[0].inner[1], and so on.
+  generate
+    for(i = 0; i < 2; i = i + 1) begin : outer
+      for(j = 0; j < 2; j = j + 1) begin : inner
+        wire [7:0] x = 8'd10 + i * 2 + j;
+      end
+    end
+  endgenerate
+
+  initial p0: assert (outer[0].inner[0].x == 8'd10);
+  initial p1: assert (outer[0].inner[1].x == 8'd11);
+  initial p2: assert (outer[1].inner[0].x == 8'd12);
+
+  // the index can be any elaboration-time constant, including a genvar
+  generate
+    for(k = 0; k < 2; k = k + 1) begin : chk
+      initial p: assert (outer[k].inner[0].x == 8'd10 + k * 2);
+    end
+  endgenerate
+
+endmodule

--- a/regression/verilog/hierarchical_identifiers/generate_loop_block3.desc
+++ b/regression/verilog/hierarchical_identifiers/generate_loop_block3.desc
@@ -1,0 +1,11 @@
+CORE
+generate_loop_block3.sv
+--module main --bound 0
+^\[main\.p0\] main\.s\.blk\[0\]\.x == 10: PROVED up to bound 0$
+^\[main\.p1\] main\.s\.blk\[1\]\.x == 11: PROVED up to bound 0$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Hierarchical references into the blocks of a generate loop in a submodule.

--- a/regression/verilog/hierarchical_identifiers/generate_loop_block3.sv
+++ b/regression/verilog/hierarchical_identifiers/generate_loop_block3.sv
@@ -1,0 +1,22 @@
+module sub;
+
+  genvar i;
+
+  generate
+    for(i = 0; i < 2; i = i + 1) begin : blk
+      wire [7:0] x = 8'd10 + i;
+    end
+  endgenerate
+
+endmodule
+
+module main;
+
+  sub s();
+
+  // 1800-2017 27.6: the generate block names are part of the hierarchy of
+  // the module, and hence can be reached through the module instance.
+  initial p0: assert (s.blk[0].x == 8'd10);
+  initial p1: assert (s.blk[1].x == 8'd11);
+
+endmodule

--- a/regression/verilog/hierarchical_identifiers/hierarchical_identifiers2.desc
+++ b/regression/verilog/hierarchical_identifiers/hierarchical_identifiers2.desc
@@ -1,9 +1,11 @@
-KNOWNBUG
+CORE
 hierarchical_identifiers2.v
---module main
+--module main --bound 0
+^\[main\.p0\] main\.y == 1: PROVED up to bound 0$
 ^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-The block identifier is not found.
+1800-2017 27.6: the name of the block of a generate-if is part of the
+hierarchy, and hence can be used in a hierarchical reference.

--- a/regression/verilog/hierarchical_identifiers/hierarchical_identifiers2.v
+++ b/regression/verilog/hierarchical_identifiers/hierarchical_identifiers2.v
@@ -2,9 +2,11 @@ module main;
 
   // a named generate-if block
   if (1) begin : some_block
-    wire x;
+    wire x = 1;
   end
 
   wire y = some_block.x;
+
+  initial p0: assert (y == 1);
 
 endmodule

--- a/src/verilog/verilog_interfaces.cpp
+++ b/src/verilog/verilog_interfaces.cpp
@@ -209,6 +209,29 @@ void verilog_typecheckt::interface_generate_block(
   if(is_named)
   {
     irep_idt base_name = generate_block.base_name();
+
+    // 1800-2017 27.6: the name of a generate block is part of the
+    // hierarchy, and hence must be visible to hierarchical identifiers.
+    // Add a symbol for the scope, like interface_block does for named
+    // block statements.
+    symbolt symbol;
+
+    symbol.mode = mode;
+    symbol.base_name = base_name;
+    symbol.type = typet(ID_named_block);
+    symbol.module = module_identifier;
+    symbol.name = hierarchical_identifier(base_name);
+    symbol.pretty_name = strip_verilog_root_prefix(symbol.name);
+    symbol.value = nil_exprt();
+    symbol.location = generate_block.source_location();
+
+    if(symbol_table.add(symbol))
+    {
+      throw errort().with_location(generate_block.source_location())
+        << "duplicate definition of identifier `" << symbol.base_name
+        << "' in module `" << module_symbol().base_name << '\'';
+    }
+
     enter_named_block(base_name);
   }
 

--- a/src/verilog/verilog_typecheck_expr.cpp
+++ b/src/verilog/verilog_typecheck_expr.cpp
@@ -1874,6 +1874,90 @@ exprt verilog_typecheck_exprt::convert_verilog_identifier(
 
 /*******************************************************************\
 
+Function: is_scope
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static bool is_scope(const symbolt &symbol)
+{
+  // Something that can be given on the left-hand side of a dot in a
+  // hierarchical identifier.
+  return symbol.type.id() == ID_named_block ||
+         symbol.type.id() == ID_verilog_module_instance;
+}
+
+/*******************************************************************\
+
+Function: verilog_typecheck_exprt::resolve_scope_name
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+const symbolt *verilog_typecheck_exprt::resolve_scope_name(
+  const exprt &expr,
+  const std::string &suffix)
+{
+  if(expr.id() == ID_verilog_identifier)
+  {
+    auto base_name = to_verilog_identifier_expr(expr).base_name();
+    return resolve(id2string(base_name) + suffix);
+  }
+  else if(expr.id() == ID_hierarchical_identifier)
+  {
+    // Resolve the scope on the left of the dot first.
+    auto &hierarchical_identifier = to_hierarchical_identifier_expr(expr);
+    auto scope = resolve_scope_name(hierarchical_identifier.lhs(), "");
+
+    if(scope == nullptr || !is_scope(*scope))
+      return nullptr;
+
+    auto full_identifier =
+      id2string(scope->name) + '.' +
+      id2string(hierarchical_identifier.rhs().base_name()) + suffix;
+
+    const symbolt *symbol;
+    return ns.lookup(full_identifier, symbol) ? nullptr : symbol;
+  }
+  else if(expr.id() == ID_verilog_bit_select && suffix.empty())
+  {
+    // 1800-2017 27.6: a generate loop with a block name yields an array of
+    // generate blocks, the individual blocks being named block_name[0],
+    // block_name[1], and so on.  The parser has read the brackets as a bit
+    // select, which we undo here.
+    auto &bit_select = to_binary_expr(expr);
+
+    // An object of the given name takes precedence; the brackets are then
+    // a bit select or an array index, and the index need not be constant.
+    if(resolve_scope_name(bit_select.op0(), "") != nullptr)
+      return nullptr;
+
+    auto index = convert_integer_constant_expression(bit_select.op1());
+    auto block_suffix = '[' + integer2string(index) + ']';
+
+    auto symbol = resolve_scope_name(bit_select.op0(), block_suffix);
+
+    if(symbol == nullptr || symbol->type.id() != ID_named_block)
+      return nullptr;
+
+    return symbol;
+  }
+  else
+    return nullptr;
+}
+
+/*******************************************************************\
+
 Function: verilog_typecheck_exprt::convert_hierarchical_identifier
 
   Inputs:
@@ -1909,7 +1993,16 @@ exprt verilog_typecheck_exprt::convert_hierarchical_identifier(
     return symbol->symbol_expr().with_source_location(expr);
   }
 
-  convert_expr(expr.lhs());
+  // The brackets in a reference to a block of a generate loop are read as a
+  // bit select by the parser, which resolve_scope_name undoes.
+  auto generate_block = expr.lhs().id() == ID_verilog_bit_select
+                          ? resolve_scope_name(expr.lhs(), "")
+                          : nullptr;
+
+  if(generate_block != nullptr)
+    expr.lhs() = generate_block->symbol_expr().with_source_location(expr.lhs());
+  else
+    convert_expr(expr.lhs());
 
   DATA_INVARIANT(
     expr.rhs().id() == ID_verilog_identifier,

--- a/src/verilog/verilog_typecheck_expr.h
+++ b/src/verilog/verilog_typecheck_expr.h
@@ -198,6 +198,11 @@ protected:
     const std::optional<typet> &implicit_net_type);
   [[nodiscard]] exprt
     convert_hierarchical_identifier(class hierarchical_identifier_exprt);
+  // Resolve a hierarchical name that has not been converted yet, appending
+  // the given suffix to the last base name.  Returns nullptr when there is
+  // no such symbol.
+  [[nodiscard]] const symbolt *
+  resolve_scope_name(const exprt &, const std::string &suffix);
   [[nodiscard]] exprt convert_nullary_expr(nullary_exprt);
   [[nodiscard]] exprt convert_unary_expr(unary_exprt);
   [[nodiscard]] exprt convert_binary_expr(binary_exprt);


### PR DESCRIPTION
This is the fix for the KNOWNBUG test added in #2098, and is based on that
PR's branch.

Per 1800-2017 27.6, the name of a generate block is part of the design
hierarchy, and hence can be used in hierarchical references.  A generate
loop with a block name yields an array of generate blocks, the individual
blocks being named `block_name[0]`, `block_name[1]`, and so on -- ebmc
already uses these names when reporting properties and signals, but did
not accept them in hierarchical references, rejecting `blk[0].x` with
"unknown identifier blk".

Two changes:

* `interface_generate_block` now adds a symbol for the scope of a named
  generate block, of type `named_block`, exactly like `interface_block`
  does for named block statements.  This alone makes the reference into
  the block of a generate-if work, which is the pre-existing KNOWNBUG
  `hierarchical_identifiers2`.

* The brackets of a reference such as `blk[0].x` are parsed as a bit
  select applied to `blk`.  The new `resolve_scope_name` undoes this when
  the indexed name is not the name of an object but, with the index
  appended, is the name of a generate block.  An object of the given name
  takes precedence, and the index is only elaborated when there is no
  such object, so `arr[i].f` with a variable `i` is unaffected.

`resolve_scope_name` is recursive, and hence also covers the blocks of
nested generate loops (`outer[0].inner[1].x`) and references that reach
into a submodule (`s.blk[0].x`).  The index may be any elaboration-time
constant, including a genvar of an enclosing generate loop.

Tests:

* `hierarchical_identifiers/generate_loop_block1` is flipped from
  KNOWNBUG to CORE.
* `hierarchical_identifiers/hierarchical_identifiers2` (the generate-if
  case) is flipped from KNOWNBUG to CORE; it now drives the signal and
  has a property, as the design otherwise has no properties.
* New CORE tests `generate_loop_block2` (nested generate loops, genvar
  index) and `generate_loop_block3` (through a module instance).