### PR TITLE
Verilog: fix elsif-chain dual-emission in preprocessor

### DIFF
--- a/regression/verilog/preprocessor/elsif3.desc
+++ b/regression/verilog/preprocessor/elsif3.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 elsif3.v
 --preprocess -D A
 ^BRANCH_A$
@@ -10,15 +10,10 @@ elsif3.v
 ^BRANCH_ELSE$
 --
 In an `ifdef/`elsif/`elsif/`else chain, when a branch *before* the final
-`elsif matches, the preprocessor incorrectly emits both the matched branch
-and the trailing `else branch.  Here `ifdef A matches (A is defined via -D),
-so only BRANCH_A should be emitted, but BRANCH_ELSE is emitted as well.
+`elsif matches, only the matched branch must be emitted.  Here `ifdef A
+matches (A is defined via -D), so only BRANCH_A is emitted.
 
-Root cause: conditionalt (src/verilog/verilog_preprocessor.h) stores only the
-most recent branch condition and has no "a branch was already taken" flag.
-An `elsif/`else computes its own activity from the previous branch's condition
-alone (get_cond() negates conditionalt::condition for the else part), so it
-cannot tell that an earlier branch in the chain already matched.  Plain
-`ifdef/`else works because there is a single branch condition to negate, and
-a chain whose *final* `elsif matches also happens to work because that last
-condition is the one `else negates.
+Previously the preprocessor also emitted the trailing `else branch, because
+conditionalt (src/verilog/verilog_preprocessor.h) stored only the most recent
+branch condition and had no record that an earlier branch already matched.
+This is now fixed via the conditionalt::matched flag.

--- a/src/verilog/verilog_preprocessor.cpp
+++ b/src/verilog/verilog_preprocessor.cpp
@@ -675,6 +675,7 @@ void verilog_preprocessort::directive()
       throw verilog_preprocessor_errort() << "`else without `ifdef/`ifndef";
     }
 
+    conditional.into_next_branch();
     conditional.else_part=true;
     condition=conditional.get_cond();
   }
@@ -708,6 +709,7 @@ void verilog_preprocessort::directive()
       throw verilog_preprocessor_errort() << "`elsif after `else";
     }
 
+    conditional.into_next_branch();
     conditional.condition = defined;
     condition = conditional.get_cond();
   }

--- a/src/verilog/verilog_preprocessor.h
+++ b/src/verilog/verilog_preprocessor.h
@@ -81,17 +81,36 @@ protected:
   class conditionalt
   {
   public:
+    // The current branch's own condition, i.e. whether the identifier
+    // named by the most recent `ifdef/`ifndef/`elsif is defined.
     bool condition;
+    // The condition of the enclosing scope, evaluated when the `ifdef/
+    // `ifndef was seen.
     bool previous_condition;
+    // Set once the trailing `else branch has been entered.
     bool else_part;
-    
-    conditionalt()
-    { else_part=false; }
-     
+    // Set once any earlier branch in this `ifdef/`elsif/`else chain has
+    // matched. A branch (and the trailing `else) may only be active if no
+    // earlier branch has already matched.
+    bool matched;
+
+    conditionalt() : else_part(false), matched(false)
+    {
+    }
+
+    // Fold the current branch's condition into the "already matched" flag.
+    // Called before moving on to an `elsif or `else branch.
+    void into_next_branch()
+    {
+      matched = matched || condition;
+    }
+
     bool get_cond()
     {
-      return previous_condition &&
-             (else_part?(!condition):condition);
+      if(else_part)
+        return previous_condition && !matched;
+      else
+        return previous_condition && !matched && condition;
     }
   };
 


### PR DESCRIPTION
## Summary

Fixes the Verilog preprocessor defect documented as a `KNOWNBUG` in #2111: in an
`` `ifdef/`elsif/`elsif/`else `` chain, when a branch **before** the final
`` `elsif `` matches, the preprocessor emitted **both** the matched branch and
the trailing `` `else `` branch.

## Root cause

`conditionalt` (`src/verilog/verilog_preprocessor.h`) stored only the most
recent branch condition plus the enclosing scope's condition and an `else_part`
flag. It had no "a branch was already taken" record, so `get_cond()` negated
only the last `` `elsif ``'s condition for the `` `else `` part and could not
tell that an earlier branch in the chain had already matched.

## Fix

- Add a `matched` flag to `conditionalt`, folded in via a new
  `into_next_branch()` helper whenever an `` `elsif ``/`` `else `` begins.
- `get_cond()` now requires that no earlier branch matched:
  - branch active: `previous_condition && !matched && condition`
  - `` `else `` active: `previous_condition && !matched`
- Promote the `elsif3` regression test from `KNOWNBUG` to `CORE`.

## Testing

Verified with `ebmc --preprocess` that exactly one branch is emitted for every case:

| Defined | Emitted | Correct? |
|---|---|---|
| A | `BRANCH_A` | ✓ |
| B | `BRANCH_B` | ✓ |
| C | `BRANCH_C` | ✓ |
| none | `BRANCH_ELSE` | ✓ |
| A and B | `BRANCH_A` | ✓ |

* `src/verilog` and `src/ebmc` build clean with `-Werror`.
* `make -C regression/verilog test` — full suite green; `elsif3` is now `OK` (previously `SKIPPED`).