### PR TITLE
Verilog: member selects in named property declarations

### DIFF
--- a/regression/verilog/property/member_select1.desc
+++ b/regression/verilog/property/member_select1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 member_select1.sv
 --bound 3
 ^\[main\.assert\.1\] .*: PROVED up to bound 3$
@@ -7,6 +7,5 @@ member_select1.sv
 --
 ^warning: ignoring
 --
-Member selects on struct variables inside a named property yield
-"unknown identifier field2" during type checking. This is the
-second example in https://github.com/diffblue/hw-cbmc/issues/2103.
+This is the second example in
+https://github.com/diffblue/hw-cbmc/issues/2103.

--- a/regression/verilog/property/member_select1.desc
+++ b/regression/verilog/property/member_select1.desc
@@ -1,0 +1,12 @@
+KNOWNBUG
+member_select1.sv
+--bound 3
+^\[main\.assert\.1\] .*: PROVED up to bound 3$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Member selects on struct variables inside a named property yield
+"unknown identifier field2" during type checking. This is the
+second example in https://github.com/diffblue/hw-cbmc/issues/2103.

--- a/regression/verilog/property/member_select1.sv
+++ b/regression/verilog/property/member_select1.sv
@@ -1,0 +1,22 @@
+typedef struct {
+  logic field1;
+  logic field2;
+} structure_t;
+
+module main(input wire clk, input wire rst);
+
+  structure_t s;
+
+  always @(posedge clk) begin
+    s.field2 <= 0;
+  end
+
+  // The member select in the named property yields
+  // "unknown identifier field2".
+  property p;
+    @(posedge clk) rst |=> ##1 s.field2 == 0;
+  endproperty
+
+  assert property (p);
+
+endmodule

--- a/regression/verilog/property/member_select1.sv
+++ b/regression/verilog/property/member_select1.sv
@@ -11,8 +11,8 @@ module main(input wire clk, input wire rst);
     s.field2 <= 0;
   end
 
-  // The member select in the named property yields
-  // "unknown identifier field2".
+  // The member select is resolved when the named property
+  // is instantiated.
   property p;
     @(posedge clk) rst |=> ##1 s.field2 == 0;
   endproperty

--- a/src/verilog/verilog_typecheck.cpp
+++ b/src/verilog/verilog_typecheck.cpp
@@ -1810,25 +1810,33 @@ Function: verilog_typecheckt::preresolve_identifiers
 
 void verilog_typecheckt::preresolve_identifiers(exprt &expr)
 {
-  expr.visit_pre(
-    [this](exprt &node)
+  if(expr.id() == ID_verilog_identifier)
+  {
+    auto &identifier_expr = to_verilog_identifier_expr(expr);
+    auto base_name = identifier_expr.base_name();
+    auto symbol_ptr = resolve(base_name);
+    if(symbol_ptr != nullptr)
     {
-      if(node.id() == ID_verilog_identifier)
-      {
-        auto &identifier_expr = to_verilog_identifier_expr(node);
-        auto base_name = identifier_expr.base_name();
-        auto symbol_ptr = resolve(base_name);
-        if(symbol_ptr != nullptr)
-        {
-          identifier_expr.preresolved(symbol_ptr->name);
-        }
-        else
-        {
-          throw errort().with_location(node.source_location())
-            << "unknown identifier " << base_name;
-        }
-      }
-    });
+      identifier_expr.preresolved(symbol_ptr->name);
+    }
+    else
+    {
+      throw errort().with_location(expr.source_location())
+        << "unknown identifier " << base_name;
+    }
+  }
+  else if(expr.id() == ID_hierarchical_identifier)
+  {
+    // The identifier on the rhs of the '.' is a member or an
+    // identifier in the scope given by the lhs; it is resolved
+    // once the type of the lhs is known.
+    preresolve_identifiers(to_hierarchical_identifier_expr(expr).lhs());
+  }
+  else
+  {
+    for(auto &op : expr.operands())
+      preresolve_identifiers(op);
+  }
 }
 
 /*******************************************************************\


### PR DESCRIPTION
Stacked on #2120; only the top commit is new relative to that PR.

The identifiers in named property and sequence declarations are annotated with their scope when the declaration is converted, since type checking of the property expression is delayed until the instantiation is known (1800-2017 F.4.1). The identifier on the rhs of a `.` is a member or an identifier in the scope given by the lhs, and hence cannot be resolved at this point; it is now skipped, and resolved once the type of the lhs is known.

This fixes the second example in https://github.com/diffblue/hw-cbmc/issues/2103; the KNOWNBUG test from #2120 becomes CORE.