### PR TITLE
KNOWNBUG test for wildcards in case items

### DIFF
--- a/regression/verilog/case/case_wildcard1.desc
+++ b/regression/verilog/case/case_wildcard1.desc
@@ -1,0 +1,16 @@
+KNOWNBUG
+case_wildcard1.sv
+--bound 1
+^\[main\.p0\] always main\.r1 == 0: PROVED .*$
+^\[main\.p1\] always \(main\.sel\[1\] == 0 \|-> main\.r2 == 1\): PROVED up to bound 1$
+^\[main\.p2\] always \(main\.sel\[1\] == 1 \|-> main\.r2 == 0\): PROVED up to bound 1$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The case items of a case statement are compared using 4-state
+equality, per 1800-2017 12.5.1, i.e., x and z in a case item are
+not wildcards. Only casex and casez have wildcards. The case items
+are currently masked irrespective of the kind of case statement,
+and hence p0 is refuted.

--- a/regression/verilog/case/case_wildcard1.sv
+++ b/regression/verilog/case/case_wildcard1.sv
@@ -1,0 +1,30 @@
+module main(input clk, input [1:0] sel);
+
+  reg r1, r2;
+
+  // 1800-2017 12.5.1: the case statement compares using 4-state
+  // equality, i.e., x and z in a case item are not wildcards.
+  // Only casex and casez have wildcards.
+  always @(*) begin
+    case(sel)
+      2'b0z: r1 = 1;
+      default: r1 = 0;
+    endcase
+  end
+
+  // casez, for comparison: here the z is a wildcard.
+  always @(*) begin
+    casez(sel)
+      2'b0z: r2 = 1;
+      default: r2 = 0;
+    endcase
+  end
+
+  // sel is two-valued, and hence never matches 2'b0z.
+  p0: assert property (@(posedge clk) r1 == 0);
+
+  // These hold.
+  p1: assert property (@(posedge clk) sel[1] == 0 |-> r2 == 1);
+  p2: assert property (@(posedge clk) sel[1] == 1 |-> r2 == 0);
+
+endmodule


### PR DESCRIPTION
The case items of a case statement are compared using 4-state equality, per 1800-2017 12.5.1, i.e., x and z in a case item are **not** wildcards. Only `casex` and `casez` have wildcards.

The case items are currently masked irrespective of the kind of case statement, and hence the following property is refuted, although `sel` is two-valued and can never match `2'b0z`:

```verilog
always @(*) begin
  case(sel)
    2'b0z: r1 = 1;
    default: r1 = 0;
  endcase
end

p0: assert property (@(posedge clk) r1 == 0);
```

The test also covers the `casez` counterpart, where the z is a wildcard; those two properties pass.
