### PR TITLE
Verilog: support macro default parameter values

### DIFF
--- a/regression/verilog/preprocessor/macro_default_param1.desc
+++ b/regression/verilog/preprocessor/macro_default_param1.desc
@@ -1,13 +1,20 @@
-KNOWNBUG
+CORE
 macro_default_param1.sv
 --preprocess
 // Macro default parameter values (IEEE 1800-2017 22.5.1):
-// `define M(A, B=x) makes B default to x when the argument is omitted.
-// EBMC currently rejects '=' in a macro parameter list with
-// "default parameters are not supported yet".
+// `define M(A, B=x) makes B default to x when the actual argument is
+// omitted or empty. Defaults may be given for several parameters and
+// may contain commas nested in (), [] or {}.
 // Enable multi-line checking
 activate-multi-line-match
-^`line 1 "macro_default_param1.sv" 0\n\na\+b\na\+x$
+^a\+b$
+^a\+x$
+^1-2-3$
+^9-2-3$
+^9-8-3$
+^9-8-7$
+^p-\{1,2\}$
+^p-\{3,4\}$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/verilog/preprocessor/macro_default_param1.sv
+++ b/regression/verilog/preprocessor/macro_default_param1.sv
@@ -1,3 +1,12 @@
 `define M(A, B=x) A+B
 `M(a, b)
 `M(a)
