### PR TITLE
KNOWNBUG test for macro default parameters

### DIFF
--- a/regression/verilog/preprocessor/macro_default_param1.desc
+++ b/regression/verilog/preprocessor/macro_default_param1.desc
@@ -1,0 +1,14 @@
+KNOWNBUG
+macro_default_param1.sv
+--preprocess
+// Macro default parameter values (IEEE 1800-2017 22.5.1):
+// `define M(A, B=x) makes B default to x when the argument is omitted.
+// EBMC currently rejects '=' in a macro parameter list with
+// "default parameters are not supported yet".
+// Enable multi-line checking
+activate-multi-line-match
+^`line 1 "macro_default_param1.sv" 0\n\na\+b\na\+x$
+^EXIT=0$
+^SIGNAL=0$
+--
+^PREPROCESSING FAILED$

--- a/regression/verilog/preprocessor/macro_default_param1.sv
+++ b/regression/verilog/preprocessor/macro_default_param1.sv
@@ -1,0 +1,3 @@
+`define M(A, B=x) A+B
+`M(a, b)
+`M(a)


### PR DESCRIPTION
Macro default parameter values (```define M(A, B=x)```) per IEEE 1800-2017 section 22.5.1 are not yet supported.

## Problem
The Verilog preprocessor rejects `=` in a macro parameter list, throwing:
```
default parameters are not supported yet
```
(see `verilog_preprocessort::parse_define_parameters` in `src/verilog/verilog_preprocessor.cpp`).

## Change
Adds a `KNOWNBUG` regression test `regression/verilog/preprocessor/macro_default_param1` that exercises the intended behaviour via `--preprocess`:
```verilog
`define M(A, B=x) A+B
`M(a, b)   // -> a+b
`M(a)      // -> a+x  (B defaults to x)
```