### PR TITLE
banner: use ebmc version, not cbmc version

### DIFF
--- a/src/ebmc/ebmc_parse_options.cpp
+++ b/src/ebmc/ebmc_parse_options.cpp
@@ -38,6 +38,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "show_properties.h"
 #include "show_trans.h"
 
+#include <climits>
 #include <iostream>
 
 #include "cegar/bmc_cegar.h"
@@ -50,6 +51,28 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "interpolation/compute-interpolant.h"
 #include "coverage/coverage.h"
 #endif
+
+/*******************************************************************\
+
+Function: ebmc_parse_optionst::log_version_and_architecture
+
+  Inputs:
+
+ Outputs:
+
+ Purpose: turn a +plusarg into a cmdlinet option
+
+\*******************************************************************/
+
+void ebmc_parse_optionst::log_version_and_architecture(
+  const std::string_view &front_end,
+  const std::string_view &version)
+{
+  log.status() << front_end << " version " << version << " "
+               << sizeof(void *) * CHAR_BIT << "-bit "
+               << config.this_architecture() << " "
+               << config.this_operating_system() << messaget::eom;
+}
 
 /*******************************************************************\
 
@@ -149,7 +172,7 @@ int ebmc_parse_optionst::doit()
     return 0;
   }
 
-  log_version_and_architecture("EBMC");
+  log_version_and_architecture("EBMC", EBMC_VERSION);
 
   try
   {

--- a/src/ebmc/ebmc_parse_options.h
+++ b/src/ebmc/ebmc_parse_options.h
@@ -69,6 +69,10 @@ protected:
   void register_languages();
   void plus_arg(const std::string &);
 
+  void log_version_and_architecture(
+    const std::string_view &front_end,
+    const std::string_view &version);
+
   ui_message_handlert ui_message_handler;
 };
 


### PR DESCRIPTION
This adds a variant of the banner-printing method that takes the version string as an argument, enabling the use of the ebmc version instead of the cbmc version in the banner.