### PR TITLE
Verilog: regression test for package import inside an interface

### DIFF
--- a/regression/verilog/interface/import1.desc
+++ b/regression/verilog/interface/import1.desc
@@ -1,0 +1,9 @@
+CORE
+import1.sv
+
+^\[main\.p0\] always main\.i\.data == 255: PROVED \(.*\)$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Package import declaration inside an interface.

--- a/regression/verilog/interface/import1.sv
+++ b/regression/verilog/interface/import1.sv
@@ -1,0 +1,16 @@
+package my_pkg;
+  parameter width = 8;
+endpackage
+
+interface my_interface;
+  // A package import declaration is a legal interface item,
+  // IEEE 1800-2017 A.1.2. The imported "width" is used below.
+  import my_pkg::*;
+  logic [width-1:0] data;
+endinterface
+
+module main;
+  my_interface i();
+  initial i.data = 255;
+  p0: assert final(i.data == 255);
+endmodule


### PR DESCRIPTION
## Summary

A package import declaration is a legal interface item per IEEE 1800-2017 (A.1.2). EBMC already parses and elaborates this construct correctly, but there was no test coverage for it. This adds a `CORE` regression test.

The test defines an interface that imports a package parameter and uses it as a signal width, then instantiates the interface from a module and proves a property over the interface signal:

```systemverilog
package my_pkg;
  parameter width = 8;
endpackage

interface my_interface;
  import my_pkg::*;
  logic [width-1:0] data;
endinterface

module main;
  my_interface i();
  initial i.data = 255;
  p0: assert final(i.data == 255);
endmodule
```

The import is load-bearing: without it, the same design fails with `unknown identifier width`, so the test genuinely exercises import resolution inside the interface scope.

## Testing

`make -C regression/verilog test` — the interface suite passes, including the new case:

```
Running interface/import1.desc  [OK]
All tests were successful
```