### PR TITLE
KNOWNBUG test for nested inline `ifdef in a false region

### DIFF
--- a/regression/verilog/preprocessor/nested_ifdef1.desc
+++ b/regression/verilog/preprocessor/nested_ifdef1.desc
@@ -1,0 +1,17 @@
+KNOWNBUG
+nested_ifdef1.sv
+--preprocess
+^module main;$
+^endmodule$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+A nested `ifdef appearing on the same line as an enclosing FALSE `ifdef is
+silently swallowed together with the rest of the file. The `ifdef directive
+reads its identifier and then skips to end of line, discarding the inline
+`ifdef/`endif/`endif that follow. As a result the outer conditional is never
+closed, the preprocessor stays in skip state, and "module main; endmodule" is
+dropped with EXIT=0 instead of being emitted (or an "unterminated `ifdef"
+error being reported).

--- a/regression/verilog/preprocessor/nested_ifdef1.sv
+++ b/regression/verilog/preprocessor/nested_ifdef1.sv
@@ -1,0 +1,7 @@
+// A nested `ifdef that appears "inline", i.e., on the same line as an
+// enclosing `ifdef that evaluates to FALSE. Both conditionals are closed
+// by the two `endif on the same line, so the conditional nesting returns
+// to depth zero and the code following the block must be emitted.
+`ifdef NOT_DEFINED `ifdef ALSO_NOT_DEFINED `endif `endif
+module main;
+endmodule


### PR DESCRIPTION
## Summary

Adds a `KNOWNBUG` regression test documenting a Verilog preprocessor bug: a
nested `` `ifdef `` that appears *inline* (on the same line) as an enclosing
`` `ifdef `` evaluating to **false** is silently swallowed along with the rest
of the file.

### Reproducer
```verilog
`ifdef NOT_DEFINED `ifdef ALSO_NOT_DEFINED `endif `endif
module main;
endmodule
```

Running `ebmc file.sv --preprocess` emits only the `` `line `` directive;
`module main; endmodule` is dropped and the tool exits 0.

### Root cause
In `src/verilog/verilog_preprocessor.cpp`, the `` `ifdef ``/`` `ifndef ``
handler reads its identifier and then calls `skip_until_eol()`, which discards
any further directives on the same line. The inline `` `ifdef ... `endif `endif ``
is skipped as text, so the two `` `endif `` never execute, the outer
conditional is never closed, `condition` stays false, and the remaining input
is dropped with no "unterminated `` `ifdef ``" error.

## Testing
- `make -C regression/verilog test` — the new test is `[SKIPPED]` (KNOWNBUG),
  all other preprocessor tests pass.
- Running the preprocessor suite with `-K` reports the new test `[OK]`,
  confirming the bug is present.

Once the underlying bug is fixed, the desired-behavior checks in the `.desc`
will pass and the harness will flag it, prompting promotion from `KNOWNBUG`
to `CORE`.