+`M(a, )
+`define N(A=1, B=2, C=3) A-B-C
+`N()
+`N(9)
+`N(9, 8)
+`N(9, 8, 7)
+`define P(A, B={1,2}) A-B
+`P(p)
+`P(p, {3,4})

--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -305,19 +305,69 @@ auto verilog_preprocessort::parse_define_parameters() -> definet::parameterst
     if(!parameter.is_identifier())
       throw verilog_preprocessor_errort() << "expecting a define parameter";
 
-    result.push_back(parameter.text);
+    definet::parametert define_parameter;
+    define_parameter.name = parameter.text;
 
     tokenizer().skip_ws();
 
     auto token = tokenizer().next_token();
 
+    if(token == '=') // SystemVerilog 2009: a default argument value
+    {
+      // 1800-2017 22.5.1: a formal argument may be followed by "= value",
+      // giving a default value that is used when the actual argument is
+      // omitted or empty. The default text runs up to the next comma or
+      // the closing parenthesis at nesting depth zero; commas nested
+      // inside (), [] or {} are part of the default text.
+      tokenizer().skip_ws();
+
+      std::vector<tokent> default_value;
+      std::size_t nesting = 0;
+
+      while(true)
+      {
+        if(tokenizer().eof())
+          throw verilog_preprocessor_errort()
+            << "eof inside a define parameter list";
+
+        if(
+          nesting == 0 &&
+          (tokenizer().peek() == ',' || tokenizer().peek() == ')'))
+        {
+          break;
+        }
+
+        auto value_token = tokenizer().next_token();
+
+        if(value_token == '(' || value_token == '[' || value_token == '{')
+          nesting++;
+        else if(value_token == ')' || value_token == ']' || value_token == '}')
+          nesting--;
+
+        default_value.push_back(std::move(value_token));
+      }
+
+      // trim trailing whitespace off the default text
+      while(!default_value.empty() && default_value.back().is_ws_not_nl())
+      {
+        default_value.pop_back();
+      }
+
+      define_parameter.default_value = std::move(default_value);
+
+      result.push_back(std::move(define_parameter));
+
+      token = tokenizer().next_token(); // the ',' or ')'
+    }
+    else
+    {
+      result.push_back(std::move(define_parameter));
+    }
+
     if(token == ')')
       break; // done
     else if(token == ',')
-      continue;           // keep going
-    else if(token == '=') // SystemVerilog 2009
-      throw verilog_preprocessor_errort()
-        << "default parameters are not supported yet";
+      continue; // keep going
     else
       throw verilog_preprocessor_errort() << "expecting a define parameter";
   }
@@ -382,8 +432,20 @@ auto verilog_preprocessort::parse_define_arguments(const definet &define)
     }
   }
 
-  // does the number of arguments match the number of parameters?
-  if(arguments.size() != define.parameters.size())
+  // An actual argument that is empty or whitespace only is treated as
+  // omitted (1800-2017 22.5.1).
+  auto is_empty = [](const std::vector<tokent> &tokens)
+  {
+    for(auto &token : tokens)
+      if(!token.is_ws())
+        return false;
+    return true;
+  };
+
+  // The number of actual arguments may be smaller than the number of
+  // formal arguments when the trailing formal arguments have default
+  // values. It may never exceed the number of formal arguments.
+  if(arguments.size() > define.parameters.size())
     throw verilog_preprocessor_errort()
       << "expected " << define.parameters.size() << " arguments, but got "
       << arguments.size();
@@ -392,7 +454,32 @@ auto verilog_preprocessort::parse_define_arguments(const definet &define)
   std::map<std::string, std::vector<tokent>> result;
 
   for(std::size_t i = 0; i < define.parameters.size(); i++)
-    result[define.parameters[i]] = std::move(arguments[i]);
+  {
+    const auto &parameter = define.parameters[i];
+    const bool have_argument = i < arguments.size();
+
+    if(have_argument && !is_empty(arguments[i]))
+    {
+      // an actual argument was given
+      result[parameter.name] = std::move(arguments[i]);
+    }
+    else if(parameter.default_value.has_value())
+    {
+      // omitted or empty, but a default value is available
+      result[parameter.name] = *parameter.default_value;
+    }
+    else if(have_argument)
+    {
+      // omitted argument without default: empty substitution
+      result[parameter.name] = std::move(arguments[i]);
+    }
+    else
+    {
+      throw verilog_preprocessor_errort()
+        << "expected " << define.parameters.size() << " arguments, but got "
+        << arguments.size();
+    }
+  }
 
   return result;
 }

--- a/src/verilog/verilog_preprocessor.h
+++ b/src/verilog/verilog_preprocessor.h
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <list>
 #include <map>
+#include <optional>
 
 class verilog_preprocessort:public preprocessort
 {
@@ -42,7 +43,14 @@ protected:
 
   struct definet
   {
-    using parameterst = std::vector<std::string>;
+    // A macro formal argument, with an optional default value
+    // (1800-2017 22.5.1).
+    struct parametert
+    {
+      std::string name;
+      std::optional<std::vector<tokent>> default_value;
+    };
+    using parameterst = std::vector<parametert>;
     parameterst parameters;
     std::vector<tokent> tokens;
     definet() = default;

--- a/src/verilog/verilog_preprocessor_tokenizer.h
+++ b/src/verilog/verilog_preprocessor_tokenizer.h
@@ -57,6 +57,11 @@ public:
     {
       return ::verilog_is_ws_not_nl(static_cast<int>(kind));
     }
+    bool is_ws() const
+    {
+      return ::verilog_is_ws_not_nl(static_cast<int>(kind)) ||
+             static_cast<int>(kind) == '\n';
+    }
     bool operator==(char ch) const
     {
       return static_cast<int>(kind) == ch;


### PR DESCRIPTION
Implements default values for text macro formal arguments, e.g. ```define M(A, B=x)```, per IEEE 1800-2017 section 22.5.1.

## Background
The preprocessor previously rejected `=` in a macro parameter list with `default parameters are not supported yet` (added as KNOWNBUG in #2104).

## Change
- `definet::parametert` now carries an optional default token sequence.
- `parse_define_parameters` parses `= default_text`; the default text runs up to the next comma or the closing `)` at nesting depth zero, so commas nested inside `()`, `[]` or `{}` are part of the default.
- `parse_define_arguments` uses the default when an actual argument is omitted or empty (whitespace only). A value-less argument is an error only when the parameter has no default. The actual argument count may be fewer than the formal count (trailing defaults) but never more.

## Test
Promotes `regression/verilog/preprocessor/macro_default_param1` from KNOWNBUG to CORE and extends it:
```verilog
`define M(A, B=x) A+B          // M(a,b)->a+b   M(a)->a+x   M(a,)->a+x
`define N(A=1, B=2, C=3) A-B-C // N()->1-2-3 ... N(9,8,7)->9-8-7
`define P(A, B={1,2}) A-B      // P(p)->p-{1,2}  P(p,{3,4})->p-{3,4}
```

## Verification
- `make -C src/verilog` and `make -C src/ebmc` build cleanly.
- `make -C regression/verilog test`: all pass (226 skipped are KNOWNBUG/buechi), including the promoted `macro_default_param1` test.
- Manually verified: omitted arg without a default still errors; normal (non-default) macros unaffected.

## Blocked features
None.