### PR TITLE
KNOWNBUG tests for import inside an interface body

### DIFF
--- a/regression/verilog/interface/modport_import1.desc
+++ b/regression/verilog/interface/modport_import1.desc
@@ -1,0 +1,16 @@
+KNOWNBUG
+modport_import1.sv
+
+^no properties$
+^EXIT=10$
+^SIGNAL=0$
+--
+^syntax error$
+--
+IEEE 1800-2017 25.7 allows a modport to import tasks and functions declared
+in the enclosing interface, using the `import` keyword inside the modport
+item list.  The parser rejects this with
+
+  syntax error, unexpected import before 'import'
+
+at the modport declaration.

--- a/regression/verilog/interface/modport_import1.sv
+++ b/regression/verilog/interface/modport_import1.sv
@@ -1,0 +1,14 @@
+interface my_interface;
+  logic [1:0] data;
+
+  function automatic logic parity(input logic [1:0] x);
+    return ^x;
+  endfunction
+
+  // IEEE 1800-2017 25.7: a modport can import interface tasks/functions
+  modport m (input data, import parity);
+endinterface
+
+module main(input clk);
+  my_interface i ();
+endmodule

--- a/regression/verilog/interface/package_import1.desc
+++ b/regression/verilog/interface/package_import1.desc
@@ -1,0 +1,18 @@
+KNOWNBUG
+package_import1.sv
+
+^no properties$
+^EXIT=10$
+^SIGNAL=0$
+--
+^CONVERSION ERROR$
+--
+A package import inside an interface body (IEEE 1800-2017 26.3) parses, and
+imported types are usable, but calling an imported function from interface
+scope fails elaboration with
+
+  unknown function `inv'
+
+i.e. the import makes typedefs visible in the interface but not functions.
+Note the import itself and imported typedefs work; only imported
+tasks/functions are affected.

--- a/regression/verilog/interface/package_import1.sv
+++ b/regression/verilog/interface/package_import1.sv
@@ -1,0 +1,18 @@
+package my_package;
+  function automatic logic inv(input logic x);
+    return ~x;
+  endfunction
+endpackage
+
+interface my_interface;
+  // IEEE 1800-2017 26.3: package import; 25.3: interface bodies may contain
+  // package import declarations, making the imported symbols visible in
+  // interface scope.
+  import my_package::*;
+  logic a, b;
+  always_comb b = inv(a);
+endinterface
+
+module main(input clk);
+  my_interface i ();
+endmodule


### PR DESCRIPTION
Two distinct failure modes, previously conflated as one issue:

**`interface/modport_import1`**: IEEE 1800-2017 25.7 allows a modport to import interface tasks/functions (`import` in the modport item list). The parser rejects this with `syntax error, unexpected import`.

**`interface/package_import1`**: a package import inside an interface body (IEEE 1800-2017 26.3) parses, and imported *typedefs* are usable, but calling an imported *function* from interface scope fails elaboration with `unknown function`. Imports make types visible in interface scope but not tasks/functions.

Both verified against `ebmc-6.0-257`: skipped in the default regression run, OK (fail-as-expected) under `test.pl -K`. The desc files document the expected post-fix behaviour (`no properties`, `EXIT=10`) so each flips from KNOWNBUG to CORE when fixed, following the `elsif3` precedent (#2112).