### PR TITLE
Verilog: helper to detect white space

### DIFF
--- a/src/verilog/scanner.l
+++ b/src/verilog/scanner.l
@@ -23,6 +23,7 @@ static int isatty(int) { return 0; }
 
 #include "verilog_parser.h"
 #include "verilog_y.tab.h"
+#include "verilog_preprocessor_tokenizer.h"
 #include "verilog_scanner.h"
 
 int yyverilogerror(const char *error);
@@ -34,8 +35,8 @@ static void line_directive()
   // skip directive
   while(*tptr!=' ' && *tptr!='\t' && *tptr!=0) tptr++;
 
-  // skip whitespace
-  while(*tptr==' ' || *tptr=='\t') tptr++;
+  // skip whitespace except newline
+  while(verilog_is_ws_not_nl(*tptr)) tptr++;
 
   PARSER.set_line_no(atoi(tptr)-1);
 
@@ -43,8 +44,8 @@ static void line_directive()
 
   while(isdigit(*tptr)) tptr++;
 
-  // skip whitespace
-  while(*tptr==' ' || *tptr=='\t') tptr++;
+  // skip whitespace except newline
+  while(verilog_is_ws_not_nl(*tptr)) tptr++;
 
   if(*tptr=='"') // filename?
   {
@@ -130,7 +131,7 @@ YYSTYPE make_identifier(irep_idt base_name, exprt &dest)
 %s STRING
 
 NL              [\n]
-WS              [ \t\r\b]
+WS              [ \t\v\f\r]
 WSNL            [{WS}{NL}]
 Digit           [0-9]
 DigitU          [0-9_]
@@ -583,8 +584,6 @@ prove           { VL2SMV_VERILOG_KEYWORD(TOK_PROVE); }
 \`line{WS}[^\n]*{NL} { line_directive(); continue; }
 \`default_nettype{WS}[^\n]*{NL} { /* ignore for now */ continue; }
 \`{Word}        { preprocessor(); continue; }
-
-\f              { /* ignore */ }
 
                 /* Identifiers and numbers */
 

--- a/src/verilog/verilog_preprocessor_tokenizer.cpp
+++ b/src/verilog/verilog_preprocessor_tokenizer.cpp
@@ -26,7 +26,7 @@ void verilog_preprocessor_token_sourcet::skip_ws()
   while(true)
   {
     auto token = peek();
-    if(token != ' ' && token != '\t')
+    if(!token.is_ws_not_nl())
       break;
     next_token(); // eat
   }

--- a/src/verilog/verilog_preprocessor_tokenizer.h
+++ b/src/verilog/verilog_preprocessor_tokenizer.h
@@ -13,6 +13,15 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <vector>
 
+// returns true if the argument is space, tab, vertical tab,
+// formfeed, carriage return, but not a newline
+static bool verilog_is_ws_not_nl(int ch)
+{
+  // We don't use isspace, since that requires that the argument
+  // is representable as an unsigned char.
+  return ch == ' ' || ch == '\t' || ch == '\v' || ch == '\f' || ch == '\r';
+}
+
 /// Note that the set of tokens recognised by the Verilog preprocessor
 /// differs from the set of tokens used by the main parser.
 
@@ -44,13 +53,17 @@ public:
     {
       return kind == STRING_LITERAL;
     }
+    bool is_ws_not_nl() const
+    {
+      return ::verilog_is_ws_not_nl(static_cast<int>(kind));
+    }
     bool operator==(char ch) const
     {
-      return static_cast<char>(kind) == ch;
+      return static_cast<int>(kind) == ch;
     }
     bool operator!=(char ch) const
     {
-      return static_cast<char>(kind) != ch;
+      return static_cast<int>(kind) != ch;
     }
     friend std::ostream &operator<<(std::ostream &out, const tokent &t)
     {


### PR DESCRIPTION
This clarifies what is white space in the Verilog front-end: IEEE 1800-2017 5.3 lists "spaces, tabs, newlines, and formfeeds", which we interpret to be ' ', \t and \v, \r and \n, and \f.

`isspace` is not used since `isspace` requires the argument to fit into an unsigned char; however, our tokens use values beyond 255.