### PR TITLE
Verilog: fix nested inline `ifdef swallowing the rest of the file

### DIFF
--- a/regression/verilog/preprocessor/nested_ifdef1.desc
+++ b/regression/verilog/preprocessor/nested_ifdef1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 nested_ifdef1.sv
 --preprocess
 ^module main;$
@@ -8,10 +8,9 @@ nested_ifdef1.sv
 --
 ^warning: ignoring
 --
-A nested `ifdef appearing on the same line as an enclosing FALSE `ifdef is
-silently swallowed together with the rest of the file. The `ifdef directive
-reads its identifier and then skips to end of line, discarding the inline
-`ifdef/`endif/`endif that follow. As a result the outer conditional is never
-closed, the preprocessor stays in skip state, and "module main; endmodule" is
-dropped with EXIT=0 instead of being emitted (or an "unterminated `ifdef"
-error being reported).
+A nested `ifdef appearing on the same line as an enclosing FALSE `ifdef must
+still be processed: the inline `ifdef/`endif/`endif close the conditional
+nesting so that the code following the block is emitted. This used to be
+broken because the `ifdef/`else/`elsif/`endif directives skipped to the end
+of the line, discarding any inline directives and, inside a FALSE region,
+silently swallowing the rest of the file.

--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -552,7 +552,12 @@ void verilog_preprocessort::directive()
 
     auto &identifier = identifier_token.text;
 
-    tokenizer().skip_until_eol();
+    // Only skip trailing whitespace, not the rest of the line: any further
+    // tokens (in particular a nested `ifdef/`endif on the same line) must
+    // still be processed. Skipping to end of line here would discard inline
+    // directives and, inside a FALSE region, silently swallow the remainder
+    // of the file.
+    tokenizer().skip_ws();
 
     bool defined = defines.find(identifier) != defines.end();
 
@@ -572,7 +577,9 @@ void verilog_preprocessort::directive()
     if(conditionals.empty())
       throw verilog_preprocessor_errort() << "`else without `ifdef/`ifndef";
 
-    tokenizer().skip_until_eol();
+    // Only skip trailing whitespace; inline directives on the same line
+    // must still be processed.
+    tokenizer().skip_ws();
 
     conditionalt &conditional=conditionals.back();
 
@@ -601,7 +608,9 @@ void verilog_preprocessort::directive()
 
     auto &identifier = identifier_token.text;
 
-    tokenizer().skip_until_eol();
+    // Only skip trailing whitespace; inline directives on the same line
+    // must still be processed.
+    tokenizer().skip_ws();
 
     bool defined = defines.find(identifier) != defines.end();
 
@@ -622,7 +631,9 @@ void verilog_preprocessort::directive()
       throw verilog_preprocessor_errort() << "`endif without `ifdef/`ifndef";
     }
 
-    tokenizer().skip_until_eol();
+    // Only skip trailing whitespace; inline directives on the same line
+    // must still be processed.
+    tokenizer().skip_ws();
 
     conditionals.pop_back();
 


### PR DESCRIPTION
## Summary

Fixes a Verilog preprocessor bug: a nested `` `ifdef `` appearing *inline* (on
the same line) as an enclosing `` `ifdef `` that evaluates to **false** left the
outer conditional unclosed, so the preprocessor stayed in skip state and
silently swallowed the rest of the file.

### Reproducer
```verilog
`ifdef NOT_DEFINED `ifdef ALSO_NOT_DEFINED `endif `endif
module main;
endmodule
```
Before: `ebmc file.sv --preprocess` dropped `module main; endmodule` (EXIT=0).
After: the module is emitted as expected.

### Root cause
The `` `ifdef ``, `` `ifndef ``, `` `else ``, `` `elsif `` and `` `endif ``
handlers called `skip_until_eol()` after consuming their argument, discarding
any further directive on the same line. The inline `` `ifdef ... `endif `endif ``
was skipped as text, the two `` `endif `` never executed, and the conditional
stack was never unwound.

### Fix
Skip only trailing whitespace (`skip_ws()`) instead of the whole line, letting
the main loop process the remaining tokens — including nested directives. Per
IEEE 1800-2017 22.6 the conditional group extends from after the identifier to
the matching `` `endif ``, so same-line content is now handled correctly.
Comments after a directive are unaffected (the tokenizer already strips them).

This promotes the `regression/verilog/preprocessor/nested_ifdef1` test
(added as KNOWNBUG in #2105) to CORE.

## Testing
- `make -C regression/verilog test` passes (`nested_ifdef1` now `[OK]` as CORE;
  no regressions across the full Verilog suite).
- Manual checks confirm inline directives in a true region and trailing
  comments after directives still behave correctly.