### PR TITLE
KNOWNBUG test for member selects in named properties

### DIFF
--- a/regression/verilog/property/member_select1.desc
+++ b/regression/verilog/property/member_select1.desc
@@ -1,0 +1,12 @@
+KNOWNBUG
+member_select1.sv
+--bound 3
+^\[main\.assert\.1\] .*: PROVED up to bound 3$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Member selects on struct variables inside a named property yield
+"unknown identifier field2" during type checking. This is the
+second example in https://github.com/diffblue/hw-cbmc/issues/2103.

--- a/regression/verilog/property/member_select1.sv
+++ b/regression/verilog/property/member_select1.sv
@@ -1,0 +1,22 @@
+typedef struct {
+  logic field1;
+  logic field2;
+} structure_t;
+
+module main(input wire clk, input wire rst);
+
+  structure_t s;
+
+  always @(posedge clk) begin
+    s.field2 <= 0;
+  end
+
+  // The member select in the named property yields
+  // "unknown identifier field2".
+  property p;
+    @(posedge clk) rst |=> ##1 s.field2 == 0;
+  endproperty
+
+  assert property (p);
+
+endmodule


### PR DESCRIPTION
Member selects on struct variables inside a named property declaration yield "unknown identifier" during type checking:

```
file member_select1.sv line 17: unknown identifier field2
CONVERSION ERROR
```

This is the second example in https://github.com/diffblue/hw-cbmc/issues/2103.