### PR TITLE
KNOWNBUG test for elsif-chain dual-emission

### DIFF
--- a/regression/verilog/preprocessor/elsif3.desc
+++ b/regression/verilog/preprocessor/elsif3.desc
@@ -1,0 +1,24 @@
+KNOWNBUG
+elsif3.v
+--preprocess -D A
+^BRANCH_A$
+^EXIT=0$
+^SIGNAL=0$
+--
+^BRANCH_B$
+^BRANCH_C$
+^BRANCH_ELSE$
+--
+In an `ifdef/`elsif/`elsif/`else chain, when a branch *before* the final
+`elsif matches, the preprocessor incorrectly emits both the matched branch
+and the trailing `else branch.  Here `ifdef A matches (A is defined via -D),
+so only BRANCH_A should be emitted, but BRANCH_ELSE is emitted as well.
+
+Root cause: conditionalt (src/verilog/verilog_preprocessor.h) stores only the
+most recent branch condition and has no "a branch was already taken" flag.
+An `elsif/`else computes its own activity from the previous branch's condition
+alone (get_cond() negates conditionalt::condition for the else part), so it
+cannot tell that an earlier branch in the chain already matched.  Plain
+`ifdef/`else works because there is a single branch condition to negate, and
+a chain whose *final* `elsif matches also happens to work because that last
+condition is the one `else negates.

--- a/regression/verilog/preprocessor/elsif3.v
+++ b/regression/verilog/preprocessor/elsif3.v
@@ -1,0 +1,9 @@
+`ifdef A
+BRANCH_A
+`elsif B
+BRANCH_B
+`elsif C
+BRANCH_C
+`else
+BRANCH_ELSE
+`endif


### PR DESCRIPTION
## Summary

Adds a `KNOWNBUG` regression test documenting a Verilog preprocessor defect:
in an `` `ifdef/`elsif/`elsif/`else `` chain, when a branch **before the final
`` `elsif `` matches, the preprocessor emits **both** the matched branch and the
trailing `` `else `` branch.

## Characterization

Verified with `ebmc --preprocess`:

| Chain `` `ifdef A / `elsif B / `elsif C / `else `` | Emitted | Correct? |
|---|---|---|
| A defined (`-D A` or in-source `` `define ``) | `BRANCH_A` **+ `BRANCH_ELSE`** | ✗ |
| B defined (middle `` `elsif ``) | `BRANCH_B` **+ `BRANCH_ELSE`** | ✗ |
| C defined (final `` `elsif ``) | `BRANCH_C` | ✓ |
| none defined | `BRANCH_ELSE` | ✓ |

Plain `` `ifdef/`else `` is correct. The bug fires whenever a branch *before*
the final `` `elsif `` matches; a chain whose final `` `elsif `` matches works by
coincidence.

## Root cause

`conditionalt` (`src/verilog/verilog_preprocessor.h`) stores only the most
recent branch condition plus the enclosing scope's condition and an
`else_part` flag. It has no "a branch was already taken" flag, so
`get_cond()` negates only the last `` `elsif ``'s condition for the `` `else ``
part and cannot tell that an earlier branch in the chain already matched.

## Testing

- `make -C regression/verilog test` — `elsif3` is `SKIPPED` (KNOWNBUG), suite green.
- `test.pl -K preprocessor` — `elsif3` is `OK`, confirming the bug is still present.

No source fix is included; this PR only documents the defect as a KNOWNBUG.