### PR TITLE
KNOWNBUG test for function declared in a generate block

### DIFF
--- a/regression/verilog/generate/generate-function1.desc
+++ b/regression/verilog/generate/generate-function1.desc
@@ -1,0 +1,13 @@
+KNOWNBUG
+generate-function1.sv
+--module main --bound 0
+^EXIT=0$
+^SIGNAL=0$
+--
+^CONVERSION ERROR$
+--
+IEEE 1800-2017 27.2 permits function declarations inside generate blocks;
+the function is usable within the scope of the generate block.  Elaboration
+rejects a call to such a function with
+
+  unknown function `plus_one'

--- a/regression/verilog/generate/generate-function1.sv
+++ b/regression/verilog/generate/generate-function1.sv
@@ -1,0 +1,18 @@
+module main(input clk);
+
+  generate
+    if (1) begin : gen_block
+      // IEEE 1800-2017 27.2: generate blocks may contain function
+      // declarations; the function is usable within the scope of the
+      // generate block.
+      function automatic [7:0] plus_one(input [7:0] x);
+        return x + 8'd1;
+      endfunction
+
+      wire [7:0] val = plus_one(8'd41);
+
+      p1: assert property (@(posedge clk) val == 8'd42);
+    end
+  endgenerate
+
+endmodule


### PR DESCRIPTION
IEEE 1800-2017 27.2 permits function declarations inside generate blocks; the function is usable within the scope of the generate block. Elaboration rejects a call to such a function with `unknown function`.

Verified against `ebmc-6.0`: skipped in the default regression run, OK (fail-as-expected) under `test.pl -K`. The desc documents the expected post-fix behaviour (`EXIT=0` with the in-block assertion provable at bound 0), so it flips from KNOWNBUG to CORE when fixed, following the `elsif3` precedent (#2112).