### PR TITLE
Verilog: wildcards in case items depend on the case kind

### DIFF
--- a/regression/verilog/case/case_wildcard1.desc
+++ b/regression/verilog/case/case_wildcard1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 case_wildcard1.sv
 --bound 1
 ^\[main\.p0\] always main\.r1 == 0: PROVED .*$
@@ -9,8 +9,6 @@ case_wildcard1.sv
 --
 ^warning: ignoring
 --
-The case items of a case statement are compared using 4-state
+The case items of a plain case statement are compared using 4-state
 equality, per 1800-2017 12.5.1, i.e., x and z in a case item are
-not wildcards. Only casex and casez have wildcards. The case items
-are currently masked irrespective of the kind of case statement,
-and hence p0 is refuted.
+not wildcards. Only casex and casez have wildcards. Hence p0 holds.

--- a/regression/verilog/case/case_wildcard2.desc
+++ b/regression/verilog/case/case_wildcard2.desc
@@ -1,0 +1,14 @@
+CORE
+case_wildcard2.sv
+--bound 1
+^\[main\.p0\] always \(main\.sel\[1\] == 0 \|-> main\.rx == 1\): PROVED up to bound 1$
+^\[main\.p1\] always \(main\.sel\[1\] == 1 \|-> main\.rx == 0\): PROVED up to bound 1$
+^\[main\.p2\] always main\.rz == 0: PROVED up to bound 1$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+1800-2017 12.5.1: casex treats both x and z bits in a case item as
+wildcards, whereas casez treats only z (and ?) bits as wildcards.
+An x bit in a casez case item is not a wildcard.

--- a/regression/verilog/case/case_wildcard2.sv
+++ b/regression/verilog/case/case_wildcard2.sv
@@ -1,0 +1,30 @@
+module main(input clk, input [1:0] sel);
+
+  reg rx, rz;
+
+  // casex: both x and z bits in the case item are wildcards.
+  always @(*) begin
+    casex(sel)
+      2'b0x: rx = 1;
+      default: rx = 0;
+    endcase
+  end
+
+  // casez: only z (and ?) bits are wildcards; x is not.
+  always @(*) begin
+    casez(sel)
+      2'b0x: rz = 1;
+      default: rz = 0;
+    endcase
+  end
+
+  // 1800-2017 12.5.1: for casex, the x in 2'b0x is a wildcard, so
+  // the item matches whenever sel[1] == 0.
+  p0: assert property (@(posedge clk) sel[1] == 0 |-> rx == 1);
+  p1: assert property (@(posedge clk) sel[1] == 1 |-> rx == 0);
+
+  // For casez, the x in 2'b0x is not a wildcard, and sel is
+  // two-valued, so the item is never matched.
+  p2: assert property (@(posedge clk) rz == 0);
+
+endmodule

--- a/src/verilog/verilog_synthesis.cpp
+++ b/src/verilog/verilog_synthesis.cpp
@@ -2630,30 +2630,69 @@ Function: verilog_synthesist::case_comparison
 \*******************************************************************/
 
 exprt verilog_synthesist::case_comparison(
+  irep_idt case_type,
   const exprt &case_operand,
   const exprt &pattern)
 {
+  PRECONDITION(
+    case_type == ID_verilog_case || case_type == ID_verilog_casex ||
+    case_type == ID_verilog_casez);
+
   // the pattern has the max type, not the case operand
   const typet &pattern_type=pattern.type();
 
-  // we need to take case of ?, x, z in the pattern
+  // 1800-2017 12.5.1: a plain 'case' statement compares the case
+  // operand and the case items using 4-state equality (i.e., ===).
+  // The x and z bits in a case item are not wildcards. Only casex and
+  // casez have wildcards:
+  // * casez treats z (and ?) bits in a case item as wildcards, and
+  // * casex treats x, z (and ?) bits in a case item as wildcards.
+  // In the aval/bval encoding, a case-item bit is
+  //   x when bval=1 and aval=0, and
+  //   z when bval=1 and aval=1.
+  // The non-wildcard bit positions are compared using 4-state
+  // equality, i.e., both the aval and the bval bits have to match.
   if(is_aval_bval(pattern_type))
   {
-    // We are using masking based on the pattern.
-    // The aval is the comparison value, and the
-    // negation of bval is the mask.
     auto pattern_aval = ::aval(pattern);
     auto pattern_bval = ::bval(pattern);
-    auto mask_expr = bitnot_exprt{pattern_bval};
 
-    auto case_operand_casted = typecast_exprt{
-      typecast_exprt::conditional_cast(
-        case_operand, aval_bval_underlying(pattern_type)),
-      mask_expr.type()};
+    auto case_operand_lowered = typecast_exprt::conditional_cast(
+      case_operand, aval_bval_underlying(pattern_type));
+    auto operand_aval =
+      typecast_exprt{::aval(case_operand_lowered), pattern_aval.type()};
+    auto operand_bval =
+      typecast_exprt{::bval(case_operand_lowered), pattern_bval.type()};
 
-    return equal_exprt{
-      bitand_exprt{case_operand_casted, mask_expr},
-      bitand_exprt{pattern_aval, mask_expr}};
+    // The wildcard bits are ignored in the comparison; keep_mask is
+    // the negation of the wildcard mask, i.e., the bits to compare.
+    exprt keep_mask;
+
+    if(case_type == ID_verilog_casex)
+    {
+      // Any bit with bval=1 (i.e., x or z) is a wildcard.
+      keep_mask = bitnot_exprt{pattern_bval};
+    }
+    else if(case_type == ID_verilog_casez)
+    {
+      // Only z bits (bval=1 and aval=1) are wildcards.
+      keep_mask = bitnot_exprt{bitand_exprt{pattern_bval, pattern_aval}};
+    }
+    else
+    {
+      // Plain case: no wildcards, compare all bits.
+      keep_mask = to_bv_type(pattern_aval.type()).all_ones_expr();
+    }
+
+    // On the compared bits, require 4-state equality: both the aval
+    // and the bval have to match.
+    return and_exprt{
+      equal_exprt{
+        bitand_exprt{operand_aval, keep_mask},
+        bitand_exprt{pattern_aval, keep_mask}},
+      equal_exprt{
+        bitand_exprt{operand_bval, keep_mask},
+        bitand_exprt{pattern_bval, keep_mask}}};
   }
 
   // 2-valued comparison
@@ -2676,6 +2715,7 @@ Function: verilog_synthesist::synth_case_values
 \*******************************************************************/
 
 exprt verilog_synthesist::synth_case_values(
+  irep_idt case_type,
   const exprt &values,
   const exprt &case_operand)
 {
@@ -2689,7 +2729,7 @@ exprt verilog_synthesist::synth_case_values(
   forall_operands(it, values)
   {
     auto pattern = synth_expr(*it, symbol_statet::CURRENT);
-    op.push_back(case_comparison(case_operand, pattern));
+    op.push_back(case_comparison(case_type, case_operand, pattern));
   }
 
   return disjunction(op);
@@ -2743,8 +2783,8 @@ void verilog_synthesist::synth_case(
     {
       exprt if_statement(ID_if);
       if_statement.reserve_operands(3);
-      if_statement.add_to_operands(
-        synth_case_values(case_item.case_value(), case_operand));
+      if_statement.add_to_operands(synth_case_values(
+        statement.id(), case_item.case_value(), case_operand));
       if_statement.add_to_operands(case_item.case_statement());
 
       last_if->add_to_operands(std::move(if_statement));

--- a/src/verilog/verilog_synthesis_class.h
+++ b/src/verilog/verilog_synthesis_class.h
@@ -315,9 +315,12 @@ protected:
 
   void post_process_initial(exprt &constraints);
   void post_process_wire(const irep_idt &identifier, exprt &expr);
-  
-  exprt case_comparison(const exprt &case_operand, const exprt &pattern);
-  
+
+  exprt case_comparison(
+    irep_idt case_type,
+    const exprt &case_operand,
+    const exprt &pattern);
+
   typedef enum { CURRENT, NEXT } curr_or_nextt;
 
   exprt symbol_expr(const symbolt &, curr_or_nextt curr_or_next) const;
@@ -331,6 +334,7 @@ protected:
     exprt &constraints);
 
   exprt synth_case_values(
+    irep_idt case_type,
     const exprt &values,
     const exprt &case_operand);
 


### PR DESCRIPTION
## Summary

Fixes the KNOWNBUG introduced in #2122. Per IEEE 1800-2017 §12.5.1, the case items of a plain `case` statement are compared using 4-state equality (`===`): `x` and `z` in a case item are **not** wildcards. Only `casex` and `casez` have wildcards:

- `casez` treats `z` (and `?`) bits in a case item as wildcards.
- `casex` treats `x`, `z` (and `?`) bits in a case item as wildcards.

Previously the case items were masked irrespective of the kind of case statement, i.e., every `case` was effectively treated like `casex`.

## Changes

- `src/verilog/verilog_synthesis.cpp`: `case_comparison` now receives the case-statement kind and selects the wildcard bits accordingly (none for `case`, z-only for `casez`, x/z for `casex`). Non-wildcard positions are compared using 4-state equality (both `aval` and `bval` must match), which also correctly handles operands containing `x`/`z`. Added a `PRECONDITION` on the case kind.
- `src/verilog/verilog_synthesis_class.h`: threaded the case kind through `case_comparison` and `synth_case_values`.
- `regression/verilog/case/case_wildcard1.desc`: `KNOWNBUG` → `CORE`.
- `regression/verilog/case/case_wildcard2.{sv,desc}`: new test locking in the `casex` vs `casez` distinction.

## Testing

- `make -C src` builds clean.
- `make -C regression/verilog test`: all `case/*.desc` pass, including both wildcard tests; no failures across the suite.
- `make -C regression/ebmc test` and `make -C regression/smv test`: no failures